### PR TITLE
Fix invalid syntax in depexts

### DIFF
--- a/liquidsoap.opam
+++ b/liquidsoap.opam
@@ -101,12 +101,12 @@ conflicts: [
   "xmlplaylist" {< "0.1.3"}
 ]
 depexts: [
-  ["automake autoconf"] {os-distribution = "alpine"}
-  ["automake autoconf"] {os-distribution = "centos"}
-  ["automake autoconf"] {os-distribution = "fedora"}
-  ["automake autoconf"] {os-family = "suse"}
-  ["automake autoconf"] {os-distribution = "debian"}
-  ["automake autoconf"] {os-distribution = "ubuntu"}
+  ["automake" "autoconf"] {os-distribution = "alpine"}
+  ["automake" "autoconf"] {os-distribution = "centos"}
+  ["automake" "autoconf"] {os-distribution = "fedora"}
+  ["automake" "autoconf"] {os-family = "suse"}
+  ["automake" "autoconf"] {os-distribution = "debian"}
+  ["automake" "autoconf"] {os-distribution = "ubuntu"}
 ]
 bug-reports: "https://github.com/savonet/liquidsoap/issues"
 dev-repo: "git+https://github.com/savonet/liquidsoap.git"


### PR DESCRIPTION
Error message:

[WARNING] Failed checks on liquidsoap package definition from source at git+https://github.com/savonet/liquidsoap.git#master:
           warning 54: External dependencies should not contain spaces nor empty string: "automake autoconf", "automake autoconf", "automake autoco
nf", "automake autoconf", "automake autoconf", "automake autoconf"