### PR TITLE
Fix source lifecycle when kept as reference

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -93,6 +93,7 @@ Fixed:
 
 - Fix implementation of recursive functions (#934).
 - Fix implementation of `rotate` (#1129).
+- Fix source lifecycle when kept as a reference (#1182).
 - Fix opam install error with some bash-completion configuration (#980).
 - Make `blank()` source unavailable past is expected duration (#668).
 - Do not crash when loading playlists using `~/path/to/..` paths.

--- a/src/source.mli
+++ b/src/source.mli
@@ -133,6 +133,25 @@ class virtual source :
        (** Check if a source is up or not. *)
        method is_up : bool
 
+       (* {1 References count}
+          Sources used a reference in the script need to be kept with
+          a dynamic activation for the duration of their reference as
+          they may be passed to any other source at any time, leading
+          to situations where we have:
+          - s := blank()
+          - o = output.dummy(!s)
+          - source.shutdown(o)
+          - o_again = output.dummy(!s)
+          This script will crash if we don't keep track of the fact
+          that there is a reference to [blank], as [blank] is cleaned
+          up during the first [source.shutdown], having to activations
+          left. See: GH#1182 for more details. *)
+       method retain : unit
+
+       (* Collected is true if the function is called in the context of a [Gc]
+          cleanup. *)
+       method release : collected:bool -> unit
+
        (** {1 Streaming} *)
 
        (** What kind of content does this source produce. *)


### PR DESCRIPTION
There is an interesting edge case with sources life cycles when they are kept as a reference. Here's a quick reproduction script:
```ruby
source = ref blank()

output = ref output.dummy(blank())

def on_source_connect(headers) =
  output := output.dummy(!source)
end

def on_source_disconnect() =
  source.shutdown(!output)
end

# configure harbor which will accept the live video stream
harbor = input.harbor(
    "live",
    port=8080,
    password="hackme",
    on_connect=on_source_connect,
    on_disconnect=on_source_disconnect
)

source := mksafe(harbor)

output.dummy(fallible=true, harbor)
```
On first connect, a dynamic output is created and `source` is activated. When this output is destroyed, seeing no more activations for `mksafe`, is cleaned up.

However, `source` is still kept as a reference, so when a second connection comes in, the source is activated again.

This is where we reach our crash condition. When cleaning up `mksafe` again, the old transition source is cleaned up again, triggering one too-many call to `leave`, which makes liquidsoap crash:
```
2020/05/01 09:51:07 [sequence_17524:1] Got ill-balanced activations (from mksafe)!
2020/05/01 09:51:07 [clock:2] Error when leaving output dummy(dot)2: File "source.ml", line 476, characters 12-18: Assertion failed!
2020/05/01 09:51:07 [clock:3] Raised at file "source.ml", line 476, characters 12-24
2020/05/01 09:51:07 [clock:3] Called from file "source.ml", line 481, characters 33-61
2020/05/01 09:51:07 [clock:3] Called from file "source.ml", line 489, characters 8-18
2020/05/01 09:51:07 [clock:3] Called from file "source.ml", line 489, characters 8-18
2020/05/01 09:51:07 [clock:3] Called from file "clock.ml", line 84, characters 6-13
```

The solution, I believe, is to keep track of source references and prevent final cleanup until the source has been released from all references. This PR does this with a reference count.

There are two edge cases:
* The source is released from a reference after it was supposed to have been cleaned
* The source is garbage collected without have been properly released from all its references.

To deal with these two situations, a state (machine) is introduced, that keep track of the source's state and deal with these two situations accordingly.

Here's a script to reproduce all these cases:
```ruby
set("log.level", 5)

o = ref output.dummy(id="placeholder",blank(id="placeholder"))

def h() =
  log("PHASE THREE")
  log("DUMMY RELEASED!")
  o := output.dummy(id="placeholder",blank(id="placeholder"))
  garbage_collect()
  garbage_collect()
  log("DONE PHASE THREE")
end

def g() =
  thread.run(delay=2.,h)

  log("PHASE TWO")
  log("DUMMY SHUTDOWN!")
  source.shutdown(!o)
  log("DONE PHASE TWO")
end

def f() =
  thread.run(delay=2., g)

  log("PHASE ONE")
  s = ref blank(id="SHARED_REF")
  o := output.dummy(id="DUMMY",!s)
  log("DONE PHASE ONE")
end

f()

output.dummy(id="placeholder",blank())
```

During `PHASE THREE`, `DUMMY` is released after being shutdown and immediately releases the sources that depend on it. Right after that, during the call to `garbage_collect`, `SHARED_REF` is also cleaned up during a garbage collection cyce.

You need to set `LIQUIDSOAP_DEBUG=true` to see the logs during garbage collection.