### PR TITLE
Add support for ffmpeg raw frame

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -194,7 +194,7 @@ tools = tools/extralib.ml tools/JSON.ml \
 stream = stream/frame_settings.ml stream/frame_content.ml \
          stream/frame.ml stream/aFrame.ml stream/vFrame.ml stream/mFrame.ml \
          stream/generator.ml \
-	 $(if $(W_FFMPEG_AVCODEC), stream/ffmpeg_copy_content.ml) \
+	 $(if $(W_FFMPEG_AVCODEC), stream/ffmpeg_content_base.ml stream/ffmpeg_copy_content.ml) \
          $(if $(W_FFMPEG_DECODER), stream/ffmpeg_raw_content.ml) \
          $(if $(W_GSTREAMER),tools/gstreamer_utils.ml)
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -42,7 +42,7 @@ decoders = \
 	decoder/wav_aiff_decoder.ml decoder/midi_decoder.ml \
 	decoder/image_decoder.ml decoder/image/ppm_decoder.ml \
 	decoder/external_decoder.ml decoder/raw_audio_decoder.ml \
-	$(if $(W_FFMPEG_DECODER),decoder/ffmpeg_internal_decoder.ml decoder/ffmpeg_raw_decoder.ml decoder/ffmpeg_copy_decoder.ml decoder/ffmpeg_decoder.ml) \
+	$(if $(W_FFMPEG_DECODER),decoder/ffmpeg_decoder_common.ml decoder/ffmpeg_internal_decoder.ml decoder/ffmpeg_raw_decoder.ml decoder/ffmpeg_copy_decoder.ml decoder/ffmpeg_decoder.ml) \
 	$(if $(W_FLAC),decoder/flac_decoder.ml) \
 	$(if $(W_FAAD),decoder/aac_decoder.ml) \
 	$(if $(W_OGG),decoder/ogg_decoder.ml) \

--- a/src/Makefile
+++ b/src/Makefile
@@ -42,7 +42,7 @@ decoders = \
 	decoder/wav_aiff_decoder.ml decoder/midi_decoder.ml \
 	decoder/image_decoder.ml decoder/image/ppm_decoder.ml \
 	decoder/external_decoder.ml decoder/raw_audio_decoder.ml \
-	$(if $(W_FFMPEG_DECODER),decoder/ffmpeg_internal_decoder.ml decoder/ffmpeg_copy_decoder.ml decoder/ffmpeg_decoder.ml) \
+	$(if $(W_FFMPEG_DECODER),decoder/ffmpeg_internal_decoder.ml decoder/ffmpeg_raw_decoder.ml decoder/ffmpeg_copy_decoder.ml decoder/ffmpeg_decoder.ml) \
 	$(if $(W_FLAC),decoder/flac_decoder.ml) \
 	$(if $(W_FAAD),decoder/aac_decoder.ml) \
 	$(if $(W_OGG),decoder/ogg_decoder.ml) \
@@ -194,7 +194,8 @@ tools = tools/extralib.ml tools/JSON.ml \
 stream = stream/frame_settings.ml stream/frame_content.ml \
          stream/frame.ml stream/aFrame.ml stream/vFrame.ml stream/mFrame.ml \
          stream/generator.ml \
-	 $(if $(W_FFMPEG_AVCODEC), stream/ffmpeg_content.ml) \
+	 $(if $(W_FFMPEG_AVCODEC), stream/ffmpeg_copy_content.ml) \
+         $(if $(W_FFMPEG_DECODER), stream/ffmpeg_raw_content.ml) \
          $(if $(W_GSTREAMER),tools/gstreamer_utils.ml)
 
 visualization = \

--- a/src/conversions/drop.ml
+++ b/src/conversions/drop.ml
@@ -21,12 +21,19 @@
  *****************************************************************************)
 
 class drop ?(audio = false) ?(video = false) ?(midi = false) ~name source =
-  let f x = if x then Some Frame.none else None in
+  let f x = if x then Some `Any else None in
   let audio_in = f audio in
   let video_in = f video in
   let midi_in = f midi in
+  let kind =
+    {
+      Frame.audio = (if audio then Frame.none else `Any);
+      video = (if video then Frame.none else `Any);
+      midi = (if midi then Frame.none else `Any);
+    }
+  in
   object
-    inherit Source.operator ?audio_in ?video_in ?midi_in Lang.any [source] ~name
+    inherit Source.operator ?audio_in ?video_in ?midi_in kind [source] ~name
 
     inherit
       Conversion.base

--- a/src/conversions/mux.ml
+++ b/src/conversions/mux.ml
@@ -133,8 +133,8 @@ module Muxer = struct
     let main_kind =
       Frame.
         {
-          audio = (if aux_content = `Audio then none else `Any);
-          video = (if aux_content = `Video then none else `Any);
+          audio = (if main_content = `Audio then `Any else none);
+          video = (if main_content = `Video then `Any else none);
           midi = `Any;
         }
     in

--- a/src/decoder/decoder.ml
+++ b/src/decoder/decoder.ml
@@ -254,7 +254,7 @@ let can_decode_type decoded_type target_type =
   in
   match target_type with
     (* Either we can decode straight away. *)
-    | _ when decoded_type = target_type -> true
+    | _ when Frame.compatible decoded_type target_type -> true
     (* Or we can convert audio and/or drop video and midi *)
     | { Frame.audio; video; midi } ->
         let audio =
@@ -262,7 +262,7 @@ let can_decode_type decoded_type target_type =
         in
         let video = if video = none then none else decoded_type.Frame.video in
         let midi = if midi = none then none else decoded_type.Frame.midi in
-        target_type = { Frame.audio; video; midi }
+        Frame.compatible target_type { Frame.audio; video; midi }
 
 let decoder_modes = function
   | Frame.{ audio; video; midi }

--- a/src/decoder/decoder.ml
+++ b/src/decoder/decoder.ml
@@ -441,7 +441,7 @@ let mk_buffer ~ctype generator =
         let data = channel_converter () data in
         let len = Audio.length data in
         let data = Frame_content.Audio.lift_data data in
-        G.put_audio ?pts generator data 0 len )
+        G.put_audio ?pts generator data 0 (Frame.master_of_audio len) )
     else fun ?pts:_ ~samplerate:_ _ -> ()
   in
 
@@ -457,7 +457,7 @@ let mk_buffer ~ctype generator =
         let data = video_resample ~in_freq:fps ~out_freq data in
         let len = Video.length data in
         let data = Frame_content.Video.lift_data data in
-        G.put_video ?pts generator data 0 len )
+        G.put_video ?pts generator data 0 (Frame.master_of_video len) )
     else fun ?pts:_ ~fps:_ _ -> ()
   in
 

--- a/src/decoder/decoder.ml
+++ b/src/decoder/decoder.ml
@@ -236,7 +236,7 @@ let test_file ?(log = log) ?mimes ?extensions fname =
     ext_ok || mime_ok )
 
 let channel_layout audio =
-  match Frame_content.Audio.get_params audio with [c] -> c | _ -> assert false
+  Frame_content.(Audio.(get_params audio).Contents.channel_layout)
 
 let none = Frame_content.None.format
 

--- a/src/decoder/external_decoder.ml
+++ b/src/decoder/external_decoder.ml
@@ -92,8 +92,12 @@ let create_stream process input =
   ret
 
 let audio_n n =
-  Frame_content.Audio.lift_params
-    [Audio_converter.Channel_layout.layout_of_channels n]
+  Frame_content.(
+    Audio.lift_params
+      {
+        Contents.channel_layout =
+          Audio_converter.Channel_layout.layout_of_channels n;
+      })
 
 let test_ctype f filename =
   (* 0 = file rejected,

--- a/src/decoder/ffmpeg_copy_decoder.ml
+++ b/src/decoder/ffmpeg_copy_decoder.ml
@@ -25,39 +25,30 @@
 open Avcodec
 module G = Decoder.G
 
-let mk_decoder ~get_duration ~stream_time_base ~lift_data ~put_data params
-    ~buffer packet =
-  let duration = get_duration (Packet.get_duration packet) in
-  let packet =
-    { Ffmpeg_copy_content.params; packet; time_base = stream_time_base }
+let mk_decoder ~stream_time_base ~lift_data ~put_data params =
+  let get_duration =
+    Ffmpeg_decoder_common.convert_duration ~src:stream_time_base
   in
-  let data = lift_data (ref [(0, packet)]) in
-  put_data ?pts:None buffer.Decoder.generator data 0 duration
+  fun ~buffer packet ->
+    let duration = get_duration (Packet.get_duration packet) in
+    let packet =
+      { Ffmpeg_copy_content.params; packet; time_base = stream_time_base }
+    in
+    let data = lift_data (ref [(0, packet)]) in
+    put_data ?pts:None buffer.Decoder.generator data 0 duration
 
 let mk_audio_decoder container =
   let idx, stream, params = Av.find_best_audio_stream container in
   let stream_time_base = Av.get_time_base stream in
-  let sample_time_base = Ffmpeg_utils.liq_audio_sample_time_base () in
-  let get_duration =
-    Ffmpeg_utils.convert_duration ~duration_time_base:stream_time_base
-      ~sample_time_base
-  in
   let lift_data = Ffmpeg_copy_content.Audio.lift_data in
   ( idx,
     stream,
-    mk_decoder ~get_duration ~lift_data ~stream_time_base ~put_data:G.put_audio
-      params )
+    mk_decoder ~lift_data ~stream_time_base ~put_data:G.put_audio params )
 
 let mk_video_decoder container =
   let idx, stream, params = Av.find_best_video_stream container in
   let stream_time_base = Av.get_time_base stream in
-  let sample_time_base = Ffmpeg_utils.liq_video_sample_time_base () in
-  let get_duration =
-    Ffmpeg_utils.convert_duration ~duration_time_base:stream_time_base
-      ~sample_time_base
-  in
   let lift_data = Ffmpeg_copy_content.Video.lift_data in
   ( idx,
     stream,
-    mk_decoder ~get_duration ~lift_data ~stream_time_base ~put_data:G.put_video
-      params )
+    mk_decoder ~lift_data ~stream_time_base ~put_data:G.put_video params )

--- a/src/decoder/ffmpeg_copy_decoder.ml
+++ b/src/decoder/ffmpeg_copy_decoder.ml
@@ -36,7 +36,7 @@ let mk_decoder ?default_duration ~stream_time_base ~sample_time_base ~lift_data
       | None, None -> failwith "Cannot decode packet: duration required!"
   in
   let packet =
-    { Ffmpeg_content.params; packet; time_base = stream_time_base }
+    { Ffmpeg_copy_content.params; packet; time_base = stream_time_base }
   in
   let data = lift_data (ref [(0, packet)]) in
   put_data ?pts:None buffer.Decoder.generator data 0 (Int64.to_int duration)
@@ -45,7 +45,7 @@ let mk_audio_decoder container =
   let idx, stream, params = Av.find_best_audio_stream container in
   let stream_time_base = Av.get_time_base stream in
   let sample_time_base = Ffmpeg_utils.liq_audio_sample_time_base () in
-  let lift_data = Ffmpeg_content.AudioCopy.lift_data in
+  let lift_data = Ffmpeg_copy_content.Audio.lift_data in
   ( idx,
     stream,
     mk_decoder ~stream_time_base ~sample_time_base ~lift_data
@@ -56,7 +56,7 @@ let mk_video_decoder container =
   let stream_time_base = Av.get_time_base stream in
   let sample_time_base = Ffmpeg_utils.liq_video_sample_time_base () in
   let default_duration = 1L in
-  let lift_data = Ffmpeg_content.VideoCopy.lift_data in
+  let lift_data = Ffmpeg_copy_content.Video.lift_data in
   ( idx,
     stream,
     mk_decoder ~default_duration ~stream_time_base ~sample_time_base ~lift_data

--- a/src/decoder/ffmpeg_copy_decoder.ml
+++ b/src/decoder/ffmpeg_copy_decoder.ml
@@ -31,11 +31,9 @@ let mk_decoder ~stream_time_base ~mk_param ~lift_data ~put_data params =
   in
   fun ~buffer packet ->
     let duration = get_duration (Packet.get_duration packet) in
-    let packet =
-      { Ffmpeg_copy_content.params; packet; time_base = stream_time_base }
-    in
+    let packet = { Ffmpeg_copy_content.packet; time_base = stream_time_base } in
     let data =
-      { Ffmpeg_content_base.param = mk_param params; data = [(0, packet)] }
+      { Ffmpeg_content_base.params = mk_param params; data = [(0, packet)] }
     in
     let data = lift_data data in
     put_data ?pts:None buffer.Decoder.generator data 0 duration

--- a/src/decoder/ffmpeg_copy_decoder.ml
+++ b/src/decoder/ffmpeg_copy_decoder.ml
@@ -20,7 +20,7 @@
 
   *****************************************************************************)
 
-(** Decode and read metadata using ffmpeg. *)
+(** Decode ffmpeg packets. *)
 
 open Avcodec
 module G = Decoder.G
@@ -35,7 +35,7 @@ let mk_decoder ~stream_time_base ~mk_param ~lift_data ~put_data params =
       { Ffmpeg_copy_content.params; packet; time_base = stream_time_base }
     in
     let data =
-      { Ffmpeg_copy_content.param = mk_param params; data = [(0, packet)] }
+      { Ffmpeg_content_base.param = mk_param params; data = [(0, packet)] }
     in
     let data = lift_data data in
     put_data ?pts:None buffer.Decoder.generator data 0 duration

--- a/src/decoder/ffmpeg_copy_decoder.ml
+++ b/src/decoder/ffmpeg_copy_decoder.ml
@@ -25,7 +25,7 @@
 open Avcodec
 module G = Decoder.G
 
-let mk_decoder ~stream_time_base ~mk_param ~lift_data ~put_data params =
+let mk_decoder ~stream_time_base ~lift_data ~put_data params =
   let get_duration =
     Ffmpeg_decoder_common.convert_duration ~src:stream_time_base
   in
@@ -33,7 +33,7 @@ let mk_decoder ~stream_time_base ~mk_param ~lift_data ~put_data params =
     let duration = get_duration (Packet.get_duration packet) in
     let packet = { Ffmpeg_copy_content.packet; time_base = stream_time_base } in
     let data =
-      { Ffmpeg_content_base.params = mk_param params; data = [(0, packet)] }
+      { Ffmpeg_content_base.params = Some params; data = [(0, packet)] }
     in
     let data = lift_data data in
     put_data ?pts:None buffer.Decoder.generator data 0 duration
@@ -42,18 +42,14 @@ let mk_audio_decoder container =
   let idx, stream, params = Av.find_best_audio_stream container in
   let stream_time_base = Av.get_time_base stream in
   let lift_data = Ffmpeg_copy_content.Audio.lift_data in
-  let mk_param = Ffmpeg_copy_content.AudioSpecs.mk_param in
   ( idx,
     stream,
-    mk_decoder ~lift_data ~mk_param ~stream_time_base ~put_data:G.put_audio
-      params )
+    mk_decoder ~lift_data ~stream_time_base ~put_data:G.put_audio params )
 
 let mk_video_decoder container =
   let idx, stream, params = Av.find_best_video_stream container in
   let stream_time_base = Av.get_time_base stream in
   let lift_data = Ffmpeg_copy_content.Video.lift_data in
-  let mk_param = Ffmpeg_copy_content.VideoSpecs.mk_param in
   ( idx,
     stream,
-    mk_decoder ~mk_param ~lift_data ~stream_time_base ~put_data:G.put_video
-      params )
+    mk_decoder ~lift_data ~stream_time_base ~put_data:G.put_video params )

--- a/src/decoder/ffmpeg_copy_decoder.ml
+++ b/src/decoder/ffmpeg_copy_decoder.ml
@@ -25,7 +25,7 @@
 open Avcodec
 module G = Decoder.G
 
-let mk_decoder ~stream_time_base ~lift_data ~put_data params =
+let mk_decoder ~stream_time_base ~mk_param ~lift_data ~put_data params =
   let get_duration =
     Ffmpeg_decoder_common.convert_duration ~src:stream_time_base
   in
@@ -34,21 +34,28 @@ let mk_decoder ~stream_time_base ~lift_data ~put_data params =
     let packet =
       { Ffmpeg_copy_content.params; packet; time_base = stream_time_base }
     in
-    let data = lift_data (ref [(0, packet)]) in
+    let data =
+      { Ffmpeg_copy_content.param = mk_param params; data = [(0, packet)] }
+    in
+    let data = lift_data data in
     put_data ?pts:None buffer.Decoder.generator data 0 duration
 
 let mk_audio_decoder container =
   let idx, stream, params = Av.find_best_audio_stream container in
   let stream_time_base = Av.get_time_base stream in
   let lift_data = Ffmpeg_copy_content.Audio.lift_data in
+  let mk_param = Ffmpeg_copy_content.AudioSpecs.mk_param in
   ( idx,
     stream,
-    mk_decoder ~lift_data ~stream_time_base ~put_data:G.put_audio params )
+    mk_decoder ~lift_data ~mk_param ~stream_time_base ~put_data:G.put_audio
+      params )
 
 let mk_video_decoder container =
   let idx, stream, params = Av.find_best_video_stream container in
   let stream_time_base = Av.get_time_base stream in
   let lift_data = Ffmpeg_copy_content.Video.lift_data in
+  let mk_param = Ffmpeg_copy_content.VideoSpecs.mk_param in
   ( idx,
     stream,
-    mk_decoder ~lift_data ~stream_time_base ~put_data:G.put_video params )
+    mk_decoder ~mk_param ~lift_data ~stream_time_base ~put_data:G.put_video
+      params )

--- a/src/decoder/ffmpeg_internal_decoder.ml
+++ b/src/decoder/ffmpeg_internal_decoder.ml
@@ -86,7 +86,7 @@ let mk_video_decoder container =
   let time_base = Av.get_time_base stream in
   let pixel_aspect = Av.get_pixel_aspect stream in
   let decoder_pts = ref 0L in
-  let cb ~buffer frame =
+  let cb ~buffer ~time_base:_ frame =
     let img =
       match Scaler.convert scaler frame with
         | [| (y, sy); (u, s); (v, _) |] ->

--- a/src/decoder/ffmpeg_raw_decoder.ml
+++ b/src/decoder/ffmpeg_raw_decoder.ml
@@ -31,7 +31,7 @@ let mk_decoder ~stream_time_base ~mk_param ~lift_data ~put_data params =
   fun ~buffer frame ->
     let duration = get_duration (Avutil.frame_pts frame) in
     let data =
-      { Ffmpeg_content_base.param = mk_param params; data = [(0, frame)] }
+      { Ffmpeg_content_base.params = mk_param params; data = [(0, frame)] }
     in
     let data = lift_data data in
     put_data ?pts:None buffer.Decoder.generator data 0 duration

--- a/src/decoder/ffmpeg_raw_decoder.ml
+++ b/src/decoder/ffmpeg_raw_decoder.ml
@@ -1,0 +1,43 @@
+(*****************************************************************************
+
+   Liquidsoap, a programmable audio stream generator.
+   Copyright 2003-2017 Savonet team
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 2 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details, fully stated in the COPYING
+   file at the root of the liquidsoap distribution.
+
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA
+
+  *****************************************************************************)
+
+(** Decode and read metadata using ffmpeg. *)
+
+open Avutil
+module G = Decoder.G
+
+let mk_audio_decoder container =
+  let idx, stream, _ = Av.find_best_audio_stream container in
+  ( idx,
+    stream,
+    fun ~buffer frame ->
+      let data = Ffmpeg_raw_content.Audio.lift_data frame in
+      G.put_audio buffer.Decoder.generator data 0 (Audio.frame_nb_samples frame)
+  )
+
+let mk_video_decoder container =
+  let idx, stream, _ = Av.find_best_video_stream container in
+  ( idx,
+    stream,
+    fun ~buffer frame ->
+      let data = Ffmpeg_raw_content.Video.lift_data (ref [(0, frame)]) in
+      G.put_video buffer.Decoder.generator data 0 1 )

--- a/src/decoder/ffmpeg_raw_decoder.ml
+++ b/src/decoder/ffmpeg_raw_decoder.ml
@@ -24,7 +24,7 @@
 
 module G = Decoder.G
 
-let mk_decoder ~stream_time_base ~mk_param ~lift_data ~put_data params =
+let mk_decoder ~stream_time_base ~mk_params ~lift_data ~put_data params =
   let get_duration =
     Ffmpeg_decoder_common.convert_duration ~src:stream_time_base
   in
@@ -32,7 +32,7 @@ let mk_decoder ~stream_time_base ~mk_param ~lift_data ~put_data params =
     let duration = get_duration (Avutil.frame_pkt_duration frame) in
     let frame = { Ffmpeg_raw_content.time_base = stream_time_base; frame } in
     let data =
-      { Ffmpeg_content_base.params = mk_param params; data = [(0, frame)] }
+      { Ffmpeg_content_base.params = mk_params params; data = [(0, frame)] }
     in
     let data = lift_data data in
     put_data ?pts:None buffer.Decoder.generator data 0 duration
@@ -41,18 +41,18 @@ let mk_audio_decoder container =
   let idx, stream, params = Av.find_best_audio_stream container in
   let stream_time_base = Av.get_time_base stream in
   let lift_data = Ffmpeg_raw_content.Audio.lift_data in
-  let mk_param = Ffmpeg_raw_content.AudioSpecs.mk_param in
+  let mk_params = Ffmpeg_raw_content.AudioSpecs.mk_params in
   ( idx,
     stream,
-    mk_decoder ~lift_data ~mk_param ~stream_time_base ~put_data:G.put_audio
+    mk_decoder ~lift_data ~mk_params ~stream_time_base ~put_data:G.put_audio
       params )
 
 let mk_video_decoder container =
   let idx, stream, params = Av.find_best_video_stream container in
   let stream_time_base = Av.get_time_base stream in
   let lift_data = Ffmpeg_raw_content.Video.lift_data in
-  let mk_param = Ffmpeg_raw_content.VideoSpecs.mk_param in
+  let mk_params = Ffmpeg_raw_content.VideoSpecs.mk_params in
   ( idx,
     stream,
-    mk_decoder ~mk_param ~lift_data ~stream_time_base ~put_data:G.put_video
+    mk_decoder ~mk_params ~lift_data ~stream_time_base ~put_data:G.put_video
       params )

--- a/src/decoder/ffmpeg_raw_decoder.ml
+++ b/src/decoder/ffmpeg_raw_decoder.ml
@@ -44,6 +44,8 @@ let mk_video_decoder container =
   ( idx,
     stream,
     fun ~buffer frame ->
-      let data = Ffmpeg_raw_content.Video.lift_data (ref [(0, frame)]) in
+      let param = Ffmpeg_raw_content.VideoSpecs.frame_param frame in
+      let data = { Ffmpeg_raw_content.VideoSpecs.param; data = [(0, frame)] } in
+      let data = Ffmpeg_raw_content.Video.lift_data data in
       G.put_video buffer.Decoder.generator data 0
         (get_duration (Avutil.frame_pkt_duration frame)) )

--- a/src/decoder/ffmpeg_raw_decoder.ml
+++ b/src/decoder/ffmpeg_raw_decoder.ml
@@ -29,7 +29,7 @@ let mk_decoder ~stream_time_base ~mk_param ~lift_data ~put_data params =
     Ffmpeg_decoder_common.convert_duration ~src:stream_time_base
   in
   fun ~buffer frame ->
-    let duration = get_duration (Avutil.frame_pts frame) in
+    let duration = get_duration (Avutil.frame_pkt_duration frame) in
     let data =
       { Ffmpeg_content_base.params = mk_param params; data = [(0, frame)] }
     in

--- a/src/decoder/ffmpeg_raw_decoder.ml
+++ b/src/decoder/ffmpeg_raw_decoder.ml
@@ -30,6 +30,7 @@ let mk_decoder ~stream_time_base ~mk_param ~lift_data ~put_data params =
   in
   fun ~buffer frame ->
     let duration = get_duration (Avutil.frame_pkt_duration frame) in
+    let frame = { Ffmpeg_raw_content.time_base = stream_time_base; frame } in
     let data =
       { Ffmpeg_content_base.params = mk_param params; data = [(0, frame)] }
     in

--- a/src/decoder/gstreamer_decoder.ml
+++ b/src/decoder/gstreamer_decoder.ml
@@ -265,12 +265,16 @@ let get_type ~channels filename =
   let audio =
     if audio = 0 then Frame_content.None.format
     else
-      Frame_content.Audio.lift_params
-        [Audio_converter.Channel_layout.layout_of_channels audio]
+      Frame_content.(
+        Audio.lift_params
+          {
+            Contents.channel_layout =
+              Audio_converter.Channel_layout.layout_of_channels audio;
+          })
   in
   let video =
     if video = 0 then Frame_content.None.format
-    else Frame_content.Video.lift_params []
+    else Frame_content.(default_format Video.kind)
   in
   { Frame.video; audio; midi = Frame_content.None.format }
 

--- a/src/decoder/image_decoder.ml
+++ b/src/decoder/image_decoder.ml
@@ -155,7 +155,7 @@ let () =
               Frame.
                 {
                   audio = Frame_content.None.format;
-                  video = Frame_content.Video.lift_params [];
+                  video = Frame_content.(default_format Video.kind);
                   midi = Frame_content.None.format;
                 }
           else None);

--- a/src/decoder/midi_decoder.ml
+++ b/src/decoder/midi_decoder.ml
@@ -71,7 +71,8 @@ let () =
               {
                 audio = Frame_content.None.format;
                 video = Frame_content.None.format;
-                midi = Frame_content.Midi.lift_params [`Channels 1];
+                midi =
+                  Frame_content.(Midi.lift_params { Contents.channels = 1 });
               });
       file_decoder =
         Some (fun ~metadata:_ ~ctype:_ filename -> decoder filename);

--- a/src/decoder/ogg_decoder.ml
+++ b/src/decoder/ogg_decoder.ml
@@ -236,12 +236,16 @@ let file_type ~ctype:_ filename =
       let audio =
         if audio = 0 then Frame_content.None.format
         else
-          Frame_content.Audio.lift_params
-            [Audio_converter.Channel_layout.layout_of_channels audio]
+          Frame_content.(
+            Audio.lift_params
+              {
+                Contents.channel_layout =
+                  Audio_converter.Channel_layout.layout_of_channels audio;
+              })
       in
       let video =
         if video = 0 then Frame_content.None.format
-        else Frame_content.Video.lift_params []
+        else Frame_content.(default_format Video.kind)
       in
       Some { Frame.audio; video; midi = Frame_content.None.format })
 

--- a/src/decoder/wav_aiff_decoder.ml
+++ b/src/decoder/wav_aiff_decoder.ml
@@ -150,8 +150,12 @@ let file_type ~ctype:_ filename =
           Frame.video = Frame_content.None.format;
           midi = Frame_content.None.format;
           audio =
-            Frame_content.Audio.lift_params
-              [Audio_converter.Channel_layout.layout_of_channels channels];
+            Frame_content.(
+              Audio.lift_params
+                {
+                  Contents.channel_layout =
+                    Audio_converter.Channel_layout.layout_of_channels channels;
+                });
         })
 
 let wav_mime_types =

--- a/src/encoder.ml
+++ b/src/encoder.ml
@@ -60,8 +60,8 @@ let kind_of_format = function
       let audio =
         match m.Ffmpeg_format.audio_codec with
           | None -> Frame.none
-          | Some `Copy -> `Format (Ffmpeg_copy_content.Audio.lift_params [])
-          | Some (`Raw _) -> `Format (Ffmpeg_raw_content.Audio.lift_params [])
+          | Some `Copy -> `Format Ffmpeg_copy_content.Audio.(lift_params [])
+          | Some (`Raw _) -> `Format Ffmpeg_raw_content.Audio.(lift_params [])
           | Some (`Internal _) ->
               let channels = m.Ffmpeg_format.channels in
               assert (channels > 0);
@@ -72,8 +72,8 @@ let kind_of_format = function
       let video =
         match m.Ffmpeg_format.video_codec with
           | None -> Frame.none
-          | Some `Copy -> `Format (Ffmpeg_copy_content.Video.lift_params [])
-          | Some (`Raw _) -> `Format (Ffmpeg_raw_content.Video.lift_params [])
+          | Some `Copy -> `Format Ffmpeg_copy_content.Video.(lift_params [])
+          | Some (`Raw _) -> `Format Ffmpeg_raw_content.Video.(lift_params [])
           | Some (`Internal _) -> `Format (Frame_content.Video.lift_params [])
       in
       { Frame.audio; video; midi = Frame.none }

--- a/src/encoder.ml
+++ b/src/encoder.ml
@@ -60,8 +60,9 @@ let kind_of_format = function
       let audio =
         match m.Ffmpeg_format.audio_codec with
           | None -> Frame.none
-          | Some `Copy -> `Format (Ffmpeg_content.AudioCopy.lift_params [])
-          | Some (`Encode _) ->
+          | Some `Copy -> `Format (Ffmpeg_copy_content.Audio.lift_params [])
+          | Some (`Raw _) -> `Format (Ffmpeg_raw_content.Audio.lift_params [])
+          | Some (`Internal _) ->
               let channels = m.Ffmpeg_format.channels in
               assert (channels > 0);
               `Format
@@ -71,8 +72,9 @@ let kind_of_format = function
       let video =
         match m.Ffmpeg_format.video_codec with
           | None -> Frame.none
-          | Some `Copy -> `Format (Ffmpeg_content.VideoCopy.lift_params [])
-          | Some (`Encode _) -> `Format (Frame_content.Video.lift_params [])
+          | Some `Copy -> `Format (Ffmpeg_copy_content.Video.lift_params [])
+          | Some (`Raw _) -> `Format (Ffmpeg_raw_content.Video.lift_params [])
+          | Some (`Internal _) -> `Format (Frame_content.Video.lift_params [])
       in
       { Frame.audio; video; midi = Frame.none }
   | FdkAacEnc m -> audio_kind m.Fdkaac_format.channels

--- a/src/encoder/ffmpeg_copy_encoder.ml
+++ b/src/encoder/ffmpeg_copy_encoder.ml
@@ -30,7 +30,7 @@ let mk_stream_copy ~get_data output =
 
   let mk_stream frame =
     let { Ffmpeg_content_base.params } = get_data frame in
-    stream := Some (Av.new_stream_copy ~params output)
+    stream := Some (Av.new_stream_copy ~params:(Option.get params) output)
   in
 
   (* Keep track of latest DTS/PTS in master time_base

--- a/src/encoder/ffmpeg_copy_encoder.ml
+++ b/src/encoder/ffmpeg_copy_encoder.ml
@@ -28,7 +28,7 @@ let mk_stream_copy ~sample_time_base ~get_data ~convert_pos output =
   let stream = ref None in
 
   let mk_stream frame =
-    let _, { Ffmpeg_content.params } = List.hd !(get_data frame) in
+    let _, { Ffmpeg_copy_content.params } = List.hd !(get_data frame) in
     stream := Some (Av.new_stream_copy ~params output)
   in
 
@@ -43,7 +43,7 @@ let mk_stream_copy ~sample_time_base ~get_data ~convert_pos output =
     in
 
     List.iter
-      (fun (pos, { Ffmpeg_content.packet; time_base }) ->
+      (fun (pos, { Ffmpeg_copy_content.packet; time_base }) ->
         let stream = Option.get !stream in
         if start_pos <= pos && pos < stop_pos then (
           let packet_pts =

--- a/src/encoder/ffmpeg_copy_encoder.ml
+++ b/src/encoder/ffmpeg_copy_encoder.ml
@@ -30,7 +30,7 @@ let mk_stream_copy ~get_data output =
 
   let mk_stream frame =
     let _, { Ffmpeg_copy_content.params } =
-      List.hd (get_data frame).Ffmpeg_copy_content.data
+      List.hd (get_data frame).Ffmpeg_content_base.data
     in
     stream := Some (Av.new_stream_copy ~params output)
   in
@@ -39,10 +39,7 @@ let mk_stream_copy ~get_data output =
 
   let encode frame start len =
     let stop = start + len in
-    let data = (get_data frame).Ffmpeg_copy_content.data in
-    let data =
-      List.sort (fun (pos, _) (pos', _) -> Stdlib.compare pos pos') data
-    in
+    let data = (get_data frame).Ffmpeg_content_base.data in
 
     List.iter
       (fun (pos, { Ffmpeg_copy_content.packet; time_base }) ->

--- a/src/encoder/ffmpeg_encoder.ml
+++ b/src/encoder/ffmpeg_encoder.ml
@@ -32,13 +32,8 @@ let () =
             let mk_audio =
               match m.Ffmpeg_format.audio_codec with
                 | Some `Copy ->
-                    let sample_time_base =
-                      Ffmpeg_utils.liq_audio_sample_time_base ()
-                    in
                     fun ~ffmpeg:_ ~options:_ ->
-                      Ffmpeg_copy_encoder.mk_stream_copy ~sample_time_base
-                        ~convert_pos:Frame.audio_of_master
-                        ~get_data:(fun frame ->
+                      Ffmpeg_copy_encoder.mk_stream_copy ~get_data:(fun frame ->
                           Ffmpeg_copy_content.Audio.get_data
                             Frame.(frame.content.audio))
                 | _ -> Ffmpeg_internal_encoder.mk_audio
@@ -46,13 +41,8 @@ let () =
             let mk_video =
               match m.Ffmpeg_format.video_codec with
                 | Some `Copy ->
-                    let sample_time_base =
-                      Ffmpeg_utils.liq_video_sample_time_base ()
-                    in
                     fun ~ffmpeg:_ ~options:_ ->
-                      Ffmpeg_copy_encoder.mk_stream_copy ~sample_time_base
-                        ~convert_pos:Frame.video_of_master
-                        ~get_data:(fun frame ->
+                      Ffmpeg_copy_encoder.mk_stream_copy ~get_data:(fun frame ->
                           Ffmpeg_copy_content.Video.get_data
                             Frame.(frame.content.video))
                 | _ -> Ffmpeg_internal_encoder.mk_video

--- a/src/encoder/ffmpeg_encoder.ml
+++ b/src/encoder/ffmpeg_encoder.ml
@@ -39,7 +39,7 @@ let () =
                       Ffmpeg_copy_encoder.mk_stream_copy ~sample_time_base
                         ~convert_pos:Frame.audio_of_master
                         ~get_data:(fun frame ->
-                          Ffmpeg_content.AudioCopy.get_data
+                          Ffmpeg_copy_content.Audio.get_data
                             Frame.(frame.content.audio))
                 | _ -> Ffmpeg_internal_encoder.mk_audio
             in
@@ -53,7 +53,7 @@ let () =
                       Ffmpeg_copy_encoder.mk_stream_copy ~sample_time_base
                         ~convert_pos:Frame.video_of_master
                         ~get_data:(fun frame ->
-                          Ffmpeg_content.VideoCopy.get_data
+                          Ffmpeg_copy_content.Video.get_data
                             Frame.(frame.content.video))
                 | _ -> Ffmpeg_internal_encoder.mk_video
             in

--- a/src/encoder/ffmpeg_internal_encoder.ml
+++ b/src/encoder/ffmpeg_internal_encoder.ml
@@ -344,15 +344,14 @@ let mk_video ~ffmpeg ~options output =
       scaler frame
     in
     fun frame start len ->
-      let vstart = Frame.video_of_master start in
-      let vstop = Frame.video_of_master (start + len) in
-      let data =
+      let stop = start + len in
+      let { Ffmpeg_raw_content.VideoSpecs.data } =
         Ffmpeg_raw_content.Video.get_data Frame.(frame.content.video)
       in
       List.iter
         (fun (pos, frame) ->
-          if vstart <= pos && pos < vstop then cb (scale frame))
-        !data
+          if start <= pos && pos < stop then cb (scale frame))
+        data
   in
 
   let converter =

--- a/src/encoder/ffmpeg_internal_encoder.ml
+++ b/src/encoder/ffmpeg_internal_encoder.ml
@@ -338,7 +338,10 @@ let mk_video ~ffmpeg ~options output =
                       src_pixel_format target_width target_height
                       src_pixel_format
                   in
-                  RawScaler.convert scaler )
+                  fun frame ->
+                    let scaled = RawScaler.convert scaler frame in
+                    Avutil.frame_set_pts scaled (Avutil.frame_pts frame);
+                    scaled )
                 else fun f -> f
               in
               scaler := Some f;

--- a/src/io/ffmpeg_filter_io.ml
+++ b/src/io/ffmpeg_filter_io.ml
@@ -134,9 +134,9 @@ class audio_input ~bufferize kind =
       let output_format =
         {
           Ffmpeg_raw_content.AudioSpecs.channel_layout =
-            Avfilter.(channel_layout v.context);
-          sample_rate = Avfilter.(sample_rate v.context);
-          sample_format = Avfilter.(sample_format v.context);
+            Some Avfilter.(channel_layout v.context);
+          sample_rate = Some Avfilter.(sample_rate v.context);
+          sample_format = Some Avfilter.(sample_format v.context);
         }
       in
       Frame_content.merge format
@@ -243,8 +243,8 @@ class video_input ~bufferize ~fps kind =
     method set_output v =
       let output_format =
         {
-          Ffmpeg_raw_content.VideoSpecs.width = Avfilter.(width v.context);
-          height = Avfilter.(height v.context);
+          Ffmpeg_raw_content.VideoSpecs.width = Some Avfilter.(width v.context);
+          height = Some Avfilter.(height v.context);
           pixel_format = Some Avfilter.(pixel_format v.context);
         }
       in

--- a/src/io/ffmpeg_filter_io.ml
+++ b/src/io/ffmpeg_filter_io.ml
@@ -135,7 +135,7 @@ class audio_input ~bufferize kind =
           let frame = output.Avfilter.handler () in
           let content =
             {
-              Ffmpeg_content_base.param =
+              Ffmpeg_content_base.params =
                 Ffmpeg_raw_content.AudioSpecs.frame_param frame;
               data = [(0, frame)];
             }
@@ -215,9 +215,9 @@ class video_input ~bufferize kind =
               (Ffmpeg_utils.convert_time_base ~src ~dst)
               (Avutil.frame_pts frame)
           in
-          let param = Ffmpeg_raw_content.VideoSpecs.frame_param frame in
+          let params = Ffmpeg_raw_content.VideoSpecs.frame_param frame in
           let content =
-            { Ffmpeg_raw_content.VideoSpecs.param; data = [(0, frame)] }
+            { Ffmpeg_raw_content.VideoSpecs.params; data = [(0, frame)] }
           in
           Generator.put_video ?pts generator
             (Ffmpeg_raw_content.Video.lift_data content)

--- a/src/io/ffmpeg_filter_io.ml
+++ b/src/io/ffmpeg_filter_io.ml
@@ -123,10 +123,7 @@ class audio_input ~bufferize kind =
       let output = Option.get output in
       let src = Avfilter.(time_base output.context) in
       let dst = Ffmpeg_utils.liq_frame_time_base () in
-      let sample_time_base = Ffmpeg_utils.liq_audio_sample_time_base () in
-      let get_duration =
-        Ffmpeg_utils.convert_duration ~duration_time_base:src ~sample_time_base
-      in
+      let get_duration = Ffmpeg_decoder_common.convert_duration ~src in
       let rec f () =
         try
           let frame = output.Avfilter.handler () in
@@ -196,10 +193,7 @@ class video_input ~bufferize kind =
       let output = Option.get output in
       let src = Avfilter.(time_base output.context) in
       let dst = Ffmpeg_utils.liq_frame_time_base () in
-      let sample_time_base = Ffmpeg_utils.liq_video_sample_time_base () in
-      let get_duration =
-        Ffmpeg_utils.convert_duration ~duration_time_base:src ~sample_time_base
-      in
+      let get_duration = Ffmpeg_decoder_common.convert_duration ~src in
       let rec f () =
         try
           let frame = output.Avfilter.handler () in

--- a/src/io/ffmpeg_io.ml
+++ b/src/io/ffmpeg_io.ml
@@ -68,7 +68,7 @@ class input ~bufferize ~log_overfull ~kind ~start ~on_start ~on_stop ?format
              (Frame.string_of_content_type self#ctype));
       container <- Some input;
       let audio, video = Ffmpeg_decoder.mk_streams ~ctype:self#ctype input in
-      Ffmpeg_decoder.mk_decoder ?audio ?video input
+      Ffmpeg_decoder.mk_decoder ?audio ?video ~target_position:(ref None) input
 
     val mutable kill_feeding = None
 

--- a/src/io/gstreamer_io.ml
+++ b/src/io/gstreamer_io.ml
@@ -613,7 +613,10 @@ class audio_video_input p kind (pipeline, audio_pipeline, video_pipeline) =
         let len = String.length b / (2 * self#audio_channels) in
         let buf = Audio.create self#audio_channels len in
         Audio.S16LE.to_audio b 0 (Audio.sub buf 0 len);
-        Generator.put_audio gen (Frame_content.Audio.lift_data buf) 0 len
+        Generator.put_audio gen
+          (Frame_content.Audio.lift_data buf)
+          0
+          (Frame.master_of_audio len)
       done
 
     method private fill_video video =
@@ -626,7 +629,8 @@ class audio_video_input p kind (pipeline, audio_pipeline, video_pipeline) =
         let stream = Video.single img in
         Generator.put_video gen
           (Frame_content.Video.lift_data stream)
-          0 (Video.length stream)
+          0
+          (Frame.master_of_video (Video.length stream))
       done
 
     method get_frame frame =

--- a/src/lang/builtins_ffmpeg_filters.ml
+++ b/src/lang/builtins_ffmpeg_filters.ml
@@ -39,6 +39,8 @@ type outputs =
 
 type graph = {
   mutable config : Avfilter.config option;
+  mutable pending_input : int;
+  init : unit Lazy.t Queue.t;
   entries : (inputs, outputs) Avfilter.io;
   clocks : Source.clock_variable Queue.t;
 }
@@ -54,7 +56,8 @@ end)
 module Audio = Lang.MkAbstract (struct
   type content =
     [ `Input of ([ `Attached ], [ `Audio ], [ `Input ]) Avfilter.pad
-    | `Output of ([ `Attached ], [ `Audio ], [ `Output ]) Avfilter.pad ]
+    | `Output of ([ `Attached ], [ `Audio ], [ `Output ]) Avfilter.pad Lazy.t
+    ]
 
   let name = "ffmpeg.filter.audio"
   let descr _ = name
@@ -64,7 +67,8 @@ end)
 module Video = Lang.MkAbstract (struct
   type content =
     [ `Input of ([ `Attached ], [ `Video ], [ `Input ]) Avfilter.pad
-    | `Output of ([ `Attached ], [ `Video ], [ `Output ]) Avfilter.pad ]
+    | `Output of ([ `Attached ], [ `Video ], [ `Output ]) Avfilter.pad Lazy.t
+    ]
 
   let name = "ffmpeg.filter.video"
   let descr _ = name
@@ -131,31 +135,42 @@ let apply_filter ~filter p =
   let flag_args = mk_args ~t:`Flag "flag" p in
   let args = int_args @ float_args @ string_args @ rational_args @ flag_args in
   Avfilter.(
-    let config = get_config (Lang.assoc "" 1 p) in
+    let graph_v = Lang.assoc "" 1 p in
+    let config = get_config graph_v in
+    let graph = Graph.of_value graph_v in
     let name = uniq_name filter.name in
     let filter = attach ~args ~name filter config in
     let audio_inputs_c = List.length filter.io.inputs.audio in
-    List.iteri
-      (fun idx input ->
-        let output =
-          match Audio.of_value (Lang.assoc "" (idx + 2) p) with
-            | `Output output -> output
-            | _ -> assert false
-        in
-        link output input)
-      filter.io.inputs.audio;
-    List.iteri
-      (fun idx input ->
-        let output =
-          match Video.of_value (Lang.assoc "" (audio_inputs_c + idx + 2) p) with
-            | `Output output -> output
-            | _ -> assert false
-        in
-        link output input)
-      filter.io.inputs.video;
+    Queue.push
+      ( lazy
+        ( List.iteri
+            (fun idx input ->
+              let output =
+                match Audio.of_value (Lang.assoc "" (idx + 2) p) with
+                  | `Output output -> Lazy.force output
+                  | _ -> assert false
+              in
+              link output input)
+            filter.io.inputs.audio;
+          List.iteri
+            (fun idx input ->
+              let output =
+                match
+                  Video.of_value (Lang.assoc "" (audio_inputs_c + idx + 2) p)
+                with
+                  | `Output output -> output
+                  | _ -> assert false
+              in
+              link (Lazy.force output) input)
+            filter.io.inputs.video ) )
+      graph.init;
     let output =
-      List.map (fun p -> Audio.to_value (`Output p)) filter.io.outputs.audio
-      @ List.map (fun p -> Video.to_value (`Output p)) filter.io.outputs.video
+      List.map
+        (fun p -> Audio.to_value (`Output (lazy p)))
+        filter.io.outputs.audio
+      @ List.map
+          (fun p -> Video.to_value (`Output (lazy p)))
+          filter.io.outputs.video
     in
     match output with [x] -> x | l -> Lang.tuple l)
 
@@ -200,7 +215,7 @@ let abuffer_args
     =
   [
     `Pair ("sample_rate", `Int sample_rate);
-    `Pair ("time_base", `Rational (Ffmpeg_utils.liq_frame_time_base ()));
+    `Pair ("time_base", `Rational (Ffmpeg_utils.liq_master_ticks_time_base ()));
     `Pair ("channel_layout", `Int (Avutil.Channel_layout.get_id channel_layout));
     `Pair ("sample_fmt", `Int (Avutil.Sample_format.get_id sample_format));
   ]
@@ -208,7 +223,7 @@ let abuffer_args
 let buffer_args { Ffmpeg_raw_content.VideoSpecs.width; height; pixel_format } =
   let pixel_format = Option.get pixel_format in
   [
-    `Pair ("time_base", `Rational (Ffmpeg_utils.liq_frame_time_base ()));
+    `Pair ("time_base", `Rational (Ffmpeg_utils.liq_master_ticks_time_base ()));
     `Pair ("width", `Int width);
     `Pair ("height", `Int height);
     `Pair ("pix_fmt", `String Avutil.Pixel_format.(to_string pixel_format));
@@ -242,41 +257,55 @@ let () =
       let config = get_config graph_v in
       let graph = Graph.of_value graph_v in
       let source_val = Lang.assoc "" 2 p in
-      let ctype = (Lang.to_source source_val)#ctype in
-      let params =
-        match Ffmpeg_raw_content.Audio.get_params ctype.Frame.audio with
-          | [p] -> p
-          | [] ->
-              let p = Ffmpeg_raw_content.Audio.internal_params () in
-              Frame_content.merge ctype.Frame.audio
-                (Ffmpeg_raw_content.Audio.lift_params [p]);
-              p
-          | _ -> assert false
+
+      let kind =
+        Frame.
+          {
+            audio = `Format Ffmpeg_raw_content.Audio.(lift_params []);
+            video = `Any;
+            midi = `Any;
+          }
       in
       let name = uniq_name "abuffer" in
-      let args = abuffer_args params in
-      let _abuffer = Avfilter.attach ~args ~name Avfilter.abuffer config in
-      let kind =
-        Frame.{ audio = `Format ctype.Frame.audio; video = none; midi = none }
-      in
       let s =
         try Ffmpeg_filter_io.(new audio_output ~name ~kind source_val)
         with Source.Kind.Conflict (a, b) ->
           raise (Lang_errors.Kind_conflict (source_val.Lang.pos, a, b))
       in
-      Queue.add s#clock graph.clocks;
-      Avfilter.(Hashtbl.add graph.entries.inputs.audio name s#set_input);
-      Audio.to_value (`Output (List.hd Avfilter.(_abuffer.io.outputs.audio))));
 
-  let kind =
-    Frame.
-      {
-        audio = `Format Ffmpeg_raw_content.Audio.(lift_params []);
-        video = none;
-        midi = none;
-      }
-  in
-  let return_t = Lang.kind_type_of_kind_format kind in
+      let audio =
+        lazy
+          (let ctype = (Lang.to_source source_val)#ctype in
+           let params =
+             match Ffmpeg_raw_content.Audio.get_params ctype.Frame.audio with
+               | [p] -> p
+               | [] ->
+                   let p = Ffmpeg_raw_content.AudioSpecs.internal_params () in
+                   Frame_content.merge ctype.Frame.audio
+                     (Ffmpeg_raw_content.Audio.lift_params [p]);
+                   p
+               | _ -> assert false
+           in
+           let args = abuffer_args params in
+           let _abuffer = Avfilter.attach ~args ~name Avfilter.abuffer config in
+           Queue.add s#clock graph.clocks;
+           Avfilter.(Hashtbl.add graph.entries.inputs.audio name s#set_input);
+           List.hd Avfilter.(_abuffer.io.outputs.audio))
+      in
+
+      graph.pending_input <- graph.pending_input + 1;
+
+      s#set_init
+        ( lazy
+          ( ignore (Lazy.force audio);
+            graph.pending_input <- graph.pending_input - 1;
+            if graph.pending_input = 0 then Queue.iter Lazy.force graph.init )
+          );
+
+      Audio.to_value (`Output audio));
+
+  let return_kind = Frame.{ audio_frame with video = none; midi = none } in
+  let return_t = Lang.kind_type_of_kind_format return_kind in
   Lang.add_operator "ffmpeg.filter.audio.output" ~category:Lang.Output
     ~descr:"Return an audio source from a filter's output" ~return_t
     (output_base_proto @ [("", Graph.t, None, None); ("", Audio.t, None, None)])
@@ -284,18 +313,34 @@ let () =
       let graph_v = Lang.assoc "" 1 p in
       let config = get_config graph_v in
       let graph = Graph.of_value graph_v in
-      let bufferize = Lang.to_float (List.assoc "buffer" p) in
-      let pad =
-        match Audio.of_value (Lang.assoc "" 2 p) with
-          | `Output p -> p
-          | _ -> assert false
+
+      let kind =
+        Frame.
+          {
+            audio = `Format Ffmpeg_raw_content.Audio.(lift_params []);
+            video = none;
+            midi = none;
+          }
       in
-      let name = uniq_name "abuffersink" in
-      let _abuffersink = Avfilter.attach ~name Avfilter.abuffersink config in
-      Avfilter.(link pad (List.hd _abuffersink.io.inputs.audio));
+      let bufferize = Lang.to_float (List.assoc "buffer" p) in
       let s = new Ffmpeg_filter_io.audio_input ~bufferize kind in
-      Queue.add s#clock graph.clocks;
-      Avfilter.(Hashtbl.add graph.entries.outputs.audio name s#set_output);
+
+      let pad = Audio.of_value (Lang.assoc "" 2 p) in
+      Queue.add
+        ( lazy
+          (let pad =
+             match pad with `Output pad -> Lazy.force pad | _ -> assert false
+           in
+           let name = uniq_name "abuffersink" in
+           let _abuffersink =
+             Avfilter.attach ~name Avfilter.abuffersink config
+           in
+           Avfilter.(link pad (List.hd _abuffersink.io.inputs.audio));
+           Queue.add s#clock graph.clocks;
+           Avfilter.(Hashtbl.add graph.entries.outputs.audio name s#set_output))
+          )
+        graph.init;
+
       (s :> Source.source));
 
   add_builtin ~cat:Liq "ffmpeg.filter.video.input"
@@ -305,63 +350,115 @@ let () =
       let config = get_config graph_v in
       let graph = Graph.of_value graph_v in
       let source_val = Lang.assoc "" 2 p in
-      let ctype = (Lang.to_source source_val)#ctype in
-      let params =
-        match Ffmpeg_raw_content.Video.get_params ctype.Frame.video with
-          | [p] -> p
-          | [] ->
-              let p = Ffmpeg_raw_content.Video.internal_params () in
-              Frame_content.merge ctype.Frame.video
-                (Ffmpeg_raw_content.Video.lift_params [p]);
-              p
-          | _ -> assert false
+
+      let kind =
+        Frame.
+          {
+            audio = `Any;
+            video = `Format Ffmpeg_raw_content.Video.(lift_params []);
+            midi = `Any;
+          }
       in
       let name = uniq_name "buffer" in
-      let args = buffer_args params in
-      let _buffer = Avfilter.attach ~args ~name Avfilter.buffer config in
-      let kind =
-        Frame.{ audio = none; video = `Format ctype.Frame.audio; midi = none }
+      let s =
+        try Ffmpeg_filter_io.(new video_output ~name ~kind source_val)
+        with Source.Kind.Conflict (a, b) ->
+          raise (Lang_errors.Kind_conflict (source_val.Lang.pos, a, b))
       in
-      let s = Ffmpeg_filter_io.(new video_output ~kind ~name source_val) in
-      Queue.add s#clock graph.clocks;
-      Avfilter.(Hashtbl.add graph.entries.inputs.video name s#set_input);
-      Video.to_value (`Output (List.hd Avfilter.(_buffer.io.outputs.video))));
 
-  let kind = Frame.{ video_frame with audio = none; midi = none } in
-  let return_t = Lang.kind_type_of_kind_format kind in
+      let video =
+        lazy
+          (let ctype = (Lang.to_source source_val)#ctype in
+           let params =
+             match Ffmpeg_raw_content.Video.get_params ctype.Frame.video with
+               | [p] -> p
+               | [] ->
+                   let p = Ffmpeg_raw_content.VideoSpecs.internal_params () in
+                   Frame_content.merge ctype.Frame.video
+                     (Ffmpeg_raw_content.Video.lift_params [p]);
+                   p
+               | _ -> assert false
+           in
+           let args = buffer_args params in
+           let _buffer = Avfilter.attach ~args ~name Avfilter.buffer config in
+           Queue.add s#clock graph.clocks;
+           Avfilter.(Hashtbl.add graph.entries.inputs.video name s#set_input);
+           List.hd Avfilter.(_buffer.io.outputs.video))
+      in
+
+      graph.pending_input <- graph.pending_input + 1;
+
+      s#set_init
+        ( lazy
+          ( ignore (Lazy.force video);
+            graph.pending_input <- graph.pending_input - 1;
+            if graph.pending_input = 0 then Queue.iter Lazy.force graph.init )
+          );
+
+      Video.to_value (`Output video));
+
+  let return_kind = Frame.{ video_frame with audio = none; midi = none } in
+  let return_t = Lang.kind_type_of_kind_format return_kind in
   Lang.add_operator "ffmpeg.filter.video.output" ~category:Lang.Output
     ~descr:"Return a video source from a filter's output" ~return_t
-    (output_base_proto @ [("", Graph.t, None, None); ("", Video.t, None, None)])
+    ( output_base_proto
+    @ [
+        ( "fps",
+          Lang.nullable_t Lang.int_t,
+          Some Lang.null,
+          Some "Output frame per seconds. Defaults to global value" );
+        ("", Graph.t, None, None);
+        ("", Video.t, None, None);
+      ] )
     (fun p ->
       let graph_v = Lang.assoc "" 1 p in
       let config = get_config graph_v in
       let graph = Graph.of_value graph_v in
+
+      let fps = Lang.to_option (Lang.assoc "fps" 1 p) in
+      let fps = Option.map (fun v -> lazy (Lang.to_int v)) fps in
+      let fps = Option.value fps ~default:Frame.video_rate in
+
+      let kind =
+        Frame.
+          {
+            audio = none;
+            video = `Format Ffmpeg_raw_content.Video.(lift_params []);
+            midi = none;
+          }
+      in
       let bufferize = Lang.to_float (List.assoc "buffer" p) in
-      let pad =
-        match Video.of_value (Lang.assoc "" 2 p) with
-          | `Output p -> p
-          | _ -> assert false
-      in
-      let name = uniq_name "buffersink" in
-      let target_frame_rate = Lazy.force Frame.video_rate in
-      let fps =
-        match Avfilter.find_opt "fps" with
-          | Some f -> f
-          | None -> failwith "Could not find ffmpeg fps filter"
-      in
-      let fps =
-        let args = [`Pair ("fps", `Int target_frame_rate)] in
-        Avfilter.attach ~name:(uniq_name "fps") ~args fps config
-      in
-      let _buffersink = Avfilter.attach ~name Avfilter.buffersink config in
-      Avfilter.(link pad (List.hd fps.io.inputs.video));
-      Avfilter.(
-        link
-          (List.hd fps.io.outputs.video)
-          (List.hd _buffersink.io.inputs.video));
-      let s = new Ffmpeg_filter_io.video_input ~bufferize kind in
-      Queue.add s#clock graph.clocks;
-      Avfilter.(Hashtbl.add graph.entries.outputs.video name s#set_output);
+      let s = new Ffmpeg_filter_io.video_input ~bufferize ~fps kind in
+
+      Queue.add
+        ( lazy
+          (let pad =
+             match Video.of_value (Lang.assoc "" 2 p) with
+               | `Output p -> Lazy.force p
+               | _ -> assert false
+           in
+           let name = uniq_name "buffersink" in
+           let target_frame_rate = Lazy.force fps in
+           let fps =
+             match Avfilter.find_opt "fps" with
+               | Some f -> f
+               | None -> failwith "Could not find ffmpeg fps filter"
+           in
+           let fps =
+             let args = [`Pair ("fps", `Int target_frame_rate)] in
+             Avfilter.attach ~name:(uniq_name "fps") ~args fps config
+           in
+           let _buffersink = Avfilter.attach ~name Avfilter.buffersink config in
+           Avfilter.(link pad (List.hd fps.io.inputs.video));
+           Avfilter.(
+             link
+               (List.hd fps.io.outputs.video)
+               (List.hd _buffersink.io.inputs.video));
+           Queue.add s#clock graph.clocks;
+           Avfilter.(Hashtbl.add graph.entries.outputs.video name s#set_output))
+          )
+        graph.init;
+
       (s :> Source.source))
 
 let () =
@@ -377,6 +474,8 @@ let () =
         Avfilter.
           {
             config = Some config;
+            pending_input = 0;
+            init = Queue.create ();
             clocks = Queue.create ();
             entries =
               {
@@ -388,36 +487,45 @@ let () =
           }
       in
       let ret = Lang.apply fn [("", Graph.to_value graph)] in
-      let filter = Avfilter.launch config in
-      Avfilter.(
-        List.iter
-          (fun (name, input) ->
-            let set_input = Hashtbl.find graph.entries.inputs.audio name in
-            set_input input)
-          filter.inputs.audio);
-      Avfilter.(
-        List.iter
-          (fun (name, input) ->
-            let set_input = Hashtbl.find graph.entries.inputs.video name in
-            set_input input)
-          filter.inputs.video);
-      Avfilter.(
-        List.iter
-          (fun (name, output) ->
-            let set_output = Hashtbl.find graph.entries.outputs.audio name in
-            set_output output)
-          filter.outputs.audio);
-      Avfilter.(
-        List.iter
-          (fun (name, output) ->
-            let set_output = Hashtbl.find graph.entries.outputs.video name in
-            set_output output)
-          filter.outputs.video);
+      Queue.add
+        ( lazy
+          ( log#info "Initializing graph";
+            let filter = Avfilter.launch config in
+            Avfilter.(
+              List.iter
+                (fun (name, input) ->
+                  let set_input =
+                    Hashtbl.find graph.entries.inputs.audio name
+                  in
+                  set_input input)
+                filter.inputs.audio);
+            Avfilter.(
+              List.iter
+                (fun (name, input) ->
+                  let set_input =
+                    Hashtbl.find graph.entries.inputs.video name
+                  in
+                  set_input input)
+                filter.inputs.video);
+            Avfilter.(
+              List.iter
+                (fun (name, output) ->
+                  let set_output =
+                    Hashtbl.find graph.entries.outputs.audio name
+                  in
+                  set_output output)
+                filter.outputs.audio);
+            Avfilter.(
+              List.iter
+                (fun (name, output) ->
+                  let set_output =
+                    Hashtbl.find graph.entries.outputs.video name
+                  in
+                  set_output output)
+                filter.outputs.video);
+            let first = Queue.take graph.clocks in
+            Queue.iter (Clock.unify first) graph.clocks ) )
+        graph.init;
+      if graph.pending_input = 0 then Queue.iter Lazy.force graph.init;
       graph.config <- None;
-      let () =
-        try
-          let first = Queue.take graph.clocks in
-          Queue.iter (Clock.unify first) graph.clocks
-        with Queue.Empty -> ()
-      in
       ret)

--- a/src/lang/builtins_ffmpeg_filters.ml
+++ b/src/lang/builtins_ffmpeg_filters.ml
@@ -267,10 +267,15 @@ let () =
           }
       in
       let name = uniq_name "abuffer" in
+      let pos = source_val.Lang.pos in
       let s =
-        try Ffmpeg_filter_io.(new audio_output ~name ~kind source_val)
-        with Source.Kind.Conflict (a, b) ->
-          raise (Lang_errors.Kind_conflict (source_val.Lang.pos, a, b))
+        try Ffmpeg_filter_io.(new audio_output ~name ~kind source_val) with
+          | Source.Clock_conflict (a, b) ->
+              raise (Lang_errors.Clock_conflict (pos, a, b))
+          | Source.Clock_loop (a, b) ->
+              raise (Lang_errors.Clock_loop (pos, a, b))
+          | Source.Kind.Conflict (a, b) ->
+              raise (Lang_errors.Kind_conflict (pos, a, b))
       in
 
       let audio =
@@ -360,10 +365,15 @@ let () =
           }
       in
       let name = uniq_name "buffer" in
+      let pos = source_val.Lang.pos in
       let s =
-        try Ffmpeg_filter_io.(new video_output ~name ~kind source_val)
-        with Source.Kind.Conflict (a, b) ->
-          raise (Lang_errors.Kind_conflict (source_val.Lang.pos, a, b))
+        try Ffmpeg_filter_io.(new video_output ~name ~kind source_val) with
+          | Source.Clock_conflict (a, b) ->
+              raise (Lang_errors.Clock_conflict (pos, a, b))
+          | Source.Clock_loop (a, b) ->
+              raise (Lang_errors.Clock_loop (pos, a, b))
+          | Source.Kind.Conflict (a, b) ->
+              raise (Lang_errors.Kind_conflict (pos, a, b))
       in
 
       let video =

--- a/src/lang/builtins_ffmpeg_filters.ml
+++ b/src/lang/builtins_ffmpeg_filters.ml
@@ -214,19 +214,24 @@ let abuffer_args
     { Ffmpeg_raw_content.AudioSpecs.channel_layout; sample_format; sample_rate }
     =
   [
-    `Pair ("sample_rate", `Int sample_rate);
+    `Pair ("sample_rate", `Int (Option.get sample_rate));
     `Pair ("time_base", `Rational (Ffmpeg_utils.liq_master_ticks_time_base ()));
-    `Pair ("channel_layout", `Int (Avutil.Channel_layout.get_id channel_layout));
-    `Pair ("sample_fmt", `Int (Avutil.Sample_format.get_id sample_format));
+    `Pair
+      ( "channel_layout",
+        `Int (Avutil.Channel_layout.get_id (Option.get channel_layout)) );
+    `Pair
+      ( "sample_fmt",
+        `Int (Avutil.Sample_format.get_id (Option.get sample_format)) );
   ]
 
 let buffer_args { Ffmpeg_raw_content.VideoSpecs.width; height; pixel_format } =
-  let pixel_format = Option.get pixel_format in
   [
     `Pair ("time_base", `Rational (Ffmpeg_utils.liq_master_ticks_time_base ()));
-    `Pair ("width", `Int width);
-    `Pair ("height", `Int height);
-    `Pair ("pix_fmt", `String Avutil.Pixel_format.(to_string pixel_format));
+    `Pair ("width", `Int (Option.get width));
+    `Pair ("height", `Int (Option.get height));
+    `Pair
+      ( "pix_fmt",
+        `String Avutil.Pixel_format.(to_string (Option.get pixel_format)) );
   ]
 
 let () =

--- a/src/lang/lang.ml
+++ b/src/lang/lang.ml
@@ -96,8 +96,10 @@ let audio_params p =
   }
 
 let audio_n n = { Frame.audio = Frame.audio_n n; video = `Any; midi = `Any }
-let audio_mono = audio_params [`Mono]
-let audio_stereo = audio_params [`Stereo]
+let audio_mono = audio_params { Frame_content.Contents.channel_layout = `Mono }
+
+let audio_stereo =
+  audio_params { Frame_content.Contents.channel_layout = `Stereo }
 
 let video_yuv420p =
   { Frame.audio = `Any; video = Frame.video_yuv420p; midi = `Any }
@@ -108,7 +110,9 @@ let midi_n n =
   {
     Frame.audio = `Any;
     video = `Any;
-    midi = `Format (Frame_content.Midi.lift_params [`Channels n]);
+    midi =
+      `Format
+        (Frame_content.Midi.lift_params { Frame_content.Contents.channels = n });
   }
 
 let kind_type_of_kind_format fields =

--- a/src/lang/lang.mli
+++ b/src/lang/lang.mli
@@ -160,7 +160,7 @@ val audio_video_internal : Frame.content_kind
 
 (* Audio (PCM format) *)
 val audio_pcm : Frame.content_kind
-val audio_params : Frame_content.Audio.param list -> Frame.content_kind
+val audio_params : Frame_content.Audio.params -> Frame.content_kind
 val audio_n : int -> Frame.content_kind
 val audio_mono : Frame.content_kind
 val audio_stereo : Frame.content_kind

--- a/src/lang/lang_errors.ml
+++ b/src/lang/lang_errors.ml
@@ -172,8 +172,10 @@ let throw print_error = function
   | Sedlexing.MalFormed -> print_error 13 "Malformed file."
   | End_of_file -> raise End_of_file
   | e ->
-      print_error (-1) "Unknown error";
-      raise e
+      let bt = Printexc.get_backtrace () in
+      error_header (-1) "unknown position";
+      Format.printf "Exception raised: %s@.%s@]@." (Printexc.to_string e) bt;
+      raise Error
 
 let report lexbuf f =
   let print_error idx error =

--- a/src/lang/lang_lexer.ml
+++ b/src/lang/lang_lexer.ml
@@ -185,7 +185,11 @@ let rec token lexbuf =
     | "%opus" -> OPUS
     | "%flac" -> FLAC
     | "%audio" -> AUDIO
+    | "%audio.raw" -> AUDIO_RAW
+    | "%audio.copy" -> AUDIO_COPY
     | "%video" -> VIDEO
+    | "%video.raw" -> VIDEO_RAW
+    | "%video.copy" -> VIDEO_COPY
     | "%ffmpeg" -> FFMPEG
     | "%vorbis.cbr" -> VORBIS_CBR
     | "%vorbis.abr" -> VORBIS_ABR

--- a/src/lang/lang_lexer.ml
+++ b/src/lang/lang_lexer.ml
@@ -187,9 +187,11 @@ let rec token lexbuf =
     | "%audio" -> AUDIO
     | "%audio.raw" -> AUDIO_RAW
     | "%audio.copy" -> AUDIO_COPY
+    | "%audio.none" -> AUDIO_NONE
     | "%video" -> VIDEO
     | "%video.raw" -> VIDEO_RAW
     | "%video.copy" -> VIDEO_COPY
+    | "%video.none" -> VIDEO_NONE
     | "%ffmpeg" -> FFMPEG
     | "%vorbis.cbr" -> VORBIS_CBR
     | "%vorbis.abr" -> VORBIS_ABR

--- a/src/lang/lang_parser.mly
+++ b/src/lang/lang_parser.mly
@@ -231,7 +231,7 @@
 %token <bool> BOOL
 %token <int option list> TIME
 %token <int option list * int option list> INTERVAL
-%token OGG FLAC AUDIO VIDEO FFMPEG OPUS VORBIS VORBIS_CBR VORBIS_ABR THEORA SPEEX GSTREAMER
+%token OGG FLAC AUDIO AUDIO_RAW AUDIO_COPY VIDEO VIDEO_RAW VIDEO_COPY FFMPEG OPUS VORBIS VORBIS_CBR VORBIS_ABR THEORA SPEEX GSTREAMER
 %token WAV AVI FDKAAC MP3 MP3_VBR MP3_ABR SHINE EXTERNAL
 %token EOF
 %token BEGIN END REC GETS TILD QUESTION LET
@@ -601,9 +601,14 @@ ffmpeg_params:
   | ffmpeg_param COMMA ffmpeg_params { $1::$3 }
 
 ffmpeg_list_elem:
-  | AUDIO LPAR ffmpeg_params RPAR { `Audio  $3 }
-  | VIDEO LPAR ffmpeg_params RPAR { `Video  $3 }
-  | ffmpeg_param                  { `Option $1 }
+  | AUDIO_COPY                        { `Audio_copy }
+  | AUDIO_RAW LPAR ffmpeg_params RPAR { `Audio_raw $3 }
+  | AUDIO LPAR ffmpeg_params RPAR     { `Audio  $3 }
+  | VIDEO_COPY                        { `Video_copy }
+  | VIDEO_RAW LPAR ffmpeg_params RPAR { `Video_raw  $3 }
+  | VIDEO LPAR ffmpeg_params RPAR     { `Video  $3 }
+  | ffmpeg_param                      { `Option $1 }
+ 
 ffmpeg_list:
   |                                    { [] }
   | ffmpeg_list_elem                   { [$1] }

--- a/src/lang/lang_parser.mly
+++ b/src/lang/lang_parser.mly
@@ -184,7 +184,7 @@
                                            ~level:(-1) ~pos:None
         | param::params ->
             let mk_format (label, value) =
-              Frame_content.format_of_param label value
+              Frame_content.parse_param label value
             in
             let f = mk_format param in
             List.iter (fun param -> Frame_content.merge f (mk_format param)) params;

--- a/src/lang/lang_parser.mly
+++ b/src/lang/lang_parser.mly
@@ -442,7 +442,14 @@ ty_source:
 
 ty_content:
   | VAR                           { $1, [] }
+  | VAR DOT VAR                   { $1 ^ "." ^ $3, [] }
+  | VAR DOT VAR DOT VAR           { $1 ^ "." ^ $3 ^ "." ^ $5, [] }
   | VARLPAR ty_content_args RPAR  { $1, $2 }
+  | VAR DOT VARLPAR ty_content_args RPAR 
+                                  { $1 ^ "." ^ $3, $4 }
+  | VAR DOT VAR DOT VARLPAR ty_content_args RPAR
+                                  { $1 ^ "." ^ $3 ^ "." ^ $5, $6 }
+
 
 ty_content_args:
   |                                      { [] }
@@ -450,8 +457,9 @@ ty_content_args:
   | ty_content_arg COMMA ty_content_args { $1::$3 }
 
 ty_content_arg:
-  | VAR          { "",$1 }
-  | VAR GETS VAR { $1,$3 }
+  | VAR                  { "",$1 }
+  | VAR GETS VAR         { $1,$3 }
+  | VAR GETS INT         { $1,string_of_int $3}
 
 ty_tuple:
   | ty TIMES ty { [$1; $3] }
@@ -593,7 +601,7 @@ ogg_video_item:
   | THEORA app_opt     { Lang_theora.make $2 }
 
 ffmpeg_param:
-  | STRING GETS expr { $1,$3 }
+  | STRING GETS expr     { $1,$3 }
   | VAR GETS expr        { $1,$3 }
 ffmpeg_params:
   |                                  { [] }

--- a/src/lang/lang_parser.mly
+++ b/src/lang/lang_parser.mly
@@ -231,7 +231,7 @@
 %token <bool> BOOL
 %token <int option list> TIME
 %token <int option list * int option list> INTERVAL
-%token OGG FLAC AUDIO AUDIO_RAW AUDIO_COPY VIDEO VIDEO_RAW VIDEO_COPY FFMPEG OPUS VORBIS VORBIS_CBR VORBIS_ABR THEORA SPEEX GSTREAMER
+%token OGG FLAC AUDIO AUDIO_RAW AUDIO_COPY AUDIO_NONE VIDEO VIDEO_RAW VIDEO_COPY VIDEO_NONE FFMPEG OPUS VORBIS VORBIS_CBR VORBIS_ABR THEORA SPEEX GSTREAMER
 %token WAV AVI FDKAAC MP3 MP3_VBR MP3_ABR SHINE EXTERNAL
 %token EOF
 %token BEGIN END REC GETS TILD QUESTION LET
@@ -601,9 +601,11 @@ ffmpeg_params:
   | ffmpeg_param COMMA ffmpeg_params { $1::$3 }
 
 ffmpeg_list_elem:
+  | AUDIO_NONE                        { `Audio_none }
   | AUDIO_COPY                        { `Audio_copy }
   | AUDIO_RAW LPAR ffmpeg_params RPAR { `Audio_raw $3 }
   | AUDIO LPAR ffmpeg_params RPAR     { `Audio  $3 }
+  | VIDEO_NONE                        { `Video_none }
   | VIDEO_COPY                        { `Video_copy }
   | VIDEO_RAW LPAR ffmpeg_params RPAR { `Video_raw  $3 }
   | VIDEO LPAR ffmpeg_params RPAR     { `Video  $3 }

--- a/src/lang_encoders/lang_ffmpeg.ml
+++ b/src/lang_encoders/lang_ffmpeg.ml
@@ -98,13 +98,6 @@ let ffmpeg_gen params =
                 { f with Ffmpeg_format.video_codec = Some (`Raw c) }
         in
         parse_args ~format ~mode f l
-    | ("raw_codec", { term = Ground (String c); _ }) :: l ->
-        let f =
-          match mode with
-            | `Audio -> { f with Ffmpeg_format.audio_codec = Some (`Raw c) }
-            | `Video -> { f with Ffmpeg_format.video_codec = Some (`Raw c) }
-        in
-        parse_args ~format ~mode f l
     | (k, { term = Ground (String s); _ }) :: l ->
         ( match mode with
           | `Audio -> Hashtbl.add f.Ffmpeg_format.audio_opts k (`String s)

--- a/src/lang_encoders/lang_ffmpeg.ml
+++ b/src/lang_encoders/lang_ffmpeg.ml
@@ -81,8 +81,7 @@ let ffmpeg_gen params =
           match mode with
             | `Audio ->
                 { f with Ffmpeg_format.audio_codec = None; channels = 0 }
-            | `Video ->
-                { f with Ffmpeg_format.video_codec = None; channels = 0 }
+            | `Video -> { f with Ffmpeg_format.video_codec = None }
         in
         parse_args ~format ~mode f l
     | ("codec", { term = Ground (String c); _ }) :: l ->

--- a/src/lang_encoders/lang_ffmpeg.ml
+++ b/src/lang_encoders/lang_ffmpeg.ml
@@ -74,16 +74,6 @@ let ffmpeg_gen params =
           { f with Ffmpeg_format.height = Lazy.from_val h }
           l
     (* Shared options *)
-    | ("codec", { term = Ground (String s); _ }) :: l
-    | ("codec", { term = Var s; _ }) :: l
-      when s = "none" ->
-        let f =
-          match mode with
-            | `Audio ->
-                { f with Ffmpeg_format.audio_codec = None; channels = 0 }
-            | `Video -> { f with Ffmpeg_format.video_codec = None }
-        in
-        parse_args ~format ~mode f l
     | ("codec", { term = Ground (String c); _ }) :: l ->
         let f =
           match (mode, format) with
@@ -116,9 +106,11 @@ let ffmpeg_gen params =
   in
   List.fold_left
     (fun f -> function
+      | `Audio_none -> { f with Ffmpeg_format.audio_codec = None; channels = 0 }
       | `Audio_copy -> { f with Ffmpeg_format.audio_codec = Some `Copy }
       | `Audio_raw l -> parse_args ~format:`Raw ~mode:`Audio f l
       | `Audio l -> parse_args ~format:`Internal ~mode:`Audio f l
+      | `Video_none -> { f with Ffmpeg_format.video_codec = None }
       | `Video_copy -> { f with Ffmpeg_format.video_codec = Some `Copy }
       | `Video_raw l -> parse_args ~format:`Raw ~mode:`Video f l
       | `Video l -> parse_args ~format:`Internal ~mode:`Video f l

--- a/src/lang_encoders/lang_ffmpeg.ml
+++ b/src/lang_encoders/lang_ffmpeg.ml
@@ -41,26 +41,38 @@ let ffmpeg_gen params =
       other_opts = Hashtbl.create 0;
     }
   in
-  let rec parse_args ~mode f = function
+  let rec parse_args ~format ~mode f = function
     | [] -> f
     (* Audio options *)
     | ("channels", { term = Ground (Int c); _ }) :: l when mode = `Audio ->
-        parse_args ~mode { f with Ffmpeg_format.channels = c } l
+        parse_args ~format ~mode { f with Ffmpeg_format.channels = c } l
     | ("ac", { term = Ground (Int c); _ }) :: l when mode = `Audio ->
-        parse_args ~mode { f with Ffmpeg_format.channels = c } l
+        parse_args ~format ~mode { f with Ffmpeg_format.channels = c } l
     | ("samplerate", { term = Ground (Int s); _ }) :: l when mode = `Audio ->
-        parse_args ~mode { f with Ffmpeg_format.samplerate = Lazy.from_val s } l
+        parse_args ~format ~mode
+          { f with Ffmpeg_format.samplerate = Lazy.from_val s }
+          l
     | ("ar", { term = Ground (Int s); _ }) :: l when mode = `Audio ->
-        parse_args ~mode { f with Ffmpeg_format.samplerate = Lazy.from_val s } l
+        parse_args ~format ~mode
+          { f with Ffmpeg_format.samplerate = Lazy.from_val s }
+          l
     (* Video options *)
     | ("framerate", { term = Ground (Int r); _ }) :: l when mode = `Video ->
-        parse_args ~mode { f with Ffmpeg_format.framerate = Lazy.from_val r } l
+        parse_args ~format ~mode
+          { f with Ffmpeg_format.framerate = Lazy.from_val r }
+          l
     | ("r", { term = Ground (Int r); _ }) :: l when mode = `Video ->
-        parse_args ~mode { f with Ffmpeg_format.framerate = Lazy.from_val r } l
+        parse_args ~format ~mode
+          { f with Ffmpeg_format.framerate = Lazy.from_val r }
+          l
     | ("width", { term = Ground (Int w); _ }) :: l when mode = `Video ->
-        parse_args ~mode { f with Ffmpeg_format.width = Lazy.from_val w } l
+        parse_args ~format ~mode
+          { f with Ffmpeg_format.width = Lazy.from_val w }
+          l
     | ("height", { term = Ground (Int h); _ }) :: l when mode = `Video ->
-        parse_args ~mode { f with Ffmpeg_format.height = Lazy.from_val h } l
+        parse_args ~format ~mode
+          { f with Ffmpeg_format.height = Lazy.from_val h }
+          l
     (* Shared options *)
     | ("codec", { term = Ground (String s); _ }) :: l
     | ("codec", { term = Var s; _ }) :: l
@@ -72,41 +84,52 @@ let ffmpeg_gen params =
             | `Video ->
                 { f with Ffmpeg_format.video_codec = None; channels = 0 }
         in
-        parse_args ~mode f l
-    | ("codec", { term = Var s; _ }) :: l when s = "copy" ->
-        let f =
-          match mode with
-            | `Audio -> { f with Ffmpeg_format.audio_codec = Some `Copy }
-            | `Video -> { f with Ffmpeg_format.video_codec = Some `Copy }
-        in
-        parse_args ~mode f l
+        parse_args ~format ~mode f l
     | ("codec", { term = Ground (String c); _ }) :: l ->
         let f =
-          match mode with
-            | `Audio -> { f with Ffmpeg_format.audio_codec = Some (`Encode c) }
-            | `Video -> { f with Ffmpeg_format.video_codec = Some (`Encode c) }
+          match (mode, format) with
+            | `Audio, `Internal ->
+                { f with Ffmpeg_format.audio_codec = Some (`Internal c) }
+            | `Audio, `Raw ->
+                { f with Ffmpeg_format.audio_codec = Some (`Raw c) }
+            | `Video, `Internal ->
+                { f with Ffmpeg_format.video_codec = Some (`Internal c) }
+            | `Video, `Raw ->
+                { f with Ffmpeg_format.video_codec = Some (`Raw c) }
         in
-        parse_args ~mode f l
+        parse_args ~format ~mode f l
+    | ("raw_codec", { term = Ground (String c); _ }) :: l ->
+        let f =
+          match mode with
+            | `Audio -> { f with Ffmpeg_format.audio_codec = Some (`Raw c) }
+            | `Video -> { f with Ffmpeg_format.video_codec = Some (`Raw c) }
+        in
+        parse_args ~format ~mode f l
     | (k, { term = Ground (String s); _ }) :: l ->
         ( match mode with
           | `Audio -> Hashtbl.add f.Ffmpeg_format.audio_opts k (`String s)
           | `Video -> Hashtbl.add f.Ffmpeg_format.video_opts k (`String s) );
-        parse_args ~mode f l
+        parse_args ~format ~mode f l
     | (k, { term = Ground (Int i); _ }) :: l ->
         ( match mode with
           | `Audio -> Hashtbl.add f.Ffmpeg_format.audio_opts k (`Int i)
           | `Video -> Hashtbl.add f.Ffmpeg_format.video_opts k (`Int i) );
-        parse_args ~mode f l
+        parse_args ~format ~mode f l
     | (k, { term = Ground (Float fl); _ }) :: l ->
         ( match mode with
           | `Audio -> Hashtbl.add f.Ffmpeg_format.audio_opts k (`Float fl)
           | `Video -> Hashtbl.add f.Ffmpeg_format.video_opts k (`Float fl) );
-        parse_args ~mode f l
+        parse_args ~format ~mode f l
     | (_, t) :: _ -> raise (generic_error t)
   in
   List.fold_left
-    (fun f -> function `Audio l -> parse_args ~mode:`Audio f l
-      | `Video l -> parse_args ~mode:`Video f l
+    (fun f -> function
+      | `Audio_copy -> { f with Ffmpeg_format.audio_codec = Some `Copy }
+      | `Audio_raw l -> parse_args ~format:`Raw ~mode:`Audio f l
+      | `Audio l -> parse_args ~format:`Internal ~mode:`Audio f l
+      | `Video_copy -> { f with Ffmpeg_format.video_codec = Some `Copy }
+      | `Video_raw l -> parse_args ~format:`Raw ~mode:`Video f l
+      | `Video l -> parse_args ~format:`Internal ~mode:`Video f l
       | `Option ("format", { term = Ground (String s); _ })
       | `Option ("format", { term = Var s; _ })
         when s = "none" ->

--- a/src/operators/pipe.ml
+++ b/src/operators/pipe.ml
@@ -96,7 +96,10 @@ class pipe ~kind ~replay_delay ~data_len ~process ~bufferize ~log_overfull ~max
         let data = resampler ~samplerate data in
         let len = Audio.length data in
         let buffered = Generator.length abg in
-        Generator.put_audio abg (Frame_content.Audio.lift_data data) 0 len;
+        Generator.put_audio abg
+          (Frame_content.Audio.lift_data data)
+          0
+          (Frame.master_of_audio len);
         let to_replay =
           Tutils.mutexify mutex
             (fun () ->

--- a/src/operators/soundtouch_op.ml
+++ b/src/operators/soundtouch_op.ml
@@ -85,8 +85,10 @@ class soundtouch ~kind (source : source) rate tempo pitch =
         in
         ignore (Soundtouch.get_samples_ba st tmp);
         let tmp = Audio.deinterleave self#audio_channels tmp in
-        Generator.put_audio abg (Frame_content.Audio.lift_data tmp) 0 available
-        );
+        Generator.put_audio abg
+          (Frame_content.Audio.lift_data tmp)
+          0
+          (Frame.master_of_audio available) );
       if AFrame.is_partial databuf then Generator.add_break abg;
 
       (* It's almost impossible to know where to add metadata,

--- a/src/source.ml
+++ b/src/source.ml
@@ -236,7 +236,8 @@ module Kind = struct
 
   exception Conflict of string * string
 
-  type t = Frame.kind Unifier.t fields
+  type kind = Frame.kind Unifier.t
+  type t = kind fields
 
   let deref = Unifier.deref
 

--- a/src/source.mli
+++ b/src/source.mli
@@ -66,13 +66,15 @@ type watcher = {
 }
 
 module Kind : sig
-  type t
+  type kind
+  type t = kind Frame.fields
 
   val of_kind : Frame.content_kind -> t
   val to_string : t -> string
 
   exception Conflict of string * string
 
+  val unify_kind : kind -> kind -> unit
   val unify : t -> t -> unit
 end
 

--- a/src/sources/audio_gen.ml
+++ b/src/sources/audio_gen.ml
@@ -39,7 +39,7 @@ class gen ~kind ~seek name g freq duration ampl =
   end
 
 let add name g =
-  let kind = Lang.any in
+  let kind = Lang.audio_pcm in
   let return_t = Lang.kind_type_of_kind_format kind in
   Lang.add_operator name ~category:Lang.Input
     ~descr:("Generate a " ^ name ^ " wave.")

--- a/src/sources/external_input_audio.ml
+++ b/src/sources/external_input_audio.ml
@@ -112,7 +112,7 @@ let () =
             (Lang_errors.Invalid_value
                (channels_v, "unsupported number of channels"))
       in
-      let kind = Lang.audio_params [channel_layout] in
+      let kind = Lang.audio_params { Frame_content.Contents.channel_layout } in
       let samplerate = Lang.to_int (List.assoc "samplerate" p) in
       let resampler = Decoder_utils.samplerate_converter () in
       let convert =

--- a/src/sources/external_input_audio.ml
+++ b/src/sources/external_input_audio.ml
@@ -42,7 +42,10 @@ class external_input ~name ~kind ~restart ~bufferize ~log_overfull
     let data = converter (Bytes.sub_string buf 0 ret) in
     let len = Audio.length data in
     let buffered = Generator.length abg in
-    Generator.put_audio abg (Frame_content.Audio.lift_data data) 0 len;
+    Generator.put_audio abg
+      (Frame_content.Audio.lift_data data)
+      0
+      (Frame.master_of_audio len);
     if abg_max_len < buffered + len then
       `Delay (Frame.seconds_of_audio (buffered + len - (3 * abg_max_len / 4)))
     else `Continue

--- a/src/sources/external_input_video.ml
+++ b/src/sources/external_input_video.ml
@@ -76,14 +76,7 @@ class video ~name ~kind ~restart ~bufferize ~log_overfull ~restart_on_error ~max
            total buffer length: %.02f s"
           (Frame.seconds_of_master (Generator.audio_length abg))
           (Frame.seconds_of_master (Generator.video_length abg))
-          (Frame.seconds_of_master (Generator.length abg)));
-    self#register_command "buffer_size" ~descr:"Show internal buffer size."
-      (fun _ ->
-        Printf.sprintf
-          "audio buffer size: %s\nvideo buffer size: %s\ntotal buffer size: %s"
-          (Utils.string_of_size (Generator.audio_size abg))
-          (Utils.string_of_size (Generator.video_size abg))
-          (Utils.string_of_size (Generator.size abg)))
+          (Frame.seconds_of_master (Generator.length abg)))
 
     method wake_up x =
       (* Now we can create the log function *)

--- a/src/sources/external_input_video.ml
+++ b/src/sources/external_input_video.ml
@@ -224,13 +224,14 @@ let () =
               let data = (Option.get !video_converter) data in
               Generator.put_video abg
                 (Frame_content.Video.lift_data (Video.single data))
-                0 1
+                0 (Frame.master_of_video 1)
           | `Frame (`Audio, _, data) ->
               let converter = Option.get !audio_converter in
               let data = converter data in
               Generator.put_audio abg
                 (Frame_content.Audio.lift_data data)
-                0 (Audio.length data)
+                0
+                (Frame.master_of_audio (Audio.length data))
           | _ -> failwith "Invalid chunk."
       in
       let bufferize = Lang.to_float (List.assoc "buffer" p) in
@@ -292,7 +293,7 @@ let () =
         (* Img.Effect.flip data; *)
         Generator.put_video abg
           (Frame_content.Video.lift_data (Video.single data))
-          0 1
+          0 (Frame.master_of_video 1)
       in
       let bufferize = Lang.to_float (List.assoc "buffer" p) in
       let log_overfull = Lang.to_bool (List.assoc "log_overfull" p) in

--- a/src/sources/request_source.ml
+++ b/src/sources/request_source.ml
@@ -88,7 +88,7 @@ class virtual unqueued ~kind ~name =
             self#log#debug "Failed to prepare track: no file.";
             false
         | Some req when Request.is_ready req ->
-            assert (Option.get (Request.ctype req) = self#ctype);
+            assert (Frame.compatible (Option.get (Request.ctype req)) self#ctype);
 
             (* [Request.is_ready] ensures that we can get a filename from the request,
                and it can be decoded. *)

--- a/src/stream/ffmpeg_content_base.ml
+++ b/src/stream/ffmpeg_content_base.ml
@@ -43,10 +43,14 @@ let copy { data; params } = { data; params }
 let default_params _ = []
 let params { params } = [params]
 
-let merge ~merge_param l l' =
+let merge ~check ~merge_p l l' =
   match (l, l') with
-    | [], [] -> []
-    | [], [p'] -> [p']
-    | [p], [] -> [p]
-    | [p], [p'] -> [merge_param p p']
-    | _ -> failwith "Incompatible parameters"
+    | [], l | l, [] -> l
+    | [p], [p'] when check p p' -> [merge_p p p']
+    | _ -> assert false
+
+let compatible ~check l l' =
+  match (l, l') with
+    | [], _ | _, [] -> true
+    | [p], [p'] -> check p p'
+    | _ -> false

--- a/src/stream/ffmpeg_content_base.ml
+++ b/src/stream/ffmpeg_content_base.ml
@@ -45,6 +45,7 @@ let params { params } = [params]
 
 let merge l l' =
   match (l, l') with
+    | [], [] -> []
     | [], [p'] -> [p']
     | [p], [] -> [p]
     | [p], [p'] when p = p' -> [p]

--- a/src/stream/ffmpeg_content_base.ml
+++ b/src/stream/ffmpeg_content_base.ml
@@ -22,9 +22,8 @@
 
 type ('a, 'b) content = { params : 'a; mutable data : (int * 'b) list }
 
-let make = function [params] -> { params; data = [] } | _ -> assert false
+let make ~size:_ params = { params; data = [] }
 let clear d = d.data <- []
-let param_of_string _ _ = None
 
 let blit src src_pos dst dst_pos len =
   let src_end = src_pos + len in
@@ -40,17 +39,4 @@ let blit src src_pos dst dst_pos len =
   dst.data <- List.sort (fun (pos, _) (pos', _) -> Stdlib.compare pos pos') data
 
 let copy { data; params } = { data; params }
-let default_params _ = []
-let params { params } = [params]
-
-let merge ~check ~merge_p l l' =
-  match (l, l') with
-    | [], l | l, [] -> l
-    | [p], [p'] when check p p' -> [merge_p p p']
-    | _ -> assert false
-
-let compatible ~check l l' =
-  match (l, l') with
-    | [], _ | _, [] -> true
-    | [p], [p'] -> check p p'
-    | _ -> false
+let params { params } = params

--- a/src/stream/ffmpeg_content_base.ml
+++ b/src/stream/ffmpeg_content_base.ml
@@ -43,10 +43,10 @@ let copy { data; params } = { data; params }
 let default_params _ = []
 let params { params } = [params]
 
-let merge l l' =
+let merge ~merge_param l l' =
   match (l, l') with
     | [], [] -> []
     | [], [p'] -> [p']
     | [p], [] -> [p]
-    | [p], [p'] when p = p' -> [p]
+    | [p], [p'] -> [merge_param p p']
     | _ -> failwith "Incompatible parameters"

--- a/src/stream/ffmpeg_content_base.ml
+++ b/src/stream/ffmpeg_content_base.ml
@@ -1,0 +1,51 @@
+(*****************************************************************************
+
+  Liquidsoap, a programmable audio stream generator.
+  Copyright 2003-2019 Savonet team
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details, fully stated in the COPYING
+  file at the root of the liquidsoap distribution.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA
+
+ *****************************************************************************)
+
+type ('a, 'b) content = { param : 'a; mutable data : (int * 'b) list }
+
+let make = function [param] -> { param; data = [] } | _ -> assert false
+let clear d = d.data <- []
+let param_of_string _ _ = None
+
+let blit src src_pos dst dst_pos len =
+  let src_end = src_pos + len in
+  let data =
+    List.fold_left
+      (fun data (pos, p) ->
+        if src_pos <= pos && pos < src_end then (
+          let pos = dst_pos + (pos - src_pos) in
+          (pos, p) :: data )
+        else data)
+      dst.data src.data
+  in
+  dst.data <- List.sort (fun (pos, _) (pos', _) -> Stdlib.compare pos pos') data
+
+let copy { data; param } = { data; param }
+let default_params _ = []
+let params { param } = [param]
+
+let merge l l' =
+  match (l, l') with
+    | [], [p'] -> [p']
+    | [p], [] -> [p]
+    | [p], [p'] when p = p' -> [p]
+    | _ -> failwith "Incompatible parameters"

--- a/src/stream/ffmpeg_content_base.ml
+++ b/src/stream/ffmpeg_content_base.ml
@@ -20,9 +20,9 @@
 
  *****************************************************************************)
 
-type ('a, 'b) content = { param : 'a; mutable data : (int * 'b) list }
+type ('a, 'b) content = { params : 'a; mutable data : (int * 'b) list }
 
-let make = function [param] -> { param; data = [] } | _ -> assert false
+let make = function [params] -> { params; data = [] } | _ -> assert false
 let clear d = d.data <- []
 let param_of_string _ _ = None
 
@@ -39,9 +39,9 @@ let blit src src_pos dst dst_pos len =
   in
   dst.data <- List.sort (fun (pos, _) (pos', _) -> Stdlib.compare pos pos') data
 
-let copy { data; param } = { data; param }
+let copy { data; params } = { data; params }
 let default_params _ = []
-let params { param } = [param]
+let params { params } = [params]
 
 let merge l l' =
   match (l, l') with

--- a/src/stream/ffmpeg_copy_content.ml
+++ b/src/stream/ffmpeg_copy_content.ml
@@ -31,12 +31,13 @@ module BaseSpecs = struct
   type kind = [ `Copy ]
 
   let kind = `Copy
-  let string_of_kind = function `Copy -> "ffmpeg.encoded"
-  let kind_of_string = function "ffmpeg.encoded" -> Some `Copy | _ -> None
 end
 
 module AudioSpecs = struct
   include BaseSpecs
+
+  let string_of_kind = function `Copy -> "ffmpeg.audio.copy"
+  let kind_of_string = function "ffmpeg.audio.copy" -> Some `Copy | _ -> None
 
   type param = audio Avcodec.params
   type data = (param, audio packet) content
@@ -54,12 +55,21 @@ module AudioSpecs = struct
       (Channel_layout.get_description channel_layout)
       (Sample_format.get_name sample_format)
       sample_rate
+
+  let merge_param p p' =
+    assert (p = p');
+    p
+
+  let merge = merge ~merge_param
 end
 
 module Audio = Frame_content.MkContent (AudioSpecs)
 
 module VideoSpecs = struct
   include BaseSpecs
+
+  let string_of_kind = function `Copy -> "ffmpeg.video.copy"
+  let kind_of_string = function "ffmpeg.video.copy" -> Some `Copy | _ -> None
 
   type param = video Avcodec.params
   type data = (param, video packet) content
@@ -78,6 +88,12 @@ module VideoSpecs = struct
       ( match pixel_format with
         | None -> "unknown"
         | Some pf -> Pixel_format.to_string pf )
+
+  let merge_param p p' =
+    assert (p = p');
+    p
+
+  let merge = merge ~merge_param
 end
 
 module Video = Frame_content.MkContent (VideoSpecs)

--- a/src/stream/ffmpeg_copy_content.ml
+++ b/src/stream/ffmpeg_copy_content.ml
@@ -23,18 +23,7 @@
 open Avutil
 open Avcodec
 
-(* We need to keep track of both the original ['a Avcodec.params]
-   and our internal param type (['b] in [type ('a, 'b) content].
-
-   ['a Avcodec.params] is used to create the encoded stream while
-   our internal param is used to display, compare & unify stream
-   types. *)
-
-type 'a packet = {
-  params : 'a Avcodec.params;
-  packet : 'a Packet.t;
-  time_base : Avutil.rational;
-}
+type 'a packet = { packet : 'a Packet.t; time_base : Avutil.rational }
 
 module BaseSpecs = struct
   include Ffmpeg_content_base
@@ -52,24 +41,17 @@ end
 module AudioSpecs = struct
   include BaseSpecs
 
-  type param = {
-    id : Audio.id;
-    channel_layout : Channel_layout.t;
-    sample_format : Sample_format.t;
-    sample_rate : int;
-  }
-
+  type param = audio Avcodec.params
   type data = (param, audio packet) content
 
-  let mk_param params =
-    {
-      id = Audio.get_params_id params;
-      channel_layout = Audio.get_channel_layout params;
-      sample_format = Audio.get_sample_format params;
-      sample_rate = Audio.get_sample_rate params;
-    }
+  let mk_param params = params
 
-  let string_of_param { id; channel_layout; sample_format; sample_rate } =
+  let string_of_param params =
+    let id = Audio.get_params_id params in
+    let channel_layout = Audio.get_channel_layout params in
+    let sample_format = Audio.get_sample_format params in
+    let sample_rate = Audio.get_sample_rate params in
+
     Printf.sprintf "codec=%S,channel_layout=%S,sample_format=%S,sample_rate=%d"
       (Audio.string_of_id id)
       (Channel_layout.get_description channel_layout)
@@ -82,26 +64,17 @@ module Audio = Frame_content.MkContent (AudioSpecs)
 module VideoSpecs = struct
   include BaseSpecs
 
-  type param = {
-    id : Video.id;
-    width : int;
-    height : int;
-    sample_aspect_ratio : Avutil.rational;
-    pixel_format : Avutil.Pixel_format.t option;
-  }
-
+  type param = video Avcodec.params
   type data = (param, video packet) content
 
-  let mk_param params =
-    {
-      id = Video.get_params_id params;
-      width = Video.get_width params;
-      height = Video.get_height params;
-      sample_aspect_ratio = Video.get_sample_aspect_ratio params;
-      pixel_format = Video.get_pixel_format params;
-    }
+  let mk_param params = params
 
-  let string_of_param { id; width; height; sample_aspect_ratio; pixel_format } =
+  let string_of_param params =
+    let id = Video.get_params_id params in
+    let width = Video.get_width params in
+    let height = Video.get_height params in
+    let sample_aspect_ratio = Video.get_sample_aspect_ratio params in
+    let pixel_format = Video.get_pixel_format params in
     Printf.sprintf "codec=%S,size=\"%dx%d\",sample_ratio=%S,pixel_format=%S)"
       (Video.string_of_id id) width height
       (string_of_rational sample_aspect_ratio)

--- a/src/stream/ffmpeg_copy_content.ml
+++ b/src/stream/ffmpeg_copy_content.ml
@@ -56,11 +56,14 @@ module AudioSpecs = struct
       (Sample_format.get_name sample_format)
       sample_rate
 
-  let merge_param p p' =
-    assert (p = p');
-    p
+  let check p p' =
+    Audio.get_params_id p = Audio.get_params_id p'
+    && Audio.get_channel_layout p = Audio.get_channel_layout p'
+    && Audio.get_sample_format p = Audio.get_sample_format p'
+    && Audio.get_sample_rate p = Audio.get_sample_rate p'
 
-  let merge = merge ~merge_param
+  let compatible = compatible ~check
+  let merge = merge ~check ~merge_p:(fun p _ -> p)
 end
 
 module Audio = Frame_content.MkContent (AudioSpecs)
@@ -89,11 +92,15 @@ module VideoSpecs = struct
         | None -> "unknown"
         | Some pf -> Pixel_format.to_string pf )
 
-  let merge_param p p' =
-    assert (p = p');
-    p
+  let check p p' =
+    Video.get_params_id p = Video.get_params_id p'
+    && Video.get_width p = Video.get_width p'
+    && Video.get_height p = Video.get_height p'
+    && Video.get_sample_aspect_ratio p = Video.get_sample_aspect_ratio p'
+    && Video.get_pixel_format p = Video.get_pixel_format p'
 
-  let merge = merge ~merge_param
+  let compatible = compatible ~check
+  let merge = merge ~check ~merge_p:(fun p _ -> p)
 end
 
 module Video = Frame_content.MkContent (VideoSpecs)

--- a/src/stream/ffmpeg_copy_content.ml
+++ b/src/stream/ffmpeg_copy_content.ml
@@ -33,9 +33,6 @@ module BaseSpecs = struct
   let kind = `Copy
   let string_of_kind = function `Copy -> "ffmpeg.encoded"
   let kind_of_string = function "ffmpeg.encoded" -> Some `Copy | _ -> None
-
-  let bytes { data } =
-    List.fold_left (fun c (_, { packet }) -> c + Packet.get_size packet) 0 data
 end
 
 module AudioSpecs = struct

--- a/src/stream/ffmpeg_copy_content.ml
+++ b/src/stream/ffmpeg_copy_content.ml
@@ -29,7 +29,7 @@ type 'a packet = {
   time_base : Avutil.rational;
 }
 
-module BaseCopySpecs = struct
+module BaseSpecs = struct
   type kind = [ `Copy ]
   type 'a content = (int * 'a packet) list ref
 
@@ -62,8 +62,8 @@ module BaseCopySpecs = struct
       | _ -> failwith "Incompatible parameters"
 end
 
-module AudioCopySpecs = struct
-  include BaseCopySpecs
+module AudioSpecs = struct
+  include BaseSpecs
 
   type param = {
     id : Audio.id;
@@ -97,10 +97,10 @@ module AudioCopySpecs = struct
       sample_rate
 end
 
-module AudioCopy = Frame_content.MkContent (AudioCopySpecs)
+module Audio = Frame_content.MkContent (AudioSpecs)
 
-module VideoCopySpecs = struct
-  include BaseCopySpecs
+module VideoSpecs = struct
+  include BaseSpecs
 
   type param = {
     id : Video.id;
@@ -137,4 +137,4 @@ module VideoCopySpecs = struct
         | Some pf -> Pixel_format.to_string pf )
 end
 
-module VideoCopy = Frame_content.MkContent (VideoCopySpecs)
+module Video = Frame_content.MkContent (VideoSpecs)

--- a/src/stream/ffmpeg_raw_content.ml
+++ b/src/stream/ffmpeg_raw_content.ml
@@ -22,6 +22,8 @@
 
 open Avutil
 
+type 'a frame = { time_base : Avutil.rational; frame : 'a Avutil.frame }
+
 module BaseSpecs = struct
   include Ffmpeg_content_base
 
@@ -46,7 +48,7 @@ module AudioSpecs = struct
   (* TODO *)
   let bytes _ = 0
 
-  let frame_param frame =
+  let frame_param { frame } =
     {
       channel_layout = Audio.frame_get_channel_layout frame;
       sample_format = Audio.frame_get_sample_format frame;
@@ -96,7 +98,7 @@ module VideoSpecs = struct
   (* TODO *)
   let bytes _ = 0
 
-  let frame_param frame =
+  let frame_param { frame } =
     {
       width = Video.frame_get_width frame;
       height = Video.frame_get_height frame;

--- a/src/stream/ffmpeg_raw_content.ml
+++ b/src/stream/ffmpeg_raw_content.ml
@@ -30,41 +30,49 @@ module BaseSpecs = struct
   type kind = [ `Raw ]
 
   let kind = `Raw
-  let string_of_kind = function `Raw -> "ffmpeg.raw"
-  let kind_of_string = function "ffmpeg.raw" -> Some `Raw | _ -> None
+
+  let merge_p ~name = function
+    | None, None -> None
+    | None, Some p | Some p, None -> Some p
+    | Some p, Some p' when p = p' -> Some p
+    | _ -> failwith ("Incompatible " ^ name)
 end
 
 module AudioSpecs = struct
   include BaseSpecs
 
+  let string_of_kind = function `Raw -> "ffmpeg.audio.raw"
+  let kind_of_string = function "ffmpeg.audio.raw" -> Some `Raw | _ -> None
+
   type param = {
-    channel_layout : Channel_layout.t;
-    sample_format : Sample_format.t;
-    sample_rate : int;
+    channel_layout : Channel_layout.t option;
+    sample_format : Sample_format.t option;
+    sample_rate : int option;
   }
 
   type data = (param, audio frame) content
 
   let frame_param { frame } =
     {
-      channel_layout = Audio.frame_get_channel_layout frame;
-      sample_format = Audio.frame_get_sample_format frame;
-      sample_rate = Audio.frame_get_sample_rate frame;
+      channel_layout = Some (Audio.frame_get_channel_layout frame);
+      sample_format = Some (Audio.frame_get_sample_format frame);
+      sample_rate = Some (Audio.frame_get_sample_rate frame);
     }
 
   let mk_param p =
     {
-      channel_layout = Avcodec.Audio.get_channel_layout p;
-      sample_format = Avcodec.Audio.get_sample_format p;
-      sample_rate = Avcodec.Audio.get_sample_rate p;
+      channel_layout = Some (Avcodec.Audio.get_channel_layout p);
+      sample_format = Some (Avcodec.Audio.get_sample_format p);
+      sample_rate = Some (Avcodec.Audio.get_sample_rate p);
     }
 
   let internal_params () =
     {
       channel_layout =
-        Avutil.Channel_layout.get_default (Lazy.force Frame.audio_channels);
-      sample_format = `Dblp;
-      sample_rate = Lazy.force Frame.audio_rate;
+        Some
+          (Avutil.Channel_layout.get_default (Lazy.force Frame.audio_channels));
+      sample_format = Some `Dblp;
+      sample_rate = Some (Lazy.force Frame.audio_rate);
     }
 
   let make = function
@@ -73,10 +81,57 @@ module AudioSpecs = struct
     | _ -> assert false
 
   let string_of_param { channel_layout; sample_format; sample_rate } =
-    Printf.sprintf "channel_layout=%S,sample_format=%S,sample_rate=%d"
-      (Channel_layout.get_description channel_layout)
-      (Sample_format.get_name sample_format)
-      sample_rate
+    let p =
+      [
+        ( "channel_layout",
+          Option.map
+            (Channel_layout.get_description ?channels:None)
+            channel_layout );
+        ("sample_format", Option.map Sample_format.get_name sample_format);
+        ("sample_rate", Option.map string_of_int sample_rate);
+      ]
+    in
+    String.concat ","
+      (List.fold_left
+         (fun cur (lbl, v) ->
+           match v with None -> cur | Some v -> (lbl ^ "=" ^ v) :: cur)
+         [] p)
+
+  let param_of_string label value =
+    match label with
+      | "channel_layout" ->
+          Some
+            {
+              channel_layout = Some (Avutil.Channel_layout.find value);
+              sample_format = None;
+              sample_rate = None;
+            }
+      | "sample_format" ->
+          Some
+            {
+              channel_layout = None;
+              sample_format = Some (Avutil.Sample_format.find value);
+              sample_rate = None;
+            }
+      | "sample_rate" ->
+          Some
+            {
+              channel_layout = None;
+              sample_format = None;
+              sample_rate = Some (int_of_string value);
+            }
+      | _ -> None
+
+  let merge_param p p' =
+    {
+      channel_layout =
+        merge_p ~name:"channel_layout" (p.channel_layout, p'.channel_layout);
+      sample_format =
+        merge_p ~name:"sample_format" (p.sample_format, p'.sample_format);
+      sample_rate = merge_p ~name:"sample_rate" (p.sample_rate, p'.sample_rate);
+    }
+
+  let merge = merge ~merge_param
 end
 
 module Audio = Frame_content.MkContent (AudioSpecs)
@@ -84,9 +139,12 @@ module Audio = Frame_content.MkContent (AudioSpecs)
 module VideoSpecs = struct
   include BaseSpecs
 
+  let string_of_kind = function `Raw -> "ffmpeg.video.raw"
+  let kind_of_string = function "ffmpeg.video.raw" -> Some `Raw | _ -> None
+
   type param = {
-    width : int;
-    height : int;
+    width : int option;
+    height : int option;
     pixel_format : Avutil.Pixel_format.t option;
   }
 
@@ -94,22 +152,22 @@ module VideoSpecs = struct
 
   let frame_param { frame } =
     {
-      width = Video.frame_get_width frame;
-      height = Video.frame_get_height frame;
+      width = Some (Video.frame_get_width frame);
+      height = Some (Video.frame_get_height frame);
       pixel_format = Some (Video.frame_get_pixel_format frame);
     }
 
   let mk_param p =
     {
-      width = Avcodec.Video.get_width p;
-      height = Avcodec.Video.get_height p;
+      width = Some (Avcodec.Video.get_width p);
+      height = Some (Avcodec.Video.get_height p);
       pixel_format = Avcodec.Video.get_pixel_format p;
     }
 
   let internal_params () =
     {
-      width = Lazy.force Frame.video_width;
-      height = Lazy.force Frame.video_height;
+      width = Some (Lazy.force Frame.video_width);
+      height = Some (Lazy.force Frame.video_height);
       pixel_format = Some `Yuv420p;
     }
 
@@ -119,10 +177,53 @@ module VideoSpecs = struct
     | _ -> assert false
 
   let string_of_param { width; height; pixel_format } =
-    Printf.sprintf "size=\"%dx%d\",pixel_format=%S)" width height
-      ( match pixel_format with
-        | None -> "unknown"
-        | Some pf -> Pixel_format.to_string pf )
+    let p =
+      [
+        ("width", Option.map string_of_int width);
+        ("height", Option.map string_of_int height);
+        ("pixel_format", Option.map Avutil.Pixel_format.to_string pixel_format);
+      ]
+    in
+    String.concat ","
+      (List.fold_left
+         (fun cur (lbl, v) ->
+           match v with None -> cur | Some v -> (lbl ^ "=" ^ v) :: cur)
+         [] p)
+
+  let param_of_string label value =
+    match label with
+      | "width" ->
+          Some
+            {
+              width = Some (int_of_string value);
+              height = None;
+              pixel_format = None;
+            }
+      | "height" ->
+          Some
+            {
+              width = None;
+              height = Some (int_of_string value);
+              pixel_format = None;
+            }
+      | "pixel_format" ->
+          Some
+            {
+              width = None;
+              height = None;
+              pixel_format = Some (Avutil.Pixel_format.of_string value);
+            }
+      | _ -> None
+
+  let merge_param p p' =
+    {
+      width = merge_p ~name:"width" (p.width, p'.width);
+      height = merge_p ~name:"height" (p.height, p'.height);
+      pixel_format =
+        merge_p ~name:"pixel_format" (p.pixel_format, p'.pixel_format);
+    }
+
+  let merge = merge ~merge_param
 end
 
 module Video = Frame_content.MkContent (VideoSpecs)

--- a/src/stream/ffmpeg_raw_content.ml
+++ b/src/stream/ffmpeg_raw_content.ml
@@ -30,6 +30,13 @@ module BaseSpecs = struct
   let kind = `Raw
   let string_of_kind = function `Raw -> "ffmpeg.raw"
   let kind_of_string = function "ffmpeg.raw" -> Some `Raw | _ -> None
+
+  let merge l l' =
+    match (l, l') with
+      | [], [p'] -> [p']
+      | [p], [] -> [p]
+      | [p], [p'] when p = p' -> [p]
+      | _ -> failwith "Incompatible parameters"
 end
 
 module AudioSpecs = struct

--- a/src/stream/ffmpeg_raw_content.ml
+++ b/src/stream/ffmpeg_raw_content.ml
@@ -60,6 +60,19 @@ module AudioSpecs = struct
       sample_rate = Avcodec.Audio.get_sample_rate p;
     }
 
+  let internal_params () =
+    {
+      channel_layout =
+        Avutil.Channel_layout.get_default (Lazy.force Frame.audio_channels);
+      sample_format = `Dblp;
+      sample_rate = Lazy.force Frame.audio_rate;
+    }
+
+  let make = function
+    | [] -> { params = internal_params (); data = [] }
+    | [params] -> { params; data = [] }
+    | _ -> assert false
+
   let string_of_param { channel_layout; sample_format; sample_rate } =
     Printf.sprintf "channel_layout=%S,sample_format=%S,sample_rate=%d"
       (Channel_layout.get_description channel_layout)
@@ -67,17 +80,7 @@ module AudioSpecs = struct
       sample_rate
 end
 
-module Audio = struct
-  include Frame_content.MkContent (AudioSpecs)
-
-  let internal_params () =
-    {
-      AudioSpecs.channel_layout =
-        Avutil.Channel_layout.get_default (Lazy.force Frame.audio_channels);
-      sample_format = `Dbl;
-      sample_rate = Lazy.force Frame.audio_rate;
-    }
-end
+module Audio = Frame_content.MkContent (AudioSpecs)
 
 module VideoSpecs = struct
   include BaseSpecs
@@ -107,6 +110,18 @@ module VideoSpecs = struct
       pixel_format = Avcodec.Video.get_pixel_format p;
     }
 
+  let internal_params () =
+    {
+      width = Lazy.force Frame.video_width;
+      height = Lazy.force Frame.video_height;
+      pixel_format = Some `Yuv420p;
+    }
+
+  let make = function
+    | [] -> { params = internal_params (); data = [] }
+    | [params] -> { params; data = [] }
+    | _ -> assert false
+
   let string_of_param { width; height; pixel_format } =
     Printf.sprintf "size=\"%dx%d\",pixel_format=%S)" width height
       ( match pixel_format with
@@ -114,13 +129,4 @@ module VideoSpecs = struct
         | Some pf -> Pixel_format.to_string pf )
 end
 
-module Video = struct
-  include Frame_content.MkContent (VideoSpecs)
-
-  let internal_params () =
-    {
-      VideoSpecs.width = Lazy.force Frame.video_width;
-      height = Lazy.force Frame.video_height;
-      pixel_format = Some `Yuv420p;
-    }
-end
+module Video = Frame_content.MkContent (VideoSpecs)

--- a/src/stream/ffmpeg_raw_content.ml
+++ b/src/stream/ffmpeg_raw_content.ml
@@ -45,9 +45,6 @@ module AudioSpecs = struct
 
   type data = (param, audio frame) content
 
-  (* TODO *)
-  let bytes _ = 0
-
   let frame_param { frame } =
     {
       channel_layout = Audio.frame_get_channel_layout frame;
@@ -94,9 +91,6 @@ module VideoSpecs = struct
   }
 
   type data = (param, video frame) content
-
-  (* TODO *)
-  let bytes _ = 0
 
   let frame_param { frame } =
     {

--- a/src/stream/ffmpeg_raw_content.ml
+++ b/src/stream/ffmpeg_raw_content.ml
@@ -1,0 +1,157 @@
+(*****************************************************************************
+
+  Liquidsoap, a programmable audio stream generator.
+  Rawright 2003-2019 Savonet team
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details, fully stated in the COPYING
+  file at the root of the liquidsoap distribution.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA
+
+ *****************************************************************************)
+
+open Avutil
+
+module BaseSpecs = struct
+  type kind = [ `Raw ]
+
+  let kind = `Raw
+  let default_params _ = []
+
+  let merge l l' =
+    match (l, l') with
+      | [], [p'] -> [p']
+      | [p], [] -> [p]
+      | [p], [p'] when p = p' -> [p]
+      | _ -> failwith "Incompatible parameters"
+end
+
+module AudioSpecs = struct
+  include BaseSpecs
+
+  type param = {
+    channel_layout : Channel_layout.t;
+    sample_format : Sample_format.t;
+    sample_rate : int;
+  }
+
+  type data = audio frame
+
+  let make = function
+    | [{ channel_layout; sample_format; sample_rate }] ->
+        Audio.create_frame sample_format channel_layout sample_rate
+          Frame.(audio_of_master (Lazy.force Frame.size))
+    | _ -> assert false
+
+  let clear _ = ()
+  let param_of_string _ _ = None
+
+  (* TODO *)
+  let bytes _ = 0
+
+  let frame_param frame =
+    {
+      channel_layout = Audio.frame_get_channel_layout frame;
+      sample_format = Audio.frame_get_sample_format frame;
+      sample_rate = Audio.frame_get_sample_rate frame;
+    }
+
+  let mk_param p =
+    {
+      channel_layout = Avcodec.Audio.get_channel_layout p;
+      sample_format = Avcodec.Audio.get_sample_format p;
+      sample_rate = Avcodec.Audio.get_sample_rate p;
+    }
+
+  let copy src =
+    let dst = make [frame_param src] in
+    frame_copy src dst;
+    dst
+
+  let params frame = [frame_param frame]
+
+  let blit src src_pos dst dst_pos len =
+    let src_pos = Frame.audio_of_master src_pos in
+    let dst_pos = Frame.audio_of_master dst_pos in
+    let len = Frame.audio_of_master len in
+    Audio.frame_copy_samples src src_pos dst dst_pos len
+
+  let string_of_kind = function `Raw -> "ffmpeg.raw"
+  let kind_of_string = function "ffmpeg.raw" -> Some `Raw | _ -> None
+
+  let string_of_param { channel_layout; sample_format; sample_rate } =
+    Printf.sprintf "channel_layout=%S,sample_format=%S,sample_rate=%d"
+      (Channel_layout.get_description channel_layout)
+      (Sample_format.get_name sample_format)
+      sample_rate
+end
+
+module Audio = Frame_content.MkContent (AudioSpecs)
+
+module VideoSpecs = struct
+  include BaseSpecs
+
+  type param = {
+    width : int;
+    height : int;
+    pixel_format : Avutil.Pixel_format.t option;
+  }
+
+  type data = (int * video frame) list ref
+
+  let make _ = ref []
+  let clear d = d := []
+  let param_of_string _ _ = None
+
+  (* TODO *)
+  let bytes data = List.fold_left (fun c _ -> c + 0) 0 !data
+  let copy data = ref !data
+
+  let frame_param params =
+    {
+      width = Video.frame_get_width params;
+      height = Video.frame_get_height params;
+      pixel_format = Some (Video.frame_get_pixel_format params);
+    }
+
+  let mk_param p =
+    {
+      width = Avcodec.Video.get_width p;
+      height = Avcodec.Video.get_height p;
+      pixel_format = Avcodec.Video.get_pixel_format p;
+    }
+
+  let params c =
+    match !c with [] -> [] | (_, frame) :: _ -> [frame_param frame]
+
+  let blit src src_pos dst dst_pos len =
+    let src_start = Frame.video_of_master src_pos in
+    let src_end = Frame.video_of_master (src_pos + len) in
+    List.iter
+      (fun (pos, p) ->
+        if src_start <= pos && pos < src_end then (
+          let pos = dst_pos + (pos - src_pos) in
+          dst := (pos, p) :: !dst ))
+      !src
+
+  let string_of_kind = function `Raw -> "ffmpeg.raw"
+  let kind_of_string = function "ffmpeg.raw" -> Some `Raw | _ -> None
+
+  let string_of_param { width; height; pixel_format } =
+    Printf.sprintf "size=\"%dx%d\",pixel_format=%S)" width height
+      ( match pixel_format with
+        | None -> "unknown"
+        | Some pf -> Pixel_format.to_string pf )
+end
+
+module Video = Frame_content.MkContent (VideoSpecs)

--- a/src/stream/ffmpeg_raw_content.ml
+++ b/src/stream/ffmpeg_raw_content.ml
@@ -30,13 +30,6 @@ module BaseSpecs = struct
   let kind = `Raw
   let string_of_kind = function `Raw -> "ffmpeg.raw"
   let kind_of_string = function "ffmpeg.raw" -> Some `Raw | _ -> None
-
-  let merge l l' =
-    match (l, l') with
-      | [], [p'] -> [p']
-      | [p], [] -> [p]
-      | [p], [p'] when p = p' -> [p]
-      | _ -> failwith "Incompatible parameters"
 end
 
 module AudioSpecs = struct

--- a/src/stream/ffmpeg_raw_content.ml
+++ b/src/stream/ffmpeg_raw_content.ml
@@ -96,7 +96,17 @@ module AudioSpecs = struct
       sample_rate
 end
 
-module Audio = Frame_content.MkContent (AudioSpecs)
+module Audio = struct
+  include Frame_content.MkContent (AudioSpecs)
+
+  let internal_params () =
+    {
+      AudioSpecs.channel_layout =
+        Avutil.Channel_layout.get_default (Lazy.force Frame.audio_channels);
+      sample_format = `Dbl;
+      sample_rate = Lazy.force Frame.audio_rate;
+    }
+end
 
 module VideoSpecs = struct
   include BaseSpecs
@@ -154,4 +164,13 @@ module VideoSpecs = struct
         | Some pf -> Pixel_format.to_string pf )
 end
 
-module Video = Frame_content.MkContent (VideoSpecs)
+module Video = struct
+  include Frame_content.MkContent (VideoSpecs)
+
+  let internal_params () =
+    {
+      VideoSpecs.width = Lazy.force Frame.video_width;
+      height = Lazy.force Frame.video_height;
+      pixel_format = Some `Yuv420p;
+    }
+end

--- a/src/stream/frame.ml
+++ b/src/stream/frame.ml
@@ -82,6 +82,11 @@ let string_of_fields fn { audio; video; midi } =
 let string_of_content_kind = string_of_fields string_of_kind
 let string_of_content_type = string_of_fields string_of_format
 
+let compatible c c' =
+  Frame_content.compatible c.audio c'.audio
+  && Frame_content.compatible c.video c'.video
+  && Frame_content.compatible c.midi c'.midi
+
 (* Frames *)
 
 (** A metadata is just a mutable hash table.

--- a/src/stream/frame.ml
+++ b/src/stream/frame.ml
@@ -34,24 +34,28 @@ type kind =
   | `Kind of Frame_content.kind
   | `Format of Frame_content.format ]
 
-let none = `Format Frame_content.None.format
-let audio_pcm = `Kind (Frame_content.Audio.lift_kind Frame_content.Audio.kind)
+let none = `Format None.format
+let audio_pcm = `Kind Audio.kind
 
 let audio_n = function
   | 0 -> none
   | c ->
       `Format
-        (Frame_content.Audio.lift_params
-           [Audio_converter.Channel_layout.layout_of_channels c])
+        Audio.(
+          lift_params
+            {
+              Contents.channel_layout =
+                Audio_converter.Channel_layout.layout_of_channels c;
+            })
 
-let audio_mono = `Format (Frame_content.Audio.lift_params [`Mono])
-let audio_stereo = `Format (Frame_content.Audio.lift_params [`Stereo])
+let audio_mono = `Format Audio.(lift_params { Contents.channel_layout = `Mono })
 
-let video_yuv420p =
-  `Kind (Frame_content.Video.lift_kind Frame_content.Video.kind)
+let audio_stereo =
+  `Format Audio.(lift_params { Contents.channel_layout = `Stereo })
 
-let midi_native = `Kind (Frame_content.Midi.lift_kind Frame_content.Midi.kind)
-let midi_n c = `Format (Frame_content.Midi.lift_params [`Channels c])
+let video_yuv420p = `Kind Video.kind
+let midi_native = `Kind Midi.kind
+let midi_n c = `Format Midi.(lift_params { Contents.channels = c })
 
 type content_kind = kind fields
 
@@ -110,7 +114,7 @@ type t = {
 }
 
 (** Create a content chunk. All chunks have the same size. *)
-let create_content = map_fields make
+let create_content ctype = map_fields (make ~size:!!size) ctype
 
 let create ctype =
   { pts = 0L; breaks = []; metadata = []; content = create_content ctype }

--- a/src/stream/frame.mli
+++ b/src/stream/frame.mli
@@ -183,6 +183,7 @@ val type_of_content : content -> content_type
 val string_of_kind : kind -> string
 val string_of_content_kind : content_kind -> string
 val string_of_content_type : content_type -> string
+val compatible : content_type -> content_type -> bool
 
 (** {2 Format settings} *)
 

--- a/src/stream/frame_content.ml
+++ b/src/stream/frame_content.ml
@@ -24,27 +24,43 @@ module Contents = struct
   type format = ..
   type kind = ..
   type data = ..
+  type audio_params = { channel_layout : [ `Mono | `Stereo | `Five_point_one ] }
+  type video_params = { width : int option; height : int option }
+  type midi_params = { channels : int }
 end
+
+let merge_param ~name = function
+  | None, None -> None
+  | None, Some p | Some p, None -> Some p
+  | Some p, Some p' when p = p' -> Some p
+  | _ -> failwith ("Incompatible " ^ name)
+
+let print_optional l =
+  String.concat ","
+    (List.fold_left
+       (fun cur (lbl, v) ->
+         match v with None -> cur | Some v -> (lbl ^ "=" ^ v) :: cur)
+       [] l)
 
 exception Invalid
 exception Incompatible_format of Contents.format * Contents.format
 
 module type ContentSpecs = sig
   type kind
-  type param
+  type params
   type data
 
-  val make : param list -> data
+  val make : size:int -> params -> data
   val blit : data -> int -> data -> int -> int -> unit
   val copy : data -> data
   val clear : data -> unit
-  val params : data -> param list
-  val merge : param list -> param list -> param list
-  val compatible : param list -> param list -> bool
-  val string_of_param : param -> string
-  val param_of_string : string -> string -> param option
+  val params : data -> params
+  val merge : params -> params -> params
+  val compatible : params -> params -> bool
+  val string_of_params : params -> string
+  val parse_param : string -> string -> params option
   val kind : kind
-  val default_params : kind -> param list
+  val default_params : kind -> params
   val string_of_kind : kind -> string
   val kind_of_string : string -> kind option
 end
@@ -56,8 +72,8 @@ module type Content = sig
   val lift_data : data -> Contents.data
   val get_data : Contents.data -> data
   val is_format : Contents.format -> bool
-  val lift_params : param list -> Contents.format
-  val get_params : Contents.format -> param list
+  val lift_params : params -> Contents.format
+  val get_params : Contents.format -> params
   val is_kind : Contents.kind -> bool
   val lift_kind : kind -> Contents.kind
   val get_kind : Contents.kind -> kind
@@ -100,7 +116,7 @@ type format = Contents.format
 
 type format_handler = {
   kind : unit -> kind;
-  make : unit -> data;
+  make : int -> data;
   string_of_format : unit -> string;
   merge : format -> unit;
   compatible : format -> bool;
@@ -124,7 +140,7 @@ let format_parsers = Queue.create ()
 
 exception Parsed_format of format
 
-let format_of_param label value =
+let parse_param label value =
   try
     Queue.iter
       (fun fn ->
@@ -155,7 +171,7 @@ let get_data_handler v =
     raise Invalid
   with Found_data h -> h
 
-let make k = (get_params_handler k).make ()
+let make ~size k = (get_params_handler k).make size
 
 let blit src src_ofs dst dst_ofs len =
   let src = get_data_handler src in
@@ -188,34 +204,31 @@ let string_of_kind f = (get_kind_handler f).string_of_kind ()
 module MkContent (C : ContentSpecs) :
   Content
     with type kind = C.kind
-     and type param = C.param
+     and type params = C.params
      and type data = C.data = struct
   type Contents.kind += Kind of C.kind
-  type Contents.format += Format of C.param list Unifier.t
+  type Contents.format += Format of C.params Unifier.t
   type Contents.data += Data of C.data
 
   let blit src src_ofs dst dst_ofs len =
     let dst = match dst with Data dst -> dst | _ -> raise Invalid in
     C.blit src src_ofs dst dst_ofs len
 
-  let merge l l' =
-    let l' = match l' with Format l' -> l' | _ -> raise Invalid in
-    let u = List.sort_uniq compare in
-    let m = C.merge (u (Unifier.deref l)) (u (Unifier.deref l')) in
-    Unifier.set l' m;
-    Unifier.(l <-- l')
+  let merge p p' =
+    let p' = match p' with Format p' -> p' | _ -> raise Invalid in
+    let m = C.merge (Unifier.deref p) (Unifier.deref p') in
+    Unifier.set p' m;
+    Unifier.(p <-- p')
 
-  let compatible l l' =
-    match l' with
-      | Format l' -> C.compatible (Unifier.deref l) (Unifier.deref l')
+  let compatible p p' =
+    match p' with
+      | Format p' -> C.compatible (Unifier.deref p) (Unifier.deref p')
       | _ -> false
 
   let kind_of_string s = Option.map (fun p -> Kind p) (C.kind_of_string s)
 
   let format_of_string label value =
-    Option.map
-      (fun p -> Format (Unifier.make [p]))
-      (C.param_of_string label value)
+    Option.map (fun p -> Format (Unifier.make p)) (C.parse_param label value)
 
   let () =
     register_kind_handler (function
@@ -228,20 +241,17 @@ module MkContent (C : ContentSpecs) :
             }
       | _ -> None);
     register_format_handler (function
-      | Format l ->
+      | Format p ->
           Some
             {
               kind = (fun () -> Kind C.kind);
-              make = (fun () -> Data (C.make (Unifier.deref l)));
-              merge = (fun l' -> merge l l');
-              compatible = (fun l' -> compatible l l');
+              make = (fun size -> Data (C.make ~size (Unifier.deref p)));
+              merge = (fun p' -> merge p p');
+              compatible = (fun p' -> compatible p p');
               string_of_format =
                 (fun () ->
                   let kind = C.string_of_kind C.kind in
-                  let params =
-                    String.concat ","
-                      (List.map C.string_of_param (Unifier.deref l))
-                  in
+                  let params = C.string_of_params (Unifier.deref p) in
                   match params with
                     | "" -> C.string_of_kind C.kind
                     | _ -> Printf.sprintf "%s(%s)" kind params);
@@ -275,20 +285,20 @@ end
 
 module NoneSpecs = struct
   type kind = unit
-  type param
+  type params = unit
   type data = unit
 
-  let make _ = ()
+  let make ~size:_ _ = ()
   let clear _ = ()
   let blit _ _ _ _ _ = ()
   let copy _ = ()
-  let params _ = []
-  let merge _ _ = []
+  let params _ = ()
+  let merge _ _ = ()
   let compatible _ _ = true
-  let string_of_param _ = assert false
-  let param_of_string _ _ = None
+  let string_of_params _ = ""
+  let parse_param _ _ = None
   let kind = ()
-  let default_params () = []
+  let default_params () = ()
   let string_of_kind () = "none"
   let kind_of_string = function "none" -> Some () | _ -> None
 end
@@ -297,34 +307,30 @@ module None = struct
   include MkContent (NoneSpecs)
 
   let data = lift_data ()
-  let format = lift_params []
+  let format = lift_params ()
 end
 
 module AudioSpecs = struct
   open Frame_settings
+  open Contents
 
   type kind = [ `Pcm ]
-  type param = [ `Mono | `Stereo | `Five_point_one ]
+  type params = Contents.audio_params
   type data = Audio.Mono.buffer array
 
   let string_of_kind = function `Pcm -> "pcm"
 
-  let string_of_param = function
-    | `Mono -> "mono"
-    | `Stereo -> "stereo"
-    | `Five_point_one -> "dolby 5.1"
+  let string_of_params { channel_layout } =
+    match channel_layout with
+      | `Mono -> "mono"
+      | `Stereo -> "stereo"
+      | `Five_point_one -> "dolby 5.1"
 
-  let merge l l' =
-    match (l, l') with
-      | [], [] -> []
-      | [x], [y] when x = y -> [x]
-      | _ -> raise Invalid
+  let merge p p' =
+    assert (p = p');
+    p
 
-  let compatible l l' =
-    match (l, l') with
-      | [], _ | _, [] -> true
-      | [p], [p'] when p = p' -> true
-      | _ -> false
+  let compatible p p' = p = p'
 
   let blit src src_pos dst dst_pos len =
     Array.iter2
@@ -338,9 +344,9 @@ module AudioSpecs = struct
   let copy d = Array.map Audio.Mono.copy d
 
   let param_of_channels = function
-    | 1 -> `Mono
-    | 2 -> `Stereo
-    | 6 -> `Five_point_one
+    | 1 -> { channel_layout = `Mono }
+    | 2 -> { channel_layout = `Stereo }
+    | 6 -> { channel_layout = `Five_point_one }
     | _ -> raise Invalid
 
   let channels_of_param = function
@@ -348,111 +354,134 @@ module AudioSpecs = struct
     | `Stereo -> 2
     | `Five_point_one -> 6
 
-  let param_of_string label value =
+  let parse_param label value =
     match (label, value) with
-      | "", "mono" -> Some `Mono
-      | "", "stereo" -> Some `Stereo
-      | "", "5.1" -> Some `Five_point_one
+      | "", "mono" -> Some { channel_layout = `Mono }
+      | "", "stereo" -> Some { channel_layout = `Stereo }
+      | "", "5.1" -> Some { channel_layout = `Five_point_one }
       | _ -> None
 
-  let params d = [param_of_channels (Array.length d)]
+  let params d = param_of_channels (Array.length d)
   let kind = `Pcm
 
   let default_params _ =
-    [param_of_channels (Lazy.force Frame_settings.audio_channels)]
+    param_of_channels (Lazy.force Frame_settings.audio_channels)
 
   let clear _ = ()
 
-  let make l =
+  let make ~size { channel_layout } =
     let channels =
-      match l with
-        | [] -> Lazy.force Frame_settings.audio_channels
-        | [p] -> channels_of_param p
-        | _ -> raise Invalid
+      match channel_layout with
+        | `Mono -> 1
+        | `Stereo -> 2
+        | `Five_point_one -> 6
     in
-    Array.init channels (fun _ -> Audio.Mono.create (audio_of_master !!size))
+    Array.init channels (fun _ -> Audio.Mono.create (audio_of_master size))
 
   let kind_of_string = function "audio" | "pcm" -> Some `Pcm | _ -> None
 end
 
 module Audio = struct
+  open Contents
   include MkContent (AudioSpecs)
 
+  let kind = lift_kind `Pcm
+
   let format_of_channels = function
-    | 1 -> lift_params [`Mono]
-    | 2 -> lift_params [`Stereo]
-    | 6 -> lift_params [`Five_point_one]
+    | 1 -> lift_params { channel_layout = `Mono }
+    | 2 -> lift_params { channel_layout = `Stereo }
+    | 6 -> lift_params { channel_layout = `Five_point_one }
     | _ -> raise Invalid
 
   let channels_of_format p =
-    match get_params p with
-      | [] -> Lazy.force Frame_settings.audio_channels
-      | [p] -> AudioSpecs.channels_of_param p
-      | _ -> raise Invalid
+    AudioSpecs.(channels_of_param (get_params p).channel_layout)
 end
 
 module VideoSpecs = struct
   open Frame_settings
+  open Contents
 
   type kind = [ `Yuv420p ]
-  type param
+  type params = Contents.video_params
   type data = Video.t
 
   let string_of_kind = function `Yuv420p -> "yuv420p"
-  let make _ = Video.make (video_of_master !!size) !!video_width !!video_height
+
+  let make ~size { width; height } =
+    let width = Option.value ~default:!!video_width width in
+    let height = Option.value ~default:!!video_height height in
+    Video.make (video_of_master size) width height
+
   let clear _ = ()
-  let string_of_param _ = assert false
-  let param_of_string _ _ = None
 
-  let merge l l' =
-    match (l, l') with
-      | [], [] -> []
-      | [x], [y] when x = y -> [x]
-      | _ -> raise Invalid
+  let string_of_params { width; height } =
+    print_optional
+      [
+        ("width", Option.map string_of_int width);
+        ("height", Option.map string_of_int height);
+      ]
 
-  let compatible l l' =
-    match (l, l') with
-      | [], _ | _, [] -> true
-      | [p], [p'] when p = p' -> true
-      | _ -> false
+  let parse_param label value =
+    match label with
+      | "width" -> Some { width = Some (int_of_string value); height = None }
+      | "height" -> Some { width = None; height = Some (int_of_string value) }
+      | _ -> None
+
+  let merge p p' =
+    {
+      width = merge_param ~name:"width" (p.width, p'.width);
+      height = merge_param ~name:"height" (p.height, p'.height);
+    }
+
+  let compatible p p' = p.width = p'.width && p.height = p'.height
 
   let blit src src_pos dst dst_pos len =
     let ( ! ) = Frame_settings.video_of_master in
     Video.blit src !src_pos dst !dst_pos !len
 
   let copy = Video.copy
-  let params _ = []
+
+  let params data =
+    if Array.length data = 0 then { width = None; height = None }
+    else (
+      let i = data.(0) in
+      {
+        width = Some (Video.Image.width i);
+        height = Some (Video.Image.height i);
+      } )
+
   let kind = `Yuv420p
-  let default_params _ = []
+
+  let default_params _ =
+    { width = Some !!video_width; height = Some !!video_height }
 
   let kind_of_string = function
     | "yuv420p" | "video" -> Some `Yuv420p
     | _ -> None
 end
 
-module Video = MkContent (VideoSpecs)
+module Video = struct
+  include MkContent (VideoSpecs)
+
+  let kind = lift_kind `Yuv420p
+end
 
 module MidiSpecs = struct
   open Frame_settings
+  open Contents
 
   type kind = [ `Midi ]
-  type param = [ `Channels of int ]
+  type params = Contents.midi_params
   type data = MIDI.Multitrack.t
 
   let string_of_kind = function `Midi -> "midi"
-  let string_of_param (`Channels c) = Printf.sprintf "midi(channels=%d)" c
+  let string_of_params { channels } = Printf.sprintf "channels=%d" channels
 
-  let merge l l' =
-    match (l, l') with
-      | [], [] -> []
-      | [x], [y] when x = y -> [x]
-      | _ -> raise Invalid
+  let merge p p' =
+    assert (p.channels = p'.channels);
+    p
 
-  let compatible l l' =
-    match (l, l') with
-      | [], _ | _, [] -> true
-      | [p], [p'] when p = p' -> true
-      | _ -> false
+  let compatible p p' = p.channels = p'.channels
 
   let blit src src_pos dst dst_pos len =
     Array.iter2
@@ -462,41 +491,44 @@ module MidiSpecs = struct
       src dst
 
   let copy m = Array.map MIDI.copy m
-  let params m = [`Channels (MIDI.Multitrack.channels m)]
+  let params m = { channels = MIDI.Multitrack.channels m }
   let kind = `Midi
-  let default_params _ = [`Channels (Lazy.force Frame_settings.midi_channels)]
+  let default_params _ = { channels = Lazy.force Frame_settings.midi_channels }
   let clear _ = ()
 
-  let make l =
-    let c =
-      match l with
-        | [] -> Lazy.force Frame_settings.midi_channels
-        | [`Channels c] -> c
-        | _ -> raise Invalid
-    in
-    MIDI.Multitrack.create c (midi_of_master !!size)
+  let make ~size { channels } =
+    MIDI.Multitrack.create channels (midi_of_master size)
 
   let kind_of_string = function "midi" -> Some `Midi | _ -> None
 
-  let param_of_string label value =
+  let parse_param label value =
     match (label, value) with
-      | "channels", c -> Some (`Channels (int_of_string c))
+      | "channels", c -> Some { channels = int_of_string c }
       | _ | (exception _) -> None
 end
 
-module Midi = MkContent (MidiSpecs)
+module Midi = struct
+  include MkContent (MidiSpecs)
+
+  let kind = lift_kind `Midi
+end
 
 let default_audio () =
   let channels = Lazy.force Frame_settings.audio_channels in
   if channels = 0 then None.format else Audio.format_of_channels channels
 
 let default_video () =
-  if Lazy.force Frame_settings.video_enabled then Video.lift_params []
+  if Lazy.force Frame_settings.video_enabled then
+    Video.lift_params
+      {
+        Contents.width = Some (Lazy.force Frame_settings.video_width);
+        height = Some (Lazy.force Frame_settings.video_height);
+      }
   else None.format
 
 let default_midi () =
   let channels = Lazy.force Frame_settings.midi_channels in
-  if channels = 0 then None.format else Midi.lift_params [`Channels channels]
+  if channels = 0 then None.format else Midi.lift_params { Contents.channels }
 
 let is_internal f =
   None.is_kind f || Audio.is_kind f || Video.is_kind f || Midi.is_kind f

--- a/src/stream/frame_content.mli
+++ b/src/stream/frame_content.mli
@@ -43,7 +43,6 @@ module type ContentSpecs = sig
 
   val make : param list -> data
   val blit : data -> int -> data -> int -> int -> unit
-  val bytes : data -> int
   val copy : data -> data
   val clear : data -> unit
 
@@ -100,7 +99,6 @@ type data = Contents.data
 
 val make : format -> data
 val blit : data -> int -> data -> int -> int -> unit
-val bytes : data -> int
 val copy : data -> data
 val clear : data -> unit
 

--- a/src/stream/frame_content.mli
+++ b/src/stream/frame_content.mli
@@ -22,14 +22,17 @@
 
 (** Generic content registration API. *)
 
-(* Raised during any invalid operation below. *)
-exception Invalid
-
 module Contents : sig
   type kind
   type format
   type data
 end
+
+(* Raised during any invalid operation below. *)
+exception Invalid
+
+(* Raised when calling [merge] below. *)
+exception Incompatible_format of Contents.format * Contents.format
 
 module type ContentSpecs = sig
   type kind

--- a/src/stream/frame_content.mli
+++ b/src/stream/frame_content.mli
@@ -50,6 +50,7 @@ module type ContentSpecs = sig
 
   val params : data -> param list
   val merge : param list -> param list -> param list
+  val compatible : param list -> param list -> bool
   val string_of_param : param -> string
 
   (* [param_of_string "label" "value"] *)
@@ -106,6 +107,7 @@ val clear : data -> unit
 
 val format : data -> format
 val merge : format -> format -> unit
+val compatible : format -> format -> bool
 val string_of_format : format -> string
 
 (* [format_of_param "label" "value"] *)

--- a/src/stream/generator.ml
+++ b/src/stream/generator.ml
@@ -716,7 +716,7 @@ module From_audio_video_plus = struct
         match t.ctype with
           | None -> t.ctype <- Some (Frame.type_of_content c)
           | Some ctype ->
-              if Frame.type_of_content c <> ctype then (
+              if not (Frame.compatible (Frame.type_of_content c) ctype) then (
                 t.log "Incorrect stream type!";
                 t.error <- true;
                 Super.clear t.gen;

--- a/src/stream/generator.ml
+++ b/src/stream/generator.ml
@@ -58,8 +58,6 @@ module Generator = struct
   (** A chunk with given offset and length. *)
   type 'a chunk = 'a * int * int
 
-  let chunk_data ((buf, _, _) : 'a chunk) = buf
-
   (** A buffer is a queue of chunks. *)
   type 'a buffer = 'a chunk Queue.t
 
@@ -375,18 +373,6 @@ module From_audio_video = struct
 
   (** Total buffered length. *)
   let buffered_length t = max (audio_length t) (video_length t)
-
-  let audio_size t =
-    Queue.fold
-      (fun n a -> n + Frame_content.bytes (Generator.chunk_data a).data)
-      0 t.audio.Generator.buffers
-
-  let video_size t =
-    Queue.fold
-      (fun n a -> n + Frame_content.bytes (Generator.chunk_data a).data)
-      0 t.video.Generator.buffers
-
-  let size t = audio_size t + video_size t
 
   (** Duration of data (in ticks) before the next break, -1 if there's none. *)
   let remaining t = match t.breaks with a :: _ -> a | _ -> -1
@@ -712,9 +698,6 @@ module From_audio_video_plus = struct
   let video_length t = Tutils.mutexify t.lock Super.video_length t.gen
   let length t = Tutils.mutexify t.lock Super.length t.gen
   let remaining t = Tutils.mutexify t.lock Super.remaining t.gen
-  let audio_size t = Tutils.mutexify t.lock Super.audio_size t.gen
-  let video_size t = Tutils.mutexify t.lock Super.video_size t.gen
-  let size t = Tutils.mutexify t.lock Super.size t.gen
   let set_rewrite_metadata t f = t.map_meta <- f
 
   let add_metadata t m =

--- a/src/stream/generator.ml
+++ b/src/stream/generator.ml
@@ -587,11 +587,15 @@ module From_audio_video = struct
 
     match mode with
       | `Audio ->
-          put_audio ~pts t (AFrame.content frame) 0 (Lazy.force Frame.size)
+          put_audio ~pts t
+            (Frame_content.copy (AFrame.content frame))
+            0 (Lazy.force Frame.size)
       | `Video ->
           put_video ~pts t (VFrame.content frame) 0 (Lazy.force Frame.size)
       | `Both ->
-          put_audio ~pts t (AFrame.content frame) 0 (Lazy.force Frame.size);
+          put_audio ~pts t
+            (Frame_content.copy (AFrame.content frame))
+            0 (Lazy.force Frame.size);
           put_video ~pts t (VFrame.content frame) 0 (Lazy.force Frame.size)
       | `Undefined -> ()
 

--- a/src/stream/generator.mli
+++ b/src/stream/generator.mli
@@ -245,11 +245,11 @@ module From_audio_video : sig
   val add_break : ?sync:bool -> t -> unit
 
   (* [put_audio ?pts buffer data offset length]: offset and length
-   * are in samples ! *)
+   * are in master ticks ! *)
   val put_audio : ?pts:int64 -> t -> Frame_content.data -> int -> int -> unit
 
   (* [put_video ?pts buffer data offset length]: offset and length
-   * are in samples ! *)
+   * are in master ticks ! *)
   val put_video : ?pts:int64 -> t -> Frame_content.data -> int -> int -> unit
 
   (** Feed from a frame, only copying data according to the mode.
@@ -299,11 +299,11 @@ module From_audio_video_plus : sig
   val add_break : ?sync:bool -> t -> unit
 
   (* [put_audio ?pts buffer data offset length]:
-   * offset and length are in audio samples! *)
+   * offset and length are in master ticks! *)
   val put_audio : ?pts:int64 -> t -> Frame_content.data -> int -> int -> unit
 
   (* [put_video buffer data offset length]:
-   * offset and length are in video samples! *)
+   * offset and length are in master ticks! *)
   val put_video : ?pts:int64 -> t -> Frame_content.data -> int -> int -> unit
   val feed_from_frame : ?mode:mode -> t -> Frame.t -> unit
   val fill : t -> Frame.t -> unit

--- a/src/stream/generator.mli
+++ b/src/stream/generator.mli
@@ -225,15 +225,6 @@ module From_audio_video : sig
       unsynced data. *)
   val buffered_length : t -> int
 
-  (** Size of audio data in bytes. *)
-  val audio_size : t -> int
-
-  (** Size of video data in bytes. *)
-  val video_size : t -> int
-
-  (** Size of data in bytes. *)
-  val size : t -> int
-
   (** Duration of data (in ticks) before the next break, -1 if there's none. *)
   val remaining : t -> int
 
@@ -291,9 +282,6 @@ module From_audio_video_plus : sig
   val video_length : t -> int
   val length : t -> int
   val remaining : t -> int
-  val audio_size : t -> int
-  val video_size : t -> int
-  val size : t -> int
   val set_rewrite_metadata : t -> (Frame.metadata -> Frame.metadata) -> unit
   val add_metadata : t -> Frame.metadata -> unit
   val add_break : ?sync:bool -> t -> unit

--- a/src/test/decoder_test.ml
+++ b/src/test/decoder_test.ml
@@ -15,15 +15,23 @@ let channel_layout_converter src dst =
 let () =
   Frame.allow_lazy_config_eval ();
   Audio_converter.Channel_layout.converters#register "native"
-    channel_layout_converter
+    channel_layout_converter;
+  Frame_settings.conf_video#set true
 
 let () =
   let none = Frame_content.None.format in
-  let mono = Frame_content.Audio.lift_params [`Mono] in
-  let stereo = Frame_content.Audio.lift_params [`Stereo] in
-  let five_point_one = Frame_content.Audio.lift_params [`Five_point_one] in
-  let yuv420p = Frame_content.Video.lift_params [] in
-  let midi = Frame_content.Midi.lift_params [`Channels 1] in
+  let mono =
+    Frame_content.(Audio.lift_params { Contents.channel_layout = `Mono })
+  in
+  let stereo =
+    Frame_content.(Audio.lift_params { Contents.channel_layout = `Stereo })
+  in
+  let five_point_one =
+    Frame_content.(
+      Audio.lift_params { Contents.channel_layout = `Five_point_one })
+  in
+  let yuv420p = Frame_content.default_video () in
+  let midi = Frame_content.(Midi.lift_params { Contents.channels = 1 }) in
   assert (
     Decoder.can_decode_type
       { audio = stereo; video = none; midi = none }

--- a/src/test/generator_test.ml
+++ b/src/test/generator_test.ml
@@ -3,16 +3,14 @@ module G = Generator.From_audio_video
 let () =
   Frame.allow_lazy_config_eval ();
   let frame_size = Lazy.force Frame.size in
-  let audio_frame_size = AFrame.size () in
-  let video_frame_size = VFrame.size () in
   let gen = G.create `Both in
   let data = Frame_content.None.data in
   (* Set this:
      0----1----2--> audio
      0----1----2----3----4----> video *)
-  G.put_audio ~pts:0L gen data 0 audio_frame_size;
-  G.put_audio ~pts:1L gen data 0 audio_frame_size;
-  G.put_audio ~pts:2L gen data 0 (audio_frame_size / 2);
+  G.put_audio ~pts:0L gen data 0 frame_size;
+  G.put_audio ~pts:1L gen data 0 frame_size;
+  G.put_audio ~pts:2L gen data 0 (frame_size / 2);
   assert (G.video_length gen = 0);
   assert (G.audio_length gen = (2 * frame_size) + (frame_size / 2));
   assert (G.length gen = 0);
@@ -26,7 +24,7 @@ let () =
   assert (G.length gen = 2 * frame_size);
 
   (* Add 2--(3)----(4)-- audio *)
-  G.put_audio ~pts:2L gen data 0 (2 * audio_frame_size);
+  G.put_audio ~pts:2L gen data 0 (2 * frame_size);
   (* Get:
      0----1----2----3----4--> audio
      0----1----2----3----4----> video *)
@@ -44,7 +42,7 @@ let () =
   assert (G.length gen = 4 * frame_size);
 
   (* Add 4--(5)-- audio *)
-  G.put_audio ~pts:4L gen data 0 audio_frame_size;
+  G.put_audio ~pts:4L gen data 0 frame_size;
   (* Get:
      0----1----2----3----4----5--> audio
      0----1----2----3----4----> video *)
@@ -62,16 +60,16 @@ let () =
   assert (G.length gen = 5 * frame_size);
 
   (* Add 5----(6)-- audio (partial out-of-sync) *)
-  G.put_audio ~pts:5L gen data 0 (3 * audio_frame_size / 2);
+  G.put_audio ~pts:5L gen data 0 (3 * frame_size / 2);
   (* Get:
      0----1----2----3----4----6--> audio
      0----1----2----3----4----6----> video *)
   assert (G.video_length gen = 6 * frame_size);
-  assert (G.audio_length gen = (5 * frame_size) + (audio_frame_size / 2));
+  assert (G.audio_length gen = (5 * frame_size) + (frame_size / 2));
   assert (G.length gen = 5 * frame_size);
 
   (* Add 7----(8)-- audio *)
-  G.put_audio ~pts:7L gen data 0 (3 * audio_frame_size / 2);
+  G.put_audio ~pts:7L gen data 0 (3 * frame_size / 2);
   (* Get:
      0----1----2----3----4----7----8--> audio
      0----1----2----3----4----> video *)
@@ -80,7 +78,7 @@ let () =
   assert (G.length gen = 5 * frame_size);
 
   (* Add 9-- audio (discontinuity) *)
-  G.put_audio ~pts:9L gen data 0 (audio_frame_size / 2);
+  G.put_audio ~pts:9L gen data 0 (frame_size / 2);
   (* Get:
        0----1----2----3----4----7----8--9--> audio
        0----1----2----3----4----> video
@@ -100,7 +98,7 @@ let () =
   assert (G.length gen = 6 * frame_size);
 
   (* Add 10-- audio (partial out-of-sync) *)
-  G.put_audio ~pts:10L gen data 0 (audio_frame_size / 2);
+  G.put_audio ~pts:10L gen data 0 (frame_size / 2);
   (* Get:
      0----1----2----3----4----7----10--> audio
      0----1----2----3----4----7----> video *)

--- a/src/test/generator_test.ml
+++ b/src/test/generator_test.ml
@@ -15,10 +15,10 @@ let () =
   assert (G.audio_length gen = (2 * frame_size) + (frame_size / 2));
   assert (G.length gen = 0);
 
-  G.put_video ~pts:0L gen data 0 video_frame_size;
-  G.put_video ~pts:1L gen data 0 video_frame_size;
-  G.put_video ~pts:2L gen data 0 video_frame_size;
-  G.put_video ~pts:3L gen data 0 (2 * video_frame_size);
+  G.put_video ~pts:0L gen data 0 frame_size;
+  G.put_video ~pts:1L gen data 0 frame_size;
+  G.put_video ~pts:2L gen data 0 frame_size;
+  G.put_video ~pts:3L gen data 0 (2 * frame_size);
   assert (G.video_length gen = 5 * frame_size);
   assert (G.audio_length gen = (2 * frame_size) + (frame_size / 2));
   assert (G.length gen = 2 * frame_size);
@@ -33,7 +33,7 @@ let () =
   assert (G.length gen = 4 * frame_size);
 
   (* Add 1---- video (non-monotonic PTS) *)
-  G.put_video ~pts:1L gen data 0 video_frame_size;
+  G.put_video ~pts:1L gen data 0 frame_size;
   (* Get:
      0----1----2----3----4--> audio
      0----1----2----3----4----> video *)
@@ -51,7 +51,7 @@ let () =
   assert (G.length gen = 5 * frame_size);
 
   (* Add 6---- video (discontinuity) *)
-  G.put_video ~pts:6L gen data 0 video_frame_size;
+  G.put_video ~pts:6L gen data 0 frame_size;
   (* Get:
      0----1----2----3----4----> audio
      0----1----2----3----4----6----> video *)
@@ -88,7 +88,7 @@ let () =
   assert (G.length gen = 5 * frame_size);
 
   (* Add 5----6----7----8----9---- video *)
-  G.put_video ~pts:5L gen data 0 (5 * video_frame_size);
+  G.put_video ~pts:5L gen data 0 (5 * frame_size);
   (* Get:
        0----1----2----3----4----7----9--> audio
        0----1----2----3----4----7----9----> video

--- a/src/tools/ffmpeg_utils.ml
+++ b/src/tools/ffmpeg_utils.ml
@@ -166,3 +166,9 @@ let convert_time_base ~src ~dst pts =
   let num = src.Avutil.num * dst.Avutil.den in
   let den = src.Avutil.den * dst.Avutil.num in
   Int64.div (Int64.mul pts (Int64.of_int num)) (Int64.of_int den)
+
+let convert_duration ~sample_time_base ~duration_time_base = function
+  | Some d ->
+      Int64.to_int
+        (convert_time_base ~src:duration_time_base ~dst:sample_time_base d)
+  | None -> failwith "No duration available!"

--- a/src/tools/ffmpeg_utils.ml
+++ b/src/tools/ffmpeg_utils.ml
@@ -153,6 +153,9 @@ module Fps = struct
           flush ()
 end
 
+let liq_master_ticks_time_base () =
+  { Avutil.num = 1; den = Lazy.force Frame.master_rate }
+
 let liq_audio_sample_time_base () =
   { Avutil.num = 1; den = Lazy.force Frame.audio_rate }
 
@@ -166,9 +169,3 @@ let convert_time_base ~src ~dst pts =
   let num = src.Avutil.num * dst.Avutil.den in
   let den = src.Avutil.den * dst.Avutil.num in
   Int64.div (Int64.mul pts (Int64.of_int num)) (Int64.of_int den)
-
-let convert_duration ~sample_time_base ~duration_time_base = function
-  | Some d ->
-      Int64.to_int
-        (convert_time_base ~src:duration_time_base ~dst:sample_time_base d)
-  | None -> failwith "No duration available!"

--- a/src/tools/ffmpeg_utils.mli
+++ b/src/tools/ffmpeg_utils.mli
@@ -33,6 +33,12 @@ val liq_frame_time_base : unit -> Avutil.rational
 val convert_time_base :
   src:Avutil.rational -> dst:Avutil.rational -> int64 -> int64
 
+val convert_duration :
+  sample_time_base:Avutil.rational ->
+  duration_time_base:Avutil.rational ->
+  Int64.t option ->
+  int
+
 module Fps : sig
   type t
 

--- a/src/tools/ffmpeg_utils.mli
+++ b/src/tools/ffmpeg_utils.mli
@@ -49,5 +49,8 @@ module Fps : sig
     t
 
   val convert :
-    t -> [ `Video ] Avutil.frame -> ([ `Video ] Avutil.frame -> unit) -> unit
+    t ->
+    [ `Video ] Avutil.frame ->
+    (time_base:Avutil.rational -> [ `Video ] Avutil.frame -> unit) ->
+    unit
 end

--- a/src/tools/ffmpeg_utils.mli
+++ b/src/tools/ffmpeg_utils.mli
@@ -26,18 +26,13 @@ val conf_log : Dtools.Conf.ut
 val conf_verbosity : string Dtools.Conf.t
 val conf_level : int Dtools.Conf.t
 val conf_scaling_algorithm : string Dtools.Conf.t
+val liq_master_ticks_time_base : unit -> Avutil.rational
 val liq_audio_sample_time_base : unit -> Avutil.rational
 val liq_video_sample_time_base : unit -> Avutil.rational
 val liq_frame_time_base : unit -> Avutil.rational
 
 val convert_time_base :
   src:Avutil.rational -> dst:Avutil.rational -> int64 -> int64
-
-val convert_duration :
-  sample_time_base:Avutil.rational ->
-  duration_time_base:Avutil.rational ->
-  Int64.t option ->
-  int
 
 module Fps : sig
   type t

--- a/src/visualization/video_volume.ml
+++ b/src/visualization/video_volume.ml
@@ -87,7 +87,7 @@ class visu ~kind source =
             create
               {
                 audio = Frame_content.None.format;
-                video = Frame_content.Video.lift_params [];
+                video = Frame_content.(default_format Video.kind);
                 midi = Frame_content.None.format;
               })
         in

--- a/tests/language/typing.liq
+++ b/tests/language/typing.liq
@@ -1,5 +1,4 @@
-# Check these examples with: liquidsoap --no-libs -i -c typing.liq
-  
+#!../../src/liquidsoap ../../libs/pervasives.liq 
 # TODO Throughout this file, parsing locations displayed in error messages
 #      are often much too inaccurate.
 
@@ -122,6 +121,12 @@ def f() =
     a+b == a
   end
   ignore(sum_eq)
+
+  (noise():source(audio=pcm,video=yuv420p,midi=none))
+
+  (single("annotate:foo=\"bla\":/nonexistent"):source(audio=ffmpeg.audio.copy,video=ffmpeg.video.copy,midi=midi))
+  (single("annotate:foo=\"bla\":/nonexistent"):source(audio=ffmpeg.audio.raw,video=ffmpeg.video.raw,midi=midi))
+  (single("annotate:foo=\"bla\":/nonexistent"):source(audio=ffmpeg.audio.raw(sample_rate=44100),video=ffmpeg.video.raw(pixel_format=yuv420p),midi=midi))
   
   test.pass()
 end

--- a/tests/media/Makefile
+++ b/tests/media/Makefile
@@ -27,14 +27,14 @@ AUDIO_VIDEO_TEST_FORMATS = \
   @ffmpeg(format=\"mp4\",@audio(codec=\"aac\",channels=2),@video(codec=\"libx264\")).mp4
 
 VIDEO_ONLY_TEST_FORMATS = \
-  @ffmpeg(format=\"mp4\",@audio(codec=none),@video(codec=\"libx264\")).mp4
+  @ffmpeg(format=\"mp4\",@audio.none,@video(codec=\"libx264\")).mp4
 
 VIDEO_TEST_FORMATS = $(AUDIO_VIDEO_TEST_FORMATS) $(VIDEO_ONLY_TEST_FORMATS)
 
 VIDEO_STREAM_TEST_FORMATS = \
   @ffmpeg(format=\"flv\",@audio(codec=\"aac\",channels=1),@video(codec=\"libx264\")).flv \
   @ffmpeg(format=\"flv\",@audio(codec=\"aac\",channels=2),@video(codec=\"libx264\")).flv \
-  @ffmpeg(format=\"flv\",@audio(codec=none),@video(codec=\"libx264\")).flv
+  @ffmpeg(format=\"flv\",@audio.none,@video(codec=\"libx264\")).flv
 
 ENCODED_AUDIO_FILES=$(AUDIO_TEST_FORMATS:%=files/audio/%)
 
@@ -115,7 +115,7 @@ test_ffmpeg_copy_and_encode_decoder: $(ENCODED_AUDIO_VIDEO_FILES) $(top_srcdir)/
 # See: https://gitlab.freedesktop.org/gstreamer/gstreamer/-/issues/555
 test_gstreamer_video_decoder: $(ENCODED_VIDEO_FILES) $(top_srcdir)/src/liquidsoap
 	@for i in $(ENCODED_VIDEO_FILES:%="%"); do \
-	  if echo $$i | grep -v 'codec=none' > /dev/null 2>&1; then \
+	  if echo $$i | grep -v 'none' > /dev/null 2>&1; then \
 	    ../run_test.sh "$(top_srcdir)/src/liquidsoap --no-pervasives $(top_srcdir)/libs/pervasives.liq - -- $$i" media/test_gstreamer_video_decoder.liq "Gstreamer video decoder test for $$i" || exit; \
           fi \
 	done

--- a/tests/media/Makefile
+++ b/tests/media/Makefile
@@ -1,9 +1,9 @@
-.PHONY: test_encoder test_stereo test_mono test_stream_audio test_stream_video test_ffmpeg_audio_decoder test_ffmpeg_video_decoder test_ffmpeg_copy_decoder test_ffmpeg_copy_and_encode_decoder test_gstreamer_audio_decoder test_gstreamer_video_decoder
+.PHONY: test_encoder test_stereo test_mono test_stream_audio test_stream_video test_ffmpeg_audio_decoder test_ffmpeg_video_decoder test_ffmpeg_copy_decoder test_ffmpeg_copy_and_encode_decoder test_ffmpeg_raw_decoder test_ffmpeg_raw_and_encode_decoder test_ffmpeg_raw_and_copy_decoder test_gstreamer_audio_decoder test_gstreamer_video_decoder
 
 DISTFILES = Makefile $(wildcard *.sh) $(wildcard *.liq *.liq.in)
 top_srcdir = $(shell realpath ../..)
 
-test: test_encoder test_stereo test_mono test_ffmpeg_audio_decoder test_ffmpeg_video_decoder test_ffmpeg_copy_decoder test_ffmpeg_copy_and_encode_decoder test_gstreamer_audio_decoder test_gstreamer_video_decoder # test_stream_audio test_stream_video
+test: test_encoder test_stereo test_mono test_ffmpeg_audio_decoder test_ffmpeg_video_decoder test_ffmpeg_copy_decoder test_ffmpeg_copy_and_encode_decoder test_ffmpeg_raw_decoder test_ffmpeg_raw_and_encode_decoder test_ffmpeg_raw_and_copy_decoder test_gstreamer_audio_decoder test_gstreamer_video_decoder # test_stream_audio test_stream_video
 
 AUDIO_TEST_FORMATS = \
   @flac(stereo).flac \
@@ -18,6 +18,8 @@ AUDIO_TEST_FORMATS = \
   @ogg(@flac(stereo)).ogg \
   @ogg(@opus(mono)).ogg \
   @ogg(@opus(stereo)).ogg \
+  @ffmpeg(format=\"mp4\",@audio(codec=\"aac\"),@videoDOTnone).mp4
+
 # TODO: fix speex or officially deprecate it?
 #  @ogg(@speex(mono)).ogg \
 #  @ogg(@speex(stereo)).ogg
@@ -27,14 +29,9 @@ AUDIO_VIDEO_TEST_FORMATS = \
   @ffmpeg(format=\"mp4\",@audio(codec=\"aac\",channels=2),@video(codec=\"libx264\")).mp4
 
 VIDEO_ONLY_TEST_FORMATS = \
-  @ffmpeg(format=\"mp4\",@audio.none,@video(codec=\"libx264\")).mp4
+  @ffmpeg(format=\"mp4\",@audioDOTnone,@video(codec=\"libx264\")).mp4
 
-VIDEO_TEST_FORMATS = $(AUDIO_VIDEO_TEST_FORMATS) $(VIDEO_ONLY_TEST_FORMATS)
-
-VIDEO_STREAM_TEST_FORMATS = \
-  @ffmpeg(format=\"flv\",@audio(codec=\"aac\",channels=1),@video(codec=\"libx264\")).flv \
-  @ffmpeg(format=\"flv\",@audio(codec=\"aac\",channels=2),@video(codec=\"libx264\")).flv \
-  @ffmpeg(format=\"flv\",@audio.none,@video(codec=\"libx264\")).flv
+VIDEO_TEST_FORMATS = $(AUDIO_VIDEO_TEST_FORMATS) $(AUDIO_ONLY_TEST_FORMATS) $(VIDEO_ONLY_TEST_FORMATS)
 
 ENCODED_AUDIO_FILES=$(AUDIO_TEST_FORMATS:%=files/audio/%)
 
@@ -72,24 +69,16 @@ files/video/%: $(top_srcdir)/src/liquidsoap
 
 test_mono: $(ENCODED_AUDIO_FILES) $(top_srcdir)/src/liquidsoap
 	@for i in $(ENCODED_AUDIO_FILES:%="%"); do \
-	  ../run_test.sh "$(top_srcdir)/src/liquidsoap --no-pervasives $(top_srcdir)/libs/pervasives.liq - -- $$i" media/test_mono.liq "Mono decoding test for $$i" || exit; \
+	  if echo $$i | grep -v 'ffmpeg' > /dev/null 2>&1; then \
+	    ../run_test.sh "$(top_srcdir)/src/liquidsoap --no-pervasives $(top_srcdir)/libs/pervasives.liq - -- $$i" media/test_mono.liq "Mono decoding test for $$i" || exit; \
+	  fi \
 	done
 
 test_stereo: $(ENCODED_AUDIO_FILES) $(top_srcdir)/src/liquidsoap
 	@for i in $(ENCODED_AUDIO_FILES:%="%"); do \
-	  ../run_test.sh "$(top_srcdir)/src/liquidsoap --no-pervasives $(top_srcdir)/libs/pervasives.liq - -- $$i" media/test_stereo.liq "Stereo decoding test for $$i" || exit; \
-	done
-
-test_stream_audio: $(top_srcdir)/src/liquidsoap
-	@for i in $(AUDIO_TEST_FORMATS:%="%"); do \
-	  ./mk_stream_test.sh $$i audio; \
-	  ../run_test.sh "$(top_srcdir)/src/liquidsoap --no-pervasives $(top_srcdir)/libs/pervasives.liq -" media/test_stream_audio.liq "Audio stream decoder test for $$i" || exit; \
-	done
-
-test_stream_video: $(top_srcdir)/src/liquidsoap
-	@for i in $(VIDEO_STREAM_TEST_FORMATS:%="%"); do \
-	  ./mk_stream_test.sh $$i video; \
-	  ../run_test.sh "$(top_srcdir)/src/liquidsoap --no-pervasives $(top_srcdir)/libs/pervasives.liq -" media/test_stream_video.liq "Video stream decoder test for $$i" || exit; \
+	  if echo $$i | grep -v 'ffmpeg' > /dev/null 2>&1; then \
+	    ../run_test.sh "$(top_srcdir)/src/liquidsoap --no-pervasives $(top_srcdir)/libs/pervasives.liq - -- $$i" media/test_stereo.liq "Stereo decoding test for $$i" || exit; \
+	  fi \
 	done
 
 test_ffmpeg_audio_decoder: $(ENCODED_AUDIO_FILES) $(top_srcdir)/src/liquidsoap
@@ -110,6 +99,21 @@ test_ffmpeg_copy_decoder: $(ENCODED_AUDIO_VIDEO_FILES) $(top_srcdir)/src/liquids
 test_ffmpeg_copy_and_encode_decoder: $(ENCODED_AUDIO_VIDEO_FILES) $(top_srcdir)/src/liquidsoap
 	@for i in $(ENCODED_AUDIO_VIDEO_FILES:%="%"); do \
 	  ../run_test.sh "$(top_srcdir)/src/liquidsoap --no-pervasives $(top_srcdir)/libs/pervasives.liq - -- $$i" media/test_ffmpeg_copy_and_encode_decoder.liq "FFmpeg copy+encode decoder test for $$i" || exit; \
+	done
+
+test_ffmpeg_raw_decoder: $(ENCODED_AUDIO_VIDEO_FILES) $(top_srcdir)/src/liquidsoap
+	@for i in $(ENCODED_AUDIO_VIDEO_FILES:%="%"); do \
+	  ../run_test.sh "$(top_srcdir)/src/liquidsoap --no-pervasives $(top_srcdir)/libs/pervasives.liq - -- $$i" media/test_ffmpeg_raw_decoder.liq "FFmpeg raw decoder test for $$i" || exit; \
+	done
+
+test_ffmpeg_raw_and_encode_decoder: $(ENCODED_AUDIO_VIDEO_FILES) $(top_srcdir)/src/liquidsoap
+	@for i in $(ENCODED_AUDIO_VIDEO_FILES:%="%"); do \
+	  ../run_test.sh "$(top_srcdir)/src/liquidsoap --no-pervasives $(top_srcdir)/libs/pervasives.liq - -- $$i" media/test_ffmpeg_raw_and_encode_decoder.liq "FFmpeg raw+encode decoder test for $$i" || exit; \
+	done
+
+test_ffmpeg_raw_and_copy_decoder: $(ENCODED_AUDIO_VIDEO_FILES) $(top_srcdir)/src/liquidsoap
+	@for i in $(ENCODED_AUDIO_VIDEO_FILES:%="%"); do \
+	  ../run_test.sh "$(top_srcdir)/src/liquidsoap --no-pervasives $(top_srcdir)/libs/pervasives.liq - -- $$i" media/test_ffmpeg_raw_and_copy_decoder.liq "FFmpeg raw+copy decoder test for $$i" || exit; \
 	done
 
 # See: https://gitlab.freedesktop.org/gstreamer/gstreamer/-/issues/555

--- a/tests/media/Makefile
+++ b/tests/media/Makefile
@@ -1,9 +1,9 @@
-.PHONY: test_encoder test_stereo test_mono test_stream_audio test_stream_video test_ffmpeg_audio_decoder test_ffmpeg_video_decoder test_ffmpeg_copy_decoder test_ffmpeg_copy_and_encode_decoder test_ffmpeg_raw_decoder test_ffmpeg_raw_and_encode_decoder test_ffmpeg_raw_and_copy_decoder test_gstreamer_audio_decoder test_gstreamer_video_decoder
+.PHONY: test_encoder test_stereo test_mono test_stream_audio test_stream_video test_ffmpeg_filter test_ffmpeg_audio_decoder test_ffmpeg_video_decoder test_ffmpeg_copy_decoder test_ffmpeg_copy_and_encode_decoder test_ffmpeg_raw_decoder test_ffmpeg_raw_and_encode_decoder test_ffmpeg_raw_and_copy_decoder test_gstreamer_audio_decoder test_gstreamer_video_decoder
 
 DISTFILES = Makefile $(wildcard *.sh) $(wildcard *.liq *.liq.in)
 top_srcdir = $(shell realpath ../..)
 
-test: test_encoder test_stereo test_mono test_ffmpeg_audio_decoder test_ffmpeg_video_decoder test_ffmpeg_copy_decoder test_ffmpeg_copy_and_encode_decoder test_ffmpeg_raw_decoder test_ffmpeg_raw_and_encode_decoder test_ffmpeg_raw_and_copy_decoder test_gstreamer_audio_decoder test_gstreamer_video_decoder # test_stream_audio test_stream_video
+test: test_encoder test_stereo test_mono test_ffmpeg_audio_decoder test_ffmpeg_video_decoder test_ffmpeg_filter test_ffmpeg_copy_decoder test_ffmpeg_copy_and_encode_decoder test_ffmpeg_raw_decoder test_ffmpeg_raw_and_encode_decoder test_ffmpeg_raw_and_copy_decoder test_gstreamer_audio_decoder test_gstreamer_video_decoder # test_stream_audio test_stream_video
 
 AUDIO_TEST_FORMATS = \
   @flac(stereo).flac \
@@ -79,6 +79,11 @@ test_stereo: $(ENCODED_AUDIO_FILES) $(top_srcdir)/src/liquidsoap
 	  if echo $$i | grep -v 'ffmpeg' > /dev/null 2>&1; then \
 	    ../run_test.sh "$(top_srcdir)/src/liquidsoap --no-pervasives $(top_srcdir)/libs/pervasives.liq - -- $$i" media/test_stereo.liq "Stereo decoding test for $$i" || exit; \
 	  fi \
+	done
+
+test_ffmpeg_filter: $(ENCODED_AUDIO_VIDEO_FILES) $(top_srcdir)/src/liquidsoap
+	@for i in $(ENCODED_AUDIO_VIDEO_FILES:%="%"); do \
+	../run_test.sh "$(top_srcdir)/src/liquidsoap --no-pervasives $(top_srcdir)/libs/pervasives.liq - -- $<" media/test_ffmpeg_filter.liq "Ffmpeg filter test for $$i" || exit; \
 	done
 
 test_ffmpeg_audio_decoder: $(ENCODED_AUDIO_FILES) $(top_srcdir)/src/liquidsoap

--- a/tests/media/mk_encoder_test.sh
+++ b/tests/media/mk_encoder_test.sh
@@ -5,7 +5,7 @@ BASEDIR=`dirname $0`
 CWD=`cd $BASEDIR && pwd`
 
 FILE=$1
-FORMAT=`echo $FILE | cut -d '.' -f 1 | sed -e "s#@#%#g"`
+FORMAT=`echo $FILE | cut -d '.' -f 1 | sed -e "s#@#%#g" | sed -e 's#DOT#.#g'`
 
 SOURCE=$2
 

--- a/tests/media/test_ffmpeg_copy_and_encode_decoder.liq
+++ b/tests/media/test_ffmpeg_copy_and_encode_decoder.liq
@@ -50,4 +50,4 @@ def on_done () =
   end
 end
 
-output.file(fallible=true, on_stop=on_done, %ffmpeg(format="mkv",%audio(codec="aac"),%video.copy), out, s)
+output.file(fallible=true, on_stop=on_done, %ffmpeg(format="mkv",%audio(codec="aac"),%video.copy.video), out, s)

--- a/tests/media/test_ffmpeg_copy_and_encode_decoder.liq
+++ b/tests/media/test_ffmpeg_copy_and_encode_decoder.liq
@@ -50,4 +50,4 @@ def on_done () =
   end
 end
 
-output.file(fallible=true, on_stop=on_done, %ffmpeg(format="mkv",%audio(codec="aac"),%video(codec=copy)), out, s)
+output.file(fallible=true, on_stop=on_done, %ffmpeg(format="mkv",%audio(codec="aac"),%video.copy), out, s)

--- a/tests/media/test_ffmpeg_copy_and_encode_decoder.liq
+++ b/tests/media/test_ffmpeg_copy_and_encode_decoder.liq
@@ -50,4 +50,4 @@ def on_done () =
   end
 end
 
-output.file(fallible=true, on_stop=on_done, %ffmpeg(format="mkv",%audio(codec="aac"),%video.copy.video), out, s)
+output.file(fallible=true, on_stop=on_done, %ffmpeg(format="mkv",%audio(codec="aac"),%video.copy), out, s)

--- a/tests/media/test_ffmpeg_copy_decoder.liq
+++ b/tests/media/test_ffmpeg_copy_decoder.liq
@@ -49,4 +49,4 @@ def on_done () =
   end
 end
 
-output.file(fallible=true, on_stop=on_done, %ffmpeg(format="mkv",%audio(codec=copy),%video(codec=copy)), out, s)
+output.file(fallible=true, on_stop=on_done, %ffmpeg(format="mkv",%audio.copy,%video.copy), out, s)

--- a/tests/media/test_ffmpeg_filter.liq
+++ b/tests/media/test_ffmpeg_filter.liq
@@ -1,0 +1,90 @@
+#!../../src/liquidsoap ../../libs/pervasives.liq
+%include "test.liq"
+
+set("log.level",4)
+
+set("decoder.decoders",["FFMPEG"])
+
+fname = argv(default="",1)
+out = "files/test.mp4"
+
+if file.exists(out) then
+  file.unlink(out)
+end
+
+def f(s) =
+  def mkfilter(graph) =
+    a = ffmpeg.filter.audio.input(graph, s)
+    a = ffmpeg.filter.flanger(graph, a, int_args=[("delay", 10)])
+    a = ffmpeg.filter.highpass(graph, a, int_args=[("frequency", 4000)])
+    a = ffmpeg.filter.audio.output(graph, a)
+
+    v = ffmpeg.filter.video.input(graph, s)
+    v = ffmpeg.filter.hflip(graph, v)
+    v = ffmpeg.filter.video.output(graph, v)
+
+    mux_audio(id="mux_audio", audio=a, v)
+  end
+
+  ffmpeg.filter.create(mkfilter)
+end
+
+s = single(fname)
+
+s = sequence([s,s,s,s,s,fail()])
+
+s = f(s)
+
+clock.assign_new(id='test_clock',sync='none',[s])
+
+def on_done () =
+  ojson = get_process_output("ffprobe -v quiet -print_format json -show_streams '#{out}'")
+
+  output_format = of_json(default=[("streams", [[("samplerate", "0")]])], ojson)
+
+  output_streams = list.assoc(default=[], "streams", output_format)
+
+  params = ["channel_layout", "sample_rate",
+            "sample_fmt", "codec_name", "pix_fmt"]
+
+  def m(s) =
+    def f(e) =
+      let (p, _) = e
+      list.mem(p, params)
+    end
+    list.filter(f, s)
+  end
+
+  output_streams = list.map(m, output_streams)
+
+  def cmp(c, c') =
+    if c < c' then
+      -1
+    elsif c' < c then
+      1
+    else
+      0
+    end
+  end
+
+  output_streams = list.map(list.sort(cmp), output_streams)
+
+  def cmd_l(l, l') =
+    cmp(list.assoc("codec_name", l), list.assoc("codec_name", l'))
+  end
+
+  output_streams = list.sort(cmd_l, output_streams)
+
+  expected = [
+    [("channel_layout", "stereo"), ("codec_name", "aac"), ("sample_fmt", "fltp"), ("sample_rate", "44100")],
+    [("codec_name", "h264"), ("pix_fmt", "yuv420p")]
+  ]
+
+  if output_streams == expected then
+    test.pass()
+  else
+    test.fail()
+  end
+end
+
+output.file(fallible=true, on_stop=on_done, %ffmpeg(format="mkv",%audio.raw(codec="aac"),%video.raw(codec="libx264")), out, s)

--- a/tests/media/test_ffmpeg_raw_and_copy_decoder.liq
+++ b/tests/media/test_ffmpeg_raw_and_copy_decoder.liq
@@ -1,0 +1,69 @@
+#!../../src/liquidsoap ../../libs/pervasives.liq
+%include "test.liq"
+
+set("log.level",4)
+
+set("decoder.decoders",["FFMPEG"])
+
+fname = argv(default="",1)
+out = "files/test.mp4"
+
+if file.exists(out) then
+  file.unlink(out)
+end
+
+s = single(fname)
+
+s = once(s)
+
+clock.assign_new(sync='none',[s])
+
+def on_done () =
+  ijson = get_process_output("ffprobe -v quiet -print_format json -show_streams '#{fname}'")
+  ojson = get_process_output("ffprobe -v quiet -print_format json -show_streams '#{out}'")
+
+  iformat = of_json(default=[("streams", [[("samplerate", "0")]])], ijson)
+  oformat = of_json(default=[("streams", [[("samplerate", "0")]])], ojson)
+
+  istreams = list.assoc(default=[], "streams", iformat)
+  ostreams = list.assoc(default=[], "streams", oformat)
+
+  params = ["channel_layout", "sample_rate",
+            "sample_fmt", "codec_name", "pix_fmt"]
+
+  def get(codec, l) =
+    def f(l) =
+      def g(e) =
+        snd(e) == codec
+      end
+      list.exists(g, l)
+    end
+    list.find(f, l)
+  end
+  iaudio = get("aac", istreams)
+  oaudio = get("aac", ostreams)
+  ovideo = get("h264", ostreams)
+
+  def m(s) =
+    def f(e) =
+      let (p, _) = e
+      list.mem(p, params)
+    end
+    list.filter(f, s)
+  end
+
+  streams = [m(ovideo), m(oaudio)]
+
+  expected = [
+    [("pix_fmt", "yuv420p"), ("codec_name", "h264")],
+    m(iaudio)
+  ]
+
+  if streams == expected then
+    test.pass()
+  else
+    test.fail()
+  end
+end
+
+output.file(fallible=true, on_stop=on_done, %ffmpeg(format="mkv",%audio.copy,%video.raw(codec="libx264")), out, s)

--- a/tests/media/test_ffmpeg_raw_and_encode_decoder.liq
+++ b/tests/media/test_ffmpeg_raw_and_encode_decoder.liq
@@ -1,0 +1,53 @@
+#!../../src/liquidsoap ../../libs/pervasives.liq
+%include "test.liq"
+
+set("log.level",4)
+
+set("decoder.decoders",["FFMPEG"])
+
+fname = argv(default="",1)
+out = "files/test.mp4"
+
+if file.exists(out) then
+  file.unlink(out)
+end
+
+s = single(fname)
+
+s = once(s)
+
+clock.assign_new(sync='none',[s])
+
+def on_done () =
+  json = get_process_output("ffprobe -v quiet -print_format json -show_streams '#{out}'")
+
+  format = of_json(default=[("streams", [[("samplerate", "0")]])], json)
+
+  streams = list.assoc(default=[], "streams", format)
+
+  params = ["channel_layout", "sample_rate",
+            "sample_fmt", "codec_name", "pix_fmt"]
+
+  def m(s) =
+    def f(e) =
+      let (p, _) = e
+      list.mem(p, params)
+    end
+    list.filter(f, s)
+  end
+
+  streams = list.map(m, streams)
+
+  expected = [
+    [("channel_layout", "stereo"), ("sample_rate", "44100"), ("sample_fmt", "fltp"), ("codec_name", "aac")],
+    [("pix_fmt", "yuv420p"), ("codec_name", "h264")]
+  ]
+
+  if streams == expected then
+    test.pass()
+  else
+    test.fail()
+  end
+end
+
+output.file(fallible=true, on_stop=on_done, %ffmpeg(format="mkv",%audio(codec="aac"),%video.raw(codec="libx264")), out, s)

--- a/tests/media/test_ffmpeg_raw_decoder.liq
+++ b/tests/media/test_ffmpeg_raw_decoder.liq
@@ -1,0 +1,71 @@
+#!../../src/liquidsoap ../../libs/pervasives.liq
+%include "test.liq"
+
+set("log.level",4)
+
+set("decoder.decoders",["FFMPEG"])
+
+fname = argv(default="",1)
+out = "files/test.mp4"
+
+if file.exists(out) then
+  file.unlink(out)
+end
+
+s = single(fname)
+
+s = once(s)
+
+clock.assign_new(sync='none',[s])
+
+def on_done () =
+  ojson = get_process_output("ffprobe -v quiet -print_format json -show_streams '#{out}'")
+
+  output_format = of_json(default=[("streams", [[("samplerate", "0")]])], ojson)
+
+  output_streams = list.assoc(default=[], "streams", output_format)
+
+  params = ["channel_layout", "sample_rate",
+            "sample_fmt", "codec_name", "pix_fmt"]
+
+  def m(s) =
+    def f(e) =
+      let (p, _) = e
+      list.mem(p, params)
+    end
+    list.filter(f, s)
+  end
+
+  output_streams = list.map(m, output_streams)
+
+  def cmp(c, c') =
+    if c < c' then
+      -1
+    elsif c' < c then
+      1
+    else
+      0
+    end
+  end
+
+  output_streams = list.map(list.sort(cmp), output_streams)
+
+  def cmd_l(l, l') =
+    cmp(list.assoc("codec_name", l), list.assoc("codec_name", l'))
+  end
+
+  output_streams = list.sort(cmd_l, output_streams)
+
+  expected = [
+    [("channel_layout", "stereo"), ("codec_name", "aac"), ("sample_fmt", "fltp"), ("sample_rate", "44100")],
+    [("codec_name", "h264"), ("pix_fmt", "yuv420p")]
+  ]
+
+  if output_streams == expected then
+    test.pass()
+  else
+    test.fail()
+  end
+end
+
+output.file(fallible=true, on_stop=on_done, %ffmpeg(format="mkv",%audio.raw(codec="aac"),%video.raw(codec="libx264")), out, s)

--- a/tests/media/test_ffmpeg_video_decoder.liq
+++ b/tests/media/test_ffmpeg_video_decoder.liq
@@ -35,4 +35,4 @@ def on_done () =
   end
 end
 
-output.file(fallible=true, on_stop=on_done, %ffmpeg(format="mp4",%audio(codec=none),%video(codec="libx264")), out, s)
+output.file(fallible=true, on_stop=on_done, %ffmpeg(format="mp4",%audio.none,%video(codec="libx264")), out, s)

--- a/tests/media/test_gstreamer_video_decoder.liq
+++ b/tests/media/test_gstreamer_video_decoder.liq
@@ -35,4 +35,4 @@ def on_done () =
   end
 end
 
-output.file(fallible=true, on_stop=on_done, %ffmpeg(format="flv",%audio(codec=none),%video(codec="libx264")), out, s)
+output.file(fallible=true, on_stop=on_done, %ffmpeg(format="flv",%audio.none,%video(codec="libx264")), out, s)


### PR DESCRIPTION
This PR adds support for `ffmpeg.raw` frame format, that is, frame format that contains decoded data that is kept as internal ffmpeg frame. This should allow `liquidsoap` to manipulate raw data using strictly `ffmpeg` without having to do any extraneous data copy on the OCaml side.

Raw content is currently derived from the `%ffmpeg` encoder as such:
* `%ffmpeg(%audio(...), ...)` and `%ffmpeg(%video(...), ...)`: internal frame format, encoded output
* `%ffmpeg(%audio.raw(...), ...)` and `%ffmpeg(%video.raw(...), ...)`: ffmpeg raw frame format, encoded output
* `%ffmpeg(%audio.copy, ...)` and `%ffmpeg(%video.copy, ...)`: ffmpeg packet format, copied output (no re-encoding)
* `%audio.none` or `%video.none`: disable audio (resp. video)

Remaining work:
* ~~Test more!~~
* ~Find a better syntax~
* ~~Fix decoding logic w.r.t. frame format~~
* ~~Update ffmpeg filters to only support these new types~~
* ~~Fix a couple of TODOs in the code~~
* ~~Add tests~~