### PR TITLE
Add support for `x ? y : z`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@ New:
 
 - Add support for errors with `error.*` and `try ... catch` (#1242).
 - Add support for optional values with `null.*` (#1242).
+- Add support for `x ? y : z` syntax (#1266).
 - Added support for video encoding and decoding using `ffmpeg` (#1038).
 - Added support for ffmpeg filters (#1038).
 - Added `output.url` for encoders that support handling data output (currently only `%ffmpeg`) (#1038).

--- a/src/lang/lang_parser.mly
+++ b/src/lang/lang_parser.mly
@@ -215,6 +215,8 @@
 %left BIN3 TIMES
 %nonassoc GET          /* (!x)+2 */
 %left DOT
+%nonassoc QUESTION    /* x ? y : z */
+%nonassoc COLON
 
 
 /* Read %ogg(...) as one block, shifting LPAR rather than reducing %ogg */
@@ -325,6 +327,11 @@ expr:
                                        let else_b = $5 in
                                        let op = mk ~pos:$loc($1) (Var "if") in
                                        mk ~pos:$loc (App (op, ["", cond; "else", else_b; "then", then_b])) }
+  | expr QUESTION expr COLON expr    { let cond = $1 in
+                                       let then_b = mk_fun ~pos:$loc($3) [] $3 in
+                                       let else_b = mk_fun ~pos:$loc($5) [] $5 in
+                                       let op = mk ~pos:$loc($1) (Var "if") in
+                                       mk ~pos:$loc (App (op, ["", cond; "else", else_b; "then", then_b])) } 
   | SERVER_WAIT exprs THEN exprs END { let condition = $2 in
                                        let op = mk ~pos:$loc (Var "server.wait") in
                                        let after = mk_fun ~pos:$loc($4) [] $4 in

--- a/tests/language/eval.liq
+++ b/tests/language/eval.liq
@@ -47,6 +47,9 @@ def f() =
 
   t("15",{ list.remove(2,[2]) == [] })
 
+  t("16", { "bla" == true ? "bla" : "foo" })
+  t("17", { "foo" == false ? "bla" : "foo" })
+
   if !fail then test.fail() else test.pass() end
 end
 

--- a/tests/language/type_errors.pl
+++ b/tests/language/type_errors.pl
@@ -44,6 +44,9 @@ incorrect('(1,1)==("1",1)');
 incorrect('1==request.create("")');
 incorrect('fun(x)->x(snd(x))');
 
+correct('true ? "foo" : "bar"');
+incorrect('false ? true : "bar"');
+
 section("SUBTYPING");
 incorrect('(1:unit)');
 # Next one requires the inference of a subtype (fixed vs. variable arity)


### PR DESCRIPTION
Fixes https://github.com/savonet/liquidsoap/issues/1263