### PR TITLE
Update ocaml compiler version error string

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -258,7 +258,7 @@ AC_MSG_RESULT([$OCAML_MAJOR.$OCAML_MINOR.$OCAML_REVISION])
 
 AC_OCAML_COMPARE_VERSION([$OCAML_MAJOR.$OCAML_MINOR.$OCAML_REVISION],[$min_ocaml_version])
 if test -z "${VERSION_OK}"; then
-  AC_MSG_ERROR([version 4.03.0 or more of the OCaml compiler is required to build liquidsoap])
+  AC_MSG_ERROR([version 4.07.0 or greater of the OCaml compiler is required to build liquidsoap])
 fi
 
 AC_SUBST(BYTE)


### PR DESCRIPTION
The error string in configure.ac for unsupported versions of the ocaml compiler wasn't updated, resulting in confusing messages like this:

```
checking for ocamlc version... 4.05.0
configure: error: version 4.03.0 or more of the OCaml compiler is required to build liquidsoap
```

even though
https://github.com/savonet/liquidsoap/blob/31d9d1b2fe6e925a0e3fcc9fb09627b31f27355c/configure.ac#L13