### PR TITLE
Cleanup use of polymorphic variants in Harbor

### DIFF
--- a/src/outputs/harbor_output.ml
+++ b/src/outputs/harbor_output.ml
@@ -369,7 +369,8 @@ class output ~kind p =
                                                                     password
                                                                     =
                                                             let (user,
-                                                                 password) =
+                                                                 password) 
+                                                              =
                                                               let f =
                                                                 Configure.
                                                                 recode_tag
@@ -563,7 +564,8 @@ class output ~kind p =
                                                                     s) in
                                                                     let 
                                                                     (metaint,
-                                                                    icyheader) =
+                                                                    icyheader) 
+                                                                    =
                                                                     try
                                                                     (assert
                                                                     ((List.
@@ -898,7 +900,8 @@ class output ~kind p =
                                                                     (acc, 0) in
                                                                     let 
                                                                     (data,
-                                                                    pos) =
+                                                                    pos) 
+                                                                    =
                                                                     f [] 0
                                                                     (b ::
                                                                     (List.rev
@@ -1067,7 +1070,8 @@ class output ~kind p =
                                                                     "^(.+)\\?(.+)$" in
                                                                     let 
                                                                     (base_uri,
-                                                                    args) =
+                                                                    args) 
+                                                                    =
                                                                     try
                                                                     let sub 
                                                                     =

--- a/src/tools/harbor.camlp4
+++ b/src/tools/harbor.camlp4
@@ -116,15 +116,15 @@ let verb_or_source_of_string s =
     | "SOURCE"  -> `Source
     | _         -> verb_of_string s
 
-let string_of_verb = 
-  function
-    | `Get     -> "GET"
-    | `Post    -> "POST"
-    | `Put     -> "PUT"
-    | `Delete  -> "DELETE"
-    | `Head    -> "HEAD"
-    | `Options -> "OPTIONS"
-    | _        -> assert false
+let string_of_verb = function
+  | `Get     -> "GET"
+  | `Post    -> "POST"
+  | `Put     -> "PUT"
+  | `Delete  -> "DELETE"
+  | `Head    -> "HEAD"
+  | `Options -> "OPTIONS"
+  | `Source -> "SOURCE"
+  | `Shout -> "SHOUT"
 
 type protocol = [
   | `Http_10
@@ -362,7 +362,6 @@ let handle_source_request ~port ~auth ~smethod hprotocol h uri headers =
          | `Put -> "PUT (source)"
          | `Post -> "POST (source)"
          | `Xaudiocast -> "X-AUDIOCAST"
-         | _ -> assert false
        in
        log#f 4 "%s request on %s." sproto uri ;
        let stype =
@@ -391,14 +390,9 @@ let handle_source_request ~port ~auth ~smethod hprotocol h uri headers =
        in
        log#f 4 "Adding source on mountpoint %S with type %S." uri stype ;
        log#f 5 "Relaying %s." (string_of_protocol hprotocol) ;
-       let protocol =
-         match hprotocol with
-           | `Ice_10
-           | `Http_10 -> "HTTP/1.0"
-           | `Http_11 -> "HTTP/1.1"
-           | _ -> assert false
-       in
-       relayed (Printf.sprintf "%s 200 OK\r\n\r\n" protocol) f
+       relayed
+         (Printf.sprintf "%s 200 OK\r\n\r\n" (string_of_protocol hprotocol))
+         f
     with
       | Mount_taken ->
          log#f 4 "Returned 403: Mount taken" ;
@@ -517,7 +511,7 @@ let handle_websocket_request ~port h mount headers =
 
 exception Handled of http_handler
 
-let handle_http_request ~hmethod ~hprotocol ~data ~port h uri headers =
+let handle_http_request ~hmethod:(hmethod:verb) ~hprotocol ~data ~port h uri headers =
   let ans_404 = fun () ->
     log#f 4 "Returned 404 for '%s'." uri ;
     reply
@@ -628,12 +622,7 @@ let handle_http_request ~hmethod ~hprotocol ~data ~port h uri headers =
     | Not_found -> uri,""
   in
   let smethod = string_of_verb hmethod in 
-  let protocol =
-    match hprotocol with
-      | `Http_10 -> "HTTP/1.0"
-      | `Http_11 -> "HTTP/1.1"
-      | _ -> assert false
-  in
+  let protocol = string_of_protocol hprotocol in
   log#f 4 "HTTP %s request on %s." smethod base_uri ;
   let args = Http.args_split args in
   (* Filter out password *)


### PR DESCRIPTION
Cf. #151. I need a review here.

Also note that the camlp4 stuff is really messy and annoying. We should not track generated files, or at least mark them binary. It's also annoying because the ocaml compiler reports errors in generated files and my editor jumps to them; I can even write to them since they are not marked read-only.
