### PR TITLE
Fix operators return type.

### DIFF
--- a/src/conversions/audio_to_stereo.ml
+++ b/src/conversions/audio_to_stereo.ml
@@ -52,7 +52,7 @@ let () =
   let input_kind = Lang.kind_type_of_kind_format Lang.audio_any in
   Lang.add_operator "audio_to_stereo" ~category:Lang.Conversions
     ~descr:"Convert any kind of audio source into a stereo source."
-    ~kind:Lang.audio_stereo
+    ~return_t:(Lang.kind_type_of_kind_format Lang.audio_stereo)
     [("", Lang.source_t input_kind, None, None)]
     (fun p kind ->
       let s = new basic ~kind (Lang.to_source (List.assoc "" p)) in

--- a/src/conversions/drop.ml
+++ b/src/conversions/drop.ml
@@ -60,8 +60,7 @@ let () =
                   let source = Lang.to_source (List.assoc "" p) in
                   new drop ~kind ~midi:true ~name:"drop_midi" source )
       in
-      Lang.add_operator name ~category:Lang.Conversions ~descr
-        ~kind:(Lang.Unconstrained output)
+      Lang.add_operator name ~category:Lang.Conversions ~descr ~return_t:output
         [("", Lang.source_t input, None, None)]
         (fun p kind -> (source p kind :> Source.source)))
     [`Audio; `Video; `Midi]

--- a/src/conversions/mean.ml
+++ b/src/conversions/mean.ml
@@ -55,7 +55,7 @@ let () =
   in
   Lang.add_operator "mean"
     [("", Lang.source_t in_kind, None, None)]
-    ~kind:(Lang.Unconstrained out_kind) ~category:Lang.Conversions
+    ~return_t:out_kind ~category:Lang.Conversions
     ~descr:"Produce mono audio by taking the mean of all audio channels."
     (fun p kind ->
       let s = Lang.to_source (Lang.assoc "" 1 p) in

--- a/src/conversions/mux.ml
+++ b/src/conversions/mux.ml
@@ -146,7 +146,7 @@ let () =
     ~descr:
       "Add video channnels to a stream. Both sources need to be infallible. \
        Track marks and metadata are taken from both sources."
-    ~kind:(Lang.Unconstrained out_t)
+    ~return_t:out_t
     [
       ("video", Lang.source_t aux_t, None, None);
       ("", Lang.source_t main_t, None, None);
@@ -165,7 +165,7 @@ let () =
     ~descr:
       "Mux an audio stream into an audio-free stream. Both sources need to be \
        infallible. Track marks and metadata are taken from both sources."
-    ~kind:(Lang.Unconstrained out_t)
+    ~return_t:out_t
     [
       ("audio", Lang.source_t aux_t, None, None);
       ("", Lang.source_t main_t, None, None);

--- a/src/conversions/swap.ml
+++ b/src/conversions/swap.ml
@@ -60,7 +60,7 @@ let () =
   let k = Lang.kind_type_of_kind_format Lang.audio_stereo in
   Lang.add_operator "swap"
     [("", Lang.source_t k, None, None)]
-    ~kind:(Lang.Unconstrained k) ~category:Lang.Conversions
+    ~return_t:k ~category:Lang.Conversions
     ~descr:"Swap two channels of a stereo source."
     (fun p kind ->
       let s = Lang.to_source (Lang.assoc "" 1 p) in

--- a/src/io/alsa_io.ml
+++ b/src/io/alsa_io.ml
@@ -298,7 +298,7 @@ let () =
           Some "Alsa device to use" );
         ("", Lang.source_t k, None, None);
       ] )
-    ~kind:(Lang.Unconstrained k) ~category:Lang.Output
+    ~return_t:k ~category:Lang.Output
     ~descr:"Output the source's stream to an ALSA output device."
     (fun p kind ->
       let e f v = f (List.assoc v p) in
@@ -342,8 +342,7 @@ let () =
           Some (Lang.string "default"),
           Some "Alsa device to use" );
       ] )
-    ~kind:(Lang.Unconstrained k) ~category:Lang.Input
-    ~descr:"Stream from an ALSA input device."
+    ~return_t:k ~category:Lang.Input ~descr:"Stream from an ALSA input device."
     (fun p kind ->
       let e f v = f (List.assoc v p) in
       let bufferize = e Lang.to_bool "bufferize" in

--- a/src/io/ffmpeg_io.ml
+++ b/src/io/ffmpeg_io.ml
@@ -180,7 +180,7 @@ let () =
              string." );
         ("", Lang.string_t, None, Some "URL to decode.");
       ] )
-    ~kind:(Lang.Unconstrained k)
+    ~return_t:k
     (fun p kind ->
       let start = Lang.to_bool (List.assoc "start" p) in
       let on_start =

--- a/src/io/gstreamer_io.ml
+++ b/src/io/gstreamer_io.ml
@@ -308,7 +308,7 @@ class output ~kind ~clock_safe ~on_error ~infallible ~on_start ~on_stop
     method output_reset = ()
   end
 
-let output_proto ~kind ~pipeline =
+let output_proto ~return_t ~pipeline =
   Output.proto
   @ [
       ( "clock_safe",
@@ -327,16 +327,16 @@ let output_proto ~kind ~pipeline =
         Lang.string_t,
         Some (Lang.string pipeline),
         Some "GStreamer pipeline for sink." );
-      ("", Lang.source_t kind, None, None);
+      ("", Lang.source_t return_t, None, None);
     ]
 
 let () =
   let kind = Lang.any_with ~audio:1 () in
-  let kind = Lang.kind_type_of_kind_format kind in
+  let return_t = Lang.kind_type_of_kind_format kind in
   Lang.add_operator "output.gstreamer.audio" ~active:true
-    (output_proto ~kind ~pipeline:"autoaudiosink")
+    (output_proto ~return_t ~pipeline:"autoaudiosink")
     ~category:Lang.Output ~descr:"Output stream to a GStreamer pipeline."
-    ~kind:(Lang.Unconstrained kind) (fun p kind ->
+    ~return_t (fun p kind ->
       let clock_safe = Lang.to_bool (List.assoc "clock_safe" p) in
       let pipeline = Lang.to_string (List.assoc "pipeline" p) in
       let infallible = not (Lang.to_bool (List.assoc "fallible" p)) in
@@ -363,11 +363,11 @@ let () =
 
 let () =
   let kind = Lang.any_with ~video:1 () in
-  let kind = Lang.kind_type_of_kind_format kind in
+  let return_t = Lang.kind_type_of_kind_format kind in
   Lang.add_operator "output.gstreamer.video" ~active:true
-    (output_proto ~kind ~pipeline:"videoconvert ! autovideosink")
+    (output_proto ~return_t ~pipeline:"videoconvert ! autovideosink")
     ~category:Lang.Output ~descr:"Output stream to a GStreamer pipeline."
-    ~kind:(Lang.Unconstrained kind) (fun p kind ->
+    ~return_t (fun p kind ->
       let clock_safe = Lang.to_bool (List.assoc "clock_safe" p) in
       let pipeline = Lang.to_string (List.assoc "pipeline" p) in
       let infallible = not (Lang.to_bool (List.assoc "fallible" p)) in
@@ -394,9 +394,9 @@ let () =
 
 let () =
   let kind = Lang.any_with ~audio:1 ~video:1 () in
-  let kind = Lang.kind_type_of_kind_format kind in
+  let return_t = Lang.kind_type_of_kind_format kind in
   Lang.add_operator "output.gstreamer.audio_video" ~active:true
-    ( output_proto ~kind ~pipeline:""
+    ( output_proto ~return_t ~pipeline:""
     @ [
         ( "audio_pipeline",
           Lang.string_t,
@@ -412,7 +412,7 @@ let () =
           Some "Pushing buffers is blocking." );
       ] )
     ~category:Lang.Output ~descr:"Output stream to a GStreamer pipeline."
-    ~kind:(Lang.Unconstrained kind)
+    ~return_t
     (fun p kind ->
       let clock_safe = Lang.to_bool (List.assoc "clock_safe" p) in
       let pipeline = Lang.to_string (List.assoc "pipeline" p) in
@@ -678,7 +678,7 @@ let input_proto =
   ]
 
 let () =
-  let k =
+  let return_t =
     Lang.kind_type_of_kind_format
       (Lang.Constrained
          {
@@ -704,8 +704,8 @@ let () =
           Some "Video pipeline to input from." );
       ]
   in
-  Lang.add_operator "input.gstreamer.audio_video" proto
-    ~kind:(Lang.Unconstrained k) ~category:Lang.Input ~flags:[]
+  Lang.add_operator "input.gstreamer.audio_video" proto ~return_t
+    ~category:Lang.Input ~flags:[]
     ~descr:"Stream audio+video from a GStreamer pipeline." (fun p kind ->
       let pipeline = Lang.to_string_getter (List.assoc "pipeline" p) in
       let audio_pipeline =
@@ -720,7 +720,7 @@ let () =
         :> Source.source ))
 
 let () =
-  let k = Lang.kind_type_of_kind_format Lang.audio_any in
+  let return_t = Lang.kind_type_of_kind_format Lang.audio_any in
   let proto =
     input_proto
     @ [
@@ -730,15 +730,14 @@ let () =
           Some "GStreamer pipeline to input from." );
       ]
   in
-  Lang.add_operator "input.gstreamer.audio" proto ~kind:(Lang.Unconstrained k)
-    ~category:Lang.Input ~flags:[]
-    ~descr:"Stream audio from a GStreamer pipeline." (fun p kind ->
+  Lang.add_operator "input.gstreamer.audio" proto ~return_t ~category:Lang.Input
+    ~flags:[] ~descr:"Stream audio from a GStreamer pipeline." (fun p kind ->
       let pipeline = Lang.to_string_getter (List.assoc "pipeline" p) in
       ( new audio_video_input p kind ((fun () -> ""), Some pipeline, None)
         :> Source.source ))
 
 let () =
-  let k = Lang.kind_type_of_kind_format (Lang.video_n 1) in
+  let return_t = Lang.kind_type_of_kind_format (Lang.video_n 1) in
   let proto =
     input_proto
     @ [
@@ -748,9 +747,8 @@ let () =
           Some "GStreamer pipeline to input from." );
       ]
   in
-  Lang.add_operator "input.gstreamer.video" proto ~kind:(Lang.Unconstrained k)
-    ~category:Lang.Input ~flags:[]
-    ~descr:"Stream video from a GStreamer pipeline." (fun p kind ->
+  Lang.add_operator "input.gstreamer.video" proto ~return_t ~category:Lang.Input
+    ~flags:[] ~descr:"Stream video from a GStreamer pipeline." (fun p kind ->
       let pipeline = Lang.to_string_getter (List.assoc "pipeline" p) in
       ( new audio_video_input p kind ((fun () -> ""), None, Some pipeline)
         :> Source.source ))

--- a/src/io/oss_io.ml
+++ b/src/io/oss_io.ml
@@ -154,7 +154,7 @@ let () =
           Some "OSS device to use." );
         ("", Lang.source_t k, None, None);
       ] )
-    ~kind:(Lang.Unconstrained k) ~category:Lang.Output
+    ~return_t:k ~category:Lang.Output
     ~descr:"Output the source's stream to an OSS output device."
     (fun p kind ->
       let e f v = f (List.assoc v p) in
@@ -187,8 +187,7 @@ let () =
           Some (Lang.string "/dev/dsp"),
           Some "OSS device to use." );
       ] )
-    ~kind:(Lang.Unconstrained k) ~category:Lang.Input
-    ~descr:"Stream from an OSS input device."
+    ~return_t:k ~category:Lang.Input ~descr:"Stream from an OSS input device."
     (fun p kind ->
       let e f v = f (List.assoc v p) in
       let clock_safe = e Lang.to_bool "clock_safe" in

--- a/src/io/portaudio_io.ml
+++ b/src/io/portaudio_io.ml
@@ -194,7 +194,7 @@ let () =
           Some "Length of a buffer in samples." );
         ("", Lang.source_t k, None, None);
       ] )
-    ~kind:(Lang.Unconstrained k) ~category:Lang.Output
+    ~return_t:k ~category:Lang.Output
     ~descr:"Output the source's stream to a portaudio output device."
     (fun p kind ->
       let e f v = f (List.assoc v p) in
@@ -226,7 +226,7 @@ let () =
           Some (Lang.int 256),
           Some "Length of a buffer in samples." );
       ] )
-    ~kind:(Lang.Unconstrained k) ~category:Lang.Input
+    ~return_t:k ~category:Lang.Input
     ~descr:"Stream from a portaudio input device."
     (fun p kind ->
       let e f v = f (List.assoc v p) in

--- a/src/io/pulseaudio_io.ml
+++ b/src/io/pulseaudio_io.ml
@@ -212,7 +212,7 @@ let () =
   in
   Lang.add_operator "output.pulseaudio" ~active:true
     (Output.proto @ proto @ [("", Lang.source_t k, None, None)])
-    ~kind:(Lang.Unconstrained k) ~category:Lang.Output
+    ~return_t:k ~category:Lang.Output
     ~descr:"Output the source's stream to a portaudio output device."
     (fun p kind ->
       let infallible = not (Lang.to_bool (List.assoc "fallible" p)) in
@@ -228,6 +228,6 @@ let () =
       (new output ~infallible ~on_start ~on_stop ~start ~kind p :> Source.source));
   Lang.add_operator "input.pulseaudio" ~active:true
     (Start_stop.input_proto @ proto)
-    ~kind:(Lang.Unconstrained k) ~category:Lang.Input
+    ~return_t:k ~category:Lang.Input
     ~descr:"Stream from a portaudio input device." (fun p kind ->
       (new input ~kind p :> Source.source))

--- a/src/io/srt_io.ml
+++ b/src/io/srt_io.ml
@@ -359,9 +359,8 @@ class input ~kind ~bind_address ~max ~log_overfull ~payload_size ~clock_safe
   end
 
 let () =
-  let kind = Lang.univ_t () in
-  Lang.add_operator "input.srt" ~kind:(Lang.Unconstrained kind)
-    ~category:Lang.Input
+  let return_t = Lang.univ_t () in
+  Lang.add_operator "input.srt" ~return_t ~category:Lang.Input
     ~descr:"Start a SRT agent in listener mode to receive and decode a stream."
     [
       ( "bind_address",
@@ -605,9 +604,9 @@ class output ~kind ~payload_size ~messageapi ~on_start ~on_stop ~infallible
   end
 
 let () =
-  let kind = Lang.univ_t () in
-  Lang.add_operator "output.srt" ~active:true ~kind:(Lang.Unconstrained kind)
-    ~category:Lang.Output ~descr:"Send a SRT stream to a distant host."
+  let return_t = Lang.univ_t () in
+  Lang.add_operator "output.srt" ~active:true ~return_t ~category:Lang.Output
+    ~descr:"Send a SRT stream to a distant host."
     ( Output.proto
     @ [
         ( "host",
@@ -632,8 +631,8 @@ let () =
           Lang.bool_t,
           Some (Lang.bool true),
           Some "Use message api" );
-        ("", Lang.format_t kind, None, Some "Encoding format.");
-        ("", Lang.source_t kind, None, None);
+        ("", Lang.format_t return_t, None, Some "Encoding format.");
+        ("", Lang.source_t return_t, None, None);
       ] )
     (fun p kind ->
       let hostname = Lang.to_string (List.assoc "host" p) in

--- a/src/io/udp_io.ml
+++ b/src/io/udp_io.ml
@@ -177,7 +177,7 @@ let () =
         ("", Lang.format_t k, None, Some "Encoding format.");
         ("", Lang.source_t k, None, None);
       ] )
-    ~kind:(Lang.Unconstrained k)
+    ~return_t:k
     (fun p kind ->
       (* Generic output parameters *)
       let autostart = Lang.to_bool (List.assoc "start" p) in
@@ -225,7 +225,7 @@ let () =
         Some "Log when the source's buffer is overfull." );
       ("", Lang.string_t, None, Some "Mime type.");
     ]
-    ~kind:(Lang.Unconstrained k)
+    ~return_t:k
     (fun p kind ->
       (* Specific UDP parameters *)
       let port = Lang.to_int (List.assoc "port" p) in

--- a/src/lang/builtins_ffmpeg_filters.ml
+++ b/src/lang/builtins_ffmpeg_filters.ml
@@ -245,10 +245,9 @@ let () =
       Avfilter.(Hashtbl.add graph.entries.inputs.audio name s#set_input);
       Audio.to_value (`Output (List.hd Avfilter.(abuffer.io.outputs.audio))));
 
-  let kind = Lang.kind_type_of_kind_format Lang.audio_any in
+  let return_t = Lang.kind_type_of_kind_format Lang.audio_any in
   Lang.add_operator "ffmpeg.filter.audio.output" ~category:Lang.Output
-    ~descr:"Return an audio source from a filter's output"
-    ~kind:(Lang.Unconstrained kind)
+    ~descr:"Return an audio source from a filter's output" ~return_t
     [("", Graph.t, None, None); ("", Audio.t, None, None)] (fun p kind ->
       let graph_v = Lang.assoc "" 1 p in
       let config = get_config graph_v in
@@ -281,10 +280,9 @@ let () =
       Avfilter.(Hashtbl.add graph.entries.inputs.video name s#set_input);
       Video.to_value (`Output (List.hd Avfilter.(buffer.io.outputs.video))));
 
-  let kind = Lang.kind_type_of_kind_format Lang.video_only in
+  let return_t = Lang.kind_type_of_kind_format Lang.video_only in
   Lang.add_operator "ffmpeg.filter.video.output" ~category:Lang.Output
-    ~descr:"Return a video source from a filter's output"
-    ~kind:(Lang.Unconstrained kind)
+    ~descr:"Return a video source from a filter's output" ~return_t
     [("", Graph.t, None, None); ("", Video.t, None, None)] (fun p kind ->
       let graph_v = Lang.assoc "" 1 p in
       let config = get_config graph_v in

--- a/src/lang/lang.ml
+++ b/src/lang/lang.ml
@@ -355,7 +355,7 @@ let string_of_category x =
   * so we have to force its value withing the acceptable range. *)
 
 let add_operator ~category ~descr ?(flags = []) ?(active = false) name proto
-    ~kind f =
+    ~return_t f =
   let compare (x, _, _, _) (y, _, _, _) =
     match (x, y) with
       | "", "" -> 0
@@ -390,8 +390,7 @@ let add_operator ~category ~descr ?(flags = []) ?(active = false) name proto
       | Source.Clock_loop (a, b) ->
           raise (Lang_errors.Clock_loop (t.T.pos, a, b))
   in
-  let kind_type = kind_type_of_kind_format kind in
-  let return_t = Term.source_t ~active kind_type in
+  let return_t = Term.source_t ~active return_t in
   let category = string_of_category category in
   add_builtin ~category ~descr ~flags name proto return_t f
 

--- a/src/lang/lang.mli
+++ b/src/lang/lang.mli
@@ -193,7 +193,7 @@ val add_operator :
   ?active:bool ->
   string ->
   proto ->
-  kind:lang_kind_formats ->
+  return_t:t ->
   (env -> Frame.content_kind -> Source.source) ->
   unit
 

--- a/src/operators/add.ml
+++ b/src/operators/add.ml
@@ -169,7 +169,7 @@ let () =
            for the homogeneous distribution." );
       ("", Lang.list_t (Lang.source_t kind_t), None, None);
     ]
-    ~kind
+    ~return_t:kind_t
     (fun p kind ->
       let sources = Lang.to_source_list (List.assoc "" p) in
       let weights =
@@ -227,7 +227,7 @@ let () =
         Some "Scale preserving the proportions." );
       ("", Lang.list_t (Lang.source_t kind_t), None, None);
     ]
-    ~kind
+    ~return_t:kind_t
     (fun p kind ->
       let sources = Lang.to_source_list (List.assoc "" p) in
       let weights =

--- a/src/operators/amplify.ml
+++ b/src/operators/amplify.ml
@@ -88,7 +88,7 @@ let () =
            disable." );
       ("", Lang.source_t k, None, None);
     ]
-    ~kind:(Lang.Unconstrained k) ~category:Lang.SoundProcessing
+    ~return_t:k ~category:Lang.SoundProcessing
     ~descr:"Multiply the amplitude of the signal."
     (fun p kind ->
       let c = Lang.to_float_getter (Lang.assoc "" 1 p) in

--- a/src/operators/append.ml
+++ b/src/operators/append.ml
@@ -162,7 +162,7 @@ let register =
            This source is allowed to fail (produce nothing) if no relevant \
            track is to be appended." );
     ]
-    ~kind:(Lang.Unconstrained k) ~category:Lang.TrackProcessing
+    ~return_t:k ~category:Lang.TrackProcessing
     ~descr:
       "Append an extra track to every track. Set the metadata 'liq_append' to \
        'false' to inhibit appending on one track."

--- a/src/operators/biquad_filter.ml
+++ b/src/operators/biquad_filter.ml
@@ -64,8 +64,7 @@ let () =
         Some "Shelf slope (dB/octave)" );
       ("", Lang.source_t k, None, None);
     ]
-    ~kind:(Lang.Unconstrained k) ~category:Lang.SoundProcessing
-    ~descr:"Low shelf biquad filter."
+    ~return_t:k ~category:Lang.SoundProcessing ~descr:"Low shelf biquad filter."
     (fun p kind ->
       let f v = List.assoc v p in
       let freq, param, src =
@@ -86,7 +85,7 @@ let () =
         Some "Shelf slope (in dB/octave)" );
       ("", Lang.source_t k, None, None);
     ]
-    ~kind:(Lang.Unconstrained k) ~category:Lang.SoundProcessing
+    ~return_t:k ~category:Lang.SoundProcessing
     ~descr:"High shelf biquad filter."
     (fun p kind ->
       let f v = List.assoc v p in
@@ -105,8 +104,7 @@ let () =
       ("q", Lang.float_t, Some (Lang.float 1.), Some "Q");
       ("", Lang.source_t k, None, None);
     ]
-    ~kind:(Lang.Unconstrained k) ~category:Lang.SoundProcessing
-    ~descr:"Low pass biquad filter."
+    ~return_t:k ~category:Lang.SoundProcessing ~descr:"Low pass biquad filter."
     (fun p kind ->
       let f v = List.assoc v p in
       let freq, param, src =
@@ -124,8 +122,7 @@ let () =
       ("q", Lang.float_t, Some (Lang.float 1.), Some "Q");
       ("", Lang.source_t k, None, None);
     ]
-    ~kind:(Lang.Unconstrained k) ~category:Lang.SoundProcessing
-    ~descr:"High pass biquad filter."
+    ~return_t:k ~category:Lang.SoundProcessing ~descr:"High pass biquad filter."
     (fun p kind ->
       let f v = List.assoc v p in
       let freq, param, src =
@@ -143,8 +140,7 @@ let () =
       ("q", Lang.float_t, Some (Lang.float 1.), Some "Q");
       ("", Lang.source_t k, None, None);
     ]
-    ~kind:(Lang.Unconstrained k) ~category:Lang.SoundProcessing
-    ~descr:"Band pass biquad filter."
+    ~return_t:k ~category:Lang.SoundProcessing ~descr:"Band pass biquad filter."
     (fun p kind ->
       let f v = List.assoc v p in
       let freq, param, src =
@@ -165,8 +161,7 @@ let () =
         Some "Bandwidth (in octaves)" );
       ("", Lang.source_t k, None, None);
     ]
-    ~kind:(Lang.Unconstrained k) ~category:Lang.SoundProcessing
-    ~descr:"All pass biquad filter."
+    ~return_t:k ~category:Lang.SoundProcessing ~descr:"All pass biquad filter."
     (fun p kind ->
       let f v = List.assoc v p in
       let freq, param, src =
@@ -184,8 +179,7 @@ let () =
       ("q", Lang.float_t, Some (Lang.float 1.), Some "Q");
       ("", Lang.source_t k, None, None);
     ]
-    ~kind:(Lang.Unconstrained k) ~category:Lang.SoundProcessing
-    ~descr:"Band pass biquad filter."
+    ~return_t:k ~category:Lang.SoundProcessing ~descr:"Band pass biquad filter."
     (fun p kind ->
       let f v = List.assoc v p in
       let freq, param, src =
@@ -204,8 +198,7 @@ let () =
       ("gain", Lang.float_t, Some (Lang.float 1.), Some "Gain (in dB)");
       ("", Lang.source_t k, None, None);
     ]
-    ~kind:(Lang.Unconstrained k) ~category:Lang.SoundProcessing
-    ~descr:"Peak EQ biquad filter."
+    ~return_t:k ~category:Lang.SoundProcessing ~descr:"Peak EQ biquad filter."
     (fun p kind ->
       let f v = List.assoc v p in
       let freq, param, gain, src =

--- a/src/operators/chord.ml
+++ b/src/operators/chord.ml
@@ -131,8 +131,7 @@ let () =
         Some "Name of the metadata containing the chords." );
       ("", Lang.source_t in_k, None, None);
     ]
-    ~kind:(Lang.Unconstrained out_k) ~category:Lang.MIDIProcessing
-    ~descr:"Generate a chord."
+    ~return_t:out_k ~category:Lang.MIDIProcessing ~descr:"Generate a chord."
     (fun p kind ->
       let f v = List.assoc v p in
       let src = Lang.to_source (f "") in

--- a/src/operators/clip.ml
+++ b/src/operators/clip.ml
@@ -50,7 +50,7 @@ let () =
   let k = Lang.kind_type_of_kind_format Lang.any in
   Lang.add_operator "clip"
     [("", Lang.source_t k, None, None)]
-    ~kind:(Lang.Unconstrained k) ~category:Lang.SoundProcessing
+    ~return_t:k ~category:Lang.SoundProcessing
     ~descr:
       "Clip samples, i.e. ensure that all values are between -1 and 1: values \
        lower than -1 become -1 and values higher than 1 become 1."

--- a/src/operators/comb.ml
+++ b/src/operators/comb.ml
@@ -73,8 +73,7 @@ let () =
         Some "Feedback coefficient in dB." );
       ("", Lang.source_t k, None, None);
     ]
-    ~kind:(Lang.Unconstrained k) ~category:Lang.SoundProcessing
-    ~descr:"Comb filter."
+    ~return_t:k ~category:Lang.SoundProcessing ~descr:"Comb filter."
     (fun p kind ->
       let f v = List.assoc v p in
       let duration, feedback, src =

--- a/src/operators/compand.ml
+++ b/src/operators/compand.ml
@@ -60,8 +60,7 @@ let () =
       ("mu", Lang.float_t, Some (Lang.float 1.), None);
       ("", Lang.source_t k, None, None);
     ]
-    ~kind:(Lang.Unconstrained k) ~category:Lang.SoundProcessing
-    ~descr:"Compand the signal"
+    ~return_t:k ~category:Lang.SoundProcessing ~descr:"Compand the signal"
     (fun p kind ->
       let f v = List.assoc v p in
       let mu, src = (Lang.to_float (f "mu"), Lang.to_source (f "")) in

--- a/src/operators/compress.ml
+++ b/src/operators/compress.ml
@@ -125,13 +125,13 @@ let () =
         Some (Lang.float 2.),
         Some "Gain reduction ratio (n:1)." )
     :: proto )
-    ~kind:(Lang.Unconstrained k) ~category:Lang.SoundProcessing
-    ~descr:"Compress the signal." compress;
+    ~return_t:k ~category:Lang.SoundProcessing ~descr:"Compress the signal."
+    compress;
   Lang.add_operator "limit"
     ( ( "ratio",
         Lang.float_getter_t (),
         Some (Lang.float 20.),
         Some "Gain reduction ratio (n:1)." )
     :: proto )
-    ~kind:(Lang.Unconstrained k) ~category:Lang.SoundProcessing
-    ~descr:"Limit the signal." compress
+    ~return_t:k ~category:Lang.SoundProcessing ~descr:"Limit the signal."
+    compress

--- a/src/operators/compress_exp.ml
+++ b/src/operators/compress_exp.ml
@@ -53,7 +53,7 @@ class compress ~kind (source : source) mu =
   end
 
 let () =
-  let kind = Lang.kind_type_of_kind_format Lang.any in
+  let return_t = Lang.kind_type_of_kind_format Lang.any in
   Lang.add_operator "compress.exponential" ~category:Lang.SoundProcessing
     ~descr:"Exponential compressor."
     [
@@ -61,9 +61,9 @@ let () =
         Lang.float_t,
         Some (Lang.float 2.),
         Some "Exponential compression factor, typically greater than 1." );
-      ("", Lang.source_t kind, None, None);
+      ("", Lang.source_t return_t, None, None);
     ]
-    ~kind:(Lang.Unconstrained kind)
+    ~return_t
     (fun p kind ->
       let f v = List.assoc v p in
       let mu, src = (Lang.to_float (f "mu"), Lang.to_source (f "")) in

--- a/src/operators/cross.ml
+++ b/src/operators/cross.ml
@@ -481,7 +481,7 @@ let () =
            transition, and the metadata." );
       ("", Lang.source_t k, None, None);
     ]
-    ~kind:(Lang.Unconstrained k) ~category:Lang.SoundProcessing
+    ~return_t:k ~category:Lang.SoundProcessing
     ~descr:
       "Cross operator, allowing the composition of the N last seconds of a \
        track with the beginning of the next track, using a transition function \

--- a/src/operators/cuepoint.ml
+++ b/src/operators/cuepoint.ml
@@ -258,9 +258,8 @@ class cue_cut ~kind ~m_cue_in ~m_cue_out (source : Source.source) =
   end
 
 let () =
-  let kind = Lang.kind_type_of_kind_format Lang.any in
-  Lang.add_operator "cue_cut" ~kind:(Lang.Unconstrained kind)
-    ~category:Lang.TrackProcessing
+  let return_t = Lang.kind_type_of_kind_format Lang.any in
+  Lang.add_operator "cue_cut" ~return_t ~category:Lang.TrackProcessing
     ~descr:
       "Start track after a cue in point and stop it at cue out point. The cue \
        points are given as metadata, in seconds from the begining of tracks."
@@ -273,7 +272,7 @@ let () =
         Lang.string_t,
         Some (Lang.string "liq_cue_out"),
         Some "Metadata for cue out points." );
-      ("", Lang.source_t kind, None, None);
+      ("", Lang.source_t return_t, None, None);
     ]
     (fun p kind ->
       let m_cue_in = Lang.to_string (Lang.assoc "cue_in_metadata" 1 p) in

--- a/src/operators/delay.ml
+++ b/src/operators/delay.ml
@@ -58,7 +58,7 @@ class delay ~kind ~initial (source : source) delay =
   end
 
 let () =
-  let kind = Lang.univ_t () in
+  let return_t = Lang.univ_t () in
   Lang.add_operator "delay"
     [
       ( "initial",
@@ -71,12 +71,12 @@ let () =
         Some
           "The source won't be ready less than this amount of seconds after \
            any end of track" );
-      ("", Lang.source_t kind, None, None);
+      ("", Lang.source_t return_t, None, None);
     ]
     ~category:Lang.TrackProcessing
     ~descr:
       "Prevents the child from being ready again too fast after a end of track"
-    ~kind:(Lang.Unconstrained kind)
+    ~return_t
     (fun p kind ->
       let f n = Lang.assoc "" n p in
       let d = Lang.to_float (f 1) in

--- a/src/operators/dyn_op.ml
+++ b/src/operators/dyn_op.ml
@@ -104,7 +104,6 @@ let () =
   let k = Lang.univ_t () in
   Lang.add_operator "source.dynamic"
     [("", Lang.fun_t [] (Lang.list_t (Lang.source_t k)), None, None)]
-    ~kind:(Lang.Unconstrained k)
-    ~descr:"Dynamically change the underlying source."
+    ~return_t:k ~descr:"Dynamically change the underlying source."
     ~category:Lang.TrackProcessing ~flags:[Lang.Experimental]
     (fun p kind -> new dyn ~kind (List.assoc "" p))

--- a/src/operators/echo.ml
+++ b/src/operators/echo.ml
@@ -74,8 +74,7 @@ let () =
         Some "Use ping-pong delay." );
       ("", Lang.source_t k, None, None);
     ]
-    ~kind:(Lang.Unconstrained k) ~category:Lang.SoundProcessing
-    ~descr:"Add echo."
+    ~return_t:k ~category:Lang.SoundProcessing ~descr:"Add echo."
     (fun p kind ->
       let f v = List.assoc v p in
       let duration, feedback, pp, src =

--- a/src/operators/filter.ml
+++ b/src/operators/filter.ml
@@ -51,14 +51,14 @@ class filter ~kind (source : source) freq q wet mode =
     val mutable notch = Array.make channels 0.
 
     (* State vartiable filter, see
-     http://www.musicdsp.org/archive.php?classid=3#23
+       http://www.musicdsp.org/archive.php?classid=3#23
 
-     TODO: the problem with this filter is that it only handles freq <= rate/4,
-     we have to find something better. See
-     http://www.musicdsp.org/showArchiveComment.php?ArchiveID=23
+       TODO: the problem with this filter is that it only handles freq <= rate/4,
+       we have to find something better. See
+       http://www.musicdsp.org/showArchiveComment.php?ArchiveID=23
 
-     Maybe should we implement Chamberlin's version instead, which handles freq
-     <= rate/2. See http://www.musicdsp.org/archive.php?classid=3#142 *)
+       Maybe should we implement Chamberlin's version instead, which handles freq
+       <= rate/2. See http://www.musicdsp.org/archive.php?classid=3#142 *)
     method private get_frame buf =
       let offset = AFrame.position buf in
       source#get buf;
@@ -109,7 +109,7 @@ let () =
            filtered and 0. means only original signal)." );
       ("", Lang.source_t k, None, None);
     ]
-    ~kind:(Lang.Unconstrained k) ~category:Lang.SoundProcessing
+    ~return_t:k ~category:Lang.SoundProcessing
     ~descr:"Perform several kinds of filtering on the signal"
     (fun p kind ->
       let f v = List.assoc v p in

--- a/src/operators/filter_rc.ml
+++ b/src/operators/filter_rc.ml
@@ -100,7 +100,7 @@ let () =
            filtered and 0. means only original signal)." );
       ("", Lang.source_t k, None, None);
     ]
-    ~kind:(Lang.Unconstrained k) ~category:Lang.SoundProcessing
+    ~return_t:k ~category:Lang.SoundProcessing
     ~descr:"First-order filter (RC filter)."
     (fun p kind ->
       let f v = List.assoc v p in

--- a/src/operators/fir_filter.ml
+++ b/src/operators/fir_filter.ml
@@ -173,8 +173,7 @@ let () =
       ("coeffs", Lang.int_t, Some (Lang.int 255), Some "Number of coefficients");
       ("", Lang.source_t k, None, None);
     ]
-    ~kind:(Lang.Unconstrained k) ~category:Lang.SoundProcessing
-    ~descr:"Low-pass FIR filter."
+    ~return_t:k ~category:Lang.SoundProcessing ~descr:"Low-pass FIR filter."
     (fun p kind ->
       let f v = List.assoc v p in
       let freq, beta, num, src =

--- a/src/operators/flanger.ml
+++ b/src/operators/flanger.ml
@@ -94,8 +94,7 @@ let () =
         Some "Phase difference between channels in radians." );
       ("", Lang.source_t k, None, None);
     ]
-    ~kind:(Lang.Unconstrained k) ~category:Lang.SoundProcessing
-    ~descr:"Flanger effect."
+    ~return_t:k ~category:Lang.SoundProcessing ~descr:"Flanger effect."
     (fun p kind ->
       let f v = List.assoc v p in
       let duration, freq, feedback, phase, src =

--- a/src/operators/frei0r_op.ml
+++ b/src/operators/frei0r_op.ml
@@ -307,11 +307,11 @@ let register_plugin fname =
   in
   if inputs > 2 then raise Unhandled_number_of_inputs;
   let k = if inputs = 0 then Lang.video_only else Lang.any_with ~video:1 () in
-  let k = Lang.kind_type_of_kind_format k in
+  let return_t = Lang.kind_type_of_kind_format k in
   let liq_params, params = params plugin info in
   let liq_params =
     let inputs =
-      List.init inputs (fun _ -> ("", Lang.source_t k, None, None))
+      List.init inputs (fun _ -> ("", Lang.source_t return_t, None, None))
     in
     liq_params @ inputs
   in
@@ -330,9 +330,8 @@ let register_plugin fname =
     a
   in
   let descr = Printf.sprintf "%s (by %s)." explanation author in
-  Lang.add_operator ("video.frei0r." ^ name) liq_params
-    ~kind:(Lang.Unconstrained k) ~category:Lang.VideoProcessing ~flags:[] ~descr
-    (fun p kind ->
+  Lang.add_operator ("video.frei0r." ^ name) liq_params ~return_t
+    ~category:Lang.VideoProcessing ~flags:[] ~descr (fun p kind ->
       let instance =
         let width = Lazy.force Frame.video_width in
         let height = Lazy.force Frame.video_height in

--- a/src/operators/iir_filter.ml
+++ b/src/operators/iir_filter.ml
@@ -463,8 +463,7 @@ let () =
       ("order", Lang.int_t, Some (Lang.int 4), Some "Filter order");
       ("", Lang.source_t k, None, None);
     ]
-    ~kind:(Lang.Unconstrained k) ~category:Lang.SoundProcessing
-    ~descr:"IIR filter"
+    ~return_t:k ~category:Lang.SoundProcessing ~descr:"IIR filter"
     (fun p kind ->
       let f v = List.assoc v p in
       let freq, order, src =
@@ -479,8 +478,7 @@ let () =
       ("order", Lang.int_t, Some (Lang.int 4), Some "Filter order");
       ("", Lang.source_t k, None, None);
     ]
-    ~kind:(Lang.Unconstrained k) ~category:Lang.SoundProcessing
-    ~descr:"IIR filter"
+    ~return_t:k ~category:Lang.SoundProcessing ~descr:"IIR filter"
     (fun p kind ->
       let f v = List.assoc v p in
       let freq, order, src =
@@ -496,8 +494,7 @@ let () =
       ("order", Lang.int_t, Some (Lang.int 4), Some "Filter order");
       ("", Lang.source_t k, None, None);
     ]
-    ~kind:(Lang.Unconstrained k) ~category:Lang.SoundProcessing
-    ~descr:"IIR filter"
+    ~return_t:k ~category:Lang.SoundProcessing ~descr:"IIR filter"
     (fun p kind ->
       let f v = List.assoc v p in
       let freq1, freq2, order, src =
@@ -514,8 +511,7 @@ let () =
       ("order", Lang.int_t, Some (Lang.int 4), Some "Filter order");
       ("", Lang.source_t k, None, None);
     ]
-    ~kind:(Lang.Unconstrained k) ~category:Lang.SoundProcessing
-    ~descr:"IIR filter"
+    ~return_t:k ~category:Lang.SoundProcessing ~descr:"IIR filter"
     (fun p kind ->
       let f v = List.assoc v p in
       let freq1, freq2, order, src =
@@ -531,8 +527,7 @@ let () =
       ("q", Lang.float_t, Some (Lang.float 60.), Some "Quality factor");
       ("", Lang.source_t k, None, None);
     ]
-    ~kind:(Lang.Unconstrained k) ~category:Lang.SoundProcessing
-    ~descr:"IIR filter"
+    ~return_t:k ~category:Lang.SoundProcessing ~descr:"IIR filter"
     (fun p kind ->
       let f v = List.assoc v p in
       let freq, q, src =
@@ -547,8 +542,7 @@ let () =
       ("q", Lang.float_t, Some (Lang.float 60.), Some "Quality factor");
       ("", Lang.source_t k, None, None);
     ]
-    ~kind:(Lang.Unconstrained k) ~category:Lang.SoundProcessing
-    ~descr:"IIR filter"
+    ~return_t:k ~category:Lang.SoundProcessing ~descr:"IIR filter"
     (fun p kind ->
       let f v = List.assoc v p in
       let freq, q, src =
@@ -563,8 +557,7 @@ let () =
       ("q", Lang.float_t, Some (Lang.float 60.), Some "Quality factor");
       ("", Lang.source_t k, None, None);
     ]
-    ~kind:(Lang.Unconstrained k) ~category:Lang.SoundProcessing
-    ~descr:"IIR filter"
+    ~return_t:k ~category:Lang.SoundProcessing ~descr:"IIR filter"
     (fun p kind ->
       let f v = List.assoc v p in
       let freq, q, src =

--- a/src/operators/ladspa_op.ml
+++ b/src/operators/ladspa_op.ml
@@ -296,25 +296,25 @@ let register_descr plugin_name descr_n d inputs outputs =
   let no = Array.length outputs in
   let mono = ni = 1 && no = 1 in
   let liq_params, params = params_of_descr d in
-  let k =
+  let input_t =
     Lang.kind_type_of_kind_format (if mono then Lang.any else Lang.audio_n ni)
   in
   let liq_params =
-    liq_params @ if ni = 0 then [] else [("", Lang.source_t k, None, None)]
+    liq_params
+    @ if ni = 0 then [] else [("", Lang.source_t input_t, None, None)]
   in
   let maker = Descriptor.maker d in
   let maker = Pcre.substitute ~pat:"@" ~subst:(fun _ -> "(at)") maker in
   let descr = Printf.sprintf "%s by %s." (Descriptor.name d) maker in
-  let k =
-    if mono then k
+  let return_t =
+    if mono then input_t
     else
       (* TODO: do we really need a fresh variable here? *)
       Lang.kind_type_of_kind_format (Lang.audio_n no)
   in
   Lang.add_operator
     ("ladspa." ^ Utils.normalize_parameter_string (Descriptor.label d))
-    liq_params ~kind:(Lang.Unconstrained k) ~category:Lang.SoundProcessing
-    ~flags:[] ~descr
+    liq_params ~return_t ~category:Lang.SoundProcessing ~flags:[] ~descr
     (fun p kind ->
       let f v = List.assoc v p in
       let source = try Some (Lang.to_source (f "")) with Not_found -> None in

--- a/src/operators/lilv_op.ml
+++ b/src/operators/lilv_op.ml
@@ -298,11 +298,12 @@ let register_plugin plugin =
   let no = Array.length outputs in
   let mono = ni = 1 && no = 1 in
   let liq_params, params = params_of_plugin plugin in
-  let k =
+  let input_t =
     Lang.kind_type_of_kind_format (if mono then Lang.any else Lang.audio_n ni)
   in
   let liq_params =
-    liq_params @ if ni = 0 then [] else [("", Lang.source_t k, None, None)]
+    liq_params
+    @ if ni = 0 then [] else [("", Lang.source_t input_t, None, None)]
   in
   let maker = Plugin.author_name plugin in
   let maker_homepage = Plugin.author_homepage plugin in
@@ -318,16 +319,15 @@ let register_plugin plugin =
     ^ "."
   in
   let descr = descr ^ " See <" ^ Plugin.uri plugin ^ ">." in
-  let k =
-    if mono then k
+  let return_t =
+    if mono then input_t
     else
       (* TODO: do we really need a fresh variable here? *)
       Lang.kind_type_of_kind_format (Lang.audio_n no)
   in
   Lang.add_operator
     ("lv2." ^ Utils.normalize_parameter_string (Plugin.name plugin))
-    liq_params ~kind:(Lang.Unconstrained k) ~category:Lang.SoundProcessing
-    ~flags:[] ~descr
+    liq_params ~return_t ~category:Lang.SoundProcessing ~flags:[] ~descr
     (fun p kind ->
       let f v = List.assoc v p in
       let source = try Some (Lang.to_source (f "")) with Not_found -> None in

--- a/src/operators/map_metadata.ml
+++ b/src/operators/map_metadata.ml
@@ -75,7 +75,7 @@ class map_metadata ~kind source rewrite_f insert_missing update strip =
   end
 
 let register =
-  let kind = Lang.univ_t () in
+  let return_t = Lang.univ_t () in
   Lang.add_operator "map_metadata"
     [
       ( "",
@@ -105,11 +105,10 @@ let register =
           "Treat track beginnings without metadata as having empty ones. The \
            operational order is: create empty if needed, map and strip if \
            enabled." );
-      ("", Lang.source_t kind, None, None);
+      ("", Lang.source_t return_t, None, None);
     ]
     ~category:Lang.TrackProcessing
-    ~descr:"Rewrite metadata on the fly using a function."
-    ~kind:(Lang.Unconstrained kind)
+    ~descr:"Rewrite metadata on the fly using a function." ~return_t
     (fun p kind ->
       let source = Lang.to_source (Lang.assoc "" 2 p) in
       let f = Lang.assoc "" 1 p in

--- a/src/operators/map_op.ml
+++ b/src/operators/map_op.ml
@@ -59,8 +59,7 @@ let () =
       ("", Lang.fun_t [(false, "", Lang.float_t)] Lang.float_t, None, None);
       ("", Lang.source_t k, None, None);
     ]
-    ~kind:(Lang.Unconstrained k)
-    ~descr:"Map a function to all audio samples. This is SLOW!"
+    ~return_t:k ~descr:"Map a function to all audio samples. This is SLOW!"
     ~category:Lang.SoundProcessing
     ~flags:[Lang.Hidden] (* It works well but is probably useless. *)
     (fun p kind ->

--- a/src/operators/max_duration.ml
+++ b/src/operators/max_duration.ml
@@ -83,7 +83,7 @@ class max_duration ~kind ~override_meta ~duration source =
   end
 
 let () =
-  let k = Lang.univ_t () in
+  let return_t = Lang.univ_t () in
   Lang.add_operator "max_duration"
     [
       ( "override",
@@ -93,10 +93,9 @@ let () =
           "Metadata field which, if present and containing a float, overrides \
            the remaining play time." );
       ("", Lang.float_t, None, Some "Maximum duration");
-      ("", Lang.source_t k, None, None);
+      ("", Lang.source_t return_t, None, None);
     ]
-    ~category:Lang.TrackProcessing ~descr:"Limit source duration"
-    ~kind:(Lang.Unconstrained k)
+    ~category:Lang.TrackProcessing ~descr:"Limit source duration" ~return_t
     (fun p kind ->
       let override_meta = Lang.to_string (List.assoc "override" p) in
       let duration =

--- a/src/operators/midi_routing.ml
+++ b/src/operators/midi_routing.ml
@@ -69,7 +69,7 @@ let () =
       ("track_out", Lang.int_t, Some (Lang.int 0), Some "Destination track.");
       ("", Lang.source_t k, None, None);
     ]
-    ~kind:(Lang.Unconstrained k) ~category:Lang.MIDIProcessing
+    ~return_t:k ~category:Lang.MIDIProcessing
     ~descr:"Merge all MIDI tracks in one."
     (fun p kind ->
       let f v = List.assoc v p in
@@ -84,8 +84,7 @@ let () =
       ("", Lang.list_t Lang.int_t, None, Some "Tracks to remove.");
       ("", Lang.source_t k, None, None);
     ]
-    ~kind:(Lang.Unconstrained k) ~category:Lang.MIDIProcessing
-    ~descr:"Remove MIDI tracks."
+    ~return_t:k ~category:Lang.MIDIProcessing ~descr:"Remove MIDI tracks."
     (fun p kind ->
       (* let f v = List.assoc v p in *)
       let t = List.map Lang.to_int (Lang.to_list (Lang.assoc "" 1 p)) in

--- a/src/operators/mixing_table.ml
+++ b/src/operators/mixing_table.ml
@@ -125,7 +125,7 @@ let () =
   let k = Lang.kind_type_of_kind_format Lang.any in
   Lang.add_operator "mix"
     [("", Lang.list_t (Lang.source_t k), None, None)]
-    ~kind:(Lang.Unconstrained k) ~category:Lang.SoundProcessing
+    ~return_t:k ~category:Lang.SoundProcessing
     ~descr:"Mixing table controllable via the telnet interface."
     (fun p kind ->
       let sources = Lang.to_source_list (List.assoc "" p) in

--- a/src/operators/ms_stereo.ml
+++ b/src/operators/ms_stereo.ml
@@ -67,7 +67,7 @@ let () =
   let k = Lang.kind_type_of_kind_format Lang.audio_stereo in
   Lang.add_operator "stereo.ms.encode"
     [("", Lang.source_t k, None, None)]
-    ~kind:(Lang.Unconstrained k) ~category:Lang.SoundProcessing
+    ~return_t:k ~category:Lang.SoundProcessing
     ~descr:"Encode left+right stereo to mid+side stereo (M/S)."
     (fun p kind ->
       let s = Lang.to_source (Lang.assoc "" 1 p) in
@@ -80,7 +80,7 @@ let () =
         Some "Width of the stereo field." );
       ("", Lang.source_t k, None, None);
     ]
-    ~kind:(Lang.Unconstrained k) ~category:Lang.SoundProcessing
+    ~return_t:k ~category:Lang.SoundProcessing
     ~descr:"Decode mid+side stereo (M/S) to left+right stereo."
     (fun p kind ->
       let s = Lang.to_source (Lang.assoc "" 1 p) in

--- a/src/operators/noblank.ml
+++ b/src/operators/noblank.ml
@@ -227,7 +227,7 @@ class eat ~kind ~track_sensitive ~at_beginning ~start_blank ~max_blank
       done
   end
 
-let kind = Lang.kind_type_of_kind_format Lang.any
+let return_t = Lang.kind_type_of_kind_format Lang.any
 
 let proto =
   [
@@ -251,7 +251,7 @@ let proto =
       Lang.bool_t,
       Some (Lang.bool true),
       Some "Reset blank counter at each track." );
-    ("", Lang.source_t kind, None, None);
+    ("", Lang.source_t return_t, None, None);
   ]
 
 let extract p =
@@ -277,8 +277,7 @@ let extract p =
   (start_blank, max_blank, min_noise, threshold, ts, s)
 
 let () =
-  Lang.add_operator "on_blank" ~kind:(Lang.Unconstrained kind)
-    ~category:Lang.TrackProcessing
+  Lang.add_operator "on_blank" ~return_t ~category:Lang.TrackProcessing
     ~descr:"Calls a given handler when detecting a blank."
     ( ( "",
         Lang.fun_t [] Lang.unit_t,
@@ -299,7 +298,7 @@ let () =
       new on_blank
         ~kind ~start_blank ~max_blank ~min_noise ~threshold ~track_sensitive
         ~on_blank ~on_noise s);
-  Lang.add_operator "strip_blank" ~active:true ~kind:(Lang.Unconstrained kind)
+  Lang.add_operator "strip_blank" ~active:true ~return_t
     ~category:Lang.TrackProcessing
     ~descr:"Make the source unavailable when it is streaming blank." proto
     (fun p kind ->
@@ -309,8 +308,7 @@ let () =
       ( new strip
           ~kind ~track_sensitive ~start_blank ~max_blank ~min_noise ~threshold s
         :> Source.source ));
-  Lang.add_operator "eat_blank" ~kind:(Lang.Unconstrained kind)
-    ~category:Lang.TrackProcessing
+  Lang.add_operator "eat_blank" ~return_t ~category:Lang.TrackProcessing
     ~descr:
       "Eat blanks, i.e., drop the contents of the stream until it is not blank \
        anymore."

--- a/src/operators/normalize.ml
+++ b/src/operators/normalize.ml
@@ -158,7 +158,7 @@ let () =
         Some "Maximal gain value (dB)." );
       ("", Lang.source_t k, None, None);
     ]
-    ~kind:(Lang.Unconstrained k) ~category:Lang.SoundProcessing
+    ~return_t:k ~category:Lang.SoundProcessing
     ~descr:
       "Normalize the signal. Dynamic normalization of the signal is sometimes \
        the only option, and can make a listening experience much nicer. \

--- a/src/operators/on_end.ml
+++ b/src/operators/on_end.ml
@@ -59,7 +59,7 @@ class on_end ~kind ~delay f s =
   end
 
 let () =
-  let kind = Lang.univ_t () in
+  let return_t = Lang.univ_t () in
   Lang.add_operator "on_end"
     [
       ( "delay",
@@ -77,13 +77,13 @@ let () =
           "Function to execute. First argument is the remaining time, second \
            is the latest metadata. That function should be fast because it is \
            executed in the main streaming thread." );
-      ("", Lang.source_t kind, None, None);
+      ("", Lang.source_t return_t, None, None);
     ]
     ~category:Lang.TrackProcessing
     ~descr:
       "Call a given handler when there is less than a given amount of time \
        remaining before then end of track."
-    ~kind:(Lang.Unconstrained kind)
+    ~return_t
     (fun p kind ->
       let delay = Lang.to_float_getter (List.assoc "delay" p) in
       let f = Lang.assoc "" 1 p in

--- a/src/operators/on_metadata.ml
+++ b/src/operators/on_metadata.ml
@@ -48,7 +48,7 @@ class on_metadata ~kind f s =
   end
 
 let () =
-  let kind = Lang.univ_t () in
+  let return_t = Lang.univ_t () in
   Lang.add_operator "on_metadata"
     [
       ( "",
@@ -61,11 +61,10 @@ let () =
         Some
           "Function called on every metadata packet in the stream. It should \
            be fast because it is executed in the main streaming thread." );
-      ("", Lang.source_t kind, None, None);
+      ("", Lang.source_t return_t, None, None);
     ]
     ~category:Lang.TrackProcessing
-    ~descr:"Call a given handler on metadata packets."
-    ~kind:(Lang.Unconstrained kind)
+    ~descr:"Call a given handler on metadata packets." ~return_t
     (fun p kind ->
       let f = Lang.assoc "" 1 p in
       let s = Lang.to_source (Lang.assoc "" 2 p) in

--- a/src/operators/on_offset.ml
+++ b/src/operators/on_offset.ml
@@ -92,7 +92,7 @@ class on_offset ~kind ~force ~offset ~override f s =
   end
 
 let () =
-  let kind = Lang.univ_t () in
+  let return_t = Lang.univ_t () in
   Lang.add_operator "on_offset"
     [
       ( "offset",
@@ -123,13 +123,13 @@ let () =
            the current track, second is the latest metadata. That function \
            should be fast because it is executed in the main streaming thread."
       );
-      ("", Lang.source_t kind, None, None);
+      ("", Lang.source_t return_t, None, None);
     ]
     ~category:Lang.TrackProcessing
     ~descr:
       "Call a given handler when position in track is equal or more than a \
        given amount of time."
-    ~kind:(Lang.Unconstrained kind)
+    ~return_t
     (fun p kind ->
       let offset = Lang.to_float (List.assoc "offset" p) in
       let force = Lang.to_bool (List.assoc "force" p) in

--- a/src/operators/on_track.ml
+++ b/src/operators/on_track.ml
@@ -54,7 +54,7 @@ class on_track ~kind f s =
   end
 
 let () =
-  let kind = Lang.univ_t () in
+  let return_t = Lang.univ_t () in
   Lang.add_operator "on_track"
     [
       ( "",
@@ -69,10 +69,10 @@ let () =
            corresponding metadata as argument. If there is no metadata at the \
            beginning of track, the empty list is passed. That function should \
            be fast because it is executed in the main streaming thread." );
-      ("", Lang.source_t kind, None, None);
+      ("", Lang.source_t return_t, None, None);
     ]
     ~category:Lang.TrackProcessing ~descr:"Call a given handler on new tracks."
-    ~kind:(Lang.Unconstrained kind)
+    ~return_t
     (fun p kind ->
       let f = Lang.assoc "" 1 p in
       let s = Lang.to_source (Lang.assoc "" 2 p) in

--- a/src/operators/pan.ml
+++ b/src/operators/pan.ml
@@ -67,8 +67,7 @@ let () =
         Some "Field width in degrees (between 0 and 90)." );
       ("", Lang.source_t k, None, None);
     ]
-    ~kind:(Lang.Unconstrained k) ~category:Lang.SoundProcessing
-    ~descr:"Pan a stereo sound."
+    ~return_t:k ~category:Lang.SoundProcessing ~descr:"Pan a stereo sound."
     (fun p kind ->
       let s = Lang.to_source (Lang.assoc "" 1 p) in
       let phi_0 = Lang.to_float_getter (Lang.assoc "field" 1 p) in

--- a/src/operators/pipe.ml
+++ b/src/operators/pipe.ml
@@ -271,7 +271,7 @@ class pipe ~kind ~replay_delay ~data_len ~process ~bufferize ~log_overfull ~max
         ()
   end
 
-let k = Lang.audio_any
+let return_t = Lang.kind_type_of_kind_format Lang.audio_any
 
 let proto =
   [
@@ -312,7 +312,7 @@ let proto =
       Lang.bool_t,
       Some (Lang.bool true),
       Some "Restart process when exited with error." );
-    ("", Lang.source_t (Lang.kind_type_of_kind_format k), None, None);
+    ("", Lang.source_t return_t, None, None);
   ]
 
 let pipe p kind =
@@ -342,5 +342,5 @@ let pipe p kind =
     :> source )
 
 let () =
-  Lang.add_operator "pipe" proto ~kind:k ~category:Lang.SoundProcessing
+  Lang.add_operator "pipe" proto ~return_t ~category:Lang.SoundProcessing
     ~descr:"Process audio signal through a given process stdin/stdout." pipe

--- a/src/operators/pitch.ml
+++ b/src/operators/pitch.ml
@@ -122,7 +122,7 @@ let () =
         Some "Maximal frequency" );
       ("", Lang.source_t k, None, None);
     ]
-    ~kind:(Lang.Unconstrained k) ~category:Lang.SoundProcessing
+    ~return_t:k ~category:Lang.SoundProcessing
     ~descr:"Compute the pitch of a sound."
     ~flags:[Lang.Hidden; Lang.Experimental]
     (fun p kind ->

--- a/src/operators/prepend.ml
+++ b/src/operators/prepend.ml
@@ -163,7 +163,7 @@ let register =
            relevant track is to be appended. However, success must be \
            immediate or it will not be taken into account." );
     ]
-    ~kind:(Lang.Unconstrained k) ~category:Lang.TrackProcessing
+    ~return_t:k ~category:Lang.TrackProcessing
     ~descr:
       ( "Prepend an extra track before every track. "
       ^ "Set the metadata 'liq_prepend' to 'false' to "

--- a/src/operators/resample.ml
+++ b/src/operators/resample.ml
@@ -162,7 +162,7 @@ class resample ~kind ~active ~ratio (source : source) =
   end
 
 let () =
-  let k = Lang.audio_any in
+  let return_t = Lang.kind_type_of_kind_format Lang.audio_any in
   Lang.add_operator "stretch" (* TODO better name *)
     [
       ( "ratio",
@@ -178,9 +178,9 @@ let () =
            based on what is streamed off the child source, which results in \
            time-dependent active sources to be frozen when that source is \
            stopped." );
-      ("", Lang.source_t (Lang.kind_type_of_kind_format k), None, None);
+      ("", Lang.source_t return_t, None, None);
     ]
-    ~kind:k ~category:Lang.SoundProcessing
+    ~return_t ~category:Lang.SoundProcessing
     ~descr:
       "Slow down or accelerate an audio stream by stretching (sounds lower) or \
        squeezing it (sounds higher)."

--- a/src/operators/sequence.ml
+++ b/src/operators/sequence.ml
@@ -143,7 +143,7 @@ let () =
     ~descr:
       "Play only one track of every successive source, except for the last one \
        which is played as much as available."
-    ~kind:(Lang.Unconstrained k)
+    ~return_t:k
     (fun p kind ->
       new sequence
         ~kind
@@ -158,5 +158,5 @@ let () =
     ~descr:
       "Merge consecutive tracks from the input source. They will be considered \
        as one big track, so `on_track()` will not trigger for example."
-    ~kind:(Lang.Unconstrained k)
+    ~return_t:k
     (fun p kind -> new merge_tracks ~kind (Lang.to_source (List.assoc "" p)))

--- a/src/operators/sleeper.ml
+++ b/src/operators/sleeper.ml
@@ -72,7 +72,7 @@ let () =
         Some "Freeze after given amount of time (don't freeze if negative)." );
       ("", Lang.source_t k, None, None);
     ]
-    ~kind:(Lang.Unconstrained k)
+    ~return_t:k
     ~descr:"Sleep at each frame. Useful for emulating network delays, etc."
     ~category:Lang.SoundProcessing
     ~flags:[Lang.Hidden; Lang.Experimental]

--- a/src/operators/soundtouch_op.ml
+++ b/src/operators/soundtouch_op.ml
@@ -100,15 +100,15 @@ class soundtouch ~kind (source : source) rate tempo pitch =
 
 let () =
   (* TODO: could we keep the video in some cases? *)
-  let k = Lang.kind_type_of_kind_format Lang.audio_any in
+  let return_t = Lang.kind_type_of_kind_format Lang.audio_any in
   Lang.add_operator "soundtouch"
     [
       ("rate", Lang.float_getter_t (), Some (Lang.float 1.0), None);
       ("tempo", Lang.float_getter_t (), Some (Lang.float 1.0), None);
       ("pitch", Lang.float_getter_t (), Some (Lang.float 1.0), None);
-      ("", Lang.source_t k, None, None);
+      ("", Lang.source_t return_t, None, None);
     ]
-    ~category:Lang.SoundProcessing ~kind:(Lang.Unconstrained k)
+    ~category:Lang.SoundProcessing ~return_t
     ~descr:"Change the rate, the tempo or the pitch of the sound."
     ~flags:[Lang.Experimental]
     (fun p kind ->

--- a/src/operators/st_bpm.ml
+++ b/src/operators/st_bpm.ml
@@ -74,8 +74,8 @@ let () =
         Some "Callback function." );
       ("", Lang.source_t k, None, None);
     ]
-    ~kind:(Lang.Unconstrained k) ~category:Lang.SoundProcessing
-    ~descr:"Detect the BPM." ~flags:[]
+    ~return_t:k ~category:Lang.SoundProcessing ~descr:"Detect the BPM."
+    ~flags:[]
     (fun p kind ->
       let f v = List.assoc v p in
       let every = Lang.to_float (f "every") in

--- a/src/operators/store_metadata.ml
+++ b/src/operators/store_metadata.ml
@@ -68,17 +68,17 @@ class store ~kind n s =
   end
 
 let () =
-  let kind = Lang.univ_t () in
+  let return_t = Lang.univ_t () in
   Lang.add_operator "store_metadata"
     [
       ("size", Lang.int_t, Some (Lang.int 10), Some "Size of the history");
-      ("", Lang.source_t kind, None, None);
+      ("", Lang.source_t return_t, None, None);
     ]
     ~category:Lang.TrackProcessing
     ~descr:
       "Keep track of the last N metadata packets in the stream, and make the \
        history available via a server command."
-    ~kind:(Lang.Unconstrained kind)
+    ~return_t
     (fun p kind ->
       let s = Lang.to_source (List.assoc "" p) in
       let size = Lang.to_int (List.assoc "size" p) in

--- a/src/operators/switch.ml
+++ b/src/operators/switch.ml
@@ -372,7 +372,7 @@ class lang_switch ~kind ~override_meta ~transition_length mode ?replay_meta
   end
 
 let () =
-  let kind = Lang.univ_t () in
+  let return_t = Lang.univ_t () in
   let pred_t = Lang.fun_t [] Lang.bool_t in
   let proto =
     [
@@ -383,7 +383,7 @@ let () =
           "Forbid the selection of a branch for two tracks in a row. The empty \
            list stands for `[false,...,false]`." );
       ( "",
-        Lang.list_t (Lang.product_t pred_t (Lang.source_t kind)),
+        Lang.list_t (Lang.product_t pred_t (Lang.source_t return_t)),
         None,
         Some "Sources with the predicate telling when they can be played." );
     ]
@@ -392,8 +392,8 @@ let () =
     ~descr:
       "At the beginning of a track, select the first source whose predicate is \
        true."
-    (common kind @ proto)
-    ~kind:(Lang.Unconstrained kind)
+    (common return_t @ proto)
+    ~return_t
     (fun p kind ->
       let children =
         List.map
@@ -448,19 +448,19 @@ class fallback ~kind ~override_meta ~transition_length ?replay_meta mode
   end
 
 let () =
-  let kind = Lang.univ_t () in
+  let return_t = Lang.univ_t () in
   let proto =
     [
       ( "",
-        Lang.list_t (Lang.source_t kind),
+        Lang.list_t (Lang.source_t return_t),
         None,
         Some "Select the first ready source in this list." );
     ]
   in
   Lang.add_operator "fallback" ~category:Lang.TrackProcessing
     ~descr:"At the beginning of each track, select the first ready child."
-    (common kind @ proto)
-    ~kind:(Lang.Unconstrained kind)
+    (common return_t @ proto)
+    ~return_t
     (fun p kind ->
       let children = Lang.to_source_list (List.assoc "" p) in
       let replay_meta, ts, tr, tl, override_meta =
@@ -519,18 +519,18 @@ class random ~kind ~override_meta ~transition_length ?replay_meta strict mode
 
 let () =
   let add name strict descr weight_descr =
-    let kind = Lang.univ_t () in
+    let return_t = Lang.univ_t () in
     let weight_t = Lang.int_getter_t () in
     Lang.add_operator name ~descr ~category:Lang.TrackProcessing
-      ( common kind
+      ( common return_t
       @ [
           ( "weights",
             Lang.list_t weight_t,
             Some (Lang.list ~t:weight_t []),
             Some weight_descr );
-          ("", Lang.list_t (Lang.source_t kind), None, None);
+          ("", Lang.list_t (Lang.source_t return_t), None, None);
         ] )
-      ~kind:(Lang.Unconstrained kind)
+      ~return_t
       (fun p kind ->
         let children = Lang.to_source_list (List.assoc "" p) in
         let replay_meta, ts, tr, tl, override_meta =

--- a/src/operators/time_warp.ml
+++ b/src/operators/time_warp.ml
@@ -133,7 +133,7 @@ let () =
           Some "Maximum amount of buffered data, in seconds." );
         ("", Lang.source_t k, None, None);
       ] )
-    ~kind:(Lang.Unconstrained k) ~category:Lang.Liquidsoap
+    ~return_t:k ~category:Lang.Liquidsoap
     ~descr:"Create a buffer between two different clocks."
     (fun p kind ->
       let infallible = not (Lang.to_bool (List.assoc "fallible" p)) in
@@ -189,20 +189,20 @@ module AdaptativeBuffer = struct
             assert (not c.buffering);
 
             (* Update the average length of the ringbuffer (with a damping
-             coefficient in order not to be too sensitive to quick local
-             variations). *)
+               coefficient in order not to be too sensitive to quick local
+               variations). *)
             (* y: average length, dt: frame duration, x: read length, A=a/dt
 
-             y(t+dt)=(1-a)y(t)+ax(t)
-             y'(t)=(a/dt)(x(t)-y(t))
-             y'(t)+Ay(t)=Ax(t)
+               y(t+dt)=(1-a)y(t)+ax(t)
+               y'(t)=(a/dt)(x(t)-y(t))
+               y'(t)+Ay(t)=Ax(t)
 
-             When x=x0 is constant and we start at y0, the solution is
-             y(t) = (y0-x0)exp(-At)+x0
+               When x=x0 is constant and we start at y0, the solution is
+               y(t) = (y0-x0)exp(-At)+x0
 
-             half-life is at th = ln(2)/A
-             we should thus choose alpha = (dt * ln 2)/th
-          *)
+               half-life is at th = ln(2)/A
+               we should thus choose alpha = (dt * ln 2)/th
+            *)
             c.rb_length <-
               ((1. -. alpha) *. c.rb_length)
               +. (alpha *. float (RB.read_space c.rb));
@@ -214,7 +214,7 @@ module AdaptativeBuffer = struct
             (* Fill dlen samples of dst using slen samples of the ringbuffer. *)
             let fill dst dofs dlen slen =
               (* TODO: when the RB is low on space we'd better not fill the whole
-               frame *)
+                 frame *)
               let slen = min slen (RB.read_space c.rb) in
               if slen > 0 then (
                 let src = Audio.create channels slen in
@@ -223,8 +223,8 @@ module AdaptativeBuffer = struct
                   Audio.blit (Audio.sub src 0 slen) (Audio.sub dst dofs slen)
                 else
                   (* TODO: we could do better than nearest interpolation. However,
-                   for slight adaptations the difference should not really be
-                   audible. *)
+                     for slight adaptations the difference should not really be
+                     audible. *)
                   for c = 0 to channels - 1 do
                     let srcc = src.(c) in
                     let dstc = dst.(c) in
@@ -235,7 +235,7 @@ module AdaptativeBuffer = struct
                   done )
             in
             (* We scale the reading so that the buffer always approximatively
-             contains prebuf data. *)
+               contains prebuf data. *)
             let scaling = c.rb_length /. prebuf in
             let scale n = int_of_float (float n *. scaling) in
             let unscale n = int_of_float (float n /. scaling) in
@@ -355,7 +355,7 @@ let () =
              again." );
         ("", Lang.source_t k, None, None);
       ] )
-    ~kind:(Lang.Unconstrained k) ~category:Lang.Liquidsoap
+    ~return_t:k ~category:Lang.Liquidsoap
     ~descr:
       "Create a buffer between two different clocks. The speed of the output \
        is adapted so that no buffer underrun or overrun occurs. This wonderful \

--- a/src/operators/video_effects.ml
+++ b/src/operators/video_effects.ml
@@ -46,12 +46,12 @@ class effect ~kind effect (source : source) =
             Video.iter effect rgb offset length
   end
 
-let kind = Lang.kind_type_of_kind_format (Lang.any_with ~video:1 ())
+let return_t = Lang.kind_type_of_kind_format (Lang.any_with ~video:1 ())
 
 let () =
   Lang.add_operator "video.greyscale"
-    [("", Lang.source_t kind, None, None)]
-    ~kind:(Lang.Unconstrained kind) ~category:Lang.VideoProcessing
+    [("", Lang.source_t return_t, None, None)]
+    ~return_t ~category:Lang.VideoProcessing
     ~descr:"Convert video to greyscale."
     (fun p kind ->
       let f v = List.assoc v p in
@@ -60,9 +60,8 @@ let () =
 
 let () =
   Lang.add_operator "video.sepia"
-    [("", Lang.source_t kind, None, None)]
-    ~kind:(Lang.Unconstrained kind) ~category:Lang.VideoProcessing
-    ~descr:"Convert video to sepia."
+    [("", Lang.source_t return_t, None, None)]
+    ~return_t ~category:Lang.VideoProcessing ~descr:"Convert video to sepia."
     (fun p kind ->
       let f v = List.assoc v p in
       let src = Lang.to_source (f "") in
@@ -70,9 +69,8 @@ let () =
 
 let () =
   Lang.add_operator "video.invert"
-    [("", Lang.source_t kind, None, None)]
-    ~kind:(Lang.Unconstrained kind) ~category:Lang.VideoProcessing
-    ~descr:"Invert video."
+    [("", Lang.source_t return_t, None, None)]
+    ~return_t ~category:Lang.VideoProcessing ~descr:"Invert video."
     (fun p kind ->
       let f v = List.assoc v p in
       let src = Lang.to_source (f "") in
@@ -85,7 +83,7 @@ let () =
       "", Lang.float_t, None, Some "Coefficient to scale opacity with.";
       "", Lang.source_t kind, None, None
     ]
-    ~kind:(Lang.Unconstrained kind)
+    ~return_t
     ~category:Lang.VideoProcessing
     ~descr:"Scale opacity of video."
     (fun p kind ->
@@ -98,7 +96,7 @@ let () =
     [
       "", Lang.source_t kind, None, None
     ]
-    ~kind:(Lang.Unconstrained kind)
+    ~return_t
     ~category:Lang.VideoProcessing
     ~descr:"Blur opacity of video."
     (fun p kind ->
@@ -108,7 +106,7 @@ let () =
 let () =
   Lang.add_operator "video.lomo"
     [ "", Lang.source_t kind, None, None ]
-    ~kind:(Lang.Unconstrained kind)
+    ~return_t
     ~category:Lang.VideoProcessing
     ~descr:"Emulate the \"Lomo effect\"."
     (fun p kind ->
@@ -128,7 +126,7 @@ let () =
 
       "", Lang.source_t kind, None, None
     ]
-    ~kind:(Lang.Unconstrained kind)
+    ~return_t
     ~category:Lang.VideoProcessing
     ~descr:"Set a color to be transparent."
     (fun p kind ->
@@ -150,7 +148,7 @@ let () =
 
       "", Lang.source_t kind, None, None
     ]
-    ~kind:(Lang.Unconstrained kind)
+    ~return_t
     ~category:Lang.VideoProcessing
     ~descr:"Fill frame with a color."
     (fun p kind ->
@@ -173,7 +171,7 @@ let () =
 
       "", Lang.source_t kind, None, None
     ]
-    ~kind:(Lang.Unconstrained kind)
+    ~return_t
     ~category:Lang.VideoProcessing
     ~descr:"Rotate video."
     (fun p kind ->
@@ -212,10 +210,9 @@ let () =
       ("yscale", Lang.float_t, Some (Lang.float 1.), Some "y scaling.");
       ("x", Lang.int_t, Some (Lang.int 0), Some "x offset.");
       ("y", Lang.int_t, Some (Lang.int 0), Some "y offset.");
-      ("", Lang.source_t kind, None, None);
+      ("", Lang.source_t return_t, None, None);
     ]
-    ~kind:(Lang.Unconstrained kind) ~category:Lang.VideoProcessing
-    ~descr:"Scale and translate video."
+    ~return_t ~category:Lang.VideoProcessing ~descr:"Scale and translate video."
     (fun p kind ->
       let f v = List.assoc v p in
       let src = Lang.to_source (f "") in

--- a/src/operators/video_fade.ml
+++ b/src/operators/video_fade.ml
@@ -45,10 +45,10 @@ class fade_in ~kind ?(meta = "liq_video_fade_in") duration fader fadefun source
       let off_ticks = Frame.position ab in
       let video_content = VFrame.get_content ab source in
       (* In video frames: [length] of the fade, [count] since beginning.
-      * This must be done before accessing the (possibly empty video content)
-      * because the state has to be updated anyway. Also, it is important
-      * that the metadata is ready at the position in ticks rather than
-      * video, otherwise we might miss some data. *)
+         * This must be done before accessing the (possibly empty video content)
+         * because the state has to be updated anyway. Also, it is important
+         * that the metadata is ready at the position in ticks rather than
+         * video, otherwise we might miss some data. *)
       let fade, fadefun, length, count =
         match state with
           | `Idle ->
@@ -148,7 +148,7 @@ class fade_out ~kind ?(meta = "liq_video_fade_out") duration fader fadefun
 
 (** Lang interface *)
 
-let kind = Lang.kind_type_of_kind_format (Lang.any_with ~video:1 ())
+let return_t = Lang.kind_type_of_kind_format (Lang.any_with ~video:1 ())
 
 (* TODO: share more with fade.ml *)
 let proto =
@@ -171,7 +171,7 @@ let proto =
       Some
         "Fader shape (lin|sin|log|exp): linear, sinusoidal, logarithmic or \
          exponential." );
-    ("", Lang.source_t kind, None, None);
+    ("", Lang.source_t return_t, None, None);
   ]
 
 let rec transition_of_string p transition =
@@ -284,7 +284,7 @@ let () =
         Some (Lang.string "liq_video_fade_in"),
         override_doc )
     :: proto )
-    ~kind:(Lang.Unconstrained kind) ~category:Lang.VideoProcessing
+    ~return_t ~category:Lang.VideoProcessing
     ~descr:
       "Fade the beginning of tracks. Metadata 'liq_video_fade_in' can be used \
        to set the duration for a specific track (float in seconds)."
@@ -298,7 +298,7 @@ let () =
         Some (Lang.string "liq_video_fade_out"),
         override_doc )
     :: proto )
-    ~kind:(Lang.Unconstrained kind) ~category:Lang.VideoProcessing
+    ~return_t ~category:Lang.VideoProcessing
     ~descr:
       "Fade the end of tracks. Metadata 'liq_video_fade_out' can be used to \
        set the duration for a specific track (float in seconds)."

--- a/src/operators/video_text.ml
+++ b/src/operators/video_text.ml
@@ -143,8 +143,7 @@ let register name init render_text =
         ("", Lang.string_getter_t (), None, Some "Text to display.");
         ("", Lang.source_t k, None, None);
       ]
-      ~kind:(Lang.Unconstrained k) ~category:Lang.VideoProcessing
-      ~descr:"Display a text."
+      ~return_t:k ~category:Lang.VideoProcessing ~descr:"Display a text."
       (fun p kind ->
         let f v = List.assoc v p in
         let ttf, ttf_size, color, x, y, speed, cycle, meta, txt, source =

--- a/src/outputs/ao_out.ml
+++ b/src/outputs/ao_out.ml
@@ -101,7 +101,7 @@ class output ~kind ~clock_safe ~nb_blocks ~driver ~infallible ~on_start ~on_stop
 
 let () =
   let kind = Lang.any_with ~audio:1 () in
-  let kind = Lang.kind_type_of_kind_format kind in
+  let return_t = Lang.kind_type_of_kind_format kind in
   Lang.add_operator "output.ao" ~active:true
     ( Output.proto
     @ [
@@ -125,11 +125,10 @@ let () =
           Lang.metadata_t,
           Some (Lang.list ~t:(Lang.product_t Lang.string_t Lang.string_t) []),
           Some "List of parameters, depends on the driver." );
-        ("", Lang.source_t kind, None, None);
+        ("", Lang.source_t return_t, None, None);
       ] )
     ~category:Lang.Output
-    ~descr:"Output stream to local sound card using libao."
-    ~kind:(Lang.Unconstrained kind)
+    ~descr:"Output stream to local sound card using libao." ~return_t
     (fun p kind ->
       let clock_safe = Lang.to_bool (List.assoc "clock_safe" p) in
       let driver = Lang.to_string (List.assoc "driver" p) in

--- a/src/outputs/bjack_out.ml
+++ b/src/outputs/bjack_out.ml
@@ -115,8 +115,7 @@ let () =
           Some "Jack server to connect to." );
         ("", Lang.source_t k, None, None);
       ] )
-    ~kind:(Lang.Unconstrained k) ~category:Lang.Output
-    ~descr:"Output stream to jack."
+    ~return_t:k ~category:Lang.Output ~descr:"Output stream to jack."
     (fun p kind ->
       let source = List.assoc "" p in
       let clock_safe = Lang.to_bool (List.assoc "clock_safe" p) in

--- a/src/outputs/graphics_out.ml
+++ b/src/outputs/graphics_out.ml
@@ -56,7 +56,7 @@ let () =
   let k = Lang.kind_type_of_kind_format Lang.video in
   Lang.add_operator "output.graphics" ~active:true
     (Output.proto @ [("", Lang.source_t k, None, None)])
-    ~kind:(Lang.Unconstrained k) ~category:Lang.Output
+    ~return_t:k ~category:Lang.Output
     ~descr:"Display video stream using the Graphics library."
     (fun p kind ->
       let autostart = Lang.to_bool (List.assoc "start" p) in

--- a/src/outputs/harbor_output.ml
+++ b/src/outputs/harbor_output.ml
@@ -622,11 +622,10 @@ module Make (T : T) = struct
     end
 
   let () =
-    let k = Lang.univ_t () in
+    let return_t = Lang.univ_t () in
     Lang.add_operator ~category:Lang.Output ~active:true
-      ~descr:T.source_description T.source_name (proto k)
-      ~kind:(Lang.Unconstrained k) (fun p kind ->
-        (new output ~kind p :> Source.source))
+      ~descr:T.source_description T.source_name (proto return_t) ~return_t
+      (fun p kind -> (new output ~kind p :> Source.source))
 end
 
 module Unix_output = struct

--- a/src/outputs/hls_output.ml
+++ b/src/outputs/hls_output.ml
@@ -578,9 +578,9 @@ class hls_output p =
   end
 
 let () =
-  let kind = Lang.univ_t () in
-  Lang.add_operator "output.file.hls" (hls_proto kind) ~active:true
-    ~kind:(Lang.Unconstrained kind) ~category:Lang.Output
+  let return_t = Lang.univ_t () in
+  Lang.add_operator "output.file.hls" (hls_proto return_t) ~active:true
+    ~return_t ~category:Lang.Output
     ~descr:
       "Output the source stream to an HTTP live stream served from a local \
        directory." (fun p _ -> (new hls_output p :> Source.source))

--- a/src/outputs/icecast2.ml
+++ b/src/outputs/icecast2.ml
@@ -602,8 +602,8 @@ class output ~kind p =
   end
 
 let () =
-  let k = Lang.univ_t () in
+  let return_t = Lang.univ_t () in
   Lang.add_operator "output.icecast" ~active:true ~category:Lang.Output
     ~descr:"Encode and output the stream to an icecast2 or shoutcast server."
-    (proto k) ~kind:(Lang.Unconstrained k) (fun p kind ->
+    (proto return_t) ~return_t (fun p kind ->
       (new output ~kind p :> Source.source))

--- a/src/outputs/output.ml
+++ b/src/outputs/output.ml
@@ -217,11 +217,11 @@ class dummy ~infallible ~on_start ~on_stop ~autostart ~kind source =
   end
 
 let () =
-  let kind = Lang.univ_t () in
+  let return_t = Lang.univ_t () in
   Lang.add_operator "output.dummy" ~active:true
-    (proto @ [("", Lang.source_t kind, None, None)])
+    (proto @ [("", Lang.source_t return_t, None, None)])
     ~category:Lang.Output ~descr:"Dummy output for debugging purposes."
-    ~kind:(Lang.Unconstrained kind)
+    ~return_t
     (fun p kind ->
       let infallible = not (Lang.to_bool (List.assoc "fallible" p)) in
       let autostart = Lang.to_bool (List.assoc "start" p) in

--- a/src/outputs/pipe_output.ml
+++ b/src/outputs/pipe_output.ml
@@ -117,9 +117,9 @@ class url_output p =
   end
 
 let () =
-  let kind = Lang.univ_t () in
-  Lang.add_operator "output.url" ~active:true (url_proto kind)
-    ~kind:(Lang.Unconstrained kind) ~category:Lang.Output
+  let return_t = Lang.univ_t () in
+  Lang.add_operator "output.url" ~active:true (url_proto return_t) ~return_t
+    ~category:Lang.Output
     ~descr:
       "Encode and let encoder handle data output. Useful with encoder with no \
        expected output or to encode to files that need full control from the \
@@ -374,10 +374,10 @@ let file_proto kind =
   @ chan_proto kind "Filename where to output the stream."
 
 let () =
-  let kind = Lang.univ_t () in
-  Lang.add_operator "output.file" (file_proto kind) ~active:true
-    ~kind:(Lang.Unconstrained kind) ~category:Lang.Output
-    ~descr:"Output the source stream to a file." (fun p _ ->
+  let return_t = Lang.univ_t () in
+  Lang.add_operator "output.file" (file_proto return_t) ~active:true ~return_t
+    ~category:Lang.Output ~descr:"Output the source stream to a file."
+    (fun p _ ->
       let format_val = Lang.assoc "" 1 p in
       let format = Lang.to_format format_val in
       let kind = Encoder.kind_of_format format in
@@ -423,9 +423,9 @@ let pipe_proto kind descr =
   :: chan_proto kind descr
 
 let () =
-  let kind = Lang.univ_t () in
+  let return_t = Lang.univ_t () in
   Lang.add_operator "output.external" ~active:true
-    (pipe_proto kind "Process to pipe data to.")
-    ~kind:(Lang.Unconstrained kind) ~category:Lang.Output
+    (pipe_proto return_t "Process to pipe data to.")
+    ~return_t ~category:Lang.Output
     ~descr:"Send the stream to a process' standard input." (fun p _ ->
       (new external_output p :> Source.source))

--- a/src/outputs/sdl_out.ml
+++ b/src/outputs/sdl_out.ml
@@ -60,9 +60,9 @@ class output ~infallible ~on_start ~on_stop ~autostart ~kind source =
         match Sdl.Event.(enum (get e typ)) with
           | `Quit ->
               (* Avoid an immediate restart (which would happen with autostart). But
-           do not cancel autostart. We should perhaps have a method in the
-           output class for that kind of thing, and try to get an uniform
-           behavior. *)
+                 do not cancel autostart. We should perhaps have a method in the
+                 output class for that kind of thing, and try to get an uniform
+                 behavior. *)
               request_start <- false;
               request_stop <- true
           | `Key_down ->
@@ -101,8 +101,7 @@ let () =
   let k = Lang.kind_type_of_kind_format Lang.video in
   Lang.add_operator "output.sdl" ~active:true
     (Output.proto @ [("", Lang.source_t k, None, None)])
-    ~kind:(Lang.Unconstrained k) ~category:Lang.Output
-    ~descr:"Display a video using SDL."
+    ~return_t:k ~category:Lang.Output ~descr:"Display a video using SDL."
     (fun p kind ->
       let autostart = Lang.to_bool (List.assoc "start" p) in
       let infallible = not (Lang.to_bool (List.assoc "fallible" p)) in

--- a/src/sources/audio_gen.ml
+++ b/src/sources/audio_gen.ml
@@ -39,7 +39,7 @@ class gen ~kind ~seek name g freq duration ampl =
 let add name g =
   Lang.add_operator name ~category:Lang.Input
     ~descr:("Generate a " ^ name ^ " wave.")
-    ~kind:Lang.audio_any
+    ~return_t:(Lang.kind_type_of_kind_format Lang.audio_any)
     [
       ( "duration",
         Lang.float_t,

--- a/src/sources/bjack_in.ml
+++ b/src/sources/bjack_in.ml
@@ -135,8 +135,7 @@ let () =
         Some (Lang.string ""),
         Some "Jack server to connect to." );
     ]
-    ~kind:(Lang.Unconstrained k) ~category:Lang.Input
-    ~descr:"Get stream from jack."
+    ~return_t:k ~category:Lang.Input ~descr:"Get stream from jack."
     (fun p kind ->
       let clock_safe = Lang.to_bool (List.assoc "clock_safe" p) in
       let nb_blocks = Lang.to_int (List.assoc "buffer_size" p) in

--- a/src/sources/blank.ml
+++ b/src/sources/blank.ml
@@ -66,9 +66,11 @@ class blank ~kind duration =
   end
 
 let () =
+  let return_t =
+    Lang.kind_type_of_kind_format (Lang.Unconstrained (Lang.univ_t ()))
+  in
   Lang.add_operator "blank" ~category:Lang.Input
-    ~descr:"Produce silence and blank images."
-    ~kind:(Lang.Unconstrained (Lang.univ_t ()))
+    ~descr:"Produce silence and blank images." ~return_t
     [
       ( "duration",
         Lang.float_t,
@@ -104,9 +106,11 @@ let () =
   let audio = Lang.univ_t () in
   let video = Lang.univ_t () in
   let midi = Lang.univ_t () in
+  let return_t =
+    Lang.kind_type_of_kind_format
+      (Lang.Unconstrained (Lang.frame_kind_t ~audio ~video ~midi))
+  in
   Lang.add_operator "empty" ~category:Lang.Input
     ~descr:
       "A source that does not produce anything. No silence, no track at all."
-    ~kind:(Lang.Unconstrained (Lang.frame_kind_t ~audio ~video ~midi))
-    []
-    (fun _ kind -> (new empty ~kind :> source))
+    ~return_t [] (fun _ kind -> (new empty ~kind :> source))

--- a/src/sources/external_input_audio.ml
+++ b/src/sources/external_input_audio.ml
@@ -93,7 +93,7 @@ let () =
         ("channels", Lang.int_t, Some (Lang.int 2), Some "Number of channels.");
         ("samplerate", Lang.int_t, Some (Lang.int 44100), Some "Samplerate.");
       ] )
-    ~kind:Lang.audio_any
+    ~return_t:(Lang.kind_type_of_kind_format Lang.audio_any)
     (fun p kind ->
       let command = Lang.to_string (List.assoc "" p) in
       let bufferize = Lang.to_float (List.assoc "buffer" p) in
@@ -121,7 +121,7 @@ let () =
 let () =
   Lang.add_operator "input.external.wav" ~category:Lang.Input
     ~descr:"Stream WAV data from an external application." proto
-    ~kind:Lang.audio_any (fun p kind ->
+    ~return_t:(Lang.kind_type_of_kind_format Lang.audio_any) (fun p kind ->
       let command = Lang.to_string (List.assoc "" p) in
       let bufferize = Lang.to_float (List.assoc "buffer" p) in
       let log_overfull = Lang.to_bool (List.assoc "log_overfull" p) in

--- a/src/sources/external_input_video.ml
+++ b/src/sources/external_input_video.ml
@@ -105,8 +105,7 @@ class video ~name ~kind ~restart ~bufferize ~log_overfull ~restart_on_error ~max
 let log = Log.make ["input"; "external"; "video"]
 
 let () =
-  let k = Lang.kind_type_of_kind_format Lang.audio_video_any in
-  let kind = Lang.Unconstrained k in
+  let return_t = Lang.kind_type_of_kind_format Lang.audio_video_any in
   Lang.add_operator "input.external.avi" ~category:Lang.Input
     ~flags:[Lang.Experimental]
     ~descr:"Stream data from an external application."
@@ -133,7 +132,7 @@ let () =
         Some "Restart process when exited with error." );
       ("", Lang.string_t, None, Some "Command to execute.");
     ]
-    ~kind
+    ~return_t
     (fun p kind ->
       let command = Lang.to_string (List.assoc "" p) in
       let video_format = ref None in
@@ -245,8 +244,7 @@ let () =
 (***** raw video *****)
 
 let () =
-  let k = Lang.kind_type_of_kind_format Lang.video_only in
-  let kind = Lang.Unconstrained k in
+  let return_t = Lang.kind_type_of_kind_format Lang.video_only in
   Lang.add_operator "input.external.rawvideo" ~category:Lang.Input
     ~flags:[Lang.Experimental]
     ~descr:"Stream data from an external application."
@@ -273,7 +271,7 @@ let () =
         Some "Restart process when exited with error." );
       ("", Lang.string_t, None, Some "Command to execute.");
     ]
-    ~kind
+    ~return_t
     (fun p kind ->
       let command = Lang.to_string (List.assoc "" p) in
       let width = Lazy.force Frame.video_width in

--- a/src/sources/harbor_input.ml
+++ b/src/sources/harbor_input.ml
@@ -269,8 +269,7 @@ module Make (Harbor : T) = struct
     end
 
   let () =
-    Lang.add_operator Harbor.source_name
-      ~kind:(Lang.Unconstrained (Lang.univ_t ()))
+    Lang.add_operator Harbor.source_name ~return_t:(Lang.univ_t ())
       ~category:Lang.Input ~descr:Harbor.source_description
       [
         ( "buffer",

--- a/src/sources/http_source.ml
+++ b/src/sources/http_source.ml
@@ -551,8 +551,7 @@ module Make (Config : Config_t) = struct
     end
 
   let register protocol =
-    Lang.add_operator ("input." ^ protocol)
-      ~kind:(Lang.Unconstrained (Lang.univ_t ()))
+    Lang.add_operator ("input." ^ protocol) ~return_t:(Lang.univ_t ())
       ~category:Lang.Input
       ~descr:("Create a source that fetches a " ^ protocol ^ " stream.")
       [

--- a/src/sources/noise.ml
+++ b/src/sources/noise.ml
@@ -52,5 +52,5 @@ let () =
   Lang.add_operator "noise" ~category:Lang.Input
     ~descr:"Generate (audio and/or video) white noise."
     [("duration", Lang.float_t, Some (Lang.float 0.), None)]
-    ~kind:(Lang.Unconstrained k)
+    ~return_t:k
     (fun p kind -> new noise ~kind (Lang.to_float (List.assoc "duration" p)))

--- a/src/sources/request_simple.ml
+++ b/src/sources/request_simple.ml
@@ -70,7 +70,7 @@ let () =
          Some (Lang.bool false),
          Some "Enforce fallibility of the request." )
     :: queued_proto )
-    ~kind:(Lang.Unconstrained (Lang.univ_t ()))
+    ~return_t:(Lang.univ_t ())
     (fun p kind ->
       let val_uri = List.assoc "" p in
       let fallible = Lang.to_bool (List.assoc "fallible" p) in
@@ -89,7 +89,7 @@ let () =
       "Loops on a request, which has to be ready and should be persistent. \
        WARNING: if used uncarefully, it can crash your application!"
     [("", Lang.request_t k, None, None)]
-    ~kind:(Lang.Unconstrained k)
+    ~return_t:k
     (fun p kind ->
       let r = Lang.to_request (List.assoc "" p) in
       (new unqueued ~kind r :> source))
@@ -132,7 +132,7 @@ let () =
            "Whether some new requests are available (when set to false, it \
             stops after current playing request)." )
     :: queued_proto )
-    ~kind:(Lang.Unconstrained k)
+    ~return_t:k
     (fun p kind ->
       let f = List.assoc "" p in
       let available = Lang.to_bool_getter (List.assoc "available" p) in

--- a/src/synth/dssi_op.ml
+++ b/src/synth/dssi_op.ml
@@ -150,7 +150,7 @@ let register_descr plugin_name descr_n descr outputs =
       ]
     @ liq_params
     @ [("", Lang.source_t k, None, None)] )
-    ~kind:(Lang.Unconstrained k) ~category:Lang.SoundSynthesis ~flags:[]
+    ~return_t:k ~category:Lang.SoundSynthesis ~flags:[]
     ~descr:(Ladspa.Descriptor.name ladspa_descr ^ ".")
     (fun p kind ->
       let f v = List.assoc v p in
@@ -171,7 +171,7 @@ let register_descr plugin_name descr_n descr outputs =
     ( "synth.all.dssi."
     ^ Utils.normalize_parameter_string (Ladspa.Descriptor.label ladspa_descr) )
     (liq_params @ [("", Lang.source_t k, None, None)])
-    ~kind:(Lang.Unconstrained k) ~category:Lang.SoundSynthesis ~flags:[]
+    ~return_t:k ~category:Lang.SoundSynthesis ~flags:[]
     ~descr:(Ladspa.Descriptor.name ladspa_descr ^ ".")
     (fun p kind ->
       let f v = List.assoc v p in

--- a/src/synth/keyboard.ml
+++ b/src/synth/keyboard.ml
@@ -139,13 +139,14 @@ class keyboard ~kind =
 
 let () =
   Lang.add_operator "input.keyboard" []
-    ~kind:
-      (Lang.Constrained
-         {
-           Frame.audio = Lang.At_least 0;
-           video = Lang.Fixed 0;
-           midi = Lang.At_least 1;
-         })
+    ~return_t:
+      (Lang.kind_type_of_kind_format
+         (Lang.Constrained
+            {
+              Frame.audio = Lang.At_least 0;
+              video = Lang.Fixed 0;
+              midi = Lang.At_least 1;
+            }))
     ~category:Lang.Input
     ~flags:[Lang.Hidden; Lang.Experimental]
     ~descr:"Play notes from the keyboard."

--- a/src/synth/keyboard_sdl.ml
+++ b/src/synth/keyboard_sdl.ml
@@ -162,6 +162,15 @@ class keyboard ~kind velocity =
   end
 
 let () =
+  let kind =
+    Lang.kind_type_of_kind_format
+      (Lang.Constrained
+         {
+           Frame.audio = Lang.At_least 0;
+           video = Lang.Fixed 0;
+           midi = Lang.At_least 1;
+         })
+  in
   Lang.add_operator "input.keyboard.sdl"
     [
       ( "velocity",
@@ -169,14 +178,7 @@ let () =
         Some (Lang.float 0.8),
         Some "Velocity of notes." );
     ]
-    ~return_t:
-      (Lang.Constrained
-         {
-           Frame.audio = Lang.At_least 0;
-           video = Lang.Fixed 0;
-           midi = Lang.At_least 1;
-         })
-    ~category:Lang.Input ~flags:[Lang.Experimental]
+    ~return_t:kind ~category:Lang.Input ~flags:[Lang.Experimental]
     ~descr:"Play notes from the keyboard."
     (fun p kind ->
       let f v = List.assoc v p in

--- a/src/synth/keyboard_sdl.ml
+++ b/src/synth/keyboard_sdl.ml
@@ -169,7 +169,7 @@ let () =
         Some (Lang.float 0.8),
         Some "Velocity of notes." );
     ]
-    ~kind:
+    ~return_t:
       (Lang.Constrained
          {
            Frame.audio = Lang.At_least 0;

--- a/src/synth/synth_op.ml
+++ b/src/synth/synth_op.ml
@@ -80,7 +80,7 @@ let register obj name descr =
         Some "Envelope release (in seconds)." );
       ("", Lang.source_t k, None, None);
     ]
-    ~kind:(Lang.Unconstrained k) ~category:Lang.SoundSynthesis ~descr
+    ~return_t:k ~category:Lang.SoundSynthesis ~descr
     (fun p kind ->
       let f v = List.assoc v p in
       let chan = Lang.to_int (f "channel") in
@@ -120,7 +120,7 @@ let register obj name descr =
         Some "Envelope release (in seconds)." );
       ("", Lang.source_t k, None, None);
     ]
-    ~kind:(Lang.Unconstrained k) ~category:Lang.SoundSynthesis
+    ~return_t:k ~category:Lang.SoundSynthesis
     ~descr:(descr ^ " It creates one synthesizer for each channel.")
     (fun p kind ->
       let f v = List.assoc v p in

--- a/src/visualization/midimeter.ml
+++ b/src/visualization/midimeter.ml
@@ -62,7 +62,7 @@ let () =
   let k = Lang.kind_type_of_kind_format Lang.any in
   Lang.add_operator "midimeter"
     [("", Lang.source_t k, None, None)]
-    ~kind:(Lang.Unconstrained k) ~category:Lang.Visualization
+    ~return_t:k ~category:Lang.Visualization
     ~flags:[Lang.Hidden; Lang.Experimental]
     ~descr:"Display midi events."
     (fun p kind ->

--- a/src/visualization/video_volume.ml
+++ b/src/visualization/video_volume.ml
@@ -150,8 +150,8 @@ let () =
   in
   Lang.add_operator "video.volume"
     [("", Lang.source_t k, None, None)]
-    ~kind:(Lang.Constrained fmt) ~category:Lang.Visualization
-    ~descr:"Graphical visualization of the sound."
+    ~return_t:(Lang.kind_type_of_kind_format (Lang.Constrained fmt))
+    ~category:Lang.Visualization ~descr:"Graphical visualization of the sound."
     (fun p kind ->
       let f v = List.assoc v p in
       let src = Lang.to_source (f "") in

--- a/src/visualization/vis_volume.ml
+++ b/src/visualization/vis_volume.ml
@@ -122,7 +122,7 @@ let () =
   let k = Lang.kind_type_of_kind_format Lang.audio_any in
   Lang.add_operator "visu.volume"
     [("", Lang.source_t k, None, None)]
-    ~kind:(Lang.Unconstrained k) ~category:Lang.Visualization
+    ~return_t:k ~category:Lang.Visualization
     ~descr:"Graphical visualization of the volume."
     (fun p kind ->
       let f v = List.assoc v p in


### PR DESCRIPTION
This is the real fix for #1136!

It was probably hidden before we switched to fixed content type but here's the problem:

In d52eaeab300109135badfff3c4a53b8d7cad52bf, we cleaned up the definition for universal type, which used to rely on a arbitrary number passed to track different universal types.

However, there was one gotcha here: https://github.com/savonet/liquidsoap/commit/d52eaeab300109135badfff3c4a53b8d7cad52bf#diff-0dc99674d3e13c55a23227a9e4e19ee5L430-L431:
```ocaml
  let fresh = (* TODO *) 1 in
  let kind_type = kind_type_of_kind_format ~fresh kind in
```

The use of this magic number made some operator's return type implicitly unified with their input types. Typically, before those changes, we had:
```
% liquidsoap -h add

Mix sources, with optional normalization. Only relay metadata from the first
source that is effectively summed.

Type: (?id : string, ?normalize : bool, ?weights : [float],
 [source(audio='#a, video='#b, midi=0)]) ->
source(audio='#a, video='#c, midi=0)
```

And after:
```
% liquidsoap -h add

Mix sources, with optional normalization. Only relay metadata from the first
source that is effectively summed.

Type: (?id : string, ?normalize : bool, ?weights : [float],
 [source(audio='#a, video='#b, midi=0)]) ->
source(audio='#c, video='#d, midi=0)
```

This PR restores the previous behavior while keeping the cleaner API for universal variables by expecting operators to return not just content constraints but a full type, allowing operators to tightly control universal variables shared between their input and output.