### PR TITLE
Add lib64 location for ladspa plugins

### DIFF
--- a/src/operators/ladspa_op.ml
+++ b/src/operators/ladspa_op.ml
@@ -40,7 +40,7 @@ let plugin_dirs =
     let path = Unix.getenv "LIQ_LADSPA_PATH" in
       Pcre.split ~pat:":" path
   with
-    | Not_found -> ["/usr/lib/ladspa";"/usr/local/lib/ladspa"]
+    | Not_found -> ["/usr/lib64/ladspa";"/usr/lib/ladspa";"/usr/local/lib/ladspa"]
 
 
 let port_t d p =


### PR DESCRIPTION
Some modern distros seem to install ladspa plugins into `/usr/lib64/ladspa` (I'm look at you centos). Adding an additional path to the search seems sensible since the paths are hardcoded anyhow.