### PR TITLE
Remove ref as a keyword.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -106,6 +106,8 @@ Changed:
   strings (#1240).
 - Generalize the `l[k]` notation so that the key `k` can be of any type (on
   which we know how to compare).
+- `ref` is not a keyword anymore: this means that `ref x` is not accepted
+  anymore, you need to write `ref(x)` (#1254).
 
 Fixed:
 

--- a/doc/liquidsoap.xml
+++ b/doc/liquidsoap.xml
@@ -39,7 +39,6 @@
       <item>and</item>
       <item>or</item>
       <item>not</item>
-      <item>ref</item>
       <item>!</item>
     </list>
 

--- a/libs/fades.liq
+++ b/libs/fades.liq
@@ -46,7 +46,7 @@ def mkfade(~type="lin",~start=0.,~stop=1.,~duration=3.,~on_done={()},s) =
       lin_shape
     end
 
-  start_time = ref (-1.)
+  start_time = ref(-1.)
   def fade() =
     if !start_time < 0. then
       start_time := source.time(s)
@@ -89,10 +89,10 @@ def fade.out(~id="fade.out",~duration=3.,
              ~override_type="liq_fade_type",
              ~type="lin",s) =
   log = log(label=source.id(s),level=4)
-  fn = ref (fun () -> 1.)
-  type = ref type
-  duration = ref duration
-  start_time = ref (-1.)
+  fn = ref(fun () -> 1.)
+  type = ref(type)
+  duration = ref(duration)
+  start_time = ref(-1.)
 
   def start_fade(d,_) =
     log("Fading out with #{d}s remaining..")
@@ -142,9 +142,9 @@ def fade.skip(~id="fade.skip",~duration=5.,
              ~override_skip="liq_skip_meta",
              ~type="lin",s) =
   log = log(label=source.id(s),level=4)
-  fn = ref (fun () -> 1.)
-  type = ref type
-  duration = ref duration  
+  fn = ref(fun () -> 1.)
+  type = ref(type)
+  duration = ref(duration)
 
   def apply() =
     fn = !fn
@@ -191,7 +191,7 @@ end
 # @param ~type Fader shape (lin|sin|log|exp): linear, sinusoidal, logarithmic or exponential.
 def fade.final(~id="fade.final",~duration=3.,~type="lin",s) =
   fn = mkfade(start=1.,stop=0.,type=type,duration=duration,s)
-  should_play = ref true
+  should_play = ref(true)
 
   def fn() =
     v = fn()
@@ -218,9 +218,9 @@ def fade.in(~id="fade.in",~duration=3.,
             ~override_type="liq_fade_type",
             ~type="lin",s) =
   log = log(label=source.id(s),level=4)
-  fn = ref (fun () -> 0.)
-  duration = ref duration
-  type = ref type
+  fn = ref(fun () -> 0.)
+  duration = ref(duration)
+  type = ref(type)
 
   def apply() =
     fn = !fn
@@ -382,7 +382,7 @@ end
 # @param ~special The special source.
 def smooth_add(~delay=0.5,~p=float_getter(0.2),~normal,~special)
   p = to_float_getter(p)
-  last_p = ref p()
+  last_p = ref(p())
 
   def c(fn,s) =
     def v() =
@@ -392,10 +392,10 @@ def smooth_add(~delay=0.5,~p=float_getter(0.2),~normal,~special)
     fade.scale(v,s)
   end
 
-  special_volume = ref fun () -> 0.
+  special_volume = ref(fun () -> 0.)
   special = c(special_volume,special)
 
-  normal_volume = ref fun () -> 1.
+  normal_volume = ref(fun () -> 1.)
   normal = c(normal_volume,normal)
 
   def to_special(b,special) =

--- a/libs/hls.liq
+++ b/libs/hls.liq
@@ -5,9 +5,9 @@
 # @param uri Playlist URI
 # @flag experimental
 def input.hls(~id="",~reload=10.,uri)
-  playlistr = ref []
-  sequence = ref 0
-  playlist_uri = ref uri
+  playlistr = ref([])
+  sequence = ref(0)
+  playlist_uri = ref(uri)
 
   def load_playlist () =
     pl = request.create(!playlist_uri)

--- a/libs/http.liq
+++ b/libs/http.liq
@@ -30,11 +30,11 @@ def http_response(~protocol="HTTP/1.1",
     else
       headers
     end
-  resp = ref
+  resp = ref(
     "#{protocol} #{code} #{status}\r\n\
      #{headers}\
      \r\n\
-     #{data}"
+     #{data}")
   def resp () =
     ret = !resp
     resp := ""
@@ -76,7 +76,7 @@ def http_response_stream(
     "#{protocol} #{code} #{status}\r\n\
      #{headers}\
      \r\n"
-  head_sent = ref false
+  head_sent = ref(false)
   def resp () =
     if !head_sent then
       data()

--- a/libs/switches.liq
+++ b/libs/switches.liq
@@ -30,8 +30,8 @@ def rotate(~id="", ~override="liq_transition_length", ~replay_metadata=true,
            ~transition_length=5., ~transitions=[],
            ~weights=[], sources) =
   weights = list.map(to_int_getter, weights)
-  picked_index = ref -1
-  tracks_played = ref 0
+  picked_index = ref(-1)
+  tracks_played = ref(0)
   default_weight = fun () -> 1
 
   def pick() =
@@ -99,7 +99,7 @@ def replaces random(~id="", ~override="liq_transition_length", ~replay_metadata=
            ~weights=[], sources) =
   weights = list.map(to_int_getter, weights)
   default_weight = fun () -> 1
-  next_index = ref -1
+  next_index = ref(-1)
 
   def pick() =
     def available_weighted_sources(cur, s) =

--- a/libs/utils.liq
+++ b/libs/utils.liq
@@ -324,7 +324,7 @@ end
 # @param ~weights Weights of the children (padded with 1), defining for each child how many tracks are played from it per round, if that many are actually available.
 # @param sources Sequence of sources to be merged
 def rotate.merge(~id="",~transitions=[],~weights=[],sources)
-  ready = ref true
+  ready = ref(true)
   duration = get(default=0.04,"frame.duration")
 
   def to_first(old,new) =
@@ -382,7 +382,7 @@ end
 def overlap_sources(~id="",~normalize=false,
                     ~start_next="liq_start_next",
                     ~weights=[],sources) =
-  position = ref 0
+  position = ref(0)
   length   = list.length(sources)
 
   def current_position() =
@@ -391,8 +391,8 @@ def overlap_sources(~id="",~normalize=false,
     pos
   end
 
-  ready_list = list.map(fun (_) -> ref false,sources)
-  grab_ready = list.nth(default=ref false,ready_list)
+  ready_list = list.map(fun (_) -> ref(false),sources)
+  grab_ready = list.nth(default=ref(false),ready_list)
 
   def set_ready(pos,b) =
     is_ready = grab_ready(pos)
@@ -417,7 +417,7 @@ def overlap_sources(~id="",~normalize=false,
   sources = list.mapi(disable,sources)
 
   # Relay metadata from all sources
-  send_to_main_source = ref fun (_) -> ()
+  send_to_main_source = ref(fun (_) -> ())
 
   def relay_metadata(m) =
     fn = !send_to_main_source
@@ -473,7 +473,7 @@ def chop(~duration=float_getter(3.),~metadata=[],s) =
   s = insert_metadata(s)
 
   # Track time in the source's context:
-  start_time = ref 0.
+  start_time = ref(0.)
   def f() =
     if duration () <= source.time(s) - !start_time then
       start_time := source.time(s)

--- a/scripts/liquidsoap-mode.el
+++ b/scripts/liquidsoap-mode.el
@@ -6,7 +6,7 @@
    ("#.*" . 'font-lock-comment-face)
    ("^\\(%ifdef .*\\|%ifndef .*\\|%ifencoder .*\\|%ifnencoder .*\\|%endif\\|%include\\|%define\\)" . 'font-lock-preprocessor-face)
    ("\\<\\(fun\\|def\\|rec\\|replaces\\|begin\\|end\\|if\\|then\\|else\\|elsif\\|let\\|try\\|catch\\|while\\|for\\|in\\|do\\)\\>\\|->\\|;" . font-lock-keyword-face)
-   ("\\<\\(and\\|or\\|not\\|mod\\|ref\\|??\\)\\>\\|:=" . font-lock-builtin-face)
+   ("\\<\\(and\\|or\\|not\\|mod\\|??\\)\\>\\|:=" . font-lock-builtin-face)
    ("\\<\\(true\\|false\\)\\>" . font-lock-constant-face)
    ("\\<def[ \t]+\\([^ (]*\\)" 1 'font-lock-function-name-face)
   )

--- a/src/lang/lang_lexer.ml
+++ b/src/lang/lang_lexer.ml
@@ -159,7 +159,6 @@ let rec token lexbuf =
     | "%define" -> PP_DEFINE
     | '#', Star (Compl '\n'), eof -> EOF
     | eof -> EOF
-    | "ref" -> REF
     | "def" -> PP_DEF
     | "replaces" -> REPLACES
     | "try" -> TRY

--- a/src/lang/lang_parser.mly
+++ b/src/lang/lang_parser.mly
@@ -195,7 +195,7 @@
 %token MINUS UMINUS
 %token UNDERSCORE
 %token NOT
-%token REF GET SET
+%token GET SET
 %token<string> PP_IFDEF PP_IFNDEF
 %token PP_IFENCODER PP_IFNENCODER PP_ENDIF
 %token PP_ENDL PP_DEF PP_DEFINE
@@ -206,7 +206,6 @@
 %nonassoc YIELDS       /* fun x -> (x+x) */
 %nonassoc COALESCE         /* (x | y) == z */
 %right SET             /* expr := (expr + expr), expr := (expr := expr) */
-%nonassoc REF          /* ref (1+2) */
 %right DOTDOT
 %left BIN0             /* ((x+(y*z))==3) or ((not a)==b) */
 %left BIN1
@@ -268,7 +267,6 @@ expr:
   | STRING                           { mk ~pos:$loc (Ground (String $1)) }
   | VAR                              { mk ~pos:$loc (Var $1) }
   | varlist                          { mk ~pos:$loc (List $1) }
-  | REF expr                         { mk ~pos:$loc (App (mk ~pos:$loc($1) (Var "ref"), ["", $2])) }
   | GET expr                         { mk ~pos:$loc (App (mk ~pos:$loc($1) (Invoke (mk ~pos:$loc($1) (Var "ref"), "get")), ["", $2])) }
   | expr SET expr                    { mk ~pos:$loc (App (mk ~pos:$loc($2) (Invoke (mk ~pos:$loc($1) (Var "ref"), "set")), ["", $1; "", $3])) }
   | MP3 app_opt                      { mk_enc ~pos:$loc (Lang_mp3.make_cbr $2) }
@@ -291,7 +289,6 @@ expr:
   | LCUR RCUR                        { mk ~pos:$loc (Tuple []) }
   | expr DOT VAR                     { mk ~pos:$loc (Invoke ($1, $3)) }
   | expr DOT VARLPAR app_list RPAR   { mk ~pos:$loc (App (mk ~pos:($startpos($1),$endpos($3)) (Invoke ($1, $3)), $4)) }
-  | REF DOT VARLPAR app_list RPAR    { mk ~pos:$loc (App (mk ~pos:($startpos($1),$endpos($3)) (Invoke (mk ~pos:$loc($1) (Var "ref"), $3)), $4)) }
   | VARLPAR app_list RPAR            { mk ~pos:$loc (App (mk ~pos:$loc($1) (Var $1), $2)) }
   | VARLBRA expr RBRA                { mk ~pos:$loc (App (mk ~pos:$loc (Var "_[_]"), ["", mk ~pos:$loc($1) (Var $1); "", $2])) }
   | expr DOT VARLBRA expr RBRA       { mk ~pos:$loc (App (mk ~pos:$loc (Var "_[_]"), ["", mk ~pos:($startpos($1),$endpos($3)) (Invoke ($1, $3)); "", $4])) }
@@ -363,7 +360,6 @@ expr:
 ty:
   | VAR                       { mk_ty ~pos:$loc $1 [] }
   | VARLPAR ty_args RPAR      { mk_ty ~pos:$loc $1 $2 }
-  | REF LPAR ty RPAR          { Lang_values.ref_t ~pos:(Some $loc) $3 }
   | LBRA ty RBRA              { Lang_types.make (Lang_types.List $2) }
   | LPAR ty_tuple RPAR        { Lang_types.make (Lang_types.Tuple $2) }
   | INT                       { Lang_values.type_of_int $1 }
@@ -465,7 +461,6 @@ var:
 varlpar:
   | VARLPAR         { [$1] }
   | VAR DOT varlpar { $1::$3 }
-  | REF DOT varlpar { "ref"::$3 }
 
 arglist:
   |                   { [] }

--- a/tests/language/Makefile
+++ b/tests/language/Makefile
@@ -5,7 +5,7 @@ TESTS = $(filter-out test, $(basename $(LIQ)))
 DISTFILES = Makefile $(LIQ)
 top_srcdir = $(shell realpath ../..)
 
-test: type_errors $(TESTS)
+test: $(TESTS) type_errors
 
 %: %.liq
 	@../run_test.sh "$(top_srcdir)/src/liquidsoap --no-pervasives $(top_srcdir)/libs/pervasives.liq -" language/$<

--- a/tests/language/json.liq
+++ b/tests/language/json.liq
@@ -4,7 +4,7 @@
 
 %include "test.liq"
 
-success = ref true
+success = ref(true)
 
 def t(d,x) =
   y = of_json(default=d,json_of(x))

--- a/tests/performance/Makefile
+++ b/tests/performance/Makefile
@@ -17,7 +17,7 @@ big-record.liq:
 	@echo "def sum () =" >> $@
 	@echo "r = ()" >> $@
 	@for i in `seq 5000`; do echo "let r.a$$i = $$i"; done >> $@
-	@echo "n = ref 0" >> $@
+	@echo "n = ref(0)" >> $@
 	@for i in `seq 5000`; do echo "n := !n + r.a$$i"; done >> $@
 	@echo "end" >> $@
 	@echo 'time("sum of fields", sum)' >> $@

--- a/tests/regression/115-2.liq
+++ b/tests/regression/115-2.liq
@@ -2,7 +2,7 @@
 
 sa = sine()
 
-sb_on = ref false
+sb_on = ref(false)
 sb = switch([({!sb_on},once(sine(220.,duration=2.)))])
 thread.run(delay=1., { sb_on := true })
 

--- a/tests/regression/BUG403.liq
+++ b/tests/regression/BUG403.liq
@@ -12,7 +12,7 @@
 
 %include "test.liq"
 
-r = ref false
+r = ref(false)
 def pred () =
   v = !r
   r := false

--- a/tests/regression/GH1129.liq
+++ b/tests/regression/GH1129.liq
@@ -7,7 +7,7 @@
 # Track selection 2 -> s1 ready, s2 ready, s3 ready -> switch to s1
 # Bug appears when it switches to s3 again on step 2
 
-selected = ref []
+selected = ref([])
 
 s1 = blank(duration=0.04)
 
@@ -17,7 +17,7 @@ end
 
 s1 = map_metadata(id="s1",m1,s1)
 
-s2_ready = ref false
+s2_ready = ref(false)
 
 s2 = switch(id="s2",[({!s2_ready},blank(duration=0.04))])
 

--- a/tests/regression/GH1146.liq
+++ b/tests/regression/GH1146.liq
@@ -5,7 +5,7 @@
 # makes sure we don't have such regression in the
 # future.
 
-track_count = ref 0
+track_count = ref(0)
 
 s = single("../media/files/audio/@flac(stereo).flac")
 

--- a/tests/regression/LS354-1.liq
+++ b/tests/regression/LS354-1.liq
@@ -4,7 +4,7 @@ s = on_track(
      fun(_)-> begin test.pass(); shutdown() end,
      blank(duration=1.))
 
-r = ref false
+r = ref(false)
 d = source.dynamic({ if !r then [s] else [] end })
 
 output.dummy(mksafe(d))

--- a/tests/regression/LS354-2.liq
+++ b/tests/regression/LS354-2.liq
@@ -5,7 +5,7 @@ s2 = on_track(
        fun(_)-> begin test.pass(); shutdown() end,
        blank(duration=1.))
 
-r = ref 0
+r = ref(0)
 d = source.dynamic({ if !r==1 then [s1]
                      elsif !r==2 then [s2]
                      else [] end })

--- a/tests/streams/random.liq
+++ b/tests/streams/random.liq
@@ -5,7 +5,7 @@
 # Track selection 2 -> s1 not ready, s2 ready -> switch to s2
 # Track selection 3 -> s1 ready, s2 with weight 0 -> switch to s1
 
-selected = ref []
+selected = ref([])
 
 s1 = blank(duration=0.04)
 
@@ -15,11 +15,11 @@ end
 
 s1 = map_metadata(m1,s1)
 
-s1_ready = ref true
+s1_ready = ref(true)
 
 s1 = switch(id="s1",[({!s1_ready},s1)])
 
-s1_weight = ref 1
+s1_weight = ref(1)
 
 s2 = blank(duration=0.04)
 
@@ -29,13 +29,13 @@ end
 
 s2 = map_metadata(id="s2",m2,s2)
 
-s2_ready = ref false
+s2_ready = ref(false)
 
 s2 = switch(id="s2",[({!s2_ready},s2)])
 
-s2_weight = ref 1
+s2_weight = ref(1)
 
-round = ref 1
+round = ref(1)
 
 def f(m) =
   if !round == 1 then


### PR DESCRIPTION
There was no need for `ref` to be a keyword and it used to uselessly complicate the grammar.