### PR TITLE
Adapt to new ocaml-ffmpeg API

### DIFF
--- a/.travis.docker-file
+++ b/.travis.docker-file
@@ -10,7 +10,6 @@ ARG TRAVIS_COMMIT
 
 RUN eval $(opam config env) && make update && \
     cd liquidsoap && git checkout $TRAVIS_COMMIT && cd .. && \
-    cd ocaml-ffmpeg && git checkout 0.1.2 && cd .. \
     ./bootstrap && ./configure && make clean && make && make doc
 
 WORKDIR /tmp/liquidsoap-full/liquidsoap

--- a/.travis.docker-file
+++ b/.travis.docker-file
@@ -10,6 +10,7 @@ ARG TRAVIS_COMMIT
 
 RUN eval $(opam config env) && make update && \
     cd liquidsoap && git checkout $TRAVIS_COMMIT && cd .. && \
+    cd ocaml-ffmpeg && git checkout 0.1.2 && cd .. \
     ./bootstrap && ./configure && make clean && make && make doc
 
 WORKDIR /tmp/liquidsoap-full/liquidsoap

--- a/src/converters/video/ffmpeg_video_converter.ml
+++ b/src/converters/video/ffmpeg_video_converter.ml
@@ -43,22 +43,22 @@ let format_of frame =
   | P.RGB fmt ->
     (
       match fmt with
-      | P.RGB24  -> Avutil.Pixel_format.RGB24
-      | P.BGR24  -> Avutil.Pixel_format.BGR24
-      | P.RGB32  -> Avutil.Pixel_format.RGBA
-      | P.BGR32  -> Avutil.Pixel_format.BGRA
-      | P.RGBA32 -> Avutil.Pixel_format.RGBA
+      | P.RGB24  -> `Rgb24
+      | P.BGR24  -> `Bgr24
+      | P.RGB32  -> `Rgba
+      | P.BGR32  -> `Bgra
+      | P.RGBA32 -> `Rgba
     )
   | P.YUV fmt ->
     (
       match fmt with
-      | P.YUV422  -> Avutil.Pixel_format.YUV422p
-      | P.YUV444  -> Avutil.Pixel_format.YUV444p
-      | P.YUV411  -> Avutil.Pixel_format.YUV411p
-      | P.YUV410  -> Avutil.Pixel_format.YUV410p
-      | P.YUVJ420 -> Avutil.Pixel_format.YUV420p
-      | P.YUVJ422 -> Avutil.Pixel_format.YUVJ422p
-      | P.YUVJ444 -> Avutil.Pixel_format.YUVJ444p
+      | P.YUV422  -> `Yuv422p
+      | P.YUV444  -> `Yuv444p
+      | P.YUV411  -> `Yuv411p
+      | P.YUV410  -> `Yuv410p
+      | P.YUVJ420 -> `Yuv420p
+      | P.YUVJ422 -> `Yuvj422p
+      | P.YUVJ444 -> `Yuvj444p
     )
 
 type fmt = Avutil.Pixel_format.t * int * int


### PR DESCRIPTION
Maybe this adaptation of Liquidsoap to the new API of Ffmpeg may interest you.
Note that on my repository, the CI fails with the following error :
**fatal: reference is not a tree: 53a6ce816b36a811d7fb5d6c3a98375896732403**.
I do not understand the cause of this error.
