### PR TITLE
Remove useless data copy in ffmpeg_decoder

### DIFF
--- a/src/decoder/ffmpeg_decoder.ml
+++ b/src/decoder/ffmpeg_decoder.ml
@@ -104,7 +104,7 @@ let create_decoder fname =
       Frame.master_of_audio (Array.length data.(0))
     in
     decr_remaining consumed;
-    Array.init (Array.length data) (fun i -> Array.copy data.(i))
+    data
   in
   let seek ticks =
     let position = Frame.seconds_of_master ticks in


### PR DESCRIPTION
Ocaml-ffmpeg no longer reuses output buffers by default. So it is not necessary to copy the output data anymore.
