### PR TITLE
add example to string.escape documentation

### DIFF
--- a/src/lang/lang_builtins.ml
+++ b/src/lang/lang_builtins.ml
@@ -286,7 +286,7 @@ let () =
        "mimes",Lang.list_t (Lang.string_t),
        Some (Lang.list ~t:Lang.string_t []),
        Some "List of mime types supported by this decoder \
-             for decoding streams."; 
+             for decoding streams.";
        test_arg;
        "",Lang.string_t,None,Some "Process to start."]
       Lang.unit_t
@@ -663,7 +663,9 @@ let () =
                       ~descr:"Escape special charaters in a \
                               string. String is parsed char by char. \
                               See @string.utf8.escape@ for an UTF8-aware \
-                              parsing function."
+                              parsing function.\n\n \
+                              Example:\n \
+                              meta = string.escape(meta)"
                       ~escape ~escape_char:Utils.escape_char ;
   let escape ~special_char ~escape_char f s =
     Utils.escape_utf8 ~special_char ~escape_char f s


### PR DESCRIPTION
I propose we add inline examples to the documentation for using the functions. Reading a lot of posts on the mailing lists and talking to people on IRC, it seems like users could really benefit from just seeing an example of the function being used right there. It would be easier to make a connection from the function signature to how to actually use it.

I am trying to add an example to the documentation comment, I'm not sure exactly how this will look when generated.

My inspiration from this is admittedly the rubyonrails docs, where they usually have examples inline api.rubyonrails.org 
