### PR TITLE
HLS video support

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,8 @@ New:
 - Added support for list spread and deconstruction syntax (#1269).
 - Added support for video encoding and decoding using `ffmpeg` (#1038).
 - Added support for ffmpeg filters (#1038).
+- Added video support to `output.hls` (#1391).
+- Added mp4 support to `output.hls` (#1391).
 - Added `output.url` for encoders that support handling data output (currently only `%ffmpeg`) (#1038).
 - Added `output.file.dash.ffmpeg`.
 - Added LV2 support (#906).

--- a/src/encoder.mli
+++ b/src/encoder.mli
@@ -1,0 +1,117 @@
+(*****************************************************************************
+
+  Liquidsoap, a programmable audio stream generator.
+  Copyright 2003-2020 Savonet team
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details, fully stated in the COPYING
+  file at the root of the liquidsoap distribution.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA
+
+ *****************************************************************************)
+
+(** Common infrastructure for encoding streams *)
+
+type format =
+  | WAV of Wav_format.t
+  | AVI of Avi_format.t
+  | Ogg of Ogg_format.t
+  | MP3 of Mp3_format.t
+  | Shine of Shine_format.t
+  | Flac of Flac_format.t
+  | Ffmpeg of Ffmpeg_format.t
+  | FdkAacEnc of Fdkaac_format.t
+  | External of External_encoder_format.t
+  | GStreamer of Gstreamer_format.t
+
+val audio_kind : int -> Frame.kind Frame.fields
+val audio_video_kind : int -> Frame.kind Frame.fields
+val kind_of_format : format -> Frame.kind Frame.fields
+val string_of_format : format -> string
+
+(** ISO Base Media File Format, see RFC 6381 section 3.3. *)
+val iso_base_file_media_file_format : format -> string
+
+(** Proposed extension for files. *)
+val extension : format -> string
+
+(** Mime types *)
+val mime : format -> string
+
+(** Video size when available. *)
+val video_size : format -> (int * int) option
+
+(** Bitrate estimation in bits per second. *)
+val bitrate : format -> int
+
+(** Encoders that can output to a file. *)
+val file_output : format -> bool
+
+val with_file_output : format -> string -> format
+
+(** Encoders that can output to a arbitrary url. *)
+val url_output : format -> bool
+
+val with_url_output : format -> string -> format
+
+(** An encoder, once initialized, is something that consumes
+  * frames, insert metadata and that you eventually close 
+  * (triggers flushing). 
+  * Insert metadata is really meant for inline metadata, i.e.
+  * in most cases, stream sources. Otherwise, metadata are
+  * passed when creating the encoder. For instance, the mp3 
+  * encoder may accept metadata initally and write them as 
+  * id3 tags but does not support inline metadata. 
+  * Also, the ogg encoder supports inline metadata but restarts
+  * its stream. This is ok, though, because the ogg container/streams 
+  * is meant to be sequentialized but not the mp3 format. 
+  * header contains data that should be sent first to streaming 
+  * client. *)
+
+type split_result =
+  [ (* Returns (flushed, first_bytes_for_next_segment) *)
+    `Ok of
+    Strings.t * Strings.t
+  | `Nope of Strings.t ]
+
+type hls = {
+  (* Returns (init_segment, first_bytes) *)
+  init_encode : Frame.t -> int -> int -> Strings.t option * Strings.t;
+  split_encode : Frame.t -> int -> int -> split_result;
+  codec_attrs : unit -> string option;
+  bitrate : unit -> int option;
+  (* width x height *)
+  video_size : unit -> (int * int) option;
+}
+
+type encoder = {
+  insert_metadata : Meta_format.export_metadata -> unit;
+  (* Encoder are all called from the main 
+   * thread so there's no need to protect this
+   * value with a mutex so far.. *)
+  mutable header : Strings.t;
+  hls : hls;
+  encode : Frame.t -> int -> int -> Strings.t;
+  stop : unit -> Strings.t;
+}
+
+type factory = string -> Meta_format.export_metadata -> encoder
+
+(** A plugin might or might not accept a given format.
+  * If it accepts it, it gives a function creating suitable encoders. *)
+type plugin = format -> factory option
+
+val plug : plugin Plug.plug
+
+(** Return the first available encoder factory for that format. *)
+val get_factory : format -> factory

--- a/src/encoder/avi_encoder.ml
+++ b/src/encoder/avi_encoder.ml
@@ -78,8 +78,18 @@ let encoder avi =
       Strings.dda header ans )
     else ans
   in
+  let hls =
+    {
+      Encoder.init_encode = (fun f o l -> (None, encode f o l));
+      split_encode = (fun f o l -> `Ok (Strings.empty, encode f o l));
+      codec_attrs = (fun () -> None);
+      bitrate = (fun () -> None);
+      video_size = (fun () -> None);
+    }
+  in
   {
     Encoder.insert_metadata = (fun _ -> ());
+    hls;
     encode;
     header = Strings.of_string header;
     stop = (fun () -> Strings.empty);

--- a/src/encoder/external_encoder.ml
+++ b/src/encoder/external_encoder.ml
@@ -153,12 +153,22 @@ let encoder id ext =
         Condition.wait condition mutex;
         Strings.Mutable.flush buf)
   in
+  let hls =
+    {
+      Encoder.init_encode = (fun f o l -> (None, encode f o l));
+      split_encode = (fun f o l -> `Ok (Strings.empty, encode f o l));
+      codec_attrs = (fun () -> None);
+      bitrate = (fun () -> None);
+      video_size = (fun () -> None);
+    }
+  in
   {
     Encoder.insert_metadata;
     (* External encoders do not support 
      * headers for now. They will probably
      * never do.. *)
     header = Strings.empty;
+    hls;
     encode;
     stop;
   }

--- a/src/encoder/fdkaac_encoder.ml
+++ b/src/encoder/fdkaac_encoder.ml
@@ -159,9 +159,19 @@ module Register (Fdkaac : Fdkaac_t) = struct
       Strings.Mutable.add rem (Fdkaac.Encoder.flush enc);
       Strings.Mutable.to_strings rem
     in
+    let hls =
+      {
+        Encoder.init_encode = (fun f o l -> (None, encode f o l));
+        split_encode = (fun f o l -> `Ok (Strings.empty, encode f o l));
+        codec_attrs = (fun () -> None);
+        bitrate = (fun () -> None);
+        video_size = (fun () -> None);
+      }
+    in
     {
       Encoder.insert_metadata = (fun _ -> ());
       header = Strings.empty;
+      hls;
       encode;
       stop;
     }

--- a/src/encoder/flac_encoder.ml
+++ b/src/encoder/flac_encoder.ml
@@ -64,11 +64,21 @@ let encoder flac meta =
     Flac.Encoder.finish !enc cb;
     Strings.Mutable.flush buf
   in
+  let hls =
+    {
+      Encoder.init_encode = (fun f o l -> (None, encode f o l));
+      split_encode = (fun f o l -> `Ok (Strings.empty, encode f o l));
+      codec_attrs = (fun () -> None);
+      bitrate = (fun () -> None);
+      video_size = (fun () -> None);
+    }
+  in
   {
     Encoder.insert_metadata = (fun _ -> ());
     (* Flac encoder do not support header
      * for now. It will probably never do.. *)
     header = Strings.empty;
+    hls;
     encode;
     stop;
   }

--- a/src/encoder/gstreamer_encoder.ml
+++ b/src/encoder/gstreamer_encoder.ml
@@ -187,7 +187,16 @@ let encoder ext =
       decr_samples ();
       Strings.of_string ans )
   in
-  { Encoder.insert_metadata; header = Strings.empty; encode; stop }
+  let hls =
+    {
+      Encoder.init_encode = (fun f o l -> (None, encode f o l));
+      split_encode = (fun f o l -> `Ok (Strings.empty, encode f o l));
+      codec_attrs = (fun () -> None);
+      bitrate = (fun () -> None);
+      video_size = (fun () -> None);
+    }
+  in
+  { Encoder.insert_metadata; header = Strings.empty; hls; encode; stop }
 
 let () =
   Encoder.plug#register "GSTREAMER" (function

--- a/src/encoder/lame_encoder.ml
+++ b/src/encoder/lame_encoder.ml
@@ -249,7 +249,16 @@ module Register (Lame : Lame_t) = struct
       in
       (* Try to insert initial metadata now.. *)
       insert_metadata metadata;
-      { insert_metadata; encode; header = Strings.empty; stop }
+      let hls =
+        {
+          Encoder.init_encode = (fun f o l -> (None, encode f o l));
+          split_encode = (fun f o l -> `Ok (Strings.empty, encode f o l));
+          codec_attrs = (fun () -> None);
+          bitrate = (fun () -> None);
+          video_size = (fun () -> None);
+        }
+      in
+      { insert_metadata; hls; encode; header = Strings.empty; stop }
     in
     Encoder.plug#register name (function
       | Encoder.MP3 mp3 -> Some (fun _ meta -> mp3_encoder mp3 meta)

--- a/src/encoder/ogg_encoder.ml
+++ b/src/encoder/ogg_encoder.ml
@@ -102,7 +102,7 @@ let encoder { Ogg_format.audio; video } =
     let skeleton = List.length tracks > 1 in
     let ogg_enc = Ogg_muxer.create ~skeleton name in
     let rec enc =
-      { Encoder.insert_metadata; encode; header = Strings.empty; stop }
+      { Encoder.insert_metadata; hls; encode; header = Strings.empty; stop }
     and streams_start () =
       let f track =
         match track.id with
@@ -123,6 +123,14 @@ let encoder { Ogg_format.audio; video } =
       in
       List.iter f tracks;
       Ogg_muxer.get_data ogg_enc
+    and hls =
+      {
+        Encoder.init_encode = (fun f o l -> (None, encode f o l));
+        split_encode = (fun f o l -> `Ok (Strings.empty, encode f o l));
+        codec_attrs = (fun () -> None);
+        bitrate = (fun () -> None);
+        video_size = (fun () -> None);
+      }
     and ogg_stop () =
       let f track = track.id <- None in
       List.iter f tracks;

--- a/src/encoder/shine_encoder.ml
+++ b/src/encoder/shine_encoder.ml
@@ -65,9 +65,19 @@ let encoder shine =
     Strings.Mutable.flush encoded
   in
   let stop () = Strings.of_string (Shine.flush enc) in
+  let hls =
+    {
+      Encoder.init_encode = (fun f o l -> (None, encode f o l));
+      split_encode = (fun f o l -> `Ok (Strings.empty, encode f o l));
+      codec_attrs = (fun () -> None);
+      bitrate = (fun () -> None);
+      video_size = (fun () -> None);
+    }
+  in
   {
     Encoder.insert_metadata = (fun _ -> ());
     header = Strings.empty;
+    hls;
     encode;
     stop;
   }

--- a/src/encoder/wav_encoder.ml
+++ b/src/encoder/wav_encoder.ml
@@ -72,8 +72,18 @@ let encoder wav =
       Strings.of_list [header; s] )
     else Strings.of_string s
   in
+  let hls =
+    {
+      Encoder.init_encode = (fun f o l -> (None, encode f o l));
+      split_encode = (fun f o l -> `Ok (Strings.empty, encode f o l));
+      codec_attrs = (fun () -> None);
+      bitrate = (fun () -> None);
+      video_size = (fun () -> None);
+    }
+  in
   {
     Encoder.insert_metadata = (fun _ -> ());
+    hls;
     encode;
     header = Strings.of_string header;
     stop = (fun () -> Strings.empty);


### PR DESCRIPTION
This PR adds video and mp4 format support to `output.file.hls`!

TODO:
* ~~Test with `ffmpeg.copy`~~
* ~~Test persistence with `mp4` format~~
* ~~Cleanup default ISO codes and bitrate~~
* ~~Better convention for init segment name~~

Test script:
```ruby
set("log.level",5)

source = playlist("~/Documents/playlist")

#source = single("/tmp/bla.mkv")

# To re-encode with liquidsoap internal format:
mpegts = %ffmpeg(
           format="mpegts",
           %audio(
              codec="aac",
              b="128k",
              channels=2,
              ar=44100
           ),
           %video(
             codec="libx264",
             b="5M"
           )
         )

mp4 = %ffmpeg(
        format="mp4",
        movflags="+dash+skip_sidx+skip_trailer+frag_custom",
        frag_duration=10,
        %audio(
          codec="aac",
          b="128k",
          channels=2,
          ar=44100),
        %video(
          codec="libx264",
          b="5M"
        )
      )

# To re-encode with ffmpeg raw frames:
mpegts = %ffmpeg(
           format="mpegts",
           %audio.raw(
              codec="aac",
              b="128k",
              channels=2,
              ar=44100
           ),
           %video.raw(
             codec="libx264",
             b="5M"
           )
         )

mp4 = %ffmpeg(
        format="mp4",
        movflags="+dash+skip_sidx+skip_trailer+frag_custom",
        frag_duration=10,
        %audio.raw(
          codec="aac",
          b="128k",
          channels=2,
          ar=44100),
        %video.raw(
          codec="libx264",
          b="5M"
        )
      )

# To copy without re-encoding:
mpegts = %ffmpeg(
           format="mpegts",
           %audio.copy,
           %video.copy)

mp4 = %ffmpeg(
        format="mp4",
        movflags="+dash+skip_sidx+skip_trailer+frag_custom",
        frag_duration=10,
        %audio.copy,
        %video.copy)

streams = [
  ("mpegts",mpegts),
  ("mp4", mp4)
]

def segment_name(~position,~extname,stream_name) =
  timestamp = int_of_float(time())
  "#{stream_name}_#{timestamp}_#{position}.#{extname}"
end

output.file.hls(playlist="live.m3u8",
                segment_duration=2.0,
                segments=5,
                segments_overhead=5,
                segment_name=segment_name,
                #persist_at="/tmp/state.config",
                "/tmp/hls",
                streams,
                fallible=true,
                source)
```