### PR TITLE
Add AWS protocol setting for different endpoint URLs.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -25,7 +25,7 @@ New:
 
 - Added `youtube-pl:<ID>` protocol to resolve and parse youtube playlists (or any playlist supported by `youtube-dl`) (#761)
 
-- Added `protocol.aws.endpoint` setting for the `s3://` protocol. (#778)
+- Added `protocol.aws.endpoint` setting for the `s3://` protocol, thanks to @RecursiveGreen. (#778)
 
 Changed:
 

--- a/CHANGES
+++ b/CHANGES
@@ -25,6 +25,8 @@ New:
 
 - Added `youtube-pl:<ID>` protocol to resolve and parse youtube playlists (or any playlist supported by `youtube-dl`) (#761)
 
+- Added `protocol.aws.endpoint` setting for the `s3://` protocol. (#778)
+
 Changed:
 
 - Depends on OCaml >= 4.07.0

--- a/lib/protocols.liq
+++ b/lib/protocols.liq
@@ -418,6 +418,8 @@ add_protocol(static=true,"say",say_protocol,
 register(name="AWS protocols settings","protocol.aws",())
 register(name="Profile",descr="Use a specific profile from your credential file.",
          "protocol.aws.profile","")
+register(name="Endpoint URL",descr="Alternative endpoint URL (useful for other S3 implementations).",
+         "protocol.aws.endpoint","")
 register(name="Region",descr="AWS Region",
          "protocol.aws.region","")
 register(name="Binary",descr="Path to aws CLI binary",
@@ -438,6 +440,15 @@ def aws_base() =
   aws =
     if region !="" then
       "#{aws} --region #{region}"
+    else
+      aws
+    end
+
+  endpoint = get(default="","protocol.aws.endpoint")
+
+  aws =
+    if endpoint !="" then
+      "#{aws} --endpoint-url #{quote(endpoint)}"
     else
       aws
     end


### PR DESCRIPTION
I'm proposing to add an additional setting for the s3:// protocol that allows to set the endpoint URL for the S3 bucket. This will enable other S3-like implementations (like Digital Ocean's Spaces) to work.