### PR TITLE
Filter playlist

### DIFF
--- a/scripts/utils.liq
+++ b/scripts/utils.liq
@@ -507,8 +507,9 @@ end
 # @param ~id Force the value of the source ID.
 # @param ~random Randomize playlist content
 # @param ~on_done Function to execute when the playlist is finished
+# @param ~filter Filter out some files depending on metadata
 # @param uri Playlist URI
-def playlist.reloadable(~id="",~random=false,~on_done={()},uri)
+def playlist.reloadable(~id="",~random=false,~on_done={()},~filter=fun(_)->true,uri)
   # A reference to the playlist
   playlist = ref []
   # A reference to the uri
@@ -516,6 +517,7 @@ def playlist.reloadable(~id="",~random=false,~on_done={()},uri)
   # A reference to know if the source has been stopped
   has_stopped = ref false
   # The next function
+  rec_next = ref ({request.create("")}) # trick to have recursion
   def next () =
     file =
       if list.length(!playlist) > 0 then
@@ -530,8 +532,15 @@ def playlist.reloadable(~id="",~random=false,~on_done={()},uri)
         end
         ""
       end
-    request.create(file)
+    r = request.create(file)
+    if filter(request.metadata(r)) then
+      r
+    else
+      next = !rec_next
+      next ()
+    end
   end
+  rec_next := next
   # Instanciate the source
   source = request.dynamic(id=id,next)
   # Get its id.
@@ -539,7 +548,7 @@ def playlist.reloadable(~id="",~random=false,~on_done={()},uri)
   # The load function
   def load_playlist () =
     files =
-      if test_process("test -d #{quote(!playlist_uri)}") then
+      if file.is_directory(!playlist_uri) then
         log(label=id,"playlist is a directory.")
         get_process_lines("find #{quote(!playlist_uri)} -type f | sort")
       else

--- a/src/lang/lang_builtins.ml
+++ b/src/lang/lang_builtins.ml
@@ -2044,7 +2044,15 @@ let () =
     ~descr:"Returns true if the file or directory exists."
     (fun p ->
        let f = Lang.to_string (List.assoc "" p) in
-         Lang.bool (Sys.file_exists f))
+       Lang.bool (Sys.file_exists f))
+
+let () =
+  add_builtin "file.is_directory" ~cat:Sys
+    ["",Lang.string_t,None,None] Lang.bool_t
+    ~descr:"Returns true if the file exists and is a directory."
+    (fun p ->
+       let f = Lang.to_string (List.assoc "" p) in
+       Lang.bool (try Sys.is_directory f with Sys_error _ -> false))
 
 let () =
   (* This is not named "file.read" because we might want to use that for a


### PR DESCRIPTION
Add a filter function to playlist.reloadable. This can help to filter files in a directory depending on metadata. For instance, files with a x in the title are played with:

```
def f(m) =
  string.match(pattern=".*x.*", m["title"])
end

s = snd(playlist.reloadable(filter=f,"playlist"))
out(s)
```

It should fix #282.