### PR TITLE
Invert parser priorities.

### DIFF
--- a/src/lang/lang_parser.mly
+++ b/src/lang/lang_parser.mly
@@ -200,17 +200,16 @@
 %token <string> PP_INCLUDE
 %token <string list> PP_COMMENT
 
-%nonassoc YIELDS       /* fun x -> (x+x) */
-%right SET             /* expr := (expr + expr), expr := (expr := expr) */
-%nonassoc REF          /* ref (1+2) */
-%left BIN0             /* ((x+(y*z))==3) or ((not a)==b) */
-%left BIN1
-%nonassoc NOT
-%left BIN2 MINUS
-%left BIN3 TIMES
-%nonassoc GET          /* (!x)+2 */
 %left DOT
-
+%nonassoc GET          /* (!x)+2 */
+%left BIN3 TIMES
+%left BIN2 MINUS
+%nonassoc NOT
+%left BIN1
+%left BIN0             /* ((x+(y*z))==3) or ((not a)==b) */
+%nonassoc REF          /* ref (1+2) */
+%right SET             /* expr := (expr + expr), expr := (expr := expr) */
+%nonassoc YIELDS       /* fun x -> (x+x) */
 
 /* Read %ogg(...) as one block, shifting LPAR rather than reducing %ogg */
 %nonassoc no_app


### PR DESCRIPTION
Looking from the `menhir` doc it looks like the priorities are in inverted order. That probably comes from when this code was migrated. Doc says:
> The priority level assigned to uid1, . . . , uidn is not defined explicitly: instead, it is defined to be higher than the priority level assigned by the previous %nonassoc, %left, or %right declaration, and lower than that assigned by the next %nonassoc, %left, or %right declaration. 
Link: http://gallium.inria.fr/~fpottier/menhir/manual.pdf

Example before:
```
# ref 1 + 2;;
- : ref(int) = ref(3)
```
After:
```
# ref 1 + 2;;
At line 1, char 0-5:
Error 5: this value has type
  ref(int)
but it should be a subtype of
  something that is a number type
```