### PR TITLE
Correct xxx_getter type.

### DIFF
--- a/src/lang/lang_builtins.ml
+++ b/src/lang/lang_builtins.ml
@@ -103,12 +103,12 @@ let () =
       (fun p ->
         let getter = to_get (Lang.assoc "" 1 p) in
         Lang.val_fun [] ~ret_t:type_t (fun _ _ -> to_val (getter ())));
+    let a = get_t () in
     add_builtin ~cat:Liq (name ^ "_getter")
       ~descr:
         ( "Identity function over " ^ name ^ " getters. "
         ^ "This is useful to make types explicit." )
-      [("", get_t (), None, None)]
-      (get_t ())
+      [("", a, None, None)] a
       (fun p -> List.assoc "" p)
   in
   add_getters "string" Lang.string_getter_t Lang.string_t Lang.to_string_getter


### PR DESCRIPTION
The attached patch corrects the type of `xxx_getter` (e.g. `int_getter`) to what it was in the past, which is what it should actually be: we should keep the link between the input and the output, both should be `xxx` or both should be `{xxx}`, but we cannot change them independently. However, with this patch I cannot seem to give default values to getter arguments, which is quite a limitation (and would justify in my opinion being slightly unsafe).

For instance, the following code is going on without any problem:
```
def f(~x)
  x = to_int_getter(x)
  print(x() + 2)
end

f(x=3)
f(x={4})
```
We can thus define functions with getter arguments.

However, as soon as we try to give a default value for the argument, things go bad. The following code
```
def g(~x=int_getter(2))
  x = to_int_getter(x)
  print(x() + 2)
end

g()
g(x=3)
g(x={4})
```
is not accepted with the patch in the PR, but is accepted in the current master. The result of `int_getter(2)` is an integer and not a getter to an integer and the last call (`g(x={4})`) is failing.

How do we properly fix this?