### PR TITLE
Validate setting before changing its value

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -53,6 +53,8 @@ Changed:
 - Renamed `which` to `file.which`.
 - Change `blank()` duration semantics to mean forever only on negative values.
 - Get rid of numbering of universal variables (#1037).
+- Add `validate` parameter to `register`, which allows to validate a value
+  before setting it.
 
 Fixed:
 
@@ -156,7 +158,7 @@ Changed:
 - Renamed `input.external` into `input.external.rawaudio`, added
   `input.external.wav`.
 - Renamed `gstreamer.hls` to `output.file.hls.gstreamer`.
-- Raise an error when using a format (e.g. `%vorbis`, `%mp3`, ..) that is not 
+- Raise an error when using a format (e.g. `%vorbis`, `%mp3`, ..) that is not
   enabled. (#857)
 - Set default encoders and ladspa plugins samplerate and channels to configured
   internal `"frame.audio.samplerate"` and `"frame.audio.channels"`. (#870)
@@ -193,7 +195,7 @@ Fixed:
 - Fixed exit getting stuck when using `input.jack` (#769)
 - Stop lo server on shutdown. (#820)
 - Fixed external process stop not detected on second and further calls (#833)
-- Add `seek` in operators where implementation is clear (#853) 
+- Add `seek` in operators where implementation is clear (#853)
 - Do not enter buffering mode between tracks in `buffer` (#836)
 - Fixed file descriptor leak in external processes (#865)
 - Fixed encoded output creating empty files from failing sources (#876)
@@ -293,7 +295,7 @@ Fixed:
 - Support for OCaml >= 4.06
 - File descriptor leak in `output.icecast` (#548)
 - Fixed URL regexp for `input.https` (#593)
-- Multiple gstreamer fixes: 
+- Multiple gstreamer fixes:
   - File decoder with video.
   - Memory leaks (#516, #511, #434, #318)
   - Process freeze (#608, 278)
@@ -615,7 +617,7 @@ Fixes:
   content kinds, and also allow video for harbor [LS-601]
 - request.equeue() now allows to remove requests from the primary queue
 - fix compilation of lame dynamic plugin.
- 
+
 New:
 
 - new values for metadata fields does not override old one anymore;
@@ -636,16 +638,16 @@ New:
 1.0.0 (08-10-2011)
 ==================
 
-Finally, the 1.0.0 release! It brings several important fixes, but 
+Finally, the 1.0.0 release! It brings several important fixes, but
 also some nice novelties.
-The most outstanding difference concerns output.icecast(): its restart 
-and restart_delay parameters are gone, replaced by a new on_stop handler 
-which is called on every error (failed connection or disconnection) and 
-returns the new restart delay. The on_error handler receives a string 
+The most outstanding difference concerns output.icecast(): its restart
+and restart_delay parameters are gone, replaced by a new on_stop handler
+which is called on every error (failed connection or disconnection) and
+returns the new restart delay. The on_error handler receives a string
 describing the error which enables user-friendly reporting, adaptative
 delays, etc.
 Note that on_error defaults to fun(_)->3. which is equivalent to having
-restart=true, restart_delay=3. in previous versions, NOT the same as the 
+restart=true, restart_delay=3. in previous versions, NOT the same as the
 former restart=false default. As a result, liquidsoap won't fail to startup
 if an initial connection attempt fails.
 
@@ -689,7 +691,7 @@ Enhancements:
 - Text-to-speech: festival and sox are now only runtime dependencies
 - LS-475,516: better support for dynamic URL change in input.http()
 - LS-484: display user-friendly error messages in interactive mode
-- LS-308: use seconds internally in request sources, avoid overflow and 
+- LS-308: use seconds internally in request sources, avoid overflow and
   display more user-friendly debug messages
 - Cleanup visu.volume() and video.vis_volume()
 - LS-573: replace " " by "_" in identifiers to make them valid in the server
@@ -737,11 +739,11 @@ Decoders:
 - Fixes in Ogg decoding: LS-515 (loss of data) and LS-537 (segfault).
 - Fix LS-337: periodical failures when decoding AAC(+) streams
 - AAC(+): use new ocaml-faad with builtin mp4ff, easier to build
-- New detection mechanism mixing extensions and MIME types (when available), 
+- New detection mechanism mixing extensions and MIME types (when available),
   with corresponding settings "decoder.file_extensions.<format>" and
   "decoder.mime_types.<format>".
-- Decoder order can be user-defined thanks to new settings 
-  "decoder.file_decoders", "decoder.stream_decoders" and 
+- Decoder order can be user-defined thanks to new settings
+  "decoder.file_decoders", "decoder.stream_decoders" and
   "decoder.metadata_decoders".
 - Indicate which decoder is used in the "decoder" metadata
 - More helpful log for various errors
@@ -1017,7 +1019,7 @@ New:
   AAC+ streaming. Enabled wrappers for external encoders for AAC+ format
   aacplusenc (#220 and #136). Also added custom IRC, AIM and ICQ headers
   to shoutcast wrappers (#192).
-- Harbor now supports Shoutcast/ICY headers properly. This allows in 
+- Harbor now supports Shoutcast/ICY headers properly. This allows in
   particular the use of any supported data format for the source client.
 - Harbor sources now also consider "song" field when updating metadata.
 - Added built-in support for m4a audio files and metadata.
@@ -1084,7 +1086,7 @@ Bugs fixed:
 
 - Fixed byte swapping function.
 - Fixed unix server socket failure (#160).
-- Fixed mp3 audio glitches when decoding 
+- Fixed mp3 audio glitches when decoding
   files with picture id3v2 tags using ocaml-mad (#162).
 - Fixed liquidsoap crash on weird telnet and harbor input (#164).
 - Fixed request.queue() not considering initial queue on wake-up (#196).
@@ -1131,7 +1133,7 @@ New:
 - Added EXPERIMENTAL support for AU, AIFF and NSV mp3 audio files
   using ocaml-natty.
 - Added "prefix" parameter to the playlist operators. Allows to prefix
-  each uri in order to force resolution through a specific protocol, 
+  each uri in order to force resolution through a specific protocol,
   like replaygain: for instance. (#166)
 - Support for external processes as audio encoder:
   * Added output.icecast.lame to output to icecast using the lame binary.
@@ -1189,7 +1191,7 @@ Bugs fixed:
 - Fixed inter-thread mutex lock/unlock in playlist.ml
 - Fixed "next" playlist command
 - Fixed race conditions in request_source.ml feeding task
-- cross/smartcross: raise the default for inhibition as 
+- cross/smartcross: raise the default for inhibition as
   setting it to exactly duration is not enough
 - Don't fail when $HOME is not set
 - Fixed metadata update in input.harbor with icecast2 source protocol
@@ -1202,17 +1204,17 @@ New:
 - Enhanced smart_crossfade
 - Added string.case and string.capitalize
 - New "exec_at" operator, to execute a function depending on a given predicate
-- Added script example in the documentation to listen to radio Nova and get 
+- Added script example in the documentation to listen to radio Nova and get
   the metadata from a web page.
 - Changed parameters name in fallback.skip to reflect who are the fallback
   and input source.
 - Added a dump file parameter to input.harbor, for debugging purpose.
-- Added an auth function parameter to input.harbor for custom 
+- Added an auth function parameter to input.harbor for custom
   authentifications. Fixes #157
 - Added "primary_queue" and "secondary_queue" commands to request.queue and
   request.equeue sources. Also set the metadata "queue" to either "primary"
   or "secondary" for each request in the queue. Documented it too.
-- Insert latest metadata for a node of a switch source when switching 
+- Insert latest metadata for a node of a switch source when switching
   back to it in a middle of a track.
 - Added a 'conservative' parameter to cross, smilar to the one in smartcross.
 
@@ -1247,16 +1249,16 @@ New:
 - New Jack support. The old one has been renamed to in/output.jack.legacy().
 - Harbor: per-mount passwords and the stop command to kick a source client.
 - Official Last.FM client.
-- Metadata is no more punctual but interval-based, which suppresses some 
+- Metadata is no more punctual but interval-based, which suppresses some
   surprising behaviours.
 - Perfected daemon behaviour.
-- All output.file.*() now have the features that used to be only in 
-  output.file.vorbis(), notable re-opening. Added %w to the strftime-like 
+- All output.file.*() now have the features that used to be only in
+  output.file.vorbis(), notable re-opening. Added %w to the strftime-like
   format codes allowed in their filename parameter.
 - Add clear_metadata() and map_metadata(). Now, rewrite_metadata() is a simple
   specialization of map_metadata(), written in utils.liq.
 - Dynamic amplification factor in amplify(), e.g. useful for replay gain.
-- Lots of new functions in the scripting API: for lists, requests, system 
+- Lots of new functions in the scripting API: for lists, requests, system
   interaction, shutdown, command-line parsing, scripted server commands, etc.
 
 As always:
@@ -1327,7 +1329,7 @@ Notation: "-" stands for a change, "+" for an addition.
 * Lots of sound processing operators: compand, compress, normalize,
   pitch, bpm, soundtouch, saw, square, etc. Add more shapes to fade.*().
 * New track processing operators: insert_metadata, on_track.
-* Smart cross: allows to select a transition based on the volumes around the 
+* Smart cross: allows to select a transition based on the volumes around the
   end-of-track.
 * Support for AAC encoding/decoding.
 * Several fixes to output.icecast.mp3 in order to support shoutcast servers.
@@ -1337,7 +1339,7 @@ Notation: "-" stands for a change, "+" for an addition.
 * Server interface via UNIX domain sockets.
 * Better output.file.vorbis with support for re-opening the file, appending,
   interpolate strftime format codes, etc.
-* Add pre-processing and math primitives to the language, new _[_] notation for 
+* Add pre-processing and math primitives to the language, new _[_] notation for
   assoc(), ruby-style anti-quotation ("..#{..}.."), add_timeout(), execute(),
   log()...
 * Ability to tweak the internal PCM stream format.
@@ -1356,7 +1358,7 @@ Notation: "-" stands for a change, "+" for an addition.
 * Per-track settings for cross(), fade.*(), prepend() and append()
   using requests' metadatas.
 * Implemented input.http.mp3(), including support for icy metadata.
-* New pipe() operator which allows one to filter the raw audio through an 
+* New pipe() operator which allows one to filter the raw audio through an
   external program. However, sox and other common tools aren't suitable for that
   because they don't flush their output often enough.
 * New on_blank() operator for calling a callback on excessive blanks.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,6 +23,8 @@ New:
 - Added `source.dump`.
 - Added `synth` protocol (#1014).
 - Added support for `srt.enforced_encryption` setting.
+- Add `validate` parameter to `register`, which allows to validate a value
+  before setting it (#1046, @CyberDomovoy)
 
 Changed:
 
@@ -53,8 +55,6 @@ Changed:
 - Renamed `which` to `file.which`.
 - Change `blank()` duration semantics to mean forever only on negative values.
 - Get rid of numbering of universal variables (#1037).
-- Add `validate` parameter to `register`, which allows to validate a value
-  before setting it.
 
 Fixed:
 

--- a/src/lang/builtins_dtools.ml
+++ b/src/lang/builtins_dtools.ml
@@ -43,6 +43,9 @@ let () =
      "on_change",Lang.fun_t [false,"",univ] Lang.unit_t,
      Some (Lang.val_cst_fun ["",univ,None] Lang.unit),
      Some "Callback executed when the setting is changed.";
+     "validate",Lang.fun_t [false,"",univ] Lang.bool_t,
+     Some (Lang.val_cst_fun ["",univ,None] (Lang.bool true)),
+     Some "Callback executed to validate a new value.";
      "",Lang.string_t,None,Some "Setting key";
      "",univ,None,Some "Setting initial value"]
     Lang.unit_t
@@ -51,12 +54,17 @@ let () =
        let descr = Lang.to_string (List.assoc "descr" p) in
        let descr = if descr = "" then [] else [descr] in
        let path = Lang.to_string (Lang.assoc "" 1 p) in
+       let validate =
+         Lang.to_fun ~t:Lang.bool_t (List.assoc "validate" p)
+       in
        let on_change =
          Lang.to_fun ~t:Lang.unit_t (List.assoc "on_change" p)
        in
        let v = Lang.assoc "" 2 p in
        let make to_value b ?p ?l ?comments name  =
          let conf = b ?p ?l ?comments name in
+         conf#validate (fun v ->
+          Lang.to_bool (validate ["",to_value v]));
          conf#on_change (fun v ->
            ignore(on_change ["",to_value v]));
          conf#ut
@@ -104,42 +112,52 @@ let () =
        "",Lang.univ_t ~constraints:[Lang_types.Dtools] (),None,None]
       Lang.unit_t
       (fun p ->
-         let s = Lang.assoc "" 1 p in
-         let path = Lang.to_string s in
-           try begin match (Lang.assoc "" 2 p).Lang.value with
-               | Lang.Tuple []  -> set Dtools.Conf.as_unit   path ()
-               | Lang.String s -> set Dtools.Conf.as_string path s
-               | Lang.Int    s -> set Dtools.Conf.as_int    path s
-               | Lang.Bool   s -> set Dtools.Conf.as_bool   path s
-               | Lang.Float  s -> set Dtools.Conf.as_float  path s
-               | Lang.List   l ->
-                   let l = List.map Lang.to_string l in
-                     set Dtools.Conf.as_list path l
-               | _ -> assert false
-             end ;
-             Lang.unit
-           with Dtools.Conf.Mismatch _ ->
-             let t =
-               Configure.conf#path
-                 (Dtools.Conf.path_of_string path)
-             in
-             let kind =
-               match t#kind with
-                 | Some "unit" -> "of type unit"
-                 | Some "int" -> "of type int"
-                 | Some "float" -> "of type float"
-                 | Some "bool" -> "of type bool"
-                 | Some "string" -> "of type string"
-                 | Some "list" -> "of type [string]"
-                 | _ -> "untyped"
-             in
-             let msg =
-               Printf.sprintf
-                 "key %S is %s, thus cannot be set to %s"
-                 (Lang.to_string s)
-                 kind (Lang.print_value (Lang.assoc "" 2 p))
-             in
-               raise (Lang_errors.Invalid_value (s,msg)))
+        let s = Lang.assoc "" 1 p in
+        let path = Lang.to_string s in
+        try begin match (Lang.assoc "" 2 p).Lang.value with
+            | Lang.Tuple []  -> set Dtools.Conf.as_unit   path ()
+            | Lang.String s -> set Dtools.Conf.as_string path s
+            | Lang.Int    s -> set Dtools.Conf.as_int    path s
+            | Lang.Bool   s -> set Dtools.Conf.as_bool   path s
+            | Lang.Float  s -> set Dtools.Conf.as_float  path s
+            | Lang.List   l ->
+              let l = List.map Lang.to_string l in
+              set Dtools.Conf.as_list path l
+            | _ -> assert false
+          end ;
+          Lang.unit
+        with
+          | Dtools.Conf.Mismatch _ ->
+            let t =
+              Configure.conf#path
+                (Dtools.Conf.path_of_string path)
+            in
+            let kind =
+              match t#kind with
+                | Some "unit" -> "of type unit"
+                | Some "int" -> "of type int"
+                | Some "float" -> "of type float"
+                | Some "bool" -> "of type bool"
+                | Some "string" -> "of type string"
+                | Some "list" -> "of type [string]"
+                | _ -> "untyped"
+            in
+            let msg =
+              Printf.sprintf
+                "key %S is %s, thus cannot be set to %s"
+                (Lang.to_string s)
+                kind (Lang.print_value (Lang.assoc "" 2 p))
+            in
+            raise (Lang_errors.Invalid_value (s,msg))
+          | Dtools.Conf.Invalid_Value _ ->
+            let msg =
+              Printf.sprintf
+                "invalid value %s for key %S"
+                (Lang.print_value (Lang.assoc "" 2 p))
+                (Lang.to_string s)
+            in
+            raise (Lang_errors.Invalid_value (s,msg))
+      )
 
 let () =
   let get cast path v =

--- a/src/lang/builtins_dtools.ml
+++ b/src/lang/builtins_dtools.ml
@@ -126,7 +126,7 @@ let () =
                   | Some "bool" -> "of type bool"
                   | Some "string" -> "of type string"
                   | Some "list" -> "of type [string]"
-                  | _ -> "untyped"
+                  | _ -> assert false
               in
               let msg =
                 Printf.sprintf


### PR DESCRIPTION
Add a new parameter to register: validate (fun(v) -> bool)
It register a function to be called before changing the value of a setting (when using set), if the function returns false, an error is raised.

In order for this to work, ocaml-dtools need to be changed, i'm sending a pull request for it right after this one.

Please tell me if there is anything i could have done better, i'm new to ocaml.