### PR TITLE
 Use aacgain to extract replay gain from mp3 files

### DIFF
--- a/scripts/extract-replaygain
+++ b/scripts/extract-replaygain
@@ -29,6 +29,12 @@ if (($file =~ /\.mp3$/i) || (test_mime() =~ /audio\/mpeg/))  {
     $out =~ /Recommended "Track" dB change: (.*)$/m || die ;
     print "$1 dB\n" ;
 
+  } elsif (`which aacgain`) {
+
+    my $out = `aacgain -q "$file" 2> /dev/null` ;
+    $out =~ /Recommended "Track" dB change: (.*)$/m || die ;
+    print "$1 dB\n" ;
+
   } elsif (`which replaygain`) {
     use_replaygain()
   } else {

--- a/scripts/extract-replaygain
+++ b/scripts/extract-replaygain
@@ -39,7 +39,7 @@ if (($file =~ /\.mp3$/i) || (test_mime() =~ /audio\/mpeg/))  {
     use_replaygain()
   } else {
 
-    print STDERR "Cannot find mp3gain nor replaygain binaries!\n";
+    print STDERR "Cannot find mp3gain, aacgain nor replaygain binaries!\n";
 
   }
 


### PR DESCRIPTION
`aacgain` is a drop in replacement for `mp3gain`. `aacgain` is easily available in recent Linux distributions, which is not necessarily the case with `mp3gain`.