### PR TITLE
:lipstick: Remove unused Dtools open

### DIFF
--- a/src/outputs/alsa_out.ml
+++ b/src/outputs/alsa_out.ml
@@ -23,7 +23,6 @@
 (* Buffered ALSA output *)
 
 open Alsa
-open Dtools
 
 class output ~kind ~clock_safe ~infallible
              ~on_stop ~on_start ~start dev source =


### PR DESCRIPTION
This is a purely cosmetic change to get rid of the "unused open Dtools." warning i saw fly by during a compile. 