### PR TITLE
Account for buffer contents when seeking backwards (#390)

### DIFF
--- a/src/decoder/decoder.ml
+++ b/src/decoder/decoder.ml
@@ -426,17 +426,13 @@ struct
     in
     let fseek len = 
       let gen_len = Generator.length gen in
-      if len < 0 then
-       begin
-        Generator.clear gen;
-        decoder.seek len
-       end
-      else if len > gen_len then 
+      if len < 0 || len > gen_len then
         begin
          Generator.clear gen;
          gen_len + decoder.seek (len-gen_len)
         end
        else
+        (* Seek within the pre-buffered data if possible *)
         begin
          Generator.remove gen len;
          len


### PR DESCRIPTION
I _think_ this fixes #390. (I don't really know OCaml)

Tested with the flac and mad decoders.

Seek is still off by a little (-81 samples for mad, +21 samples with flac), but it is not audible any more.