### PR TITLE
Smartcross cleanup.

### DIFF
--- a/src/source.ml
+++ b/src/source.ml
@@ -500,6 +500,9 @@ object (self)
      * - A starts streaming again, needs to receive an EOT before
      *   having to worry about availability.
      *
+     *   Another important example is smart_crossfade, if e.g. a transition
+     *   returns a failling source.
+     *
      * So we add special cases where, instead of calling #get_frame, we
      * call silent_end_track to properly end a track by inserting a break.
      *


### PR DESCRIPTION
Avoid building a stack of `sequence` sources, be more agressive when keeping last metadata, general code cleanup.