### PR TITLE
Native avi support

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -158,6 +158,7 @@ analyze = analyze/analyze_rms.ml
 
 encoders = \
 	encoder/wav_encoder.ml \
+	encoder/avi_encoder.ml \
 	encoder/lame_encoder.ml \
 	encoder/fdkaac_encoder.ml \
 	encoder/aacplus_encoder.ml \
@@ -265,7 +266,7 @@ liquidsoap_sources += \
 	lang/lang_types.ml lang/lang_values.ml \
 	lang/lang_encoders.ml lang/lang_parser.ml lang/lang_lexer.ml \
 	lang/lang_pp.ml lang/lang.ml tools/start_stop.ml tools/ioRing.ml \
-	tools/icecast_utils.ml \
+	tools/icecast_utils.ml tools/avi.ml \
 	$(video_converters) $(audio_converters) $(ogg_demuxer) $(protocols) \
 	$(sources) $(conversions) $(outputs) $(operators) \
 	$(encoders) $(ogg_muxer) $(io) \

--- a/src/encoder/encoder.ml
+++ b/src/encoder/encoder.ml
@@ -85,6 +85,26 @@ struct
 
 end
 
+module AVI =
+struct
+  type t =
+    {
+      samplerate : int;
+      channels : int;
+      duration : float option
+    }
+
+  let to_string w =
+    let duration = 
+      match w.duration with
+        | None -> ""
+        | Some d -> Printf.sprintf ",duration=%f" d
+    in
+    Printf.sprintf
+      "%%wav(samplerate=%d,channels=%d,%s)"
+      w.samplerate w.channels duration
+end
+
 module Vorbis =
 struct
 
@@ -457,6 +477,7 @@ struct
   type t = {
     channels            : int ;
     samplerate          : int ;
+    video               : bool ;
     header              : bool ;
     restart_on_crash    : bool ;
     restart             : restart_condition ;
@@ -470,10 +491,11 @@ struct
         | Metadata        -> "restart_on_metadata"
         | No_condition    -> ""
     in
-    Printf.sprintf "%%external(channels=%i,samplerate=%i,header=%s,\
+    Printf.sprintf "%%external(channels=%i,samplerate=%i,video=%s,header=%s,\
                               restart_on_crash=%s,%s,process=%s)"
       e.channels
       e.samplerate
+      (string_of_bool e.video)
       (string_of_bool e.header)
       (string_of_bool e.restart_on_crash)
       (string_of_restart_condition e.restart)
@@ -684,6 +706,7 @@ end
 
 type format =
   | WAV of WAV.t
+  | AVI of AVI.t
   | Ogg of Ogg.t
   | MP3 of MP3.t
   | Shine of Shine.t
@@ -698,6 +721,9 @@ let kind_of_format = function
   | WAV w ->
       { Frame.audio = w.WAV.channels ;
         Frame.video = 0 ; Frame.midi = 0 }
+  | AVI a ->
+      { Frame.audio = a.AVI.channels ;
+        Frame.video = 1 ; Frame.midi = 0 }
   | MP3 m ->
       { Frame.audio = if m.MP3.stereo then 2 else 1 ;
         Frame.video = 0 ; Frame.midi = 0 }
@@ -736,7 +762,7 @@ let kind_of_format = function
         l
   | External e ->
       { Frame.audio = e.External.channels ;
-        Frame.video = 0 ; Frame.midi = 0 }
+        Frame.video = if e.External.video then 1 else 0 ; Frame.midi = 0 }
   | GStreamer e ->
     { Frame.audio = GStreamer.audio_channels e;
       Frame.video = GStreamer.video_channels e;
@@ -750,6 +776,7 @@ let kind_of_format f =
 
 let string_of_format = function
   | WAV w -> WAV.to_string w
+  | AVI w -> AVI.to_string w
   | Ogg w -> Ogg.to_string w
   | MP3 w -> MP3.to_string w
   | Shine w -> Shine.to_string w

--- a/src/encoder/encoder.ml
+++ b/src/encoder/encoder.ml
@@ -91,18 +91,12 @@ struct
     {
       samplerate : int;
       channels : int;
-      duration : float option
     }
 
   let to_string w =
-    let duration = 
-      match w.duration with
-        | None -> ""
-        | Some d -> Printf.sprintf ",duration=%f" d
-    in
     Printf.sprintf
-      "%%wav(samplerate=%d,channels=%d,%s)"
-      w.samplerate w.channels duration
+      "%%wav(samplerate=%d,channels=%d)"
+      w.samplerate w.channels
 end
 
 module Vorbis =

--- a/src/encoder/encoder.ml
+++ b/src/encoder/encoder.ml
@@ -95,7 +95,7 @@ struct
 
   let to_string w =
     Printf.sprintf
-      "%%wav(samplerate=%d,channels=%d)"
+      "%%avi(samplerate=%d,channels=%d)"
       w.samplerate w.channels
 end
 
@@ -485,13 +485,13 @@ struct
         | Metadata        -> "restart_on_metadata"
         | No_condition    -> ""
     in
-    Printf.sprintf "%%external(channels=%i,samplerate=%i,video=%s,header=%s,\
-                              restart_on_crash=%s,%s,process=%s)"
+    Printf.sprintf "%%external(channels=%i,samplerate=%i,video=%b,header=%b,\
+                              restart_on_crash=%b,%s,process=%s)"
       e.channels
       e.samplerate
-      (string_of_bool e.video)
-      (string_of_bool e.header)
-      (string_of_bool e.restart_on_crash)
+      e.video
+      e.header
+      e.restart_on_crash
       (string_of_restart_condition e.restart)
       e.process
 

--- a/src/encoder/external_encoder.ml
+++ b/src/encoder/external_encoder.ml
@@ -202,7 +202,9 @@ let encoder id ext =
     let channels = h.params.channels in
     let sbuf =
       if h.params.video then
-        Avi_encoder.encode_frame ~channels ~samplerate:h.params.samplerate ~converter:h.converter frame start len
+        Avi_encoder.encode_frame
+          ~channels ~samplerate:h.params.samplerate ~converter:h.converter
+          frame start len
       else
         (
           let start = Frame.audio_of_master start in

--- a/src/encoder/external_encoder.ml
+++ b/src/encoder/external_encoder.ml
@@ -66,33 +66,33 @@ let encoder id ext =
   (* The encoding logic *)
   let stop_process h = 
     match h.encoder with
-      | Some (_,out_e as enc) ->
-         h.log#f 3 "stopping current process" ;
-         begin
-           try
-             begin
-              try
-               flush out_e;
-               Unix.close (Unix.descr_of_out_channel out_e)
-              with
-                | _ -> ()
-             end;
-             Tutils.mutexify h.cond_m (fun () ->
-               if h.is_task then
-                 Condition.wait h.cond h.cond_m) ();
-             begin
-              try
-                ignore(Unix.close_process enc)
-              with
-                | _ -> ()
-             end;
-             h.encoder <- None
-           with
-             | e ->
-                 h.log#f 2 "couldn't stop the reading task.";
-                 raise e
-         end
-      | None -> ()
+    | Some (_,out_e as enc) ->
+       h.log#f 3 "stopping current process" ;
+      begin
+        try
+          begin
+            try
+              flush out_e;
+              Unix.close (Unix.descr_of_out_channel out_e)
+            with
+            | _ -> ()
+          end;
+          Tutils.mutexify h.cond_m (fun () ->
+            if h.is_task then
+              Condition.wait h.cond h.cond_m) ();
+          begin
+            try
+              ignore(Unix.close_process enc)
+            with
+            | _ -> ()
+          end;
+          h.encoder <- None
+        with
+        | e ->
+           h.log#f 2 "couldn't stop the reading task.";
+          raise e
+      end
+    | None -> ()
   in
 
   let reset_process start_f h = 
@@ -111,12 +111,19 @@ let encoder id ext =
     assert(h.encoder = None);
     let (in_e,out_e as enc) = Unix.open_process process in
     h.encoder <- Some enc;
-    if h.params.header then
+    if h.params.video then
+      begin
+        let header =
+          Avi.header ~channels:h.params.channels ~samplerate:h.params.samplerate ()
+        in
+        output_string out_e header
+      end
+    else if h.params.header then
       begin
         let header =
           Wav_aiff.wav_header ~channels:h.params.channels
-                     ~sample_rate:h.params.samplerate
-                     ~sample_size:16 ()
+            ~sample_rate:h.params.samplerate
+            ~sample_size:16 ()
         in
         (* Write WAV header *)
         output_string out_e header
@@ -143,45 +150,45 @@ let encoder id ext =
         let ret = read () in
         if ret > 0 then
           [{ Duppy.Task.
-               priority = priority ;
-               events   = events ;
-               handler  = pull }]
+             priority = priority ;
+             events   = events ;
+             handler  = pull }]
         else
-         begin
-           h.log#f 4 "Reading task reached end of data";
-           stop (); []
-         end
+          begin
+            h.log#f 4 "Reading task reached end of data";
+            stop (); []
+          end
       with e -> 
         h.log#f 3
           "Error while reading data from encoding process: %s"
           (Printexc.to_string e) ;
         stop (); 
         (if h.params.restart_on_crash then
-          reset_process start_process h
+            reset_process start_process h
          else
-          raise e);
+            raise e);
         []
     in
     Duppy.Task.add Tutils.scheduler
       { Duppy.Task.
-          priority = priority ;
-          events   = events ;
-          handler  = pull };
+        priority = priority ;
+        events   = events ;
+        handler  = pull };
     h.is_task <- true;
     (** Creating restart task. *)
     match h.params.restart with
-      | Delay d -> 
-          let f _ =
-            h.log#f 3 "Restarting encoder after delay (%is)" d;
-            reset_process start_process h ;
-            []
-          in
-          Duppy.Task.add Tutils.scheduler
-            { Duppy.Task.
-                priority = priority ;
-                events   = [`Delay (float d)] ;
-                handler  = f }
-      | _ -> ()
+    | Delay d -> 
+       let f _ =
+         h.log#f 3 "Restarting encoder after delay (%is)" d;
+         reset_process start_process h ;
+         []
+       in
+       Duppy.Task.add Tutils.scheduler
+         { Duppy.Task.
+           priority = priority ;
+           events   = [`Delay (float d)] ;
+           handler  = f }
+    | _ -> ()
   in
 
   let reset_process = reset_process start_process in
@@ -193,41 +200,49 @@ let encoder id ext =
 
   let encode h ratio frame start len =
     let channels = h.params.channels in
-    let start = Frame.audio_of_master start in
-    let b = AFrame.content_of_type ~channels frame start in
-    let len = Frame.audio_of_master len in
-    (* Resample if needed. *)
-    let b,start,len =
-      if ratio = 1. then
-        b,start,len
+    let sbuf =
+      if h.params.video then
+        Avi_encoder.encode_frame ~channels ~samplerate:h.params.samplerate ~converter:h.converter frame start len
       else
-        let b =
-          Audio_converter.Samplerate.resample
-                 h.converter ratio b start len
-        in
-        b,0,Array.length b.(0)
+        (
+          let start = Frame.audio_of_master start in
+          let b = AFrame.content_of_type ~channels frame start in
+          let len = Frame.audio_of_master len in
+          (* Resample if needed. *)
+          let b,start,len =
+            if ratio = 1. then
+              b,start,len
+            else
+              let b =
+                Audio_converter.Samplerate.resample
+                  h.converter ratio b start len
+              in
+              b,0,Array.length b.(0)
+          in
+          let slen = 2 * len * Array.length b in
+          let sbuf = Bytes.create slen in
+          Audio.S16LE.of_audio b start sbuf 0 len;
+          sbuf
+        )
     in
-    let slen = 2 * len * Array.length b in
-    let sbuf = Bytes.create slen in
-    Audio.S16LE.of_audio b start sbuf 0 len;
     (** Wait for any possible creation.. *)
     begin
       try
         Tutils.mutexify h.create_m (fun () ->
-         match h.encoder with
-           | Some (_,x) ->
-              output_string x sbuf;
-           | None ->
-              raise Not_found) ()
+          match h.encoder with
+          | Some (_,x) ->
+             output_string x sbuf;
+          | None ->
+             raise Not_found) ()
       with
-        | e ->
-           h.log#f 3
-             "Error while writing data to encoding process: %s"
-             (Printexc.to_string e) ;
-           if h.params.restart_on_crash then
-             reset_process h
-           else
-             raise e
+      | e ->
+         h.log#f 3
+           "Error while writing data to encoding process: %s"
+           (Printexc.to_string e) ;
+        if h.params.restart_on_crash then
+          reset_process h
+        else
+          raise e
     end;
     Tutils.mutexify h.read_m (fun () ->
       let ret = Buffer.contents h.read in
@@ -243,13 +258,13 @@ let encoder id ext =
     Buffer.reset h.read;
     ret
   in
- 
+  
   (* Create an initial process *)
   start_process handle ;
 
   (* Return the encoding handle *)
   {
-   Encoder. 
+    Encoder. 
     insert_metadata  = insert_metadata handle ;
     (* External encoders do not support 
      * headers for now. They will probably

--- a/src/lang/lang_encoders.ml
+++ b/src/lang/lang_encoders.ml
@@ -82,7 +82,6 @@ let avi params =
     {
       Encoder.AVI.
       channels = 2;
-      duration = None;
       samplerate = 44100
     }
   in
@@ -92,8 +91,6 @@ let avi params =
         function
           | ("channels",{ term = Int c; _ }) ->
               { f with Encoder.AVI.channels = c }
-          | ("duration",{ term = Float d; _ }) ->
-              { f with Encoder.AVI.duration = Some d }
           | ("samplerate",{ term = Int i; _ }) ->
               { f with Encoder.AVI.samplerate = i }
           | (_,t) -> raise (generic_error t))

--- a/src/lang/lang_encoders.ml
+++ b/src/lang/lang_encoders.ml
@@ -77,6 +77,30 @@ let wav params =
   in
     Encoder.WAV wav
 
+let avi params =
+  let defaults =
+    {
+      Encoder.AVI.
+      channels = 2;
+      duration = None;
+      samplerate = 44100
+    }
+  in
+  let avi =
+    List.fold_left
+      (fun f ->
+        function
+          | ("channels",{ term = Int c; _ }) ->
+              { f with Encoder.AVI.channels = c }
+          | ("duration",{ term = Float d; _ }) ->
+              { f with Encoder.AVI.duration = Some d }
+          | ("samplerate",{ term = Int i; _ }) ->
+              { f with Encoder.AVI.samplerate = i }
+          | (_,t) -> raise (generic_error t))
+      defaults params
+  in
+  Encoder.AVI avi
+      
 let mp3_base_defaults = 
     { Encoder.MP3.
         stereo = true ;
@@ -443,6 +467,7 @@ let external_encoder params =
     { Encoder.External.
         channels = 2 ;
         samplerate = 44100 ;
+        video = false ;
         header  = true ;
         restart_on_crash = false ;
         restart = Encoder.External.No_condition ;
@@ -455,7 +480,9 @@ let external_encoder params =
           | ("channels",{ term = Int c; _}) ->
               { f with Encoder.External.channels = c }
           | ("samplerate",{ term = Int i; _}) ->
-              { f with Encoder.External.samplerate = i }
+             { f with Encoder.External.samplerate = i }
+          | ("video",{ term = Bool h; _}) ->
+              { f with Encoder.External.video = h }
           | ("header",{ term = Bool h; _}) ->
               { f with Encoder.External.header = h }
           | ("restart_on_crash",{ term = Bool h; _}) ->

--- a/src/lang/lang_lexer.mll
+++ b/src/lang/lang_lexer.mll
@@ -149,6 +149,7 @@ rule token = parse
   | "%dirac"  { DIRAC  }
   | "%speex"  { SPEEX }
   | "%wav" { WAV }
+  | "%avi" { AVI }
   | "%mp3"     { MP3 }
   | "%mp3.cbr" { MP3 }
   | "%mp3.abr" { MP3_ABR }

--- a/src/lang/lang_parser.mly
+++ b/src/lang/lang_parser.mly
@@ -166,7 +166,7 @@
 %token <int option list> TIME
 %token <int option list * int option list> INTERVAL
 %token OGG FLAC OPUS VORBIS VORBIS_CBR VORBIS_ABR THEORA DIRAC SPEEX GSTREAMER
-%token WAV FDKAAC VOAACENC AACPLUS MP3 MP3_VBR MP3_ABR SHINE EXTERNAL
+%token WAV AVI FDKAAC VOAACENC AACPLUS MP3 MP3_VBR MP3_ABR SHINE EXTERNAL
 %token EOF
 %token BEGIN END GETS TILD QUESTION
 %token <Doc.item * (string*string) list> DEF
@@ -299,6 +299,7 @@ expr:
   | EXTERNAL app_opt                 { mk_enc (external_encoder $2) }
   | GSTREAMER app_opt                { mk_enc (gstreamer ~pos:(curpos ()) $2) }
   | WAV app_opt                      { mk_enc (wav $2) }
+  | AVI app_opt                      { mk_enc (avi $2) }
   | OGG LPAR ogg_items RPAR          { mk (Encoder (Encoder.Ogg $3)) }
   | top_level_ogg_item               { mk (Encoder (Encoder.Ogg [$1])) }
   | LPAR RPAR                        { mk Unit }
@@ -395,6 +396,7 @@ cexpr:
   | FDKAAC app_opt                   { mk_enc (fdkaac $2) }
   | EXTERNAL app_opt                 { mk_enc (external_encoder $2) }
   | WAV app_opt                      { mk_enc (wav $2) }
+  | AVI app_opt                      { mk_enc (avi $2) }
   | OGG LPAR ogg_items RPAR          { mk (Encoder (Encoder.Ogg $3)) }
   | top_level_ogg_item               { mk (Encoder (Encoder.Ogg [$1])) }
   | LPAR RPAR                        { mk Unit }

--- a/src/outputs/icecast2.ml
+++ b/src/outputs/icecast2.ml
@@ -114,6 +114,12 @@ struct
               samplerate = Some m.Encoder.WAV.samplerate ;
               channels = Some m.Encoder.WAV.channels
             }
+        | Encoder.AVI m ->
+            { quality = None ;
+              bitrate = None ;
+              samplerate = Some m.Encoder.AVI.samplerate ;
+              channels = Some m.Encoder.AVI.channels
+            }
         | Encoder.Ogg o ->
             match o with
               | [Encoder.Ogg.Vorbis

--- a/src/tools/avi.ml
+++ b/src/tools/avi.ml
@@ -45,7 +45,7 @@ let chunk id data =
 let list = chunk "LIST"
 
 let header ~channels ~samplerate () =
-  let max_dword = 0x7fffffff in
+  let max_dword = 0xffffffff in
   let file_size = max_dword in
   let video_rate = Lazy.force Frame.video_rate in
   let width = Lazy.force Frame.video_width in

--- a/src/tools/avi.ml
+++ b/src/tools/avi.ml
@@ -1,0 +1,176 @@
+(*****************************************************************************
+
+  Liquidsoap, a programmable audio stream generator.
+  Copyright 2003-2015 Savonet team
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details, fully stated in the COPYING
+  file at the root of the liquidsoap distribution.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+*****************************************************************************)
+
+let word n =
+  let s = Bytes.create 2 in
+  Bytes.set s 0 (char_of_int (n land 0xff));
+  Bytes.set s 1 (char_of_int ((n land 0xff00) lsr 8));
+  s
+
+let dword n =
+  let s = Bytes.create 4 in
+  Bytes.set s 0 (char_of_int (n land 0xff));
+  Bytes.set s 1 (char_of_int ((n land 0xff00) lsr 8));
+  Bytes.set s 2 (char_of_int ((n land 0xff0000) lsr 16));
+  Bytes.set s 3 (char_of_int ((n land 0x7f000000) lsr 24));
+  s
+
+let chunk id data =
+  let n = Bytes.length data in
+  let ans = id ^ dword n ^ data in
+  if n mod 2 = 0 then
+    ans
+  else
+    ans ^ "\000"
+
+let list = chunk "LIST"
+
+let header ~channels ~samplerate () =
+  let max_dword = 0x7fffffff in
+  let file_size = max_dword in
+  let video_rate = Lazy.force Frame.video_rate in
+  let width = Lazy.force Frame.video_width in
+  let height = Lazy.force Frame.video_height in
+  let avi_header =
+    chunk
+      "avih"
+      (
+        dword (1000000 / video_rate) (* microsec per frame *)
+        ^ dword 0 (* maximum bytes per second *)
+        ^ dword 0 (* reserved *)
+        ^ dword 0x0100 (* flags (interleaved) *)
+        ^ dword max_dword (* number of frames *)
+        ^ dword 0 (* initial frame *)
+        ^ dword 2 (* number of streams *)
+        ^ dword 0 (* suggested buffer size *)
+        ^ dword width (* width *)
+        ^ dword height (* height *)
+        ^ dword 0 (* reserved *)
+        ^ dword 0 (* reserved *)
+        ^ dword 0 (* reserved *)
+        ^ dword 0 (* reserved *)
+      )
+  in
+  let video_header =
+    let stream_header =
+      chunk
+        "strh"
+        (
+          "vids" (* stream type *)
+          ^ dword 0 (* stream codec *)
+          ^ dword 0 (* flags *)
+          ^ word 0 (* priority *)
+          ^ word 0 (* language *)
+          ^ dword 0 (* initial frames *)
+          ^ dword 1 (* scale *)
+          ^ dword video_rate (* rate *)
+          ^ dword 0 (* start time *)
+          ^ dword max_dword (* stream length *)
+          ^ dword 0 (* suggested buffer size *)
+          ^ dword 0xffffffff (* quality *)
+          ^ dword 0 (* sample size *)
+          ^ word 0 (* left *)
+          ^ word 0 (* top *)
+          ^ word width (* right *)
+          ^ word height (* bottom *)
+        )
+    in
+    let stream_format =
+      (* see BITMAPINFO *)
+      chunk
+        "strf"
+        (
+          dword 40 (* size of this structure *)
+          ^ dword width (* width *)
+          ^ dword height (* height *)
+          ^ word 1 (* panes *)
+          ^ word 24 (* depth *)
+          ^ dword 0 (* RGB uncompressed format *)
+          ^ dword 0 (* image size *)
+          ^ dword 0 (* pixels / x meter *)
+          ^ dword 0 (* pixels / y meter *)
+          ^ dword 0 (* colors used *)
+          ^ dword 0 (* important colors *)
+        )
+    in
+    list ("strl" ^ stream_header ^ stream_format)
+  in
+  let audio_header =
+    let stream_header =
+      chunk
+        "strh"
+        (
+          "auds" (* stream type *)
+          ^ dword 0 (* stream *)
+          ^ dword 0 (* flags *)
+          ^ word 0 (* priority *)
+          ^ word 0 (* language *)
+          ^ dword 0 (* initial frames *)
+          ^ dword 1 (* scale *)
+          ^ dword samplerate (* rate *)
+          ^ dword 0 (* start time *)
+          ^ dword max_dword (* stream length *)
+          ^ dword 0 (* suggested buffer size *)
+          ^ dword 0xffffffff (* quality *)
+          ^ dword (2 * channels) (* sample size *)
+          ^ word 0 (* left *)
+          ^ word 0 (* top *)
+          ^ word 0 (* right *)
+          ^ word 0 (* bottom *)
+        )
+    in
+    let stream_format =
+      chunk
+        "strf"
+        (
+          word 1 (* stream type (PCM) *)
+          ^ word channels (* channels *)
+          ^ dword samplerate (* rate *)
+          ^ dword (2 * channels * samplerate) (* byte rate *)
+          ^ word (2 * channels) (* block align *)
+          ^ word 16 (* bits per sample *)
+          ^ word 0 (* size of extra information *)
+        )
+    in
+    list ("strl" ^ stream_header ^ stream_format)
+  in
+  let headers =
+    list ("hdrl" ^ avi_header ^ video_header ^ audio_header)
+  in
+  let info =
+    let producer = chunk "ISFT" Configure.vendor in
+    list ("INFO" ^ producer)
+  in
+  "RIFF"
+  ^ dword file_size
+  ^ "AVI "
+  ^ headers
+  ^ info
+  ^ "LIST" ^ dword max_dword ^ "movi"
+
+(* Audio in 16LE *)
+let audio_chunk b =
+  chunk "01wb" b
+
+(* Video in RGB. *)
+let video_chunk b =
+  chunk "00db" b

--- a/src/tools/icecast_utils.ml
+++ b/src/tools/icecast_utils.ml
@@ -25,6 +25,7 @@ let ogg_application_mime = "application/ogg"
 let ogg_audio_mime = "audio/ogg"
 let ogg_video_mime = "video/ogg"
 let wav_mime = "audio/wav"
+let avi_mime = "video/avi"
 let aac_mime = "audio/aac"
 let aacplus_mime = "audio/aacp"
 let flac_mime = "audio/x-flac"
@@ -60,6 +61,7 @@ struct
   let ogg_video = M.format_of_content ogg_video_mime
   let ogg = ogg_application
   let wav = M.format_of_content wav_mime
+  let avi = M.format_of_content avi_mime
   let aac = M.format_of_content aac_mime
   let aacplus = M.format_of_content aacplus_mime
   let flac = M.format_of_content flac_mime
@@ -75,6 +77,7 @@ struct
       | Encoder.GStreamer _ -> None
       | Encoder.Flac _ -> Some flac
       | Encoder.WAV _ -> Some wav
+      | Encoder.AVI _ -> Some avi
       | Encoder.Ogg _ -> Some ogg
 
   let encoder_data p =


### PR DESCRIPTION
This is nice and enables external for video too, see #233. For instance, we can encode avi with
```
output.file(%external(process="ffmpeg -i pipe:0 -f avi pipe:1",video=true),"/tmp/test.avi",s)
```
