### PR TITLE
Remove the warning log level.

### DIFF
--- a/lib/utils.liq
+++ b/lib/utils.liq
@@ -647,16 +647,10 @@ def log.info(~label="lang",msg) =
   log(label=label,level=4,msg)
 end
 
-# Log a warning message
-# @category Liquidsoap
-def log.warning(~label="lang",msg) =
-  log(label=label,level=5,msg)
-end
-
 # Log a debug message
 # @category Liquidsoap
 def log.debug(~label="lang",msg) =
-  log(label=label,level=6,msg)
+  log(label=label,level=5,msg)
 end
 
 # Regularly insert track boundaries in a stream (useful for testing tracks).

--- a/src/conversions/mux.ml
+++ b/src/conversions/mux.ml
@@ -98,7 +98,7 @@ object (self)
       done;
       let _, c = Frame.content frame pos in
       let end_pos = Frame.position frame in
-      if inicon != c then self#log#warning "Copy-avoiding optimization isn't working!";
+      if inicon != c then self#log#debug "Copy-avoiding optimization isn't working!";
       Frame.set_breaks frame breaks;
       c, end_pos
     in

--- a/src/decoder/external_decoder.ml
+++ b/src/decoder/external_decoder.ml
@@ -39,7 +39,7 @@ let external_input process input =
     end
   in
   let on_stderr puller =
-    log#warning "stderr: %s" (Bytes.unsafe_to_string (Process_handler.read 1024 puller));
+    log#debug "stderr: %s" (Bytes.unsafe_to_string (Process_handler.read 1024 puller));
     `Continue
   in
   let log = log#important "%s" in
@@ -165,7 +165,7 @@ let log = Log.make ["decoder";"external";"oblivious"]
 
 let external_input_oblivious process filename prebuf = 
   let on_stderr puller =
-    log#warning "stderr: %s" (Bytes.unsafe_to_string (Process_handler.read 1024 puller));
+    log#debug "stderr: %s" (Bytes.unsafe_to_string (Process_handler.read 1024 puller));
     `Continue
   in
   let command = process filename in

--- a/src/decoder/gstreamer_decoder.ml
+++ b/src/decoder/gstreamer_decoder.ml
@@ -43,7 +43,7 @@ module Make (Generator : Generator.S_Asio) = struct
     let decode_video = mode = `Both || mode = `Video in
 
     log#info "Using %s." (Gstreamer.version_string ());
-    log#warning "Decode A/V: %B/%B." decode_audio decode_video;
+    log#debug "Decode A/V: %B/%B." decode_audio decode_video;
 
     let gst_max_buffers = GU.max_buffers () in
 
@@ -69,7 +69,7 @@ module Make (Generator : Generator.S_Asio) = struct
         Printf.sprintf "filesrc location=%S ! decodebin name=d%s%s"
           fname audio_pipeline video_pipeline
       in
-      log#warning "Gstreamer pipeline: %s." pipeline;
+      log#debug "Gstreamer pipeline: %s." pipeline;
       let bin = Gstreamer.Pipeline.parse_launch pipeline in
       let audio_sink =
         if decode_audio then
@@ -238,7 +238,7 @@ let get_type ~channels filename =
     GU.flush ~log bin;
     if state = Gstreamer.Element.State_paused then
       (
-        log#warning "File %s has audio." filename;
+        log#debug "File %s has audio." filename;
         channels
       )
     else
@@ -255,7 +255,7 @@ let get_type ~channels filename =
       ignore (Gstreamer.Element.set_state bin Gstreamer.Element.State_null);
       if state = Gstreamer.Element.State_paused then
         (
-          log#warning "File %s has video." filename;
+          log#debug "File %s has video." filename;
           1
         )
       else

--- a/src/decoder/ogg_decoder.ml
+++ b/src/decoder/ogg_decoder.ml
@@ -116,7 +116,7 @@ let video_resample () =
         (Utils.get_some !resampler) buf off len
       end
 
-let demuxer_log x = log#warning "%s" x
+let demuxer_log x = log#debug "%s" x
 
 module Make (Generator:Generator.S_Asio) =
 struct

--- a/src/encoder/external_encoder.ml
+++ b/src/encoder/external_encoder.ml
@@ -54,7 +54,7 @@ let encoder id ext =
   in
 
   let on_stderr puller =
-    log#warning "stderr: %s" (Bytes.unsafe_to_string (Process_handler.read 1024 puller));
+    log#debug "stderr: %s" (Bytes.unsafe_to_string (Process_handler.read 1024 puller));
     `Continue
   in
   let on_start pusher =

--- a/src/harbor/harbor.ml
+++ b/src/harbor/harbor.ml
@@ -500,7 +500,7 @@ module Make (T : Transport_t) : T with type socket = T.socket = struct
               in
               let f () = s#relay ?read stype headers h.Duppy.Monad.Io.socket in
               log#info "Adding source on mountpoint %S with type %S." uri stype ;
-              log#warning "Relaying %s." (string_of_protocol hprotocol) ;
+              log#debug "Relaying %s." (string_of_protocol hprotocol) ;
               let protocol =
                 match hprotocol with
                 | `Icy -> "ICY"
@@ -560,7 +560,7 @@ module Make (T : Transport_t) : T with type socket = T.socket = struct
       try
         match Websocket.read s with
         | `Text s -> (
-            log#warning "Hello packet: %s\n%!" s ;
+            log#debug "Hello packet: %s\n%!" s ;
             match extract_packet s with
             | "hello", data ->
                 let data = Utils.get_some data in
@@ -606,7 +606,7 @@ module Make (T : Transport_t) : T with type socket = T.socket = struct
                       | `Text s -> (
                         match extract_packet s with
                         | "metadata", data ->
-                            log#warning "Metadata packet: %s\n%!" s ;
+                            log#debug "Metadata packet: %s\n%!" s ;
                             let data = Utils.get_some data in
                             let m =
                               List.map

--- a/src/io/gstreamer_io.ml
+++ b/src/io/gstreamer_io.ml
@@ -225,7 +225,7 @@ object (self)
       else
         pipeline
     in
-    self#log#warning "GStreamer pipeline: %s" pipeline;
+    self#log#debug "GStreamer pipeline: %s" pipeline;
     let bin = Pipeline.parse_launch pipeline in
     let audio_src =
       if has_audio then
@@ -535,7 +535,7 @@ object (self)
      else
        pipeline
    in
-   log#warning "GStreamer pipeline: %s" pipeline;
+   log#debug "GStreamer pipeline: %s" pipeline;
    let bin = Pipeline.parse_launch pipeline in
    let wrap_sink sink pull =
      let m = Mutex.create () in

--- a/src/operators/chord.ml
+++ b/src/operators/chord.ml
@@ -115,7 +115,7 @@ object (self)
                  | "dim" ->
                      play t [c;c+3;c+6]
                  | m ->
-                     self#log#warning "Unknown mode: %s\n%!" m
+                     self#log#debug "Unknown mode: %s\n%!" m
              );
         ) chords
 end

--- a/src/operators/on_metadata.ml
+++ b/src/operators/on_metadata.ml
@@ -36,7 +36,7 @@ object (self)
       List.iter
         (fun (i,m) ->
            if i>=p then begin
-             self#log#warning "Got metadata at position %d: calling handler..." i ;
+             self#log#debug "Got metadata at position %d: calling handler..." i ;
              ignore (Lang.apply ~t:Lang.unit_t f ["",Lang.metadata m])
            end)
         (Frame.get_all_metadata ab)

--- a/src/operators/pipe.ml
+++ b/src/operators/pipe.ml
@@ -267,7 +267,7 @@ object(self)
     source#get_ready [(self:>source)];
     (* Now we can create the log function *)
     log_ref := self#log#info "%s";
-    log_error := self#log#warning "%s";
+    log_error := self#log#debug "%s";
     handler <- Some (Process_handler.run ~on_stop ~on_start ~on_stdout 
                                          ~on_stdin:self#on_stdin
                                          ~on_stderr ~log process)

--- a/src/operators/time_warp.ml
+++ b/src/operators/time_warp.ml
@@ -257,7 +257,7 @@ struct
           let salen = scale alen in
           fill buf aofs alen salen;
           Frame.add_break frame (ofs+len);
-          (* self#log#warning "filled %d from %d (x %f)" len ofs scaling; *)
+          (* self#log#debug "filled %d from %d (x %f)" len ofs scaling; *)
 
           (* Fill in metadata *)
           let md = MG.metadata c.mg (scale len) in
@@ -268,7 +268,7 @@ struct
           (* If there is no data left, we should buffer again. *)
           if RB.read_space c.rb = 0 then begin
             self#log#important "Buffer emptied, start buffering...";
-            self#log#warning "Current scaling factor is x%f." scaling;
+            self#log#debug "Current scaling factor is x%f." scaling;
             MG.advance c.mg (MG.length c.mg); (* sync just in case *)
             c.buffering <- true
           end)

--- a/src/outputs/hls_output.ml
+++ b/src/outputs/hls_output.ml
@@ -254,7 +254,7 @@ class hls_output p =
       List.iter2 self#write_pipe streams b;
       if not reopening && Unix.gettimeofday () > segment_duration +. open_date then
         begin
-          self#log#warning "New segment..." ;
+          self#log#debug "New segment..." ;
           (* #output_stop can trigger #send, the [reopening] flag avoids loops *)
           reopening <- true;
           self#output_stop;

--- a/src/playlists/playlist_xml.ml
+++ b/src/playlists/playlist_xml.ml
@@ -44,7 +44,7 @@ let tracks ?pwd s =
       (fun (a,b) -> recode_metas a, Playlist_parser.get_file ?pwd b) 
       (Xmlplaylist.tracks s)
   with
-    | Xmlplaylist.Error(e) -> log#warning "Parsing failed: %s" 
+    | Xmlplaylist.Error(e) -> log#debug "Parsing failed: %s" 
                                  (Xmlplaylist.string_of_error e) ;
 		              raise (Xmlplaylist.Error(e))
 

--- a/src/sources/external_input.ml
+++ b/src/sources/external_input.ml
@@ -157,7 +157,7 @@ object (self)
   method wake_up _ =
     (* Now we can create the log function *)
     log_ref := self#log#info "%s" ;
-    self#log#warning "Generator mode: %s." (match Generator.mode abg with `Video -> "video" | `Both -> "both" | _ -> "???");
+    self#log#debug "Generator mode: %s." (match Generator.mode abg with `Video -> "video" | `Both -> "both" | _ -> "???");
     self#log#important "Starting process.";
     let (_, in_d) as x = create () in
     let rec process ((in_e,in_d) as x) l =

--- a/src/sources/request_source.ml
+++ b/src/sources/request_source.ml
@@ -80,7 +80,7 @@ object (self)
     assert (current = None) ;
     match self#get_next_file with
       | None ->
-          self#log#warning "Failed to prepare track: no file." ;
+          self#log#debug "Failed to prepare track: no file." ;
           false
       | Some req when Request.is_ready req ->
           assert (Frame.kind_sub_kind
@@ -404,7 +404,7 @@ object (self)
           Some r.request
       with
         | Queue.Empty ->
-            self#log#warning "Queue is empty!" ;
+            self#log#debug "Queue is empty!" ;
             None
     in
       Mutex.unlock qlock ;

--- a/src/tools/gstreamer_utils.ml
+++ b/src/tools/gstreamer_utils.ml
@@ -133,7 +133,7 @@ let handler ~(log:Log.t) ~on_error msg =
             | Gstreamer.Element.State_void_pending -> ""
             | _ -> Printf.sprintf " (pending: %s)" (f p)
         in
-        log#warning "[%s] State change: %s -> %s%s" source o n p
+        log#debug "[%s] State change: %s -> %s%s" source o n p
     | _ -> assert false
 
 let flush ~log ?(types=[`Error;`Warning;`Info;`State_changed]) ?(on_error=fun _ -> ()) bin =

--- a/src/tools/log.ml
+++ b/src/tools/log.ml
@@ -29,7 +29,6 @@ type t =
     severe : 'a. ('a, unit, string, unit) format4 -> 'a;
     important : 'a. ('a, unit, string, unit) format4 -> 'a;
     info : 'a. ('a, unit, string, unit) format4 -> 'a;
-    warning : 'a. ('a, unit, string, unit) format4 -> 'a;
     debug : 'a. ('a, unit, string, unit) format4 -> 'a;
   >
 
@@ -51,9 +50,6 @@ let make path : t =
     (** The advanced user should be interested in this. *)
     method info : 'a. ('a, unit, string, unit) format4 -> 'a = log#f 4
 
-    (** By the way. *)
-    method warning : 'a. ('a, unit, string, unit) format4 -> 'a = log#f 5
-
     (** If you are debugging. *)
-    method debug : 'a. ('a, unit, string, unit) format4 -> 'a = log#f 6
+    method debug : 'a. ('a, unit, string, unit) format4 -> 'a = log#f 5
   end

--- a/src/tools/log.mli
+++ b/src/tools/log.mli
@@ -5,7 +5,6 @@ type t =
     severe : 'a. ('a, unit, string, unit) format4 -> 'a;
     important : 'a. ('a, unit, string, unit) format4 -> 'a;
     info : 'a. ('a, unit, string, unit) format4 -> 'a;
-    warning : 'a. ('a, unit, string, unit) format4 -> 'a;
     debug : 'a. ('a, unit, string, unit) format4 -> 'a;
   >
 


### PR DESCRIPTION
The terminology "warning" looks like a warning is more important than an information whereas it is not. Moreover, we never needed more than 5 levels.