### PR TITLE
Avoiding UTF-8 failures

### DIFF
--- a/src/request.ml
+++ b/src/request.ml
@@ -66,9 +66,9 @@ let string_of_metadata metadata =
     Hashtbl.iter (fun k v ->
                     if !first then begin
                       first := false ;
-                      Format.fprintf f "%s=%a" k escape v
+                      try (Format.fprintf f "%s=%a" k escape v) with _ -> (Format.fprintf f "%s=ERROR" k )
                     end else
-                      Format.fprintf f "\n%s=%a" k escape v)
+                      try (Format.fprintf f "\n%s=%a" k escape v) with _ -> (Format.fprintf f "\n%s=ERROR" k ))
       metadata ;
     Format.pp_print_flush f () ;
     Buffer.contents b
@@ -115,7 +115,7 @@ let string_of_log log =
   * from the current active URI to the root.
   * At the end of the previous example, the tree looks like:
   * [ [ "/tmp/localfile_from_smb" ] ;
-  *   [ 
+  *   [
   *     (* Some http://something was there but was removed without producing
   *      * anything. *)
   *     "smb://something" ; (* The successfully downloaded URI *)
@@ -289,7 +289,7 @@ let get_decoders conf decoders =
 let mresolvers_doc =
   "Methods to extract metadata from a file."
 let mresolvers =
-  Plug.create 
+  Plug.create
     ~register_hook:(fun (name,_) -> f conf_metadata_decoders name)
     ~doc:mresolvers_doc ~insensitive:true "metadata formats"
 


### PR DESCRIPTION
Hey guys,

Love your work, we used it for 5+ years now on http://podradio.fr/.

We're having an issue sometimes with some UTF-8 failure when getting metadata. Basically when sometimes something can't be converted to UTF-8 we get "Failure: Utils.utf_8.next" instead of all the infos.

I made this dirty fix (I don't know OCaml, and no offense but I found it absolutely incomprehensible and incoherent). The fix return key=ERROR when a failure happens, instead of blocking all the metadata.

If you can do better, and that wouldn't be difficult, please do it ^^

Thanks.
