### PR TITLE
Restore request.dynamic.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -87,7 +87,7 @@ Changed:
 - Allow crossfading for video (#1132, #1135).
 - Use getters for parameters of synthesizer sources (#1036).
 - Renamed `empty` to `fail`.
-- Restored `request.dynamic` ().
+- Restored `request.dynamic` (#1213).
 
 Fixed:
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -87,6 +87,7 @@ Changed:
 - Allow crossfading for video (#1132, #1135).
 - Use getters for parameters of synthesizer sources (#1036).
 - Renamed `empty` to `fail`.
+- Restored `request.dynamic` ().
 
 Fixed:
 

--- a/libs/deprecations.liq
+++ b/libs/deprecations.liq
@@ -231,14 +231,6 @@ def register_flow(~server="",~user="default",~password="default",
   on_metadata(metadata,s)
 end
 
-# @flag hidden
-def request.dynamic(~id="",~conservative=false,~default_duration=30.,
-                    ~length=10.,~timeout=20.,fn) =
-  deprecated("request.dynamic", "request.dynamic.list")
-  request.dynamic.list(id=id,conservative=conservative,default_duration=default_duration,
-                   length=length,timeout=timeout,fun () -> [fn()])
-end
-
 # Deprecated: this function has been replaced by fail.
 # @flag hidden
 def empty(~id="")

--- a/libs/request.liq
+++ b/libs/request.liq
@@ -1,3 +1,17 @@
+# Play request dynamically created by a given function.
+# @category Source / Input
+# @param ~id Force the value of the source ID.
+# @param ~available Whether some new requests are available (when set to false, it stops after current playing request).
+# @param ~conservative If true, estimated remaining time on the current track is not considered when computing queue length.
+# @param ~default_duration When unknown, assume this duration (in sec.) for files.
+# @param ~length How much audio (in sec.) should be queued in advance.
+# @param ~retry_delay Retry after a given time (in seconds) when callback returns an empty list.
+# @param ~timeout Timeout (in sec.) for a single download.
+# @param f Function producing requests.
+def request.dynamic(~id="", ~available={true}, ~conservative=false, ~default_duration=30., ~length=10., ~timeout=20., f) =
+  request.dynamic.list(id=id, available=available, conservative=conservative, default_duration=default_duration, length=length, timeout=timeout, {[f()]})
+end
+
 # Play a queue of uris. Returns a function to push new uris in the queue as well as the resulting source.
 # @category Source / Track Processing
 # @param ~id Force the value of the source ID.


### PR DESCRIPTION
Following a question on slack, I don't think that it is a good idea to deprecate `request.dynamic`: since we have the `available` parameter, there is a perfectly good way of functioning by using this to indicate that we have no request to push, and when it is the case we typically want to add one request at a time. Of course, this is an easy variation over `request.dynamic.list`, but since some users were already used to this one, let's keep it simple for them.