### PR TITLE
Improve request.dynamic

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,7 @@ New:
 - Added `list.ind`.
 - Added `list.index`.
 - Added `request.id`.
+- Added `retry_delay` argument to `request.dynamic` (#1169).
 - Added a profiler for the language. It can be enabled with `profiler.enable` and
   the results are obtained with `profiler.stats.string` (#1027).
 - Added `gtts` protocol to use Google TTS (#1034).
@@ -43,6 +44,9 @@ Changed:
   the default safe behavior. (#1012)
 - Switch to YUV420 as internal image format, much more efficient (#848).
 - Use bigarrays for audio buffers (#950).
+- Changed `request.dynamic` callback function type to return an array of requests,
+  making possible to return multiple requests at once but, more importantly,
+  to return `[]`  when no next requests are available. (#1169)
 - Renamed `verb` argument info `method` in `output.icecast`.
 - Simplified `add` behavior, also fixing an clock issue (#668).
 - Switch to more efficient callback API for decoders (#979).

--- a/libs/hls.liq
+++ b/libs/hls.liq
@@ -51,16 +51,14 @@ def input.hls(~id="",~reload=10.,uri)
   end
 
   def rec next () =
-    file =
-      if list.length(!playlist) > 0 then
-        let (_,ret) = list.hd(default=(1,""),!playlist)
-        playlist := list.tl(!playlist)
-        sequence := !sequence + 1
-        ret
-      else
-        ""
-      end
-    request.create(file)
+    if list.length(!playlist) > 0 then
+      let (_,ret) = list.hd(default=(1,""),!playlist)
+      playlist := list.tl(!playlist)
+      sequence := !sequence + 1
+      [request.create(ret)]
+    else
+      []
+    end
   end
 
   def find_stream () =

--- a/libs/playlist.liq
+++ b/libs/playlist.liq
@@ -51,14 +51,18 @@ def playlist.list.reloadable(~id="playlist.list.reloadable", ~check_next=fun(_)-
         end
         ""
       end
-    log.debug(label=id, "Next song will be \"#{file}\".")
-    r = request.create(file)
-    if check_next(r) then
-      r
+    if file == "" then
+      []
     else
-      log.info(label=id, "Request #{request.uri(r)} rejected by check_next.")
-      request.destroy(r)
-      next()
+      log.debug(label=id, "Next song will be \"#{file}\".")
+      r = request.create(file)
+      if check_next(r) then
+        [r]
+      else
+        log.info(label=id, "Request #{request.uri(r)} rejected by check_next.")
+        request.destroy(r)
+        next()
+      end
     end
   end
   # Instantiate the source

--- a/libs/request.liq
+++ b/libs/request.liq
@@ -10,10 +10,9 @@
 def request.queue.pushable(~id="", ~conservative=false, ~default_duration=30., ~interactive=true, ~length=40., ~queue=[], ~timeout=20.)
   queue = ref(queue)
   def next()
-    r = list.hd(default=request.create(""), !queue)
-    queue := list.tl(!queue)
-    log.info(label=id, "Next song will be #{request.uri(r)}.")
-    r
+    reqs = !queue
+    queue := []
+    reqs
   end
   def push(uri)
     log.info(label=id, "Pushing #{uri} on the queue.")

--- a/src/sources/request_simple.ml
+++ b/src/sources/request_simple.ml
@@ -94,37 +94,69 @@ let () =
       let r = Lang.to_request (List.assoc "" p) in
       (new unqueued ~kind r :> source))
 
-class dynamic ~kind ~available (f : Lang.value) length default_duration timeout
-  conservative =
+class dynamic ~kind ~retry_delay ~available (f : Lang.value) length
+  default_duration timeout conservative =
   object (self)
     inherit
       Request_source.queued
         ~kind ~name:"request.dynamic" ~length ~default_duration ~timeout
           ~conservative () as super
 
-    method is_ready =
-      let ready = super#is_ready in
-      if (not ready) && available () then super#notify_new_request;
-      ready
+    val mutable retry_status = None
 
-    method get_next_request =
+    method is_ready =
+      match (super#is_ready, retry_status) with
+        | true, _ -> true
+        | false, Some d when Unix.gettimeofday () < d -> false
+        | false, _ ->
+            if available () then super#notify_new_request;
+            false
+
+    (* First cache last requests. *)
+    val mutable last_requests = []
+
+    method private get_next_requests =
       try
         if available () then (
           let t = Lang.request_t (Lang.kind_type_of_frame_kind kind) in
-          let req = Lang.to_request (Lang.apply ~t f []) in
-          Request.set_root_metadata req "source" self#id;
-          Some req )
-        else None
+          let reqs =
+            List.map Lang.to_request (Lang.to_list (Lang.apply ~t f []))
+          in
+          List.iter
+            (fun req -> Request.set_root_metadata req "source" self#id)
+            reqs;
+          reqs )
+        else []
       with e ->
         log#severe "Failed to obtain a media request!";
         raise e
+
+    method get_next_request =
+      match last_requests with
+        | req :: tl ->
+            last_requests <- tl;
+            Some req
+        | [] -> (
+            match self#get_next_requests with
+              | req :: tl ->
+                  last_requests <- tl;
+                  Some req
+              | [] ->
+                  retry_status <- Some (Unix.gettimeofday () +. retry_delay ());
+                  None )
   end
 
 let () =
   let k = Lang.univ_t () in
   Lang.add_operator "request.dynamic" ~category:Lang.Input
     ~descr:"Play request dynamically created by a given function."
-    ( ("", Lang.fun_t [] (Lang.request_t k), None, None)
+    ( ("", Lang.fun_t [] (Lang.list_t (Lang.request_t k)), None, None)
+    :: ( "retry_delay",
+         Lang.float_getter_t (),
+         Some (Lang.float 0.1),
+         Some
+           "Retry after a given time (in seconds) when callback returns an \
+            empty list." )
     :: ( "available",
          Lang.bool_getter_t (),
          Some (Lang.bool true),
@@ -136,5 +168,6 @@ let () =
     (fun p kind ->
       let f = List.assoc "" p in
       let available = Lang.to_bool_getter (List.assoc "available" p) in
+      let retry_delay = Lang.to_float_getter (List.assoc "retry_delay" p) in
       let l, d, t, c = extract_queued_params p in
-      (new dynamic ~kind ~available f l d t c :> source))
+      (new dynamic ~kind ~available ~retry_delay f l d t c :> source))


### PR DESCRIPTION
- Change callback return type to `[request('a)]` to allow for proper
  empty result
- Add `retry_delay` to allow for a better fetch timing when no requests
  are available.