### PR TITLE
Preliminary implementation of AVI decoder.

### DIFF
--- a/scripts/externals.liq
+++ b/scripts/externals.liq
@@ -262,3 +262,25 @@ def input.mplayer(~id="input.mplayer",
                     -vc null -vo null #{quote(s)} 2>/dev/null")
 end
 %endif
+
+%ifdef input.external.avi
+  def input.ffmpeg.video(~id="input.ffmpeg.video",
+    ~restart=true,~restart_on_error=false,
+    ~buffer=0.2,~max=10.,~format="",s) =
+      format = if format == "" then "" else "-f #{format}" end
+      audiorate = get(default=44100,"frame.audio.samplerate")
+      width = get(default=320,"frame.video.width")
+      height = get(default=240,"frame.video.height")
+      videorate = get(default=24,"frame.video.samplerate")
+      command = "ffmpeg -v 16 #{format} -i #{quote(s)} \
+      -f avi -vf format=rgb24 -vcodec rawvideo -r #{videorate} -s #{width}x#{height} \
+      -acodec pcm_s16le -ar #{audiorate} \
+      pipe:1"
+      log("********************")
+      log(command)
+      input.external.avi(id=id,restart=restart,
+        restart_on_error=restart_on_error,
+        buffer=buffer,max=max,
+        command)
+  end
+%endif

--- a/scripts/externals.liq
+++ b/scripts/externals.liq
@@ -264,6 +264,14 @@ end
 %endif
 
 %ifdef input.external.avi
+  # Stream video from ffmpeg
+  # @category Source / Input
+  # @param s data URI.
+  # @param ~restart restart on exit.
+  # @param ~restart_on_error restart on exit with error.
+  # @param ~buffer Duration of the pre-buffered data.
+  # @param ~max Maximum duration of the buffered data.
+  # @category Source / Input
   def input.ffmpeg.video(~id="input.ffmpeg.video",
     ~restart=true,~restart_on_error=false,
     ~buffer=0.2,~max=10.,~format="",s) =
@@ -276,7 +284,22 @@ end
       -f avi -vf format=rgb24 -vcodec rawvideo -r #{videorate} -s #{width}x#{height} \
       -acodec pcm_s16le -ar #{audiorate} \
       pipe:1"
-      log("********************")
+      # log(command)
+      input.external.avi(id=id,restart=restart,
+        restart_on_error=restart_on_error,
+        buffer=buffer,max=max,
+        command)
+  end
+
+  # TODO: not working yet
+  def input.mencoder.video(~id="input.mencoder.video",
+    ~restart=true,~restart_on_error=false,
+    ~buffer=0.2,~max=10.,s) =
+      # audiorate = get(default=44100,"frame.audio.samplerate")
+      # width = get(default=320,"frame.video.width")
+      # height = get(default=240,"frame.video.height")
+      # videorate = get(default=24,"frame.video.samplerate")
+      command = "mencoder -really-quiet #{quote(s)} -of avi -ovc raw -oac pcm -vf format=rgb24 -o -"
       log(command)
       input.external.avi(id=id,restart=restart,
         restart_on_error=restart_on_error,

--- a/scripts/externals.liq
+++ b/scripts/externals.liq
@@ -284,7 +284,7 @@ end
       -f avi -vf format=rgb24 -vcodec rawvideo -r #{videorate} -s #{width}x#{height} \
       -acodec pcm_s16le -ar #{audiorate} \
       pipe:1"
-      # log(command)
+      log("FFMpeg command: " ^ command)
       input.external.avi(id=id,restart=restart,
         restart_on_error=restart_on_error,
         buffer=buffer,max=max,
@@ -292,18 +292,18 @@ end
   end
 
   # TODO: not working yet
-  def input.mencoder.video(~id="input.mencoder.video",
-    ~restart=true,~restart_on_error=false,
-    ~buffer=0.2,~max=10.,s) =
+  # def input.mencoder.video(~id="input.mencoder.video",
+    # ~restart=true,~restart_on_error=false,
+    # ~buffer=0.2,~max=10.,s) =
       # audiorate = get(default=44100,"frame.audio.samplerate")
       # width = get(default=320,"frame.video.width")
       # height = get(default=240,"frame.video.height")
       # videorate = get(default=24,"frame.video.samplerate")
-      command = "mencoder -really-quiet #{quote(s)} -of avi -ovc raw -oac pcm -vf format=rgb24 -o -"
-      log(command)
-      input.external.avi(id=id,restart=restart,
-        restart_on_error=restart_on_error,
-        buffer=buffer,max=max,
-        command)
-  end
+      # command = "mencoder -really-quiet #{quote(s)} -of avi -ovc raw -oac pcm -vf format=rgb24 -o -"
+      # log(command)
+      # input.external.avi(id=id,restart=restart,
+        # restart_on_error=restart_on_error,
+        # buffer=buffer,max=max,
+        # command)
+  # end
 %endif

--- a/src/sources/external_input.ml
+++ b/src/sources/external_input.ml
@@ -36,8 +36,7 @@ class external_input ~kind ~restart ~bufferize ~channels
     Rutils.create_from_iff ~format:`Wav ~channels ~samplesize:16
                            ~audio_src_rate:in_freq
   in
-  (* We need a temporary log until
-   * the source has an id *)
+  (* We need a temporary log until the source has an id *)
   let log_ref = ref (fun _ -> ()) in
   let log = (fun x -> !log_ref x) in
   let abg = Generator.create ~log ~kind `Audio in
@@ -176,3 +175,155 @@ let () =
           ((new external_input ~kind ~restart ~bufferize ~channels
                                ~restart_on_error ~max
                                ~samplerate command):>Source.source))
+
+
+
+
+(* Video-only input. Ideally this should be merged with previous one and we
+   should add support for audio in AVI files. *)
+
+module Img = Image.RGBA32
+      
+class video ~kind ~restart ~bufferize ~restart_on_error ~max command =
+  let width = Lazy.force Frame.video_width in
+  let height = Lazy.force Frame.video_height in
+  let abg_max_len = Frame.master_of_seconds max in
+  (* We need a temporary log until the source has an id *)
+  let log_ref = ref (fun _ -> ()) in
+  let log = (fun x -> !log_ref x) in
+  let abg = Generator.create ~log ~kind `Video in
+  let priority = Tutils.Non_blocking in
+object (self)
+  inherit Source.source ~name:"input.external.video" kind
+  inherit Generated.source abg ~empty_on_abort:false ~bufferize
+
+  val mutable should_stop = false
+
+  method stype = Source.Fallible
+
+  method wake_up _ =
+    (* Now we can create the log function *)
+    log_ref := self#log#f 3 "%s" ;
+    self#log#f 2 "Starting process.";
+    let create () =
+      let in_e = Unix.open_process_in command in
+      let f = Unix.descr_of_in_channel in_e in
+      let h, _ = Avi.Read.headers_simple f in
+      (
+        match h with
+        | [`Video (w,h,fps)] ->
+           if w <> width then failwith "Wrong width.";
+           if h <> height then failwith "Wrong height.";
+           if fps <> float (Lazy.force Frame.video_rate) then failwith "Wrong rate.";
+        | _ -> failwith "Only AVI with video only are supported for now."
+      );
+      in_e, f
+    in
+    let (_, in_d) as x = create () in
+    let counter = ref 0 in
+    let rec process ((in_e,in_d) as x) l =
+      let get_data () =
+        try
+          match Avi.Read.chunk in_d with
+          | `Frame (`Video, _, data) ->
+             assert (Bytes.length data = width * height * 3);
+             incr counter; self#log#f 2 "FRAME: %d%!" !counter;
+             let data = Img.of_RGB24_string data width in
+             Img.swap_rb data;
+             (* Img.Effect.flip data; *)
+             Generator.put_video abg [|[|data|]|] 0 1
+          | _ -> failwith "Invalid chunk."
+        with
+        | End_of_file -> raise (Finished ("Process exited.", restart))
+      in
+      let do_restart s restart f =
+        self#log#f 2 "%s" s;
+        begin
+          try
+            ignore (Unix.close_process_in in_e);
+          with
+          | _ -> ()
+        end;
+        if restart then
+          begin
+            self#log#f 2 "Restarting process.";
+            let ((_,in_d) as x) = create () in
+            [{ Duppy.Task.
+               priority = priority;
+               events   = [`Read in_d];
+               handler  = process x
+             }]
+          end
+        else
+          begin
+            f ();
+            self#log#f 2 "Task exited.";
+            []
+          end
+      in
+      try
+        let events =
+          if should_stop then raise (Finished ("Source stoped: closing process.",false));
+          let len = Generator.length abg - abg_max_len in
+          if len >= 0 then
+            let delay = Frame.seconds_of_audio len in
+            [`Delay delay]
+          else
+            begin
+              if List.mem (`Read in_d) l then get_data ();
+              [`Read in_d]
+            end
+        in
+        [{ Duppy.Task.
+           priority = priority;
+           events   = events;
+           handler  = process x
+         }]
+      with
+      | Finished (s,b) -> do_restart s b (fun () -> ())
+      | e ->
+         do_restart
+           (Printf.sprintf "Process exited with error: %s" (Printexc.to_string e)) restart_on_error
+           (fun () -> raise e)
+    in
+    let task =
+      { Duppy.Task.
+        priority = priority;
+        events   = [`Read in_d];
+        handler  = process x
+      }
+    in
+    Duppy.Task.add Tutils.scheduler task
+
+  method sleep = should_stop <- true
+end
+
+let () =
+    Lang.add_operator "input.external.video"
+      ~category:Lang.Input
+      ~flags:[Lang.Experimental]
+      ~descr:"Stream data from an external application."
+      [
+        "buffer", Lang.float_t, Some (Lang.float 1.),
+         Some "Duration of the pre-buffered data." ;
+
+        "max", Lang.float_t, Some (Lang.float 10.),
+        Some "Maximum duration of the buffered data.";
+
+        "restart", Lang.bool_t, Some (Lang.bool true),
+        Some "Restart process when exited.";
+
+        "restart_on_error", Lang.bool_t, Some (Lang.bool false),
+        Some "Restart process when exited with error.";
+
+        "", Lang.string_t, None,
+        Some "Command to execute."
+      ]
+      ~kind:Lang.video_only
+      (fun p kind ->
+         let command = Lang.to_string (List.assoc "" p) in
+         let bufferize = Lang.to_float (List.assoc "buffer" p) in
+         let restart = Lang.to_bool (List.assoc "restart" p) in
+         let restart_on_error = Lang.to_bool (List.assoc "restart_on_error" p) in
+         let max = Lang.to_float (List.assoc "max" p) in
+          ((new video ~kind ~restart ~bufferize ~restart_on_error ~max command):>Source.source))

--- a/src/sources/external_input.ml
+++ b/src/sources/external_input.ml
@@ -220,14 +220,14 @@ object (self)
       in_e, f
     in
     let (_, in_d) as x = create () in
-    let counter = ref 0 in
+    (* let counter = ref 0 in *)
     let rec process ((in_e,in_d) as x) l =
       let get_data () =
         try
           match Avi.Read.chunk in_d with
           | `Frame (`Video, _, data) ->
              assert (Bytes.length data = width * height * 3);
-             incr counter; self#log#f 2 "FRAME: %d%!" !counter;
+             (* incr counter; self#log#f 2 "FRAME: %d%!" !counter; *)
              let data = Img.of_RGB24_string data width in
              Img.swap_rb data;
              (* Img.Effect.flip data; *)
@@ -299,7 +299,7 @@ object (self)
 end
 
 let () =
-    Lang.add_operator "input.external.video"
+    Lang.add_operator "input.external.avi"
       ~category:Lang.Input
       ~flags:[Lang.Experimental]
       ~descr:"Stream data from an external application."

--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -4,6 +4,7 @@ OCAML_CFLAGS = -I ../tools -I .. $(liquidsoap_ocamlcflags) -thread
 OCAML_LFLAGS = $(liquidsoap_ocamllflags) \
 		stdlib.cmx utils.cmx dyntools.cmx shutdown.cmx tutils.cmx \
 		file_watcher_mtime.cmx configure.cmx http.cmx JSON.cmx \
+		stream/frame.cmx avi.cmx \
 		../tools/locale_c.o
 
 all: $(TESTS)

--- a/src/tools/avi.ml
+++ b/src/tools/avi.ml
@@ -20,6 +20,8 @@
 
 *****************************************************************************)
 
+open Stdlib
+
 let word n =
   let s = Bytes.create 2 in
   Bytes.set s 0 (char_of_int (n land 0xff));
@@ -174,3 +176,166 @@ let audio_chunk b =
 (* Video in RGB. *)
 let video_chunk b =
   chunk "00db" b
+
+module Read = struct
+  let read n f =
+    let s = Bytes.create n in
+    let k = Unix.read_retry f s 0 n in
+    if k = 0 && n <> 0 then raise End_of_file;
+    assert (k = n);
+    s
+
+  let word f =
+    let s = read 2 f in
+    int_of_char (Bytes.get s 0)
+    + int_of_char (Bytes.get s 1) lsl 8
+
+  let dword f =
+    let s = read 4 f in
+    int_of_char (Bytes.get s 0)
+    + int_of_char (Bytes.get s 1) lsl 8
+    + int_of_char (Bytes.get s 2) lsl 16
+    + int_of_char (Bytes.get s 3) lsl 24
+
+  exception Invalid
+
+  let must b = if not b then raise Invalid
+
+  let rec chunk f =
+    let tag = read 4 f in
+    let len = dword f in
+    (* Printf.printf "Read: %s\n%!" tag; *)
+    len + 8,
+    match tag with
+    | "LIST" ->
+       let subtag = read 4 f in
+       if subtag = "movi" then
+         (* for obvious size reasons we stop parsing here *)
+         `movi (len - 4)
+       else
+         let rem = ref (len - 4) in
+         let ll = ref [] in
+         (* Printf.printf "<<\n%!"; *)
+         while !rem <> 0 do
+           if !rem < 0 then raise Invalid;
+           let l,c = chunk f in
+           rem := !rem - l;
+           ll := c :: !ll
+         done;
+         (* Printf.printf ">>\n%!"; *)
+         `LIST (subtag, List.rev !ll)
+    | "avih" ->
+       let microsec_per_frame = dword f in
+       let max_bytes_per_sec = dword f in
+       let reserved = read 4 f in
+       let flags = dword f in
+       must (flags land 0x0100 <> 0); (* interleaved *)
+       let total_frame = dword f in
+       let init_frame = dword f in
+       let nb_stream = dword f in
+       let sug_buf_size = dword f in
+       let width = dword f in
+       let height = dword f in
+       let scale = dword f in
+       must (scale = 0);
+       let rate = dword f in
+       let start = dword f in
+       let length = dword f in
+       `avih (width, height)
+    | "strh" ->
+       let stream_type = read 4 f in
+       must (len = 56);
+       let fourcc = dword f in
+       must (fourcc = 0);
+       let flags = dword f in
+       must (flags = 0);
+       let priority = word f in
+       let language = word f in
+       let init_frames = dword f in
+       let scale = dword f in
+       let rate = dword f in
+       let fps = float rate /. float scale in
+       let start = dword f in
+       let length = dword f in
+       let buf_size = dword f in
+       let quality = dword f in
+       let sample_size = dword f in
+       let left = word f in
+       let top = word f in
+       let right = word f in
+       let bottom = word f in
+       `strh (stream_type, fps)
+    | "strf" ->
+       let s = read len f in
+       `strf s
+    | "JUNK" ->
+       let s = read len f in
+       `JUNK s
+    | "00dc" ->
+       let s = read len f in
+       (* TODO: other channels and audio frames too (first argument is channel
+          number) *)
+       `Frame (`Video, 0, s)
+    | _ ->
+       let s = read len f in
+       `Other s
+
+  let chunk f = snd (chunk f)
+
+  let headers f =
+    must (read 4 f = "RIFF");
+    let filesize = dword f in
+    must (read 4 f = "AVI ");
+    let h = ref [] in
+    try
+      while true do
+        let c = chunk f in
+        h := c :: !h;
+        match c with
+        | `movi _ -> raise Exit
+        | _ -> ()
+      done;
+      assert false
+    with
+    | Exit ->
+       List.rev !h
+
+  let headers_simple f =
+    let headers = headers f in
+    if List.length headers < 2 then raise Invalid;
+    let h =
+      match List.hd headers with
+      | `LIST ("hdrl", h) -> h
+      | _ -> raise Invalid
+    in
+    let width, height =
+      match List.hd h with
+      | `avih (width, height) -> width, height
+      | _  -> raise Invalid;
+    in
+    let h = List.tl h in
+    let streams = ref [] in
+    List.iter
+      (function
+      | `LIST ("strl", l) ->
+         if List.length l < 2 then raise Invalid;
+        let strf =
+          match List.hd (List.tl l) with
+          | `strf s -> s
+          | _ -> raise Invalid
+        in
+        begin
+          match List.hd l with
+          | `strh (stream_type, fps) ->
+             if stream_type = "vids" then streams := `Video (width, height, fps) :: !streams
+             else if stream_type = "auds" then streams := `Audio :: !streams
+             else raise Invalid
+          | _ -> ()
+        end
+      | _ -> ()
+      ) h;
+    let streams = List.rev !streams in
+    match List.last headers with
+    | `movi len -> streams, len
+    | _ -> raise Invalid
+end

--- a/src/tools/stdlib.ml
+++ b/src/tools/stdlib.ml
@@ -30,6 +30,11 @@ module List = struct
 
   let assoc_all x l =
     may_map (fun (y,v) -> if x = y then Some v else None) l
+
+  let rec last = function
+    | [x] -> x
+    | _::l -> last l
+    | [] -> raise Not_found
 end
 
 module String = struct


### PR DESCRIPTION
Implement an AVI decoder so that we can do
```
s = input.external.video("ffmpeg -f lavfi -i testsrc -f avi -an -vcodec rawvideo pipe:1")
output.sdl(fallible=true, s)
```
as requested in #284. Some debugging and fine-tuning is still needed on this PR.