### PR TITLE
Make it possible to disable overrun logs.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -33,6 +33,7 @@ New:
 - Add `string.null_terminated` (#960).
 - Add `file.metadata` (#1058).
 - Add `predicate.activates`, `predicate.changes`, `predicate.once` (#1075).
+- Make it possible to disable buffer overrun logs.
 
 Changed:
 

--- a/src/stream/generator.mli
+++ b/src/stream/generator.mli
@@ -266,6 +266,7 @@ module From_audio_video_plus : sig
     ?overfull:overfull ->
     kind:Frame.content_kind ->
     log:(string -> unit) ->
+    log_overfull:bool ->
     mode ->
     t
 


### PR DESCRIPTION
In some cases, buffer overruns are okay, for instance when intentionally leaving a `input.harbor` behind a switch, waiting to be played. 