### PR TITLE
Check sources content when passing sources to an operator.

### DIFF
--- a/src/lang/lang.ml
+++ b/src/lang/lang.ml
@@ -389,6 +389,8 @@ let add_operator ~category ~descr ?(flags = []) ?(active = false) name proto
           raise (Lang_errors.Clock_conflict (t.T.pos, a, b))
       | Source.Clock_loop (a, b) ->
           raise (Lang_errors.Clock_loop (t.T.pos, a, b))
+      | Source.Invalid_kind (a, b) ->
+          raise (Lang_errors.Invalid_kind (t.T.pos, a, b))
   in
   let kind_type = kind_type_of_kind_format kind in
   let return_t = Term.source_t ~active kind_type in

--- a/src/lang/lang_errors.ml
+++ b/src/lang/lang_errors.ml
@@ -29,6 +29,9 @@ exception Invalid_value of Term.V.value * string
 exception Clock_conflict of (T.pos option * string * string)
 exception Clock_loop of (T.pos option * string * string)
 
+exception
+  Invalid_kind of (T.pos option * Frame.content_kind * Frame.content_kind)
+
 let error = Console.colorize [`red; `bold] "Error"
 let warning = Console.colorize [`magenta; `bold] "Warning"
 let position pos = Console.colorize [`bold] (String.capitalize_ascii pos)
@@ -155,6 +158,17 @@ let report lexbuf f =
             (Encoder.string_of_format fmt);
           raise Error
       | Sedlexing.MalFormed -> print_error 13 "Malformed file."
+      | Invalid_kind (pos, dst, src) ->
+          error_header 14 (T.print_pos (Utils.get_some pos));
+          Format.printf
+            "Incompatible source content! You are passing a source of type:@.  \
+             %s@.to an operator that only accepts sources of type:@.  \
+             %s@.Source content are inferred from the outputs, so make@ sure \
+             to check the content accepted by your outputs and@ use \
+             `drop_{audio,video}` and source content annotation,@ e.g. `s = \
+             (s:source(2,1,0))`.@]@."
+            (Frame.string_of_content_kind src)
+            (Frame.string_of_content_kind dst)
       | End_of_file -> raise End_of_file
       | e ->
           print_error (-1) "Unknown error";

--- a/src/lang/lang_errors.mli
+++ b/src/lang/lang_errors.mli
@@ -26,6 +26,10 @@ exception Invalid_value of Lang_values.V.value * string
 exception Clock_conflict of (Lang_types.pos option * string * string)
 exception Clock_loop of (Lang_types.pos option * string * string)
 
+exception
+  Invalid_kind of
+    (Lang_types.pos option * Frame.content_kind * Frame.content_kind)
+
 (** Exception raised by report_error after an error has been displayed.
   * Unknown errors are re-raised, so that their content is not totally lost. *)
 exception Error

--- a/src/source.ml
+++ b/src/source.ml
@@ -177,6 +177,7 @@ let var_eq a b =
 
 exception Clock_conflict of string * string
 exception Clock_loop of string * string
+exception Invalid_kind of (Frame.content_kind * Frame.content_kind)
 
 let rec sub_clocks = function
   | Known c -> c#sub_clocks
@@ -273,6 +274,15 @@ let add_new_output, iterate_new_outputs =
         l := []) )
 
 class virtual operator ?(name = "src") content_kind sources =
+  let () =
+    List.iter
+      (fun source ->
+        (* We want content_kind to be able to accept at least
+         * what source#kind has. *)
+        if not (Frame.kind_sub_kind source#kind content_kind) then
+          raise (Invalid_kind (content_kind, source#kind)))
+      sources
+  in
   object (self)
     (** Monitoring *)
     val mutable watchers = []

--- a/src/source.mli
+++ b/src/source.mli
@@ -280,6 +280,7 @@ class type clock =
 
 exception Clock_conflict of string * string
 exception Clock_loop of string * string
+exception Invalid_kind of (Frame.content_kind * Frame.content_kind)
 
 module Clock_variables : sig
   val to_string : clock_variable -> string


### PR DESCRIPTION
This is a fix for #1136. Now that we don't silently accept to change internal frame's content on the fly (see: #1083), we are now seeing cases of incompatible source content that were previously silently accepted at runtime.

These changes add a new check for these cases and raise an error with, hopefully, a user-friendly error:
![Screenshot 2020-04-04 11 25 10](https://user-images.githubusercontent.com/871060/78456132-86976800-7667-11ea-9f1a-3c88341e98d4.png)
