### PR TITLE
fix docs for http/https builtins

### DIFF
--- a/src/lang/builtins_https.ml
+++ b/src/lang/builtins_https.ml
@@ -26,21 +26,21 @@ let () =
   let add_http_request = add_http_request (module Https) in
   add_http_request
     "https.get"
-    "Perform a full https GET request and return (status,headers),data."
+    "Perform a full https GET request and return (status,headers,data)."
     Get;
   add_http_request
     "https.post"
-    "Perform a full https POST request and return (status,headers),data."
+    "Perform a full https POST request and return (status,headers,data)."
     Post;
   add_http_request
     "https.put"
-    "Perform a full https PUT request and return (status,headers),data."
+    "Perform a full https PUT request and return (status,headers,data)."
     Put;
   add_http_request
     "https.head"
-    "Perform a full https HEAD request and return (status,headers),data."
+    "Perform a full https HEAD request and return (status,headers,data)."
     Head;
   add_http_request
     "https.delete"
-    "Perform a full https DELETE request and return (status,headers),data."
+    "Perform a full https DELETE request and return (status,headers,data)."
     Delete

--- a/src/lang/builtins_https_secure_transport.ml
+++ b/src/lang/builtins_https_secure_transport.ml
@@ -24,21 +24,21 @@ let () =
   let add_http_request = Builtins_http.add_http_request (module Https_secure_transport) in
   add_http_request
     "https.get"
-    "Perform a full https GET request and return (status,headers),data."
+    "Perform a full https GET request and return (status,headers,data)."
     Builtins_http.Get;
   add_http_request
     "https.post"
-    "Perform a full https POST request and return (status,headers),data."
+    "Perform a full https POST request and return (status,headers,data)."
     Builtins_http.Post;
   add_http_request
     "https.put"
-    "Perform a full https PUT request and return (status,headers),data."
+    "Perform a full https PUT request and return (status,headers,data)."
     Builtins_http.Put;
   add_http_request
     "https.head"
-    "Perform a full https HEAD request and return (status,headers),data."
+    "Perform a full https HEAD request and return (status,headers,data)."
     Builtins_http.Head;
   add_http_request
     "https.delete"
-    "Perform a full https DELETE request and return (status,headers),data."
+    "Perform a full https DELETE request and return (status,headers,data)."
     Builtins_http.Delete


### PR DESCRIPTION
The docs currently say `return (status,headers),data` but unless I'm
mistaken this should be `return (status,headers,data)`.