### PR TITLE
Make source and active_source the same for the type checker.

### DIFF
--- a/src/lang/lang_parser.mly
+++ b/src/lang/lang_parser.mly
@@ -131,7 +131,6 @@
       | "string" -> Lang_types.make (Lang_types.Ground Lang_types.String)
       | "source" ->
           (* TODO less confusion in hiding the stream_kind constructed type *)
-          (* TODO print position in error message *)
           let audio,video,midi =
             match args with
               | ["",a;"",v;"",m] -> a,v,m

--- a/src/lang/lang_parser.mly
+++ b/src/lang/lang_parser.mly
@@ -129,7 +129,7 @@
       | "int" -> Lang_types.make (Lang_types.Ground Lang_types.Int)
       | "float" -> Lang_types.make (Lang_types.Ground Lang_types.Float)
       | "string" -> Lang_types.make (Lang_types.Ground Lang_types.String)
-      | "source" | "active_source" ->
+      | "source" ->
           (* TODO less confusion in hiding the stream_kind constructed type *)
           (* TODO print position in error message *)
           let audio,video,midi =
@@ -151,8 +151,7 @@
                   in
                     assoc "audio", assoc "video", assoc "midi"
           in
-            Lang_values.source_t
-              ~active:(name <> "source")
+            Lang_values.source_t ~active:false
               (Lang_values.frame_kind_t audio video midi)
       | _ -> raise (Parse_error (pos, "Unknown type constructor."))
 

--- a/src/lang/lang_types.ml
+++ b/src/lang/lang_types.ml
@@ -634,6 +634,7 @@ let doc_of_type ~generalized t =
 let constr_sub x y =
   match x,y with
   | _,_ when x=y -> true
+  | "source", "active_source"
   | "active_source", "source" -> true
   | _ -> false
 

--- a/src/lang/lang_values.ml
+++ b/src/lang/lang_values.ml
@@ -136,7 +136,7 @@ and in_term =
 | Float   of float
 | Encoder of Encoder.format
 | List    of term list
-| Tuple    of term list
+| Tuple   of term list
 | Ref     of term
 | Get     of term
 | Set     of term * term
@@ -427,7 +427,7 @@ struct
     | Request of Request.t
     | Encoder of Encoder.format
     | List    of value list
-    | Tuple    of value list
+    | Tuple   of value list
     | Ref     of value ref
     (** The first environment contains the parameters already passed
       * to the function. Next parameters will be inserted between that


### PR DESCRIPTION
This one seems like a straight shot to me because of this comment:
```
 * Memo: A <: B means that any value of type A can be passed where a value
 * of type B can.
```
However, I'm no expert on this part so it'd be nice to have @dbaelde's eyes on it.