### PR TITLE
fix typo in ffmpeg error message

### DIFF
--- a/src/io/ffmpeg_io.ml
+++ b/src/io/ffmpeg_io.ml
@@ -192,7 +192,7 @@ let () =
           | None ->
               raise
                 (Lang_errors.Invalid_value
-                   (format, "Could not find fffmpeg input format with that name"))
+                   (format, "Could not find ffmpeg input format with that name"))
       in
       let opts = Hashtbl.create 10 in
       parse_args ~t:`Int "int" p opts;


### PR DESCRIPTION
Hi! Just noticed this when I was trying to get input.ffmpeg to work. 