### PR TITLE
Enhance typing of lists.

### DIFF
--- a/src/lang/lang_types.ml
+++ b/src/lang/lang_types.ml
@@ -845,7 +845,7 @@ type explanation = bool * t * t * repr * repr
 
 exception Type_Error of explanation
 
-let print_type_error error_header (flipped, ta, tb, a, b) =
+let print_type_error error_header ((flipped, ta, tb, a, b) : explanation) =
   error_header (print_pos_opt ta.pos);
   match b with
     | `Meth (l, ([], `Ellipsis), `Ellipsis) ->

--- a/src/lang/lang_values.ml
+++ b/src/lang/lang_values.ml
@@ -712,27 +712,41 @@ let rec check ?(print_toplevel = false) ~level ~(env : T.env) e =
     | Encoder f -> e.t >: type_of_format ~pos:e.t.T.pos ~level f
     | List l ->
         List.iter (fun x -> check ~level ~env x) l;
-        (* Compute common methods. *)
-        let m =
-          (* All the methods of a term. *)
-          let rec methods e =
-            match e.term with
-              | Meth (l, _, e') -> (l, T.invoke e.t l) :: methods e'
-              | _ -> []
-          in
-          let method_names e = List.map fst (methods e) in
-          match l with
-            | e :: ee ->
-                let ee = List.map method_names ee in
-                List.filter
-                  (fun (l, _) -> List.for_all (List.mem l) ee)
-                  (methods e)
-            | [] -> []
-        in
         let a = T.fresh_evar ~level ~pos in
-        List.iter
-          (fun (l, t) -> a <: T.make (T.Meth (l, t, T.fresh_evar ~level ~pos)))
-          m;
+        (* Ensure that we have common methods. *)
+        let () =
+          (* Common methods. *)
+          let m =
+            (* All the methods of a term. *)
+            let rec methods e =
+              match e.term with
+                | Meth (l, _, e') -> (l, T.invoke e.t l) :: methods e'
+                | _ -> []
+            in
+            let method_names e = List.map fst (methods e) in
+            match l with
+              | e :: ee ->
+                  let ee = List.map method_names ee in
+                  List.filter
+                    (fun (l, _) -> List.for_all (List.mem l) ee)
+                    (methods e)
+              | [] -> []
+          in
+          List.iter
+            (fun (l, t) ->
+              a <: T.make (T.Meth (l, t, T.fresh_evar ~level ~pos)))
+            m
+        in
+        (* Allow lists to contain both active sources and sources. *)
+        let () =
+          let is_source e =
+            match (T.demeth e.t).T.descr with
+              | T.Constr c -> c.T.name = "source"
+              | _ -> false
+          in
+          if List.exists is_source l then
+            a <: source_t ~level ~pos (T.fresh_evar ~level ~pos)
+        in
         List.iter
           (fun e ->
             (* We demeth in order not to force methods which are not in common. *)

--- a/tests/language/list.liq
+++ b/tests/language/list.liq
@@ -71,6 +71,8 @@ def f() =
   # Ensure that common methods are kept and others are forgotten
   l = [ "a".{b = true, k = 0} , "b".{b = true, l = 1} ]
   t(list.for_all(fun (x) -> x.b, l), true)
+  # Ensure that we can have active sources and sources
+  ignore([input(), blank()])
   
   if !success then test.pass() else test.fail() end
 end

--- a/tests/language/list.liq
+++ b/tests/language/list.liq
@@ -67,6 +67,10 @@ def f() =
   let [x,_,...z] = [1,2,3]
   t(x, 1)
   t(z, [3])
+
+  # Ensure that common methods are kept and others are forgotten
+  l = [ "a".{b = true, k = 0} , "b".{b = true, l = 1} ]
+  t(list.for_all(fun (x) -> x.b, l), true)
   
   if !success then test.pass() else test.fail() end
 end


### PR DESCRIPTION
We simplify the typing of lists (I don't understand why we needed to compute the sup beforehand in previous version, this looks like a useless hack).

If the simple method does not work, we try to remove methods in order not to
uselessly force methods. Before that the following was not working:

```
queue = request.queue()
radio = fallback([queue, playlist])
```

because `queue` has a method `push` and `playlist` does not have it.