### PR TITLE
Native ID3v2 tags decoder

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,8 @@ New:
 - Added `string.nth` (#970).
 - Added `string.binary.to_int` (#970).
 - Added `file.ls` (#1011).
+- Added native id3v2 tag parser, as well as associated function `file.mp3.tags`,
+  `file.mp3.parse_apic` and `file.cover` (#987).
 
 Changed:
 

--- a/libs/metadata.liq
+++ b/libs/metadata.liq
@@ -32,3 +32,18 @@ end
 def metadata.float_getter(init, metadata, s)
   metadata.getter(init, float_of_string, metadata, s)
 end
+
+# Obtain cover-art for a file. Only MP3 files are supported for now, athough
+# more should be in the future. An empty string is return in case there is no
+# such information.
+# @param file File from which the cover should be obtained
+def file.cover(file)
+  m = file.mp3.tags(file)
+  m = list.filter(fun (lv) -> fst(lv) == "APIC", m)
+  m = list.map(snd, m)
+  if m == [] then "" else
+    # TODO: we could use file type in order to select cover if there are many
+    let (_,_,_,data) = file.mp3.parse_apic(list.hd(default="", m))
+    data
+  end
+end

--- a/src/Makefile
+++ b/src/Makefile
@@ -187,7 +187,7 @@ tools = tools/extralib.ml tools/JSON.ml tools/utils.ml \
 	tools/http.ml \
 	$(if $(W_SSL),tools/https.ml) \
 	$(if $(W_OSX_SECURE_TRANSPORT),tools/https_secure_transport.ml) \
-	tools/pool.ml tools/sha1.ml tools/websocket.ml \
+	tools/pool.ml tools/sha1.ml tools/websocket.ml tools/id3v2.ml \
 	$(if $(W_INOTIFY),tools/file_watcher_inotify.ml)
 
 stream =stream/frame.ml stream/generator.ml \

--- a/src/Makefile
+++ b/src/Makefile
@@ -44,6 +44,7 @@ decoders = \
 	decoder/wav_aiff_decoder.ml decoder/midi_decoder.ml \
 	decoder/image_decoder.ml decoder/image/ppm_decoder.ml \
 	decoder/external_decoder.ml decoder/raw_audio_decoder.ml \
+	decoder/id3v2_plug.ml \
 	$(if $(W_FFMPEG),decoder/ffmpeg_decoder.ml) \
 	$(if $(W_FLAC),decoder/flac_decoder.ml) \
 	$(if $(W_FAAD),decoder/aac_decoder.ml) \

--- a/src/decoder/id3v2_plug.ml
+++ b/src/decoder/id3v2_plug.ml
@@ -1,0 +1,58 @@
+(*****************************************************************************
+
+  Liquidsoap, a programmable audio stream generator.
+  Copyright 2003-2019 Savonet team
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details, fully stated in the COPYING
+  file at the root of the liquidsoap distribution.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA
+
+ *****************************************************************************)
+
+exception Invalid_file
+
+let log = Log.make ["decoder";"id3v2"]
+
+(** Configuration keys for id3v2. *)
+let mime_types =
+  Dtools.Conf.list ~p:(Decoder.conf_mime_types#plug "id3v2")
+    "Mime-types used for decoding metadata using native ID3v2 parser"
+    ~d:["audio/mpeg"]
+
+let conf_id3v2 =
+  Dtools.Conf.void ~p:(Decoder.conf_decoder#plug "id3v2")
+    "Native ID3v2 parser settings"
+
+let file_extensions =
+  Dtools.Conf.list ~p:(Decoder.conf_file_extensions#plug "id3v2")
+    "File extensions used for decoding metadata using native ID3v2 parser"
+    ~d:["mp3"]
+
+let get_tags fname =
+  try
+    if not (Decoder.test_file ~mimes:mime_types#get 
+                              ~extensions:file_extensions#get 
+                              ~log fname) then
+      raise Invalid_file;
+    let ic = open_in fname in
+    Tutils.finalize ~k:(fun () -> close_in ic)
+      (fun () -> Id3v2.parse (input ic))
+  with
+  | Id3v2.Invalid -> []
+  | e ->
+    log#info "Error while decoding file tags: %s" (Printexc.to_string e);       
+    log#info "Backtrace:\n%s" (Printexc.get_backtrace());
+    raise Not_found
+
+let () = Request.mresolvers#register "ID3V2" get_tags

--- a/src/lang/builtins_files.ml
+++ b/src/lang/builtins_files.ml
@@ -223,6 +223,8 @@ let () =
        Lang.list ~t:Lang.string_t files
     )
 
+(************** Paths ********************)
+
 let () =
   add_builtin "path.basename" ~cat:Sys
     ["",Lang.string_t,None,None] Lang.string_t
@@ -255,3 +257,40 @@ let () =
     (fun p ->
        let f = Lang.to_string (List.assoc "" p) in
        Lang.string (Filename.remove_extension f))
+
+(************** MP3 ********************)
+
+let () =
+  add_builtin "file.mp3.tags" ~cat:Sys
+    [
+      "",Lang.string_t,None,Some "MP3 file of which the metadata should be read."
+    ] (Lang.list_t (Lang.product_t Lang.string_t Lang.string_t))
+    ~descr:"Read the tags from an MP3 file using the builtin functions. Only \
+            ID3v2 tags are supported for now."
+    (fun p ->
+       let f = Lang.to_string (List.assoc "" p) in
+       let ic = open_in f in
+       let ans =
+         try
+           let ans = Id3v2.parse (input ic) in
+           close_in ic;
+           ans
+         with _ -> close_in ic; []
+       in
+       Lang.list ~t:(Lang.product_t Lang.string_t Lang.string_t)
+         (List.map (fun (l,v) -> Lang.product (Lang.string l) (Lang.string v)) ans)
+    )
+
+let () =
+  add_builtin "file.mp3.parse_apic" ~cat:Sys
+    [
+      "",Lang.string_t,None,Some "APIC data."
+    ] (Lang.tuple_t [Lang.string_t; Lang.int_t; Lang.string_t; Lang.string_t])
+    ~descr:"Parse APIC ID3v2 tags (such as those obtained in the APIC tag from \
+            `file.mp3.tags`). The returned values are: mime, picture type, \
+            description, and picture data."
+    (fun p ->
+       let apic = Lang.to_string (List.assoc "" p) in
+       let apic = Id3v2.parse_apic apic in
+       Lang.tuple [Lang.string apic.Id3v2.mime; Lang.int apic.Id3v2.picture_type; Lang.string apic.Id3v2.description; Lang.string apic.Id3v2.data]
+    )

--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -3,7 +3,7 @@ TESTS = $(TESTS_ML:.ml=)
 OCAML_CFLAGS = -I ../tools -I .. $(liquidsoap_ocamlcflags) -thread
 OCAML_LFLAGS = $(liquidsoap_ocamllflags) \
 		extralib.cmx utils.cmx tools/log.cmx tutils.cmx \
-		file_watcher_mtime.cmx tools/dyntools.cmx configure.cmx http.cmx JSON.cmx \
+		file_watcher_mtime.cmx tools/dyntools.cmx configure.cmx http.cmx JSON.cmx id3v2.cmx \
 		stream/frame.cmx avi.cmx \
 		../tools/unix_c.o
 

--- a/src/test/id3v2_test.ml
+++ b/src/test/id3v2_test.ml
@@ -1,0 +1,18 @@
+open Id3v2
+
+let () =
+  let fname = if Array.length Sys.argv > 1 then Sys.argv.(1) else "../test.mp3" in
+  if not (Sys.file_exists fname) then (Printf.printf "File %s not found, exiting." fname; exit 0);
+  Printf.printf "Reading %s...\n%!" fname;
+  let ic = open_in fname in
+  let tags = parse (input ic) in
+  let apic = try List.assoc "APIC" tags with Not_found -> "" in
+  let tags = List.remove_assoc "APIC" tags in
+  List.iter (fun (t,v) -> Printf.printf "%s: %s\n%!" t v) tags;
+  if apic <> "" then
+    let apic = parse_apic apic in
+    Printf.printf "\nAPIC\n";
+    Printf.printf "mime: %s\n" apic.mime;
+    Printf.printf "type: %d\n" apic.picture_type;
+    Printf.printf "description: %s\n" apic.description
+  

--- a/src/tools/id3v2.ml
+++ b/src/tools/id3v2.ml
@@ -56,11 +56,11 @@ let parse f =
       if id.[0] = 'T' then
         let id =
           match id with
-          | "TPE1" -> "Artist"
-          | "TIT2" -> "Title"
-          | "TALB" -> "Album"
-          | "TYER" -> "Year"
-          | "TRCK" -> "Track"
+          | "TPE1" -> "artist"
+          | "TIT2" -> "title"
+          | "TALB" -> "album"
+          | "TYER" -> "year"
+          | "TRCK" -> "track"
           | _ -> id
         in
         let encoding = int_of_char data.[0] in

--- a/src/tools/id3v2.ml
+++ b/src/tools/id3v2.ml
@@ -75,11 +75,13 @@ let parse f =
         if id.[0] = 'T' then
           let id =
             match id with
+            | "COMM" -> "comment"
             | "TPE1" -> "artist"
             | "TIT2" -> "title"
             | "TALB" -> "album"
             | "TYER" -> "year"
             | "TRCK" -> "track"
+            | "TBPM" -> "bpm"
             | _ -> id
           in
           let encoding = int_of_char data.[0] in

--- a/src/tools/id3v2.ml
+++ b/src/tools/id3v2.ml
@@ -1,0 +1,113 @@
+open Extralib
+
+exception Invalid
+
+let read f n =
+  let s = Bytes.create n in
+  let k = read_retry f s 0 n in
+  if k <> n then raise Invalid;
+  Bytes.unsafe_to_string s
+
+let read_byte f =
+  int_of_char (read f 1).[0]
+
+let read_size ?(synch_safe=true) f =
+  let s = read f 4 in
+  if synch_safe then int_of_char s.[0] lsl 21 + int_of_char s.[1] lsl 14 + int_of_char s.[2] lsl 7 + int_of_char s.[3]
+  else int_of_char s.[0] lsl 24 + int_of_char s.[1] lsl 16 + int_of_char s.[2] lsl 8 + int_of_char s.[3]
+
+let parse f =
+  let id = read f 3 in
+  if id <> "ID3" then raise Invalid;
+  let version =
+    let v1 = read_byte f in
+    let v2 = read_byte f in
+    [|2; v1; v2|]
+  in
+  (* Printf.printf "version: %s\n" (String.concat "." (List.map string_of_int (Array.to_list version))); *)
+  let v = version.(1) in
+  if v <> 3 && v <> 4 then raise Invalid;
+  let flags = read_byte f in
+  (* let unsynchronization = flags land 0b10000000 <> 0 in *)
+  (* Printf.printf "unsynchronization: %b\n%!" unsynchronization; *)
+  let extended_header = flags land 0b1000000 <> 0 in
+  (* Printf.printf "extended header: %b\n" extended_header; *)
+  let size = read_size f in
+  (* Printf.printf "size: %d\n" size; *)
+  if extended_header then
+    (
+      let size = read_size ~synch_safe:(v>3) f in (* size *)
+      let size = if v = 3 then size else size - 4 in
+      ignore (read f size)
+    );
+  let len = ref size in
+  let tags = ref [] in
+  while !len > 0 do
+    (* Printf.printf "len: %d\n" !len; *)
+    let id = read f 4 in
+    (* Printf.printf "id: %s\n" id; *)
+    if id = "\000\000\000\000" then len := 0 (* stop tag *)
+    else
+      let size = read_size ~synch_safe:(v>3) f in
+      (* Printf.printf "size: %d\n" size; *)
+      let _ = read f 2 in (* flags *)
+      let data = read f size in
+      (* if id <> "APIC" then Printf.printf "data: %S\n%!" data; *)
+      if id.[0] = 'T' then
+        let id =
+          match id with
+          | "TPE1" -> "Artist"
+          | "TIT2" -> "Title"
+          | "TALB" -> "Album"
+          | "TYER" -> "Year"
+          | "TRCK" -> "Track"
+          | _ -> id
+        in
+        let encoding = int_of_char data.[0] in
+        let z =
+          if encoding = 0 then
+            try String.index_from data 1 '\000' with Not_found -> String.length data
+          else
+            (* TODO: look for \000\000 *)
+            String.length data
+        in
+        let text = String.sub data 1 (z - 1) in
+        let text =
+          if encoding = 0 then Configure.recode_tag ~in_enc:"ISO-8859-1" text
+          else if encoding = 3 then text (* already UTF-8 *)
+          else if text.[0] = '\xff' && text.[1] = '\xfe' then Configure.recode_tag ~in_enc:"UTF-16" text
+          else text
+        in
+        tags := (id, text) :: !tags
+      else
+        tags := (id, data) :: !tags;
+      len := !len - (size + 10)
+  done;
+  !tags
+
+type apic =
+  {
+    mime : string;
+    picture_type : int;
+    description : string;
+    data : string
+  }
+
+let parse_apic apic =
+  let text_encoding = int_of_char apic.[0] in
+  let recode s =
+    if text_encoding = 0 then Configure.recode_tag ~in_enc:"ISO-8859-1" s
+    else if text_encoding = 1 || text_encoding = 2 then Configure.recode_tag ~in_enc:"UTF-16" s
+    else if text_encoding = 3 then s
+    else s
+  in
+  let n = String.index_from apic 1 '\000' in
+  let mime = recode (String.sub apic 1 (n-1)) in
+  let n = n+1 in
+  let picture_type = int_of_char apic.[n] in
+  let n = n+1 in
+  let n' = String.index_from apic n '\000' in
+  let description = recode (String.sub apic n (n' - n)) in
+  let n = n'+1 in
+  let data = String.sub apic n (String.length apic - n) in
+  { mime; picture_type; description ; data }


### PR DESCRIPTION
The short-term goal is to have an easy way to parse the APIC tag (cover picture), for #959, which taglib does not easily do.