### PR TITLE
Use integers for group indexes in string.extract.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -97,6 +97,8 @@ Changed:
   the kernel.
 - Use records as return type of `http.*`, `https.*`, `rms`, `peak` and
   `request.queue` (#1234).
+- Indices of groups returned by `string.extract` are now integers instead of
+  strings (#1240).
 
 Fixed:
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -44,6 +44,7 @@ New:
 - Added configure option to specify internal library install path (#1211).
 - Add support for records and methods (#1197).
 - Rename `unsafe.single.infallible` to `single.infallible`.
+- Add `list.indexed`.
 
 Changed:
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -100,6 +100,8 @@ Changed:
   `request.queue` (#1234).
 - Indices of groups returned by `string.extract` are now integers instead of
   strings (#1240).
+- Generalize the `l[k]` notation so that the key `k` can be of any type (on
+  which we know how to compare).
 
 Fixed:
 

--- a/libs/externals.liq
+++ b/libs/externals.liq
@@ -83,7 +83,7 @@ def enable_external_mpc_decoder() =
       # Otherwise test file extension
       ret = string.extract(pattern='\\.(.+)$',file)
       if list.length(ret) != 0 then
-        ext = ret["1"]
+        ext = ret[1]
         if list.mem(ext,mpc_filexts) then
           get_channels(file)
         else
@@ -213,7 +213,7 @@ def enable_external_faad_decoder() =
       # Otherwise test file extension
       ret = string.extract(pattern='\\.(.+)$',file)
       if list.length(ret) != 0 then
-        ext = ret["1"]
+        ext = ret[1]
         list.mem(ext,aac_filexts)
       else
         false
@@ -237,7 +237,7 @@ def enable_external_faad_decoder() =
             # contain aac audio data..
             "-1"
           else
-            ret["1"]
+            ret[1]
           end
         int_of_string(default=(-1),ret)
       else
@@ -254,7 +254,7 @@ def enable_external_faad_decoder() =
         def get_meta(l,s)=
           ret = string.extract(pattern="^(\\w+):\\s(.+)$",s)
           if list.length(ret) > 0 then
-            list.append([(ret["1"],ret["2"])],l)
+            list.append([(ret[1],ret[2])],l)
           else
             l
           end

--- a/libs/hls.liq
+++ b/libs/hls.liq
@@ -15,7 +15,7 @@ def input.hls(~id="",~reload=10.,uri)
       pl = request.filename(pl)
 
       m = string.extract(pattern="#EXT-X-MEDIA-SEQUENCE:(\\d+)",file.contents(pl))
-      pl_sequence = list.assoc(default="",1,m)
+      pl_sequence = m[1]
       log.info(label=id,"Sequence: " ^ pl_sequence)
       pl_sequence = int_of_string(default=0,pl_sequence)
 

--- a/libs/hls.liq
+++ b/libs/hls.liq
@@ -15,7 +15,7 @@ def input.hls(~id="",~reload=10.,uri)
       pl = request.filename(pl)
 
       m = string.extract(pattern="#EXT-X-MEDIA-SEQUENCE:(\\d+)",file.contents(pl))
-      pl_sequence = list.assoc(default="","1",m)
+      pl_sequence = list.assoc(default="",1,m)
       log.info(label=id,"Sequence: " ^ pl_sequence)
       pl_sequence = int_of_string(default=0,pl_sequence)
 
@@ -66,7 +66,7 @@ def input.hls(~id="",~reload=10.,uri)
       plfile = request.filename(pl)
 
       m = string.extract(pattern="#EXT-X-STREAM-INF[^\\n]*\\n([^\\r\\n]*)\\r?\\n",file.contents(plfile))
-      playlist_uri := list.assoc(default=!playlist_uri,"1",m)
+      playlist_uri := list.assoc(default=!playlist_uri,1,m)
 
       if not (string.contains(substring="/", !playlist_uri)) then
         playlist_uri := path.dirname(request.uri(pl)) ^ "/" ^ !playlist_uri

--- a/libs/http.liq
+++ b/libs/http.liq
@@ -106,7 +106,7 @@ def harbor.http.static.base(serve,~content_type,~basepath,~port,~headers,directo
     if list.length(ret) == 0 then
       http_response(protocol=protocol,code=404,headers=responseHeaders,data="Not Found!")
     else
-      let (_,match) = list.hd(default=("1","foo"),ret)
+      let (_,match) = list.hd(default=(1,"foo"),ret)
       match = string.trim(match)
 
       fname = path.concat(directory, match)

--- a/libs/http.liq
+++ b/libs/http.liq
@@ -1,3 +1,4 @@
+
 # Set of HTTP utils.
 
 %include "http_codes.liq"
@@ -106,8 +107,7 @@ def harbor.http.static.base(serve,~content_type,~basepath,~port,~headers,directo
     if list.length(ret) == 0 then
       http_response(protocol=protocol,code=404,headers=responseHeaders,data="Not Found!")
     else
-      let (_,match) = list.hd(default=(1,"foo"),ret)
-      match = string.trim(match)
+      match = string.trim(ret[1])
 
       fname = path.concat(directory, match)
       if file.exists(fname) then

--- a/libs/list.liq
+++ b/libs/list.liq
@@ -94,6 +94,13 @@ def list.mapi(f, l)
   list.map(f, l)
 end
 
+# Add indices to every element of a list, so that it can be accessed with the
+# notation `l[n]`.
+# @category List
+def list.indexed(l)
+  list.mapi(fun(i, x) -> (i,x), l)
+end
+
 # Fold a function on every element of a list: `list.fold(f,x1,[e1,..,en]) is f(...f(f(x1,e1),e2)...,en)`.
 # @category List
 # @param f Function `f` for which `f(x,e)` which will be called on every element `e` with the current value of `x`, returning the new value of `x`.

--- a/libs/utils.liq
+++ b/libs/utils.liq
@@ -181,9 +181,9 @@ end
 # @param uri Url to split
 def url.split(uri) =
   ret = string.extract(pattern="([^\\?]*)\\?(.*)",uri)
-  args = ret["2"]
+  args = ret[2]
   if args != "" then
-    (ret["1"],url.split_args(ret["2"]))
+    (ret[1],url.split_args(ret[2]))
   else
     (uri,[])
   end
@@ -205,8 +205,8 @@ def server.insert_metadata(~id="",s) =
       def sub(s) = string.replace(pattern='\\"',fun (_) -> '"',s) end
       if x != "" then
         ret = string.extract(pattern='([^=]+)\\s*=\\s*"((?:\\"|[^"])*)"',x)
-        if ret["1"] != "" then
-          list.append(l, [(ret["1"], sub(ret["2"]))])
+        if ret[1] != "" then
+          list.append(l, [(ret[1], sub(ret[2]))])
         else
           l
         end

--- a/src/lang/builtins_bool.ml
+++ b/src/lang/builtins_bool.ml
@@ -22,42 +22,12 @@
 
 open Lang_builtins
 
-let compare_value a b =
-  let rec aux = function
-    | Lang.(Ground (Ground.Float a)), Lang.(Ground (Ground.Float b)) ->
-        compare a b
-    | Lang.(Ground (Ground.Int a)), Lang.(Ground (Ground.Int b)) -> compare a b
-    | Lang.(Ground (Ground.String a)), Lang.(Ground (Ground.String b)) ->
-        compare a b
-    | Lang.(Ground (Ground.Bool a)), Lang.(Ground (Ground.Bool b)) ->
-        compare a b
-    | Lang.(Ground a), Lang.(Ground b) ->
-        compare (Lang.Ground.to_string a) (Lang.Ground.to_string b)
-    | Lang.Tuple l, Lang.Tuple m ->
-        List.fold_left2
-          (fun cmp a b ->
-            if cmp <> 0 then cmp else aux (a.Lang.value, b.Lang.value))
-          0 l m
-    | Lang.List l1, Lang.List l2 ->
-        let rec cmp = function
-          | [], [] -> 0
-          | [], _ -> -1
-          | _, [] -> 1
-          | h1 :: l1, h2 :: l2 ->
-              let c = aux (h1.Lang.value, h2.Lang.value) in
-              if c = 0 then cmp (l1, l2) else c
-        in
-        cmp (l1, l2)
-    | _ -> assert false
-  in
-  aux (a.Lang.value, b.Lang.value)
-
 let () =
   let t = Lang.univ_t ~constraints:[Lang_types.Ord] () in
   let register_op name op =
     add_builtin name ~cat:Bool ~descr:"Comparison of comparable values."
       [("", t, None, None); ("", t, None, None)] Lang.bool_t (function
-      | [("", a); ("", b)] -> Lang.bool (op (compare_value a b))
+      | [("", a); ("", b)] -> Lang.bool (op (Lang.compare_values a b))
       | _ -> assert false)
   in
   register_op "==" (fun c -> c = 0);

--- a/src/lang/builtins_list.ml
+++ b/src/lang/builtins_list.ml
@@ -42,10 +42,10 @@ let () =
         List.map
           (fun p ->
             let a, b = Lang.to_product p in
-            (Lang.to_string a, Lang.to_string b))
+            (a, Lang.to_string b))
           (Lang.to_list (Lang.assoc "" 1 p))
       in
-      let k = Lang.to_string (Lang.assoc "" 2 p) in
+      let k = Lang.assoc "" 2 p in
       Lang.string (try List.assoc k l with _ -> ""))
 
 let () =

--- a/src/lang/builtins_list.ml
+++ b/src/lang/builtins_list.ml
@@ -38,15 +38,15 @@ let () =
     ]
     Lang.string_t
     (fun p ->
-      let l =
-        List.map
-          (fun p ->
-            let a, b = Lang.to_product p in
-            (a, Lang.to_string b))
-          (Lang.to_list (Lang.assoc "" 1 p))
-      in
+      let l = List.map Lang.to_product (Lang.to_list (Lang.assoc "" 1 p)) in
       let k = Lang.assoc "" 2 p in
-      Lang.string (try List.assoc k l with _ -> ""))
+      let ans =
+        try
+          Lang.to_string
+            (snd (List.find (fun (k', _) -> Lang.compare_values k k' = 0) l))
+        with _ -> ""
+      in
+      Lang.string ans)
 
 let () =
   let a = Lang.univ_t () in

--- a/src/lang/builtins_list.ml
+++ b/src/lang/builtins_list.ml
@@ -27,20 +27,25 @@ let () = Lang.add_module "list"
 let () =
   (* TODO It would be good to generalize this one but we'd need a way to handle
      errors. *)
+  let a = Lang.univ_t ~constraints:[Lang_types.Ord] () in
   add_builtin "_[_]" ~cat:List
     ~descr:
       "l[k] returns the first v such that (k,v) is in the list l (or \"\" if \
        no such v exists)."
-    [("", Lang.string_t, None, None); ("", Lang.metadata_t, None, None)]
-    Lang.string_t (fun p ->
-      let k = Lang.to_string (Lang.assoc "" 1 p) in
+    [
+      ("", Lang.list_t (Lang.product_t a Lang.string_t), None, None);
+      ("", a, None, None);
+    ]
+    Lang.string_t
+    (fun p ->
       let l =
         List.map
           (fun p ->
             let a, b = Lang.to_product p in
             (Lang.to_string a, Lang.to_string b))
-          (Lang.to_list (Lang.assoc "" 2 p))
+          (Lang.to_list (Lang.assoc "" 1 p))
       in
+      let k = Lang.to_string (Lang.assoc "" 2 p) in
       Lang.string (try List.assoc k l with _ -> ""))
 
 let () =

--- a/src/lang/builtins_string.ml
+++ b/src/lang/builtins_string.ml
@@ -152,7 +152,8 @@ let () =
        list of (index,value). If the list does not have a pair associated to \
        some index, it means that the corresponding pattern was not found."
     [("pattern", Lang.string_t, None, None); ("", Lang.string_t, None, None)]
-    Lang.metadata_t (fun p ->
+    (Lang.list_t (Lang.product_t Lang.int_t Lang.string_t))
+    (fun p ->
       let pattern = Lang.to_string (List.assoc "pattern" p) in
       let string = Lang.to_string (List.assoc "" p) in
       let rex = Pcre.regexp pattern in
@@ -161,16 +162,13 @@ let () =
         let n = Pcre.num_of_subs sub in
         let rec extract l i =
           if i < n then (
-            try
-              extract (l @ [(string_of_int i, Pcre.get_substring sub i)]) (i + 1)
+            try extract (l @ [(i, Pcre.get_substring sub i)]) (i + 1)
             with Not_found -> extract l (i + 1) )
           else l
         in
         let l = extract [] 1 in
         Lang.list
-          (List.map
-             (fun (x, y) -> Lang.product (Lang.string x) (Lang.string y))
-             l)
+          (List.map (fun (x, y) -> Lang.product (Lang.int x) (Lang.string y)) l)
       with Not_found -> Lang.list [])
 
 let () =

--- a/src/lang/builtins_string.ml
+++ b/src/lang/builtins_string.ml
@@ -160,11 +160,11 @@ let () =
       try
         let sub = Pcre.exec ~rex string in
         let n = Pcre.num_of_subs sub in
-        let rec extract l i =
+        let rec extract acc i =
           if i < n then (
-            try extract (l @ [(i, Pcre.get_substring sub i)]) (i + 1)
-            with Not_found -> extract l (i + 1) )
-          else l
+            try extract ((i, Pcre.get_substring sub i) :: acc) (i + 1)
+            with Not_found -> extract acc (i + 1) )
+          else List.rev acc
         in
         let l = extract [] 1 in
         Lang.list

--- a/src/lang/lang.mli
+++ b/src/lang/lang.mli
@@ -74,6 +74,9 @@ val demeth : value -> value
 (** Get a string representation of a value. *)
 val print_value : value -> string
 
+(** Compare values. *)
+val compare_values : value -> value -> int
+
 (** Iter a function over all sources contained in a value. This only applies to
     statically referenced objects, i.e. it does not explore inside reference
     cells. *)

--- a/src/lang/lang_parser.mly
+++ b/src/lang/lang_parser.mly
@@ -288,8 +288,8 @@ expr:
   | expr DOT VARLPAR app_list RPAR   { mk ~pos:$loc (App (mk ~pos:($startpos($1),$endpos($3)) (Invoke ($1, $3)), $4)) }
   | REF DOT VARLPAR app_list RPAR    { mk ~pos:$loc (App (mk ~pos:($startpos($1),$endpos($3)) (Invoke (mk ~pos:$loc($1) (Var "ref"), $3)), $4)) }
   | VARLPAR app_list RPAR            { mk ~pos:$loc (App (mk ~pos:$loc($1) (Var $1), $2)) }
-  | VARLBRA expr RBRA                { mk ~pos:$loc (App (mk ~pos:$loc (Var "_[_]"), ["", $2; "", mk ~pos:$loc($1) (Var $1)])) }
-  | expr DOT VARLBRA expr RBRA       { mk ~pos:$loc (App (mk ~pos:$loc (Var "_[_]"), ["", $4; "", mk ~pos:($startpos($1),$endpos($3)) (Invoke ($1, $3))])) }
+  | VARLBRA expr RBRA                { mk ~pos:$loc (App (mk ~pos:$loc (Var "_[_]"), ["", mk ~pos:$loc($1) (Var $1); "", $2])) }
+  | expr DOT VARLBRA expr RBRA       { mk ~pos:$loc (App (mk ~pos:$loc (Var "_[_]"), ["", mk ~pos:($startpos($1),$endpos($3)) (Invoke ($1, $3)); "", $4])) }
   | BEGIN exprs END                  { $2 }
   | FUN LPAR arglist RPAR YIELDS expr{ mk_fun ~pos:$loc $3 $6 }
   | LCUR exprss RCUR                 { mk_fun ~pos:$loc [] $2 }

--- a/tests/language/list.liq
+++ b/tests/language/list.liq
@@ -51,6 +51,9 @@ def f() =
   end
   t(list.find(default=42,even,[1,3,5]), 42)
   t(list.find(default=42,even,[1,3,4,5,6]), 4)
+  l = [(1,"a"),(2,"b"),(3,"c")]
+  t(l[2],"b")
+  t(l[27],"")
   
   if !success then test.pass() else test.fail() end
 end

--- a/tests/language/list.liq
+++ b/tests/language/list.liq
@@ -51,6 +51,8 @@ def f() =
   end
   t(list.find(default=42,even,[1,3,5]), 42)
   t(list.find(default=42,even,[1,3,4,5,6]), 4)
+  l = list.indexed(["a","b","c"])
+  t(l[1], "b")
   l = [(1,"a"),(2,"b"),(3,"c")]
   t(l[2],"b")
   t(l[27],"")

--- a/tests/language/string.liq
+++ b/tests/language/string.liq
@@ -1,4 +1,4 @@
-#!../src/liquidsoap ../libs/pervasives.liq
+#!../../src/liquidsoap ../../libs/pervasives.liq
 
 %include "test.liq"
 
@@ -33,6 +33,9 @@ def f() =
   t(string.contains(substring="bc","acbd"), false)
   t(string.binary.to_int(little_endian=true,"abcd"),0x64636261)
   t(string.binary.to_int(little_endian=false,"abcd"),0x61626364)
+  s = string.extract(pattern="([^=]*)=(.*)", "ab=cde")
+  t(s[1], "ab")
+  t(s[2], "cde")
   
   if !success then test.pass() else test.fail() end
 end

--- a/tests/regression/123.liq
+++ b/tests/regression/123.liq
@@ -1,3 +1,5 @@
+#!../../src/liquidsoap ../../libs/pervasives.liq
+
 # Correctly parse urls with empty arguments.
 # https://github.com/savonet/liquidsoap/issues/123
 


### PR DESCRIPTION
The indices of groups returned by `string.extract` are now integers. This required generalizing `_[_]` so that the key can be any type (and I also changed the order of arguments to be the natural one).