### PR TITLE
Ffmpeg inline encoder

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [debian_stable, debian_testing, ubuntu_eoan, ubuntu_focal]
+        os: [debian_stable, debian_testing, ubuntu_focal]
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -66,7 +66,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [debian_stable, debian_testing, ubuntu_eoan, ubuntu_focal]
+        os: [debian_stable, debian_testing, ubuntu_focal]
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/src/Makefile
+++ b/src/Makefile
@@ -248,7 +248,8 @@ liquidsoap_sources += \
         tools/start_stop.ml tools/ioRing.ml \
 	tools/icecast_utils.ml tools/avi.ml \
 	$(video_converters) $(audio_converters) $(protocols) \
-	$(sources) $(outputs) $(conversions) $(operators) \
+	$(sources) $(outputs) tools/producer_consumer.ml \
+	$(conversions) $(operators) \
 	$(encoders) $(decoders) $(ogg_demuxer) $(ogg_muxer) \
 	$(analyze) $(playlists) \
 	$(visualization) $(synth) $(io) \

--- a/src/Makefile
+++ b/src/Makefile
@@ -224,6 +224,7 @@ builtins = lang/lang_builtins.ml lang/builtins_ref.ml \
            $(if $(W_CRY),lang/builtins_cry.ml) \
            $(if $(W_LASTFM),lang/builtins_lastfm.ml) \
            $(if $(W_PROMETHEUS),lang/builtins_prometheus.ml) \
+           $(if $(W_FFMPEG_ENCODER),lang/builtins_ffmpeg.ml) \
            $(if $(W_FFMPEG_LIQ_FILTER),lang/builtins_ffmpeg_filters.ml)
 
 liquidsoap_sources= \

--- a/src/encoder.ml
+++ b/src/encoder.ml
@@ -233,6 +233,9 @@ type split_result =
     Strings.t * Strings.t
   | `Nope of Strings.t ]
 
+(* Raised by [init_encode] if more data is needed. *)
+exception Not_enough_data
+
 type hls = {
   (* Returns (init_segment, first_bytes) *)
   init_encode : Frame.t -> int -> int -> Strings.t option * Strings.t;

--- a/src/encoder.mli
+++ b/src/encoder.mli
@@ -84,6 +84,9 @@ type split_result =
     Strings.t * Strings.t
   | `Nope of Strings.t ]
 
+(* Raised by [init_encode] if more data is needed. *)
+exception Not_enough_data
+
 type hls = {
   (* Returns (init_segment, first_bytes) *)
   init_encode : Frame.t -> int -> int -> Strings.t option * Strings.t;

--- a/src/encoder/ffmpeg_encoder_common.ml
+++ b/src/encoder/ffmpeg_encoder_common.ml
@@ -138,11 +138,22 @@ let encoder ~mk_audio ~mk_video ffmpeg meta =
     let encoder = !encoder in
     match encoder.video_stream with Some s -> s.video_size () | None -> None
   in
+  let audio_sent = ref false in
+  let video_sent = ref false in
   let init_encode frame start len =
     let encoder = !encoder in
     match ffmpeg.Ffmpeg_format.format with
       | Some "mp4" ->
           encode ~encoder frame start len;
+          if encoder.video_stream <> None then (
+            let d = Frame_content.sub Frame.(frame.content.video) start len in
+            video_sent := not (Frame_content.is_empty d) )
+          else video_sent := true;
+          if encoder.audio_stream <> None then (
+            let d = Frame_content.sub Frame.(frame.content.audio) start len in
+            audio_sent := not (Frame_content.is_empty d) )
+          else audio_sent := true;
+          if not (!audio_sent && !video_sent) then raise Encoder.Not_enough_data;
           Av.flush encoder.output;
           let init = Strings.Mutable.flush buf in
           (Some init, Strings.empty)

--- a/src/encoder/ffmpeg_encoder_common.ml
+++ b/src/encoder/ffmpeg_encoder_common.ml
@@ -147,11 +147,11 @@ let encoder ~mk_audio ~mk_video ffmpeg meta =
           encode ~encoder frame start len;
           if encoder.video_stream <> None then (
             let d = Frame_content.sub Frame.(frame.content.video) start len in
-            video_sent := not (Frame_content.is_empty d) )
+            video_sent := !video_sent || not (Frame_content.is_empty d) )
           else video_sent := true;
           if encoder.audio_stream <> None then (
             let d = Frame_content.sub Frame.(frame.content.audio) start len in
-            audio_sent := not (Frame_content.is_empty d) )
+            audio_sent := !audio_sent || not (Frame_content.is_empty d) )
           else audio_sent := true;
           if not (!audio_sent && !video_sent) then raise Encoder.Not_enough_data;
           Av.flush encoder.output;

--- a/src/encoder/ffmpeg_internal_encoder.ml
+++ b/src/encoder/ffmpeg_internal_encoder.ml
@@ -109,7 +109,8 @@ let mk_audio ~ffmpeg ~options output =
 
   let internal_converter () =
     let src_samplerate = Lazy.force Frame.audio_rate in
-    let src_channels = Lazy.force Frame.audio_channels in
+    (* The typing system ensures that this is the number of channels in the frame. *)
+    let src_channels = ffmpeg.Ffmpeg_format.channels in
     let src_channel_layout = get_channel_layout src_channels in
 
     let resampler =

--- a/src/encoder/ffmpeg_internal_encoder.ml
+++ b/src/encoder/ffmpeg_internal_encoder.ml
@@ -66,7 +66,7 @@ let mk_audio ~ffmpeg ~options output =
 
   let internal_converter () =
     let src_samplerate = Lazy.force Frame.audio_rate in
-    let src_channels = ffmpeg.Ffmpeg_format.channels in
+    let src_channels = Lazy.force Frame.audio_channels in
     let src_channel_layout = get_channel_layout src_channels in
 
     let resampler =

--- a/src/encoder/ffmpeg_internal_encoder.ml
+++ b/src/encoder/ffmpeg_internal_encoder.ml
@@ -44,6 +44,49 @@ let get_channel_layout channels =
           %d channels.."
          channels)
 
+let write_audio_frame ~codec ~src_time_base ~dst_time_base ~target_samplerate
+    ~target_channel_layout ~target_sample_format ~get_frame_size write_frame =
+  let variable_frame_size =
+    List.mem `Variable_frame_size (Avcodec.Audio.capabilities codec)
+  in
+
+  let nb_samples = ref 0L in
+  let write_frame frame =
+    let frame_pts =
+      Ffmpeg_utils.convert_time_base ~src:src_time_base ~dst:dst_time_base
+        !nb_samples
+    in
+    nb_samples :=
+      Int64.add !nb_samples (Int64.of_int (Avutil.Audio.frame_nb_samples frame));
+    Avutil.frame_set_pts frame (Some frame_pts);
+    write_frame frame
+  in
+
+  if variable_frame_size then write_frame
+  else (
+    let out_frame_size = get_frame_size () in
+
+    let in_params =
+      {
+        Avfilter.Utils.sample_rate = target_samplerate;
+        channel_layout = target_channel_layout;
+        sample_format = target_sample_format;
+      }
+    in
+    let filter_in, filter_out =
+      Avfilter.Utils.convert_audio ~in_params ~in_time_base:src_time_base
+        ~out_frame_size ()
+    in
+    let rec flush () =
+      try
+        write_frame (filter_out ());
+        flush ()
+      with Avutil.Error `Eagain -> ()
+    in
+    fun frame ->
+      filter_in frame;
+      flush () )
+
 let mk_audio ~ffmpeg ~options output =
   let codec =
     match ffmpeg.Ffmpeg_format.audio_codec with
@@ -160,53 +203,15 @@ let mk_audio ~ffmpeg ~options output =
     (fun l v -> if Hashtbl.mem opts l then Some v else None)
     options;
 
-  let write_frame =
-    let variable_frame_size =
-      List.mem `Variable_frame_size (Avcodec.Audio.capabilities codec)
-    in
-
-    let stream_time_base = Av.get_time_base stream in
-
-    let nb_samples = ref 0L in
-    let write_frame frame =
-      let frame_pts =
-        Ffmpeg_utils.convert_time_base ~src:target_liq_audio_sample_time_base
-          ~dst:stream_time_base !nb_samples
-      in
-      nb_samples :=
-        Int64.add !nb_samples
-          (Int64.of_int (Avutil.Audio.frame_nb_samples frame));
-      Avutil.frame_set_pts frame (Some frame_pts);
-      Av.write_frame stream frame
-    in
-
-    if variable_frame_size then write_frame
-    else (
-      let out_frame_size = Av.get_frame_size stream in
-
-      let in_params =
-        {
-          Avfilter.Utils.sample_rate = target_samplerate;
-          channel_layout = target_channel_layout;
-          sample_format = target_sample_format;
-        }
-      in
-      let filter_in, filter_out =
-        Avfilter.Utils.convert_audio ~in_params
-          ~in_time_base:target_liq_audio_sample_time_base ~out_frame_size ()
-      in
-      let rec flush () =
-        try
-          write_frame (filter_out ());
-          flush ()
-        with Avutil.Error `Eagain -> ()
-      in
-      fun frame ->
-        filter_in frame;
-        flush () )
-  in
-
   let was_keyframe () = false in
+
+  let write_frame =
+    write_audio_frame ~codec ~src_time_base:target_liq_audio_sample_time_base
+      ~dst_time_base:(Av.get_time_base stream) ~target_samplerate
+      ~target_channel_layout ~target_sample_format
+      ~get_frame_size:(fun () -> Av.get_frame_size stream)
+      (Av.write_frame stream)
+  in
 
   let encode frame start len =
     List.iter write_frame (converter frame start len)

--- a/src/lang/builtins_ffmpeg.ml
+++ b/src/lang/builtins_ffmpeg.ml
@@ -20,30 +20,124 @@
 
  *****************************************************************************)
 
+module InternalResampler =
+  Swresample.Make (Swresample.FltPlanarBigArray) (Swresample.Frame)
+
+class consumer ~output_kind ~producer ~kind ~content ~max_buffer ~pre_buffer
+  ~source ~format c =
+  let codec =
+    match format.Ffmpeg_format.audio_codec with
+      | Some (`Raw codec) | Some (`Internal codec) ->
+          Avcodec.Audio.find_encoder codec
+      | _ -> assert false
+  in
+  let src_channel_layout =
+    Avutil.Channel_layout.get_default (Lazy.force Frame.audio_channels)
+  in
+  let src_sample_rate = Lazy.force Frame.audio_rate in
+  let channels = format.Ffmpeg_format.channels in
+  let channel_layout = Avutil.Channel_layout.get_default channels in
+  let sample_rate = Lazy.force format.Ffmpeg_format.samplerate in
+  let time_base = { Avutil.num = 1; den = sample_rate } in
+  let get_duration = Ffmpeg_decoder_common.convert_duration ~src:time_base in
+  let sample_format = Avcodec.Audio.find_best_sample_format codec `Dbl in
+  let encoder =
+    Avcodec.Audio.create_encoder ~channel_layout ~channels ~sample_format
+      ~sample_rate codec
+  in
+  let resampler =
+    InternalResampler.create ~out_sample_format:sample_format src_channel_layout
+      src_sample_rate channel_layout sample_rate
+  in
+  let s = Lang.to_source source in
+  object
+    inherit
+      Producer_consumer.consumer
+        ~output_kind ~producer ~kind ~content ~max_buffer ~pre_buffer ~source c
+
+    method output_send frame =
+      let frame = InternalResampler.convert resampler (AFrame.pcm frame) in
+
+      Producer_consumer.(
+        proceed c (fun () ->
+            if c.abort then (
+              c.abort <- false;
+              s#abort_track );
+            Avcodec.encode encoder
+              (fun packet ->
+                let duration =
+                  get_duration (Avcodec.Packet.get_duration packet)
+                in
+                let packet = { Ffmpeg_copy_content.packet; time_base } in
+                let data =
+                  { Ffmpeg_content_base.params = None; data = [(0, packet)] }
+                in
+                let data = Ffmpeg_copy_content.Audio.lift_data data in
+                Generator.put_audio c.generator data 0 duration)
+              frame))
+  end
+
 let () =
   Lang.add_module "ffmpeg";
   Lang.add_module "ffmpeg.encode"
 
 let () =
-  let source_t =
-    Lang.kind_type_of_kind_format
-      Frame.{ audio = audio_pcm; video = video_yuv420p; midi = none }
+  let source_kind = Frame.{ audio = audio_pcm; video = none; midi = none } in
+  let source_t = Lang.kind_type_of_kind_format source_kind in
+  let return_kind =
+    Frame.
+      {
+        audio = `Kind Ffmpeg_copy_content.Audio.kind;
+        video = none;
+        midi = none;
+      }
   in
-  let return_t =
-    Lang.kind_type_of_kind_format
-      Frame.
-        {
-          audio = `Kind Ffmpeg_copy_content.Audio.kind;
-          video = `Kind Ffmpeg_copy_content.Video.kind;
-          midi = none;
-        }
-  in
+  let return_t = Lang.kind_type_of_kind_format return_kind in
   let proto =
     [
       ("", Lang.format_t source_t, None, Some "Encoding format.");
       ("", Lang.source_t source_t, None, None);
+      ( "buffer",
+        Lang.float_t,
+        Some (Lang.float 1.),
+        Some "Amount of data to pre-buffer, in seconds." );
+      ( "max",
+        Lang.float_t,
+        Some (Lang.float 10.),
+        Some "Maximum amount of buffered data, in seconds." );
     ]
   in
-  Lang.add_operator "ffmpeg.encode.audio_video" proto ~return_t
+  Lang.add_operator "ffmpeg.encode.audio" proto ~return_t
     ~category:Lang.Conversions ~descr:"Encode a source's content" (fun p ->
-      assert false)
+      let pre_buffer = Lang.to_float (List.assoc "buffer" p) in
+      let max_buffer = Lang.to_float (List.assoc "max" p) in
+      let max_buffer = max max_buffer (pre_buffer *. 1.1) in
+      let format = Lang.assoc "" 1 p in
+      let source = Lang.assoc "" 2 p in
+      let format =
+        match Lang.to_format format with
+          | Encoder.Ffmpeg ffmpeg -> ffmpeg
+          | _ ->
+              raise
+                (Lang_errors.Invalid_value
+                   (format, "Only %ffmpeg encoder is currently supported!"))
+      in
+      let control =
+        Producer_consumer.
+          {
+            generator = Generator.create `Both;
+            lock = Mutex.create ();
+            buffering = true;
+            abort = false;
+          }
+      in
+      let producer =
+        new Producer_consumer.producer
+          ~kind:return_kind ~name:"ffmpeg.encode" control
+      in
+      let _ =
+        new consumer
+          ~producer ~output_kind:"ffmpeg.encode" ~kind:source_kind
+          ~content:`Audio ~max_buffer ~pre_buffer ~source ~format control
+      in
+      producer)

--- a/src/lang/builtins_ffmpeg.ml
+++ b/src/lang/builtins_ffmpeg.ml
@@ -1,0 +1,49 @@
+(*****************************************************************************
+
+  Liquidsoap, a programmable audio stream generator.
+  Copyright 2003-2020 Savonet team
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details, fully stated in the COPYING
+  file at the root of the liquidsoap distribution.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA
+
+ *****************************************************************************)
+
+let () =
+  Lang.add_module "ffmpeg";
+  Lang.add_module "ffmpeg.encode"
+
+let () =
+  let source_t =
+    Lang.kind_type_of_kind_format
+      Frame.{ audio = audio_pcm; video = video_yuv420p; midi = none }
+  in
+  let return_t =
+    Lang.kind_type_of_kind_format
+      Frame.
+        {
+          audio = `Kind Ffmpeg_copy_content.Audio.kind;
+          video = `Kind Ffmpeg_copy_content.Video.kind;
+          midi = none;
+        }
+  in
+  let proto =
+    [
+      ("", Lang.format_t source_t, None, Some "Encoding format.");
+      ("", Lang.source_t source_t, None, None);
+    ]
+  in
+  Lang.add_operator "ffmpeg.encode.audio_video" proto ~return_t
+    ~category:Lang.Conversions ~descr:"Encode a source's content" (fun p ->
+      assert false)

--- a/src/lang/builtins_ffmpeg_filters.ml
+++ b/src/lang/builtins_ffmpeg_filters.ml
@@ -21,9 +21,9 @@
  *****************************************************************************)
 
 open Lang_builtins
+open Builtins_ffmpeg
 
 let () =
-  Lang.add_module "ffmpeg";
   Lang.add_module "ffmpeg.filter";
   Lang.add_module "ffmpeg.filter.audio";
   Lang.add_module "ffmpeg.filter.video"

--- a/src/lang/builtins_ffmpeg_filters.ml
+++ b/src/lang/builtins_ffmpeg_filters.ml
@@ -21,7 +21,6 @@
  *****************************************************************************)
 
 open Lang_builtins
-open Builtins_ffmpeg
 
 let () =
   Lang.add_module "ffmpeg.filter";

--- a/src/outputs/hls_output.ml
+++ b/src/outputs/hls_output.ml
@@ -656,11 +656,13 @@ class hls_output p =
           let segment = Option.get s.current_segment in
           let b =
             if s.init_state = `Todo then (
-              let init, encoded =
-                Encoder.(s.encoder.hls.init_encode frame ofs len)
-              in
-              self#process_init ~init ~segment s;
-              (None, encoded) )
+              try
+                let init, encoded =
+                  Encoder.(s.encoder.hls.init_encode frame ofs len)
+                in
+                self#process_init ~init ~segment s;
+                (None, encoded)
+              with Encoder.Not_enough_data -> (None, Strings.empty) )
             else if segment.len + len > segment_master_duration then (
               match Encoder.(s.encoder.hls.split_encode frame ofs len) with
                 | `Ok (flushed, encoded) -> (Some flushed, encoded)

--- a/src/stream/ffmpeg_content_base.ml
+++ b/src/stream/ffmpeg_content_base.ml
@@ -24,6 +24,13 @@ type ('a, 'b) content = { mutable params : 'a; mutable data : (int * 'b) list }
 
 let make ~size:_ params = { params; data = [] }
 let clear d = d.data <- []
+let is_empty { data } = data = []
+
+let sub c ofs len =
+  {
+    c with
+    data = List.filter (fun (pos, _) -> ofs <= pos && pos < ofs + len) c.data;
+  }
 
 let blit src src_pos dst dst_pos len =
   (* No compatibility check here, it's

--- a/src/stream/frame_content.mli
+++ b/src/stream/frame_content.mli
@@ -51,8 +51,10 @@ module type ContentSpecs = sig
   (* Size is in master ticks. *)
   val make : size:int -> params -> data
   val blit : data -> int -> data -> int -> int -> unit
+  val sub : data -> int -> int -> data
   val copy : data -> data
   val clear : data -> unit
+  val is_empty : data -> bool
 
   (** Params *)
 
@@ -108,8 +110,10 @@ type data = Contents.data
 
 val make : size:int -> format -> data
 val blit : data -> int -> data -> int -> int -> unit
+val sub : data -> int -> int -> data
 val copy : data -> data
 val clear : data -> unit
+val is_empty : data -> bool
 
 (** Format *)
 

--- a/src/tools/producer_consumer.ml
+++ b/src/tools/producer_consumer.ml
@@ -1,0 +1,94 @@
+(*****************************************************************************
+
+  Liquidsoap, a programmable audio stream generator.
+  Copyright 2003-2020 Savonet team
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details, fully stated in the COPYING
+  file at the root of the liquidsoap distribution.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA
+
+ *****************************************************************************)
+
+module Generator = Generator.From_audio_video
+
+(* The kind of value shared by a producer and a consumer. *)
+type control = {
+  lock : Mutex.t;
+  generator : Generator.t;
+  mutable buffering : bool;
+  mutable abort : bool;
+}
+
+let proceed control f = Tutils.mutexify control.lock f ()
+
+(** The source which produces data by reading the buffer. *)
+class producer ~name ~kind c =
+  object (self)
+    inherit Source.source kind ~name
+
+    method self_sync = false
+
+    method stype = Source.Fallible
+
+    method remaining = proceed c (fun () -> Generator.remaining c.generator)
+
+    method is_ready = proceed c (fun () -> not c.buffering)
+
+    method private get_frame frame =
+      proceed c (fun () ->
+          Generator.fill c.generator frame;
+          if Frame.is_partial frame && Generator.length c.generator = 0 then (
+            self#log#important "Buffer emptied, start buffering...";
+            c.buffering <- true ))
+
+    method abort_track = proceed c (fun () -> c.abort <- true)
+  end
+
+class consumer ~output_kind ~producer ~kind ~content ~max_buffer ~pre_buffer
+  ~source c =
+  let prebuf = Frame.master_of_seconds pre_buffer in
+  let max_buffer = Frame.master_of_seconds max_buffer in
+  let autostart = true in
+  let s = Lang.to_source source in
+  object (self)
+    inherit
+      Output.output
+        ~output_kind ~content_kind:kind ~infallible:false
+        ~on_start:(fun () -> ())
+        ~on_stop:(fun () -> ())
+        source autostart
+
+    method output_reset = ()
+
+    method output_start = ()
+
+    method output_stop = ()
+
+    method private set_clock =
+      Clock.unify self#clock producer#clock;
+      Clock.unify self#clock s#clock
+
+    method output_send frame =
+      proceed c (fun () ->
+          if c.abort then (
+            c.abort <- false;
+            s#abort_track );
+
+          Generator.feed_from_frame ~mode:content c.generator frame;
+          if Generator.length c.generator > prebuf then (
+            c.buffering <- false;
+            if Generator.buffered_length c.generator > max_buffer then
+              Generator.remove c.generator
+                (Generator.length c.generator - max_buffer) ))
+  end

--- a/tests/media/test_ffmpeg_distributed_hls.liq
+++ b/tests/media/test_ffmpeg_distributed_hls.liq
@@ -1,0 +1,119 @@
+#!../../src/liquidsoap ../../libs/pervasives.liq
+%include "test.liq"
+
+set("log.level", 5)
+set("frame.audio.samplerate",48000)
+
+main_encoder =
+  %ffmpeg(
+    %audio(
+      codec="aac",
+      b="128k",
+      channels=2,
+      ar=44100
+    ),
+    %video(
+      codec="libx264",
+      b="5M",
+      flags="+global_header"
+    )
+  )
+
+mpegts = %ffmpeg(
+  format="mpegts",
+  %audio.copy, %video.copy)
+
+mp4 = %ffmpeg(
+  format="mp4",
+  movflags="+dash+skip_sidx+skip_trailer+frag_custom",
+  frag_duration=2,
+  %audio.copy, %video.copy)
+
+s = noise(duration=1.)
+
+encoded = ffmpeg.encode.audio_video(main_encoder, s)
+
+streams = [
+  ("mp4", mp4),
+  ("mpegts",mpegts)
+]
+
+is_ready = ref(false)
+
+def segment_name(~position,~extname,stream_name) =
+  is_ready := position > 1
+  timestamp = int_of_float(time())
+  "#{stream_name}_#{timestamp}_#{position}.#{extname}"
+end
+
+output_dir = file.temp_dir("liq","hls")
+
+def cleanup() =
+  file.rmdir(output_dir)
+end
+
+on_shutdown(cleanup)
+
+def check_stream(_) =
+  if !is_ready then
+    ojson = process.read("ffprobe -v quiet -print_format json -show_streams #{output_dir}/mp4.m3u8")
+
+    output_format = of_json(default=[("streams", [[("samplerate", "0")]])], ojson)
+
+    output_streams = list.assoc(default=[], "streams", output_format)
+
+    params = ["channel_layout", "sample_rate",
+              "sample_fmt", "codec_name", "pix_fmt"]
+
+    def m(s) =
+      def f(e) =
+        let (p, _) = e
+        list.mem(p, params)
+      end
+      list.filter(f, s)
+    end
+
+    output_streams = list.map(m, output_streams)
+
+    def cmp(c, c') =
+      if c < c' then
+        -1
+      elsif c' < c then
+        1
+      else
+        0
+      end
+    end
+
+    output_streams = list.map(list.sort(cmp), output_streams)
+
+    def cmd_l(l, l') =
+      cmp(list.assoc("codec_name", l), list.assoc("codec_name", l'))
+    end
+
+    output_streams = list.sort(cmd_l, output_streams)
+
+    expected = [
+      [("channel_layout", "stereo"), ("codec_name", "aac"), ("sample_fmt", "fltp"), ("sample_rate", "44100")],
+      [("codec_name", "h264"), ("pix_fmt", "yuv420p")]
+    ]
+
+    if output_streams == expected then
+      test.pass()
+    else
+      test.fail()
+    end
+  end
+end
+
+s.on_track(check_stream)
+
+output.file.hls(playlist="live.m3u8",
+                segment_duration=2.0,
+                segments=5,
+                segments_overhead=5,
+                segment_name=segment_name,
+                output_dir,
+                streams,
+                fallible=true,
+                encoded)


### PR DESCRIPTION
Test script:
```ruby
main_encoder =
  %ffmpeg(
    %audio(
      codec="aac",
      b="128k",
      channels=2,
      ar=44100
    ),
    %video(
      codec="h264_videotoolbox",
      b="5M",
      flags="+global_header"
    )
  )

mpegts = %ffmpeg(
  format="mpegts",
  %audio.copy, %video.copy)

mp4 = %ffmpeg(
  format="mp4",
  movflags="+dash+skip_sidx+skip_trailer+frag_custom",
  frag_duration=2,
  %audio.copy, %video.copy)

s = single("/tmp/bla.mkv")

encoded = ffmpeg.encode.audio_video(main_encoder, s)

streams = [
  ("mp4", mp4),
  ("mpegts",mpegts)
]

def segment_name(~position,~extname,stream_name) =
  timestamp = int_of_float(time())
  "#{stream_name}_#{timestamp}_#{position}.#{extname}"
end

output.file.hls(playlist="live.m3u8",
                segment_duration=2.0,
                segments=5,
                segments_overhead=5,
                segment_name=segment_name,
                "/tmp/hls",
                streams,
                fallible=true,
                encoded)
```