### PR TITLE
Functions to manipulate binary strings.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,11 @@
+1.5.0
+=====
+
+New:
+
+- Added `string.char`.
+- Added `string.binary.to_int`.
+
 1.4.0 ()
 =====
 

--- a/libs/string.liq
+++ b/libs/string.liq
@@ -26,3 +26,14 @@ def string.contains(~prefix="", ~substring="", ~suffix="", s)
 
   !ans
 end
+
+# Value of an integer encoded using native memory representation.
+# @category String
+# @param ~little_endian Whether the memory representation is little endian.
+# @param s String containing the binary representation.
+def string.binary.to_int(~little_endian=true, s)
+  ans = ref(0)
+  n = string.length(s)
+  for(0, n-1, fun (i) -> ans := lsl(!ans,8) + string.char(s, if little_endian then n-1-i else i end))
+  !ans
+end

--- a/scripts/tests/string.liq
+++ b/scripts/tests/string.liq
@@ -30,5 +30,7 @@ test(string.contains(suffix="cd","abcd"), true)
 test(string.contains(suffix="dc","abcd"), false)
 test(string.contains(substring="bc","abcd"), true)
 test(string.contains(substring="bc","acbd"), false)
+test(string.binary.to_int(little_endian=true,"abcd"),0x64636261)
+test(string.binary.to_int(little_endian=false,"abcd"),0x61626364)
 
 if !success then test.pass() else test.fail() end

--- a/src/lang/builtins_string.ml
+++ b/src/lang/builtins_string.ml
@@ -42,6 +42,19 @@ let () =
        let l = List.map Lang.to_string l in
          Lang.string (String.concat sep l))
 
+let () =
+  add_builtin "string.char" ~cat:String ~descr:"Retrieve a character in a string."
+    [
+      "", Lang.string_t, None, Some "String to look into.";
+      "", Lang.int_t, None, Some "Index of the character.";
+    ]
+    Lang.int_t
+    (fun p ->
+       let s = Lang.to_string (Lang.assoc "" 1 p) in
+       let n = Lang.to_int (Lang.assoc "" 2 p) in
+       Lang.int (int_of_char s.[n])
+    )
+
 (* Special characters that must be escaped *)
 let special_chars =
   (* Control chars between 0x00 and 0x1f *)


### PR DESCRIPTION
With this (and `string.sub`) we should be able to parse binary headers in Liquidsoap, as requested in #960 (we might need some more helper functions though).