### PR TITLE
fix invalid printf format

### DIFF
--- a/src/request.ml
+++ b/src/request.ml
@@ -573,7 +573,7 @@ let resolve t timeout =
               | Some handler ->
                   add_log t
                     (Printf.sprintf
-                       "Resolving %S (timeout %.fs)..."
+                       "Resolving %S (timeout %.0fs)..."
                        i.string timeout) ;
                   let production =
                     handler.resolve ~log:(add_log t) arg maxtime


### PR DESCRIPTION
There are some format strings that are "invalid" in the liquidsoap sources.

In general, invalid formats are nonsensical format strings that were accepted in OCaml 4.01.0 and earlier, but whose semantics is unspecified. They are still accepted by the new Printf implementation of OCaml 4.02.0 but in some cases with different semantics, and they will be statically rejected by OCaml 4.03.0.

You can check for them in OCaml 4.02.0 with the flag -strict-formats.

In the case of liquidsoap, I think the behavior has not changed between 4.01.0 and 4.02.0. The only invalid format is "%.f". This is considered invalid beause it specifies limited precision without giving the limit. Even though the behaviour has not changed, you should take the opportunity to review the code and fix the format. The patch changes it to "%.0f", which keeps the behaviour unchanged, but that might still be wrong.
