### PR TITLE
Support replaygain aside mp3gain

### DIFF
--- a/scripts/extract-replaygain
+++ b/scripts/extract-replaygain
@@ -22,9 +22,15 @@ if (($file =~ /\.mp3$/i) || (test_mime() =~ /audio\/mpeg/))  {
     $out =~ /Recommended "Track" dB change: (.*)$/m || die ;
     print "$1 dB\n" ;
 
+  } elsif (`which replaygain`) {
+
+    my $out = `replaygain --no-album "$file" 2> /dev/null; replaygain --show "$file" 2> /dev/null` ;
+    $out =~ /Track gain (.*) dB$/m || die ;
+    print "$1 dB\n" ;
+
   } else {
 
-    print STDERR "Cannot find mp3gain binary!\n";
+    print STDERR "Cannot find mp3gain nor replaygain binaries!\n";
 
   }
 


### PR DESCRIPTION
Since mp3gain is not available in Debian 8 / Jessie I have tweaked the source to have support for replay gain. Command line modification works, haven't tested on my stream yet.