### PR TITLE
Improve startup time

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -232,6 +232,7 @@ liquidsoap_sources += \
 	lang/lang_types.ml lang/lang_values.ml \
 	$(lang_encoders) lang/lang_parser.ml lang/lang_lexer.ml \
 	lang/lang_pp.ml lang/lang_errors.ml lang/lang.ml \
+	lang/startup.ml \
         tools/start_stop.ml tools/ioRing.ml \
 	tools/icecast_utils.ml tools/avi.ml \
 	$(video_converters) $(audio_converters) $(ogg_demuxer) $(protocols) \

--- a/src/lang/startup.ml
+++ b/src/lang/startup.ml
@@ -1,0 +1,37 @@
+(*****************************************************************************
+
+  Liquidsoap, a programmable audio stream generator.
+  Copyright 2003-2019 Savonet team
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details, fully stated in the COPYING
+  file at the root of the liquidsoap distribution.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA
+
+ *****************************************************************************)
+
+let register_plugins = ref (fun () -> ())
+
+(** Register a function which will register plugins. *)
+let register_plugin ?(fast=true) f =
+  (* For now fast plugins are loaded immediately. *)
+  if fast then f ()
+  else
+    let g = !register_plugins in
+    register_plugins := (fun () -> g (); f ())
+
+(** Ensure that all plugins are registered. This function can be called multiple
+    times and will not do anything excepting the first time. *)
+let register_plugins () =
+  !register_plugins ();
+  register_plugins := fun () -> ()

--- a/src/main.ml
+++ b/src/main.ml
@@ -84,6 +84,7 @@ let interactive = ref false
 let load_libs =
   let loaded = ref false in
     fun () ->
+      Startup.register_plugins ();
       if !pervasives && not !loaded then begin
         let save = !Configure.display_types in
           Configure.display_types := false ;

--- a/src/operators/frei0r_op.ml
+++ b/src/operators/frei0r_op.ml
@@ -388,4 +388,5 @@ let register_plugins () =
   List.iter add plugin_dirs
 
 let () =
-  if frei0r_enable then register_plugins ()
+  if frei0r_enable then
+    Startup.register_plugin ~fast:false register_plugins


### PR DESCRIPTION
We load slow plugins such as frei0r only just before evaluation.

`liquidsoap --version` goes from 1 sec to 0.5 sec roughly.

This addresses #982.