### PR TITLE
Make avi samplerate lazy.

### DIFF
--- a/src/encoder/avi_encoder.ml
+++ b/src/encoder/avi_encoder.ml
@@ -70,7 +70,7 @@ let encode_frame ~channels ~samplerate ~converter frame start len =
 
 let encoder avi =
   let channels = avi.channels in
-  let samplerate = avi.samplerate in
+  let samplerate = Lazy.force avi.samplerate in
   let converter = Audio_converter.Samplerate.create channels in
   (* TODO: use duration *)
   let header = Avi.header ~channels ~samplerate () in

--- a/src/encoder_formats/avi_format.ml
+++ b/src/encoder_formats/avi_format.ml
@@ -22,11 +22,15 @@
 
 type t =
   {
-    samplerate : int;
+    (* Samplerate is lazy in order to avoid forcing the evaluation of the
+       samplerate at typing time, see #933. For channels this is pointless since
+       we really need that for typing. *)
+    samplerate : int Lazy.t;
     channels : int;
   }
 
 let to_string w =
+  let samplerate = Lazy.force w.samplerate in
   Printf.sprintf
     "%%avi(samplerate=%d,channels=%d)"
-    w.samplerate w.channels
+    samplerate w.channels

--- a/src/lang_encoders/lang_avi.ml
+++ b/src/lang_encoders/lang_avi.ml
@@ -28,7 +28,7 @@ let make params =
     {
       Avi_format.
       channels = Lazy.force Frame.audio_channels;
-      samplerate = Lazy.force Frame.audio_rate
+      samplerate = Frame.audio_rate
     }
   in
   let avi =
@@ -38,7 +38,7 @@ let make params =
           | ("channels",{ term = Int c; _ }) ->
               { f with Avi_format.channels = c }
           | ("samplerate",{ term = Int i; _ }) ->
-              { f with Avi_format.samplerate = i }
+              { f with Avi_format.samplerate = Lazy.from_val i }
           | (_,t) -> raise (generic_error t))
       defaults params
   in

--- a/src/outputs/icecast2.ml
+++ b/src/outputs/icecast2.ml
@@ -105,7 +105,7 @@ struct
         | Encoder.AVI m ->
             { quality = None ;
               bitrate = None ;
-              samplerate = Some m.Avi_format.samplerate ;
+              samplerate = Some (Lazy.force m.Avi_format.samplerate) ;
               channels = Some m.Avi_format.channels
             }
         | Encoder.Ogg o ->


### PR DESCRIPTION
This ensures that the evaluation of the samplerate is not forced too
early. Fixes #933.