### PR TITLE
1.3.7 dj disconnect for 1/ seconds  .. listen autodj and then comeback music dj again

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,7 +24,6 @@ src/auto_clean
 src/lang/lang_lexer.ml
 src/lang/lang_parser.ml
 src/lang/lang_parser.mli
-src/win32/process_utils.mli
 src/*_depend
 src/outputs/harbor_output.camlp4.ml
 src/tools/harbor.camlp4.ml

--- a/src/unix/process_utils.ml
+++ b/src/unix/process_utils.ml
@@ -29,9 +29,9 @@ let perform_redirections new_stdin new_stdout new_stderr =
   (*  The three dup2 close the original stdin, stdout, stderr,
       which are the descriptors possibly left open
       by file_descr_not_standard *)
-  dup2 ~cloexec:false new_stdin stdin;
-  dup2 ~cloexec:false new_stdout stdout;
-  dup2 ~cloexec:false new_stderr stderr;
+  dup2 new_stdin stdin;
+  dup2 new_stdout stdout;
+  dup2 new_stderr stderr;
   safe_close new_stdin;
   safe_close new_stdout;
   safe_close new_stderr
@@ -45,12 +45,12 @@ let open_proc prog args envopt input output error =
     | id -> id
 
 let open_process_args prog args env =
-  let (in_read, in_write) = pipe ~cloexec:true () in
+  let (in_read, in_write) = pipe () in
   let (out_read, out_write) =
-    try pipe ~cloexec:true ()
+    try pipe ()
     with e -> close in_read; close in_write; raise e in
   let (err_read, err_write) =
-    try pipe ~cloexec:true ()
+    try pipe ()
     with e -> close in_read; close in_write;
               close out_read; close out_write; raise e in
   let stdin = out_channel_of_descr out_write in

--- a/src/win32/process_utils.mli
+++ b/src/win32/process_utils.mli
@@ -1,0 +1,1 @@
+../unix/process_utils.mli


### PR DESCRIPTION
hi i have a bug with this version ..

I have sonicpanel (similar to centova cast) streaming audio panel.

It often happens to me that when the DJ is online for a second you hear the music of the autodj and after 1/2 seconds the live DJ music returns.

What can it depend on?

from the logs I see this

[dummy: 3] Source failed (no more tracks) stopping output ...

Please help me