### PR TITLE
Accept string functions for output.file filename parameter

### DIFF
--- a/src/outputs/pipe_output.ml
+++ b/src/outputs/pipe_output.ml
@@ -42,7 +42,7 @@ let pipe_proto kind arg_doc =
        Some "Encoding format." ;
 
        "",
-       Lang.string_t,
+       Lang.string_getter_t 1,
        None,
        Some (arg_doc ^
              " Some strftime conversion specifiers are available: \
@@ -80,7 +80,8 @@ class virtual piped_output p =
           raise (Lang.Invalid_value (format_val,"Unsupported format"))
   in
   let source = Lang.assoc "" 3 p in
-  let name = Lang.to_string (Lang.assoc "" 2 p) in
+  let name = Lang.to_string_getter (Lang.assoc "" 2 p) in
+  let name = name () in
   let kind = Encoder.kind_of_format format in
 object (self)
 
@@ -208,7 +209,7 @@ end
 
 class file_output p = 
   let filename =
-    Lang.to_string (Lang.assoc "" 2 p)
+    Lang.to_string_getter (Lang.assoc "" 2 p)
   in 
   let append = Lang.to_bool (List.assoc "append" p) in
   let perm = Lang.to_int (List.assoc "perm" p) in
@@ -228,6 +229,7 @@ object (self)
       Open_wronly::Open_creat::
       (if append then [Open_append] else [Open_trunc])
     in
+    let filename = filename () in
     let filename = Utils.strftime filename in
     let filename = Utils.home_unrelate filename in
     (* Avoid / in metas for filename.. *)
@@ -293,13 +295,14 @@ let () =
 
 class external_output p =
   let process =
-    Lang.to_string (Lang.assoc "" 2 p)
+    Lang.to_string_getter (Lang.assoc "" 2 p)
   in
 object (self)
   inherit piped_output p
   inherit chan_output p
 
   method open_chan =
+    let process = process () in
     let process = self#interpolate process in
     Unix.open_process_out process
 


### PR DESCRIPTION
Sometimes, it may be cool to have different filenames depending on other things than metadata.

With this patch, we can simply use a function as name, that will be evaluated on output start. We can still use metadata or time interpolation in the string returned.

This patch use `to_string_getter` which is already used in [operators/video_text.ml](https://github.com/savonet/liquidsoap/blob/3118f0299b894f4f24f92e14e868bd92d898adc9/src/operators/video_text.ml#L158).

**Rationale:** At [SynopsLive](http://synopslive.net/), we want to create new records file on demand. These records should have an understandable name, composed by a show slug given by an external process and timestamp of record beginning. To do this with current liquidsoap, we had to inject metadata, but it have weird side effects: as metadata is not known when output is starded, we need to do this: 
1. Use `reopen_with_metadata=true`,
2. Start the output,
3. Inject metadata using `insert_metadata`,
4. Ignore the fact that in the meantime, Liquidsoap created a near-empty file with a wrong name.

**Disclamer:** I never wrote any Ocaml before, so feel free to nitpick. However, this compile and run successfully at home.
