### PR TITLE
[WIP] Avoid copying video content unless told to.

### DIFF
--- a/src/operators/video_effects.ml
+++ b/src/operators/video_effects.ml
@@ -38,6 +38,8 @@ class effect ~name ~kind effect (source : source) =
 
     method abort_track = source#abort_track
 
+    method needs_fresh_video = true
+
     method private get_frame buf =
       match VFrame.get_content buf source with
         | None -> ()

--- a/src/operators/video_fade.ml
+++ b/src/operators/video_fade.ml
@@ -39,6 +39,8 @@ class fade_in ~kind ?(meta = "liq_video_fade_in") duration fader fadefun source
 
     method self_sync = source#self_sync
 
+    method needs_fresh_video = true
+
     val mutable state = `Idle
 
     method private get_frame ab =

--- a/src/operators/video_text.ml
+++ b/src/operators/video_text.ml
@@ -42,6 +42,8 @@ class text ~kind init render_text ttf ttf_size color tx ty speed cycle meta text
 
     method self_sync = source#self_sync
 
+    method needs_fresh_video = true
+
     val mutable text_frame = None
 
     val mutable pos_x = tx ()

--- a/src/source.mli
+++ b/src/source.mli
@@ -156,6 +156,11 @@ class virtual source :
        (** [is_ready] tells you if [get] can be called. *)
        method virtual is_ready : bool
 
+       (** True if any of the underlying sources manipulates video data in place.
+           If so, shared video content is copied before being passed down by this
+           operator. *)
+       method needs_fresh_video : bool
+
        (** [get buf] asks the source to fill the buffer [buf] if possible.
            The [get] call is partial when the buffer is not completely filled.
            [get] should never be called with a full buffer,

--- a/src/stream/frame.mli
+++ b/src/stream/frame.mli
@@ -51,8 +51,9 @@ and midi_t = MIDI.buffer
 
 (** [blit_content c1 o1 c2 o2 l] copies [l] data from [c1] starting at offset
     [o1] into [c2] starting at offset [o2]. All numerical values are in
-    ticks. *)
-val blit_content : content -> int -> content -> int -> int -> unit
+    ticks. Video frames are assigned unless a copy is requested. *)
+val blit_content :
+  fresh_video:bool -> content -> int -> content -> int -> int -> unit
 
 (** Make a copy of the content of a frame. *)
 val copy : content -> content
@@ -170,7 +171,7 @@ val get_past_metadata : t -> metadata option
 
 exception No_chunk
 
-val get_chunk : t -> t -> unit
+val get_chunk : fresh_video:bool -> t -> t -> unit
 
 (** {2 Compatibilities between content values, types and kinds} *)
 


### PR DESCRIPTION
This PR establishes the basis for avoiding video content copy. The reasoning is that, unless an operator explicitly declares itself as needing fresh video data, we should be able to pass video frames untouched all the way through.

Early testing seems to indicate that this should be working.