### PR TITLE
Fix rotate selection.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -72,6 +72,7 @@ Changed:
 Fixed:
 
 - Fix implementation of recursive functions (#934).
+- Fix implementation of `rotate` (#1129).
 - Fix opam install error with some bash-completion configuration (#980).
 - Make `blank()` source unavailable past is expected duration (#668).
 - Fixed implementation details with `cross` operator.

--- a/scripts/tests/GH1129.liq
+++ b/scripts/tests/GH1129.liq
@@ -1,0 +1,62 @@
+%include "test.liq"
+
+# We want:
+# Track selection 1 -> s1 ready, s2 not ready, s3 ready -> switch to s3, s2 gets ready
+# Track selection 2 -> s1 ready, s2 ready, s3 ready -> switch to s1
+# Bug appears when it switches to s3 again on step 2
+
+selected = ref []
+
+s1 = blank(duration=0.04)
+
+def m1(_) =
+  [("id","s1")]
+end
+
+s1 = map_metadata(id="s1",m1,s1)
+
+s2_ready = ref false
+
+s2 = switch(id="s2",[({!s2_ready},blank(duration=0.04))])
+
+def m2(_) =
+  [("id","s2")]
+end
+
+s2 = map_metadata(id="s2",m2,s2)
+
+s3 = blank(id="s3",duration=0.04)
+
+def m3(_) =
+  [("id","s3")]
+end
+
+s3 = map_metadata(id="s3",m3,s3)
+
+def f(m) =
+  s2_ready := !s2_ready or m["id"] == "s3"
+  selected := list.cons(m["id"],!selected)
+end
+
+s = rotate([s1,s2,s3])
+
+s = on_track(f,s)
+
+output.dummy(s)
+
+def on_done () =
+  s = list.rev(!selected)
+  if list.nth(default="",s,0) == "s1" and
+     list.nth(default="",s,1) == "s3" and
+     list.nth(default="",s,2) == "s1" and
+     list.nth(default="",s,3) == "s2" and
+     list.nth(default="",s,4) == "s3" then
+    test.pass()
+  else
+    test.fail()
+  end
+
+  shutdown()
+end
+
+thread.run(delay=1., on_done)


### PR DESCRIPTION
The current implementation of source selection on `rotate` operator is too obscure and actually bug prone. Here's one example:

- If children sources are: `[s1, s2, s3, s4]` all with weight `1`.
- `pos` is `2`
- `s2` ends its track
- `s2` is unavailable after finishing its track, all other sources are
- The calculated `ready_list` will then contain: `[s1, s3, s4]`
- The algorithm selects `s4` as `pos+1`

The issue here is that unavailable sources should be skipped over but the selection list should respect original positions and move on to the next source in the list if the source to be selected isn't available.

This PR implements that and, hopefully, clarifies the code a bit.