### PR TITLE
Saner interface for processes.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -111,6 +111,8 @@ Changed:
 - `ref` is not a keyword anymore: this means that `ref x` is not accepted
   anymore, you need to write `ref(x)` (#1254).
 - Renamed `file.unlink` to `file.remove`.
+- Deprecated `get_process_output`, `get_process_lines`, `test_process` and
+  `system` in favor of `process.run`, `process.read` and `process.read.lines`.
 
 Fixed:
 

--- a/libs/deprecations.liq
+++ b/libs/deprecations.liq
@@ -298,11 +298,44 @@ def fade.final(~id="fade.final",~duration=3.,~type="lin",s) =
 end
 
 # Deprecated: was designed for transitions only and is not
-# needed anymore
+# needed anymore.
 # @flag hidden
 def fade.initial(~id="fade.initial",~duration=3.,~type="lin",s) =
   deprecated("fade.initial", "fade.in")  
 
   fn = mkfade(start=0.,stop=1.,type=type,duration=duration,s)
   fade.scale(id=id,fn,s)
+end
+
+# Deprecated: use `process.read` instead.
+# @flag hidden
+def get_process_output(~timeout=(-1.),~env=[],~inherit_env=true,command) =
+  deprecated("get_process_output", "process.read")
+
+  stdout = process.read(timeout=timeout, env=env, inherit_env=inherit_env, command)
+  string(stdout)
+end
+
+# Deprecated: use `process.read.lines` instead.
+# @flag hidden
+def get_process_lines(~timeout=(-1.),~env=[],~inherit_env=true,command) =
+  deprecated("get_process_lines", "process.read.lines")
+
+  process.read.lines(timeout=timeout, env=env, inherit_env=inherit_env, command)
+end
+
+# Deprecated: use `process.test` instead.
+# @flag hidden
+def test_process(~timeout=(-1.),~env=[],~inherit_env=true,command) =
+  deprecated("test_process", "process.test")
+
+  process.test(timeout=timeout, env=env, inherit_env=inherit_env, command)
+end
+
+# Deprecated: use `process.run` instead.
+# @flag hidden
+def system(command) =
+  deprecated("system", "process.run")
+
+  process.run(command)
 end

--- a/libs/deprecations.liq
+++ b/libs/deprecations.liq
@@ -312,8 +312,8 @@ end
 def get_process_output(~timeout=(-1.),~env=[],~inherit_env=true,command) =
   deprecated("get_process_output", "process.read")
 
-  stdout = process.read(timeout=timeout, env=env, inherit_env=inherit_env, command)
-  string(stdout)
+  p = process.read(timeout=timeout, env=env, inherit_env=inherit_env, command)
+  p.stdout
 end
 
 # Deprecated: use `process.read.lines` instead.

--- a/libs/deprecations.liq
+++ b/libs/deprecations.liq
@@ -312,8 +312,7 @@ end
 def get_process_output(~timeout=(-1.),~env=[],~inherit_env=true,command) =
   deprecated("get_process_output", "process.read")
 
-  p = process.read(timeout=timeout, env=env, inherit_env=inherit_env, command)
-  p.stdout
+  process.read(timeout=timeout, env=env, inherit_env=inherit_env, command)
 end
 
 # Deprecated: use `process.read.lines` instead.

--- a/libs/externals.liq
+++ b/libs/externals.liq
@@ -30,7 +30,7 @@ def enable_external_ffmpeg_decoder() =
   mime_types = get(default=[],"decoder.mime_types.ffmpeg")
 
   def ffprobe_test(fname) =
-    json = get_process_output("#{ffprobe} -print_format json -show_streams #{string.quote(fname)}")
+    json = process.read("#{ffprobe} -print_format json -show_streams #{string.quote(fname)}")
     default = [("streams",[[("channels",0)]])]
     data = of_json(default=default,json)
     streams = list.assoc(default=[],"streams",data)
@@ -71,7 +71,7 @@ def enable_external_mpc_decoder() =
     def get_channels(file) =
       int_of_string(
         list.hd(default="",
-          get_process_lines("#{mpcdec} -i #{string.quote(file)} 2>&1 \
+          process.read.lines("#{mpcdec} -i #{string.quote(file)} 2>&1 \
                              | grep channels | cut -d' ' -f 2")))
     end
     # Get the file's mime
@@ -130,7 +130,7 @@ def enable_external_flac_decoder() =
     def test_flac(fname) =
       if file.which(metaflac) != "" then
         channels = list.hd(default="",
-                           get_process_lines("#{metaflac} \
+                           process.read.lines("#{metaflac} \
                                               --show-channels #{string.quote(fname)}"))
         # If the value is not an int, this returns 0 and we are ok :)
         int_of_string(channels)
@@ -155,7 +155,7 @@ def enable_external_flac_decoder() =
     log(label="decoder.external","Enabling EXTERNAL_FLAC metadata \
                 resolver.")
     def flac_meta(fname)
-      ret = get_process_lines("#{metaflac} --export-tags-to=- \
+      ret = process.read.lines("#{metaflac} --export-tags-to=- \
                    #{string.quote(fname)}")
       ret = list.map(string.split(separator="="),ret)
       # Could be made better..
@@ -228,7 +228,7 @@ def enable_external_faad_decoder() =
     def test_faad(file) =
       if faad_test(file) then
         channels = list.hd(default="",
-                           get_process_lines("#{faad} -i #{string.quote(file)} 2>&1 | \
+                           process.read.lines("#{faad} -i #{string.quote(file)} 2>&1 | \
                                               grep 'ch,'"))
         ret = string.extract(pattern=", (\\d) ch,",channels)
         ret =
@@ -248,8 +248,7 @@ def enable_external_faad_decoder() =
                           the faad binary.", test=test_faad, faad_p)
     def faad_meta(file) =
       if faad_test(file) then
-        ret = get_process_lines("#{faad} -i \
-                     #{string.quote(file)} 2>&1")
+        ret = process.read.lines("#{faad} -i #{string.quote(file)} 2>&1")
         # Yea, this is ugly programming (again)!
         def get_meta(l,s)=
           ret = string.extract(pattern="^(\\w+):\\s(.+)$",s)
@@ -296,7 +295,7 @@ def osd_metadata(~color="green",~position="top",
   osd = 'osd_cat -p #{position} --font #{string.quote(font)}'
       ^ ' --color #{color}'
   def feedback(m)
-    system("echo #{string.quote(display(m))} | #{osd} &")
+    ignore(process.run("echo #{string.quote(display(m))} | #{osd} &"))
   end
   on_metadata(feedback,s)
 end
@@ -314,7 +313,7 @@ def notify_metadata(~urgency="low",~icon="stock_smiley-22",~time=3000,
            ~title="Liquidsoap: new track",s)
   send = 'notify-send -i #{icon} -u #{urgency}'
        ^ ' -t #{time} #{string.quote(title)} '
-  on_metadata(fun (m) -> system(send^string.quote(display(m))),s)
+  on_metadata(fun (m) -> ignore(process.run(send^string.quote(display(m)))),s)
 end
 
 %ifdef input.external.wav

--- a/libs/file.liq
+++ b/libs/file.liq
@@ -37,8 +37,8 @@ end
 # @param file The file to test
 def get_mime(fname) =
   def file_method(fname) =
-    if test_process("which file") then
-      list.hd(default="",get_process_lines("file -b --mime-type #{string.quote(fname)}"))
+    if process.test("which file") then
+      list.hd(default="", process.read.lines("file -b --mime-type #{string.quote(fname)}"))
     else
       ""
     end

--- a/libs/http.liq
+++ b/libs/http.liq
@@ -139,7 +139,7 @@ end
 
 # @flag hidden
 def get_mime_process(file) =
-  list.hd(default="",get_process_lines("file -b -I #{string.quote(file)}"))
+  list.hd(default="", process.read.lines("file -b -I #{string.quote(file)}"))
 end
 
 # @flag hidden

--- a/libs/process.liq
+++ b/libs/process.liq
@@ -1,4 +1,4 @@
-# Perform a shell call and return the list of its output lines.
+# Perform a shell call and return its output.
 # @category System
 # @param ~timeout Cancel process after `timeout` has elapsed. Ignored if negative.
 # @param ~env Process environment

--- a/libs/process.liq
+++ b/libs/process.liq
@@ -1,12 +1,12 @@
-# Perform a shell call and return its output.
+# Perform a shell call and return the list of its output lines.
 # @category System
 # @param ~timeout Cancel process after `timeout` has elapsed. Ignored if negative.
 # @param ~env Process environment
 # @param ~inherit_env Inherit calling process's environment when `env` parameter is empty.
 # @param command Command to run
-def get_process_output(~timeout=(-1.),~env=[],~inherit_env=true,command) =
-  let (stdout, _, _) = run_process(timeout=timeout,env=env,inherit_env=inherit_env,command)
-  stdout
+def process.read(~timeout=(-1.),~env=[],~inherit_env=true,command)
+  p = process.run(timeout=timeout, env=env, inherit_env=inherit_env, command)
+  p.stdout
 end
 
 # Perform a shell call and return the list of its output lines.
@@ -15,8 +15,9 @@ end
 # @param ~env Process environment
 # @param ~inherit_env Inherit calling process's environment when `env` parameter is empty.
 # @param command Command to run
-def get_process_lines(~timeout=(-1.),~env=[],~inherit_env=true,command) =
-  string.split(separator="\r?\n",get_process_output(timeout=timeout,env=env,inherit_env=inherit_env,command))
+def process.read.lines(~timeout=(-1.),~env=[],~inherit_env=true,command)
+  s = process.read(timeout=timeout, env=env, inherit_env=inherit_env, command)
+  string.split(separator="\r?\n", s)
 end
 
 # Return true if process exited with 0 code.
@@ -25,9 +26,9 @@ end
 # @param ~env Process environment
 # @param ~inherit_env Inherit calling process's environment when `env` parameter is empty.
 # @param command Command to test
-def test_process(~timeout=(-1.),~env=[],~inherit_env=true,command) =
-  let (_, _, status) = run_process(timeout=timeout,env=env,command)
-  status == ("exit","0")
+def process.test(~timeout=(-1.),~env=[],~inherit_env=true,command)
+  p = process.read(timeout=timeout, env=env, inherit_env=inherit_env, command)
+  p.status == "exit"
 end
 
 # Read some value from standard input (console).
@@ -35,11 +36,11 @@ end
 # @param ~hide Hide typed characters (for passwords).
 def read(~hide=false)
   if hide then
-    system("stty -echo")
+    process.run("stty -echo")
   end
-  s = list.hd(default="",get_process_lines("read BLA && echo $BLA"))
+  s = list.hd(default="", process.read.lines("read BLA && echo $BLA"))
   if hide then
-    system("stty echo")
+    process.run("stty echo")
   end
   print("")
   s

--- a/libs/process.liq
+++ b/libs/process.liq
@@ -27,8 +27,8 @@ end
 # @param ~inherit_env Inherit calling process's environment when `env` parameter is empty.
 # @param command Command to test
 def process.test(~timeout=(-1.),~env=[],~inherit_env=true,command)
-  p = process.read(timeout=timeout, env=env, inherit_env=inherit_env, command)
-  p.status == "exit" and p.status.code == 0
+  p = process.run(timeout=timeout, env=env, inherit_env=inherit_env, command)
+  string(p.status) == "exit" and p.status.code == 0
 end
 
 # Read some value from standard input (console).

--- a/libs/process.liq
+++ b/libs/process.liq
@@ -28,7 +28,7 @@ end
 # @param command Command to test
 def process.test(~timeout=(-1.),~env=[],~inherit_env=true,command)
   p = process.read(timeout=timeout, env=env, inherit_env=inherit_env, command)
-  p.status == "exit"
+  p.status == "exit" and p.status.code == 0
 end
 
 # Read some value from standard input (console).

--- a/libs/protocols.liq
+++ b/libs/protocols.liq
@@ -63,13 +63,13 @@ def process_protocol(~rlog,~maxtime,arg)
     inherit_env = get(default=true,"protocol.process.inherit_env")
 
     delay = maxtime - gettimeofday()
-    let (stdout,stderr,status) = run_process(timeout=delay,env=env,inherit_env=inherit_env,cmd)
-    if status == ("exit","0") then
+    p = process.read(timeout=delay,env=env,inherit_env=inherit_env,cmd)
+    if p.status == "exit" then
       [output]
     else
-      log.important("Failed to execute #{cmd}: #{status}")
-      log.info("Standard output:\n#{stdout}")
-      log.info("Error output:\n#{stderr}")
+      log.important("Failed to execute #{cmd}: #{p.status}")
+      log.info("Standard output:\n#{p.stdout}")
+      log.info("Error output:\n#{p.stderr}")
       log.info("Removing #{output}.")
       file.remove(output)
       []
@@ -143,14 +143,13 @@ def download_protocol(proto,~rlog,~maxtime,arg) =
   def get_mime() =
     cmd = "#{curl} -sLI -X HEAD #{string.quote(uri)} | grep -i '^content-type' | tail -n 1 | cut -d':' -f 2 | cut -d';' -f 1"
     log(level=4,"Running #{cmd}")
-    ret = run_process(timeout=timeout,env=env,inherit_env=inherit_env,cmd)
-    let (stdout,_,(status,code)) = ret
-    if status != "exit" or code != "0" then
+    p = process.read(timeout=timeout,env=env,inherit_env=inherit_env,cmd)
+    if p.status != "exit" or p.signal != 0 then
       log(level=3,"Failed to fetch mime-type for #{uri} via curl.")
-      log(level=4,"Process return status: #{ret}")
+      log(level=4,"Process return status: #{p.status_code}")
       ""
     else
-      lines = string.split(separator="\\n",stdout)
+      lines = string.split(separator="\\n", p.stdout)
       string.case(lower=true,string.trim(list.hd(default="",lines)))
     end
   end
@@ -238,7 +237,7 @@ def youtube_dl_protocol(~rlog,~maxtime,arg)
   delay = maxtime - gettimeofday()
   cmd = "#{binary} --get-title --get-filename -- #{string.quote(arg)}"
   log(level=4,"Executing #{cmd}")
-  x = get_process_lines(timeout=delay,cmd)
+  x = process.read.lines(timeout=delay,cmd)
 
   x =
     if list.length(x) >= 2 then
@@ -322,7 +321,7 @@ def ffmpeg_protocol(~rlog,~maxtime,arg) =
     cmd = "#{ffmpeg} -i #{string.quote(file)} -f ffmetadata - 2>/dev/null | grep -v '^;'"
     delay = maxtime - gettimeofday()
     log(level=4,"Executing #{cmd}")
-    lines = get_process_lines(timeout=delay,cmd)
+    lines = process.read.lines(timeout=delay,cmd)
     def f(cur,line) =
       m = string.split(separator="=",line)
       if list.length(m) >= 2 then

--- a/libs/resolvers.liq
+++ b/libs/resolvers.liq
@@ -2,12 +2,12 @@
 def exec_replaygain(~extract_replaygain="#{configure.bindir}/extract-replaygain",
                        ~delay,file)
   log = log.info(label="extract.replaygain")
-  let (stdout, stderr, status) = run_process("#{extract_replaygain} #{string.quote(file)}")
-  stdout = string.replace(pattern='\\n',fun (_) -> "",stdout)
-  stderr = string.replace(pattern='\\n',fun (_) -> "",stderr)
-  if status == ("exit","0") then
+  p = process.read("#{extract_replaygain} #{string.quote(file)}")
+  stdout = string.replace(pattern='\\n', fun (_) -> "", p.stdout)
+  if p.status == "exit" then
     stdout
   else
+    stderr = string.replace(pattern='\\n', fun (_) -> "", p.stderr)
     log("Replaygain extraction by #{extract_replaygain} failed with: #{stderr}")
     ""
   end
@@ -46,7 +46,7 @@ def youtube_playlist_parser(~pwd="",url) =
 
   if string.match(pattern="^youtube-pl:",url) then
     uri = list.nth(default="",string.split(separator=":",url),1)
-    list.map(parse_line, get_process_lines("#{binary} -j --flat-playlist #{uri}"))
+    list.map(parse_line, process.read.lines("#{binary} -j --flat-playlist #{uri}"))
   else
     []
   end

--- a/src/lang/builtins_process.ml
+++ b/src/lang/builtins_process.ml
@@ -64,8 +64,8 @@ let () =
         path_t,
         Some (Lang.list [Lang.string "default"]),
         Some
-          "Read-only directories for sandboxing (sandbox default if not \
-           specified)." );
+          "Read-only directories for sandboxing `\"default\"` expands to \
+           sandbox default." );
       ( "network",
         Lang.nullable_t Lang.bool_t,
         Some Lang.null,

--- a/src/lang/builtins_process.ml
+++ b/src/lang/builtins_process.ml
@@ -23,21 +23,29 @@
 open Lang_builtins
 
 let log = Log.make ["lang"; "run_process"]
+let () = Lang.add_module "process"
 
 let () =
   let ret_t =
-    Lang.tuple_t
-      [Lang.string_t; Lang.string_t; Lang.product_t Lang.string_t Lang.string_t]
+    Lang.record_t
+      [
+        ("stdout", Lang.string_t);
+        ("stderr", Lang.string_t);
+        ( "status",
+          Lang.method_t Lang.string_t
+            [("code", ([], Lang.int_t)); ("description", ([], Lang.string_t))]
+        );
+      ]
   in
   let env_t = Lang.product_t Lang.string_t Lang.string_t in
   let path_t = Lang.list_t Lang.string_t in
-  add_builtin "run_process" ~cat:Sys
+  add_builtin "process.run" ~cat:Sys
     ~descr:
-      "Run a process in a shell environment. Returns: \
-       `((stdout,stderr,status)` where status is one of: `(\"exit\",\"\")`, \
-       `(\"killed\",\"<signal number>\")`, `(\"stopped\",\"<signal \
-       number>\")`, `(\"exception\",\"<exception description>\")`, \
-       `(\"timeout\",\"<run time>\")`."
+      "Run a process in a shell environment. Returns the standard output, as \
+       well as standard error and status. The status can be \"exit\" (the \
+       status code is set), \"killed\" or \"stopped\" (the status code is the \
+       signal), or \"exception\" (the description is set) or \"timeout\" (the \
+       description is the run time)."
     [
       ("env", Lang.list_t env_t, Some (Lang.list []), Some "Process environment");
       ( "inherit_env",
@@ -56,15 +64,14 @@ let () =
         path_t,
         Some (Lang.list [Lang.string "default"]),
         Some
-          "Read-only directories for sandboxing. `\"default\"` expands to \
-           sandbox default." );
+          "Read-only directories for sandboxing (sandbox default if not \
+           specified)." );
       ( "network",
-        Lang.string_t,
-        Some (Lang.string "default"),
+        Lang.nullable_t Lang.bool_t,
+        Some Lang.null,
         Some
-          "Enable or disable network inside sandboxed environment. One of: \
-           `\"default\"`, `\"true\"` or `\"false\"`. `\"default\"` is sandbox \
-           default." );
+          "Enable or disable network inside sandboxed environment (sandbox \
+           default if not specified)." );
       ( "timeout",
         Lang.float_t,
         Some (Lang.float (-1.)),
@@ -101,15 +108,9 @@ let () =
           [] sandbox_ro
       in
       let sandbox_network =
-        let v = List.assoc "network" p in
-        match Lang.to_string v with
-          | "default" -> Sandbox.conf_network#get
-          | "true" -> true
-          | "false" -> false
-          | _ ->
-              raise
-                (Lang_errors.Invalid_value
-                   (v, "should be one of: \"default\", \"true\" or \"false\""))
+        match Lang.to_option (List.assoc "network" p) with
+          | None -> Sandbox.conf_network#get
+          | Some v -> Lang.to_bool v
       in
       let inherit_env = Lang.to_bool (List.assoc "inherit_env" p) in
       let env = if env = [] && inherit_env then Utils.environment () else env in
@@ -126,22 +127,27 @@ let () =
       let on_done (timed_out, status) =
         let stdout = Buffer.contents out_buf in
         let stderr = Buffer.contents err_buf in
-        let status, arg =
+        let status, code, description =
           match (timed_out, status) with
-            | f, _ when 0. <= f -> ("timeout", string_of_float f)
-            | _, Some (`Exception e) -> ("exception", Printexc.to_string e)
+            | f, _ when 0. <= f -> ("timeout", -1, string_of_float f)
+            | _, Some (`Exception e) -> ("exception", -1, Printexc.to_string e)
             | _, Some (`Status s) -> (
                 match s with
-                  | Unix.WEXITED c -> ("exit", string_of_int c)
-                  | Unix.WSIGNALED s -> ("killed", string_of_int s)
-                  | Unix.WSTOPPED s -> ("stopped", string_of_int s) )
+                  | Unix.WEXITED c -> ("exit", c, "")
+                  | Unix.WSIGNALED s -> ("killed", s, "")
+                  | Unix.WSTOPPED s -> ("stopped", s, "") )
             | _ -> assert false
         in
-        Lang.tuple
+        Lang.record
           [
-            Lang.string stdout;
-            Lang.string stderr;
-            Lang.product (Lang.string status) (Lang.string arg);
+            ("stdout", Lang.string stdout);
+            ("stderr", Lang.string stderr);
+            ( "status",
+              Lang.meth (Lang.string status)
+                [
+                  ("code", Lang.int code);
+                  ("description", Lang.string description);
+                ] );
           ]
       in
       let synchronous () =

--- a/src/lang/builtins_string.ml
+++ b/src/lang/builtins_string.ml
@@ -23,7 +23,14 @@
 open Lang_builtins
 
 let () =
-  Lang.add_module "string";
+  add_builtin "string" ~cat:String
+    ~descr:
+      "Ensure that we have a string (useful for removing fields from strings)."
+    [("", Lang.string_t, None, None)] Lang.string_t (fun p ->
+      let s = Lang.to_string (List.assoc "" p) in
+      Lang.string s)
+
+let () =
   Lang.add_module "string.utf8";
   Lang.add_module "string.base64";
   Lang.add_module "url"

--- a/src/lang/lang_builtins.ml
+++ b/src/lang/lang_builtins.ml
@@ -488,12 +488,6 @@ let () =
       Lang.unit)
 
 let () =
-  add_builtin "system" ~cat:Sys [("", Lang.string_t, None, None)]
-    Lang.unit_t ~descr:"Shell command call." (fun p ->
-      ignore (Unix.system (Lang.to_string (List.assoc "" p)));
-      Lang.unit)
-
-let () =
   add_builtin "getpid" ~cat:Sys [] Lang.int_t ~descr:"Get the process' pid."
     (fun _ -> Lang.int (Unix.getpid ()))
 

--- a/tests/language/process.liq
+++ b/tests/language/process.liq
@@ -1,0 +1,20 @@
+#!../../src/liquidsoap ../../libs/pervasives.liq
+
+%include "test.liq"
+
+def t(x,y) =
+  if x != y then test.fail() end
+end
+
+def f() =
+  t(process.read("echo -n toto"), "toto")
+  p = process.run("exit 2")
+  t(string(p.status), "exit")
+  t(p.status.code, 2)
+  p = process.run(timeout=0.5, "sleep 1")
+  t(string(p.status), "timeout")
+
+  test.pass()
+end
+
+test.check(f)


### PR DESCRIPTION
Deprecated `get_process_output`, `get_process_lines`, `test_process` and  `system` in favor of `process.run`, `process.read` and `process.read.lines`.