### PR TITLE
Ffmpeg raw inline converter

### DIFF
--- a/src/encoder/ffmpeg_encoder.ml
+++ b/src/encoder/ffmpeg_encoder.ml
@@ -38,7 +38,12 @@ let () =
                         ~get_data:(fun frame ->
                           Ffmpeg_copy_content.Audio.get_data
                             Frame.(frame.content.audio))
-                | _ -> Ffmpeg_internal_encoder.mk_audio
+                | None | Some (`Internal (Some _)) | Some (`Raw (Some _)) ->
+                    Ffmpeg_internal_encoder.mk_audio
+                | Some (`Internal None) ->
+                    failwith "%audio encoder expects a codec variable!"
+                | Some (`Raw None) ->
+                    failwith "%audio.raw encoder expects a codec variable!"
             in
             let mk_video =
               match m.Ffmpeg_format.video_codec with
@@ -57,7 +62,12 @@ let () =
                           params
                       in
                       Ffmpeg_copy_encoder.mk_stream_copy ~video_size ~get_data
-                | _ -> Ffmpeg_internal_encoder.mk_video
+                | None | Some (`Internal (Some _)) | Some (`Raw (Some _)) ->
+                    Ffmpeg_internal_encoder.mk_video
+                | Some (`Internal None) ->
+                    failwith "%video encoder expects a codec variable!"
+                | Some (`Raw None) ->
+                    failwith "%video.raw encoder expects a codec variable!"
             in
             encoder ~mk_audio ~mk_video m)
     | _ -> None)

--- a/src/encoder/ffmpeg_internal_encoder.ml
+++ b/src/encoder/ffmpeg_internal_encoder.ml
@@ -85,7 +85,7 @@ let write_audio_frame ~src_time_base ~dst_time_base ~target_samplerate
 let mk_audio ~ffmpeg ~options output =
   let codec =
     match ffmpeg.Ffmpeg_format.audio_codec with
-      | Some (`Raw codec) | Some (`Internal codec) ->
+      | Some (`Raw (Some codec)) | Some (`Internal (Some codec)) ->
           Avcodec.Audio.find_encoder codec
       | _ -> assert false
   in
@@ -230,7 +230,7 @@ let mk_audio ~ffmpeg ~options output =
 let mk_video ~ffmpeg ~options output =
   let codec =
     match ffmpeg.Ffmpeg_format.video_codec with
-      | Some (`Raw codec) | Some (`Internal codec) ->
+      | Some (`Raw (Some codec)) | Some (`Internal (Some codec)) ->
           Avcodec.Video.find_encoder codec
       | _ -> assert false
   in

--- a/src/encoder/ffmpeg_internal_encoder.ml
+++ b/src/encoder/ffmpeg_internal_encoder.ml
@@ -44,12 +44,8 @@ let get_channel_layout channels =
           %d channels.."
          channels)
 
-let write_audio_frame ~codec ~src_time_base ~dst_time_base ~target_samplerate
-    ~target_channel_layout ~target_sample_format ~get_frame_size write_frame =
-  let variable_frame_size =
-    List.mem `Variable_frame_size (Avcodec.Audio.capabilities codec)
-  in
-
+let write_audio_frame ~src_time_base ~dst_time_base ~target_samplerate
+    ~target_channel_layout ~target_sample_format ~frame_size write_frame =
   let nb_samples = ref 0L in
   let write_frame frame =
     let frame_pts =
@@ -62,30 +58,29 @@ let write_audio_frame ~codec ~src_time_base ~dst_time_base ~target_samplerate
     write_frame frame
   in
 
-  if variable_frame_size then write_frame
-  else (
-    let out_frame_size = get_frame_size () in
-
-    let in_params =
-      {
-        Avfilter.Utils.sample_rate = target_samplerate;
-        channel_layout = target_channel_layout;
-        sample_format = target_sample_format;
-      }
-    in
-    let filter_in, filter_out =
-      Avfilter.Utils.convert_audio ~in_params ~in_time_base:src_time_base
-        ~out_frame_size ()
-    in
-    let rec flush () =
-      try
-        write_frame (filter_out ());
-        flush ()
-      with Avutil.Error `Eagain -> ()
-    in
-    fun frame ->
-      filter_in frame;
-      flush () )
+  match frame_size with
+    | None -> write_frame
+    | Some out_frame_size ->
+        let in_params =
+          {
+            Avfilter.Utils.sample_rate = target_samplerate;
+            channel_layout = target_channel_layout;
+            sample_format = target_sample_format;
+          }
+        in
+        let filter_in, filter_out =
+          Avfilter.Utils.convert_audio ~in_params ~in_time_base:src_time_base
+            ~out_frame_size ()
+        in
+        let rec flush () =
+          try
+            write_frame (filter_out ());
+            flush ()
+          with Avutil.Error `Eagain -> ()
+        in
+        fun frame ->
+          filter_in frame;
+          flush ()
 
 let mk_audio ~ffmpeg ~options output =
   let codec =
@@ -206,11 +201,16 @@ let mk_audio ~ffmpeg ~options output =
 
   let was_keyframe () = false in
 
+  let frame_size =
+    if List.mem `Variable_frame_size (Avcodec.Audio.capabilities codec) then
+      None
+    else Some (Av.get_frame_size stream)
+  in
+
   let write_frame =
-    write_audio_frame ~codec ~src_time_base:target_liq_audio_sample_time_base
+    write_audio_frame ~src_time_base:target_liq_audio_sample_time_base
       ~dst_time_base:(Av.get_time_base stream) ~target_samplerate
-      ~target_channel_layout ~target_sample_format
-      ~get_frame_size:(fun () -> Av.get_frame_size stream)
+      ~target_channel_layout ~target_sample_format ~frame_size
       (Av.write_frame stream)
   in
 

--- a/src/lang/builtins_ffmpeg.ml
+++ b/src/lang/builtins_ffmpeg.ml
@@ -437,47 +437,48 @@ let mk_encoder mode =
         let write_audio_frame =
           if has_audio then (
             match format.Ffmpeg_format.audio_codec with
-              | Some (`Raw "none") when has_raw_audio ->
+              | Some (`Raw None) when has_raw_audio ->
                   Some
                     (write_audio_frame ~mode:`Raw ~opts:audio_opts ~format
                        control)
-              | Some (`Internal codec) when has_encoded_audio ->
+              | Some (`Internal (Some codec)) when has_encoded_audio ->
                   let codec = Avcodec.Audio.find_encoder codec in
                   Some
                     (write_audio_frame ~mode:`Encoded ~opts:audio_opts ~codec
                        ~format control)
               | _ ->
                   let encoder =
-                    if has_encoded_audio then "%audio"
-                    else "%audio.raw(codec=\"none\")"
+                    if has_encoded_audio then "%audio(codec=..., ...)"
+                    else "%audio.raw"
                   in
                   raise
                     (Lang_errors.Invalid_value
-                       (format_val, "Operator expects a " ^ encoder ^ " encoder"))
-            )
+                       ( format_val,
+                         "Operator expects an encoder of the form: " ^ encoder
+                       )) )
           else None
         in
         let write_video_frame =
           if has_video then (
             match format.Ffmpeg_format.video_codec with
-              | Some (`Raw "none") when has_raw_video ->
+              | Some (`Raw None) when has_raw_video ->
                   Some
                     (write_video_frame ~mode:`Raw ~opts:video_opts ~format
                        control)
-              | Some (`Internal codec) when has_encoded_video ->
+              | Some (`Internal (Some codec)) when has_encoded_video ->
                   let codec = Avcodec.Video.find_encoder codec in
                   Some
                     (write_video_frame ~mode:`Encoded ~opts:video_opts ~codec
                        ~format control)
               | _ ->
                   let encoder =
-                    if has_encoded_video then "%video"
-                    else "%video.raw(codec=\"none\")"
+                    if has_encoded_video then "%video" else "%video.raw"
                   in
                   raise
                     (Lang_errors.Invalid_value
-                       (format_val, "Operator expects a " ^ encoder ^ " encoder"))
-            )
+                       ( format_val,
+                         "Operator expects an encoder of the form: " ^ encoder
+                       )) )
           else None
         in
         fun frame ->

--- a/src/lang/builtins_ffmpeg.ml
+++ b/src/lang/builtins_ffmpeg.ml
@@ -127,7 +127,6 @@ let write_audio_frame ~kind_t ~mode ~opts ?codec ~format c =
       ~target_channel_layout:channel_layout ~target_sample_format:sample_format
       ~frame_size write_frame
   in
-  Printf.printf "here..\n%!";
 
   fun frame ->
     let frame = InternalResampler.convert resampler (AFrame.pcm frame) in

--- a/src/lang/builtins_ffmpeg.ml
+++ b/src/lang/builtins_ffmpeg.ml
@@ -25,7 +25,7 @@ module InternalResampler =
 
 module InternalScaler = Swscale.Make (Swscale.BigArray) (Swscale.Frame)
 
-let write_audio_frame ~opts ~codec ~format c =
+let write_audio_frame ~mode ~opts ?codec ~format c =
   let src_channel_layout =
     Avutil.Channel_layout.get_default (Lazy.force Frame.audio_channels)
   in
@@ -34,15 +34,81 @@ let write_audio_frame ~opts ~codec ~format c =
   let channel_layout = Avutil.Channel_layout.get_default channels in
   let sample_rate = Lazy.force format.Ffmpeg_format.samplerate in
   let time_base = { Avutil.num = 1; den = sample_rate } in
-  let get_duration = Ffmpeg_decoder_common.convert_duration ~src:time_base in
-  let sample_format = Avcodec.Audio.find_best_sample_format codec `Dbl in
 
-  let encoder =
-    Avcodec.Audio.create_encoder ~opts ~channel_layout ~channels ~sample_format
-      ~sample_rate ~time_base codec
+  let last_pts = ref None in
+
+  let pts_duration ~get_duration pts =
+    let d =
+      match (!last_pts, pts) with
+        | Some old_pts, Some new_pts ->
+            get_duration (Some (Int64.sub new_pts old_pts))
+        | _ -> 0
+    in
+    last_pts := pts;
+    d
   in
 
-  let encoder_time_base = Avcodec.time_base encoder in
+  let sample_format, frame_size, write_frame =
+    match mode with
+      | `Encoded ->
+          let codec = Option.get codec in
+          let sample_format =
+            Avcodec.Audio.find_best_sample_format codec `Dbl
+          in
+          let encoder =
+            Avcodec.Audio.create_encoder ~opts ~channel_layout ~channels
+              ~sample_format ~sample_rate ~time_base codec
+          in
+          let encoder_time_base = Avcodec.time_base encoder in
+          let get_duration =
+            Ffmpeg_decoder_common.convert_duration ~src:encoder_time_base
+          in
+          ( sample_format,
+            ( if List.mem `Variable_frame_size (Avcodec.Audio.capabilities codec)
+            then None
+            else Some (Avcodec.Audio.frame_size encoder) ),
+            Avcodec.encode encoder (fun packet ->
+                let duration =
+                  try get_duration (Avcodec.Packet.get_duration packet)
+                  with _ ->
+                    pts_duration ~get_duration (Avcodec.Packet.get_pts packet)
+                in
+                let packet =
+                  { Ffmpeg_copy_content.packet; time_base = encoder_time_base }
+                in
+                let data =
+                  {
+                    Ffmpeg_content_base.params = Some (Avcodec.params encoder);
+                    data = [(0, packet)];
+                  }
+                in
+                let data = Ffmpeg_copy_content.Audio.lift_data data in
+                Producer_consumer.(
+                  Generator.put_audio c.generator data 0 duration)) )
+      | `Raw ->
+          let sample_format = `Dbl in
+          let params =
+            {
+              Ffmpeg_raw_content.AudioSpecs.channel_layout = Some channel_layout;
+              sample_format = Some sample_format;
+              sample_rate = Some sample_rate;
+            }
+          in
+          let get_duration =
+            Ffmpeg_decoder_common.convert_duration ~src:time_base
+          in
+          ( sample_format,
+            None,
+            fun frame ->
+              let duration =
+                pts_duration ~get_duration (Avutil.frame_pts frame)
+              in
+              let frame = { Ffmpeg_raw_content.time_base; frame } in
+              let data = { Ffmpeg_content_base.params; data = [(0, frame)] } in
+              let data = Ffmpeg_raw_content.Audio.lift_data data in
+              Producer_consumer.(
+                Generator.put_audio c.generator data 0 duration) )
+  in
 
   let resampler =
     InternalResampler.create ~out_sample_format:sample_format src_channel_layout
@@ -50,30 +116,18 @@ let write_audio_frame ~opts ~codec ~format c =
   in
 
   let write_ffmpeg_frame =
-    Ffmpeg_internal_encoder.write_audio_frame ~codec ~src_time_base:time_base
+    Ffmpeg_internal_encoder.write_audio_frame ~src_time_base:time_base
       ~dst_time_base:time_base ~target_samplerate:sample_rate
       ~target_channel_layout:channel_layout ~target_sample_format:sample_format
-      ~get_frame_size:(fun () -> Avcodec.Audio.frame_size encoder)
-      (Avcodec.encode encoder (fun packet ->
-           let duration = get_duration (Avcodec.Packet.get_duration packet) in
-           let packet =
-             { Ffmpeg_copy_content.packet; time_base = encoder_time_base }
-           in
-           let data =
-             {
-               Ffmpeg_content_base.params = Some (Avcodec.params encoder);
-               data = [(0, packet)];
-             }
-           in
-           let data = Ffmpeg_copy_content.Audio.lift_data data in
-           Producer_consumer.(Generator.put_audio c.generator data 0 duration)))
+      ~frame_size write_frame
   in
+  Printf.printf "here..\n%!";
 
   fun frame ->
     let frame = InternalResampler.convert resampler (AFrame.pcm frame) in
     write_ffmpeg_frame frame
 
-let write_video_frame ~opts ~codec ~format c =
+let write_video_frame ~mode ~opts ?codec ~format c =
   let pixel_aspect = { Avutil.num = 1; den = 1 } in
 
   let pixel_format =
@@ -82,16 +136,8 @@ let write_video_frame ~opts ~codec ~format c =
   let target_fps = Lazy.force format.Ffmpeg_format.framerate in
   let frame_rate = { Avutil.num = target_fps; den = 1 } in
   let time_base = { Avutil.num = 1; den = target_fps } in
-  let get_duration = Ffmpeg_decoder_common.convert_duration ~src:time_base in
   let width = Lazy.force format.Ffmpeg_format.width in
   let height = Lazy.force format.Ffmpeg_format.height in
-
-  let encoder =
-    Avcodec.Video.create_encoder ~opts ~frame_rate ~pixel_format ~width ~height
-      ~time_base codec
-  in
-
-  let encoder_time_base = Avcodec.time_base encoder in
 
   let flag =
     match Ffmpeg_utils.conf_scaling_algorithm#get with
@@ -116,37 +162,75 @@ let write_video_frame ~opts ~codec ~format c =
 
   let last_pts = ref None in
 
+  let pts_duration ~get_duration pts =
+    let d =
+      match (!last_pts, pts) with
+        | Some old_pts, Some new_pts ->
+            get_duration (Some (Int64.sub new_pts old_pts))
+        | _ -> 0
+    in
+    last_pts := pts;
+    d
+  in
+
+  let write_frame =
+    match mode with
+      | `Encoded ->
+          let encoder =
+            Avcodec.Video.create_encoder ~opts ~frame_rate ~pixel_format ~width
+              ~height ~time_base (Option.get codec)
+          in
+
+          let encoder_time_base = Avcodec.time_base encoder in
+
+          let get_duration =
+            Ffmpeg_decoder_common.convert_duration ~src:encoder_time_base
+          in
+          Avcodec.encode encoder (fun packet ->
+              let duration =
+                try get_duration (Avcodec.Packet.get_duration packet)
+                with _ ->
+                  pts_duration ~get_duration (Avcodec.Packet.get_pts packet)
+              in
+              Avcodec.Packet.set_duration packet (Some (Int64.of_int duration));
+              let packet =
+                { Ffmpeg_copy_content.packet; time_base = encoder_time_base }
+              in
+              let data =
+                {
+                  Ffmpeg_content_base.params = Some (Avcodec.params encoder);
+                  data = [(0, packet)];
+                }
+              in
+              let data = Ffmpeg_copy_content.Video.lift_data data in
+              Producer_consumer.(
+                Generator.put_video c.generator data 0 duration))
+      | `Raw ->
+          let params =
+            {
+              Ffmpeg_raw_content.VideoSpecs.width = Some width;
+              height = Some height;
+              pixel_format = Some pixel_format;
+            }
+          in
+          let get_duration =
+            Ffmpeg_decoder_common.convert_duration ~src:time_base
+          in
+          fun frame ->
+            let duration =
+              pts_duration ~get_duration (Avutil.frame_pts frame)
+            in
+            let frame = { Ffmpeg_raw_content.time_base; frame } in
+            let data = { Ffmpeg_content_base.params; data = [(0, frame)] } in
+            let data = Ffmpeg_raw_content.Video.lift_data data in
+            Producer_consumer.(Generator.put_video c.generator data 0 duration)
+  in
+
   (* We don't know packet duration in advance so we have to infer
      it from the next packet. *)
   let write_ffmpeg_frame frame =
     Ffmpeg_utils.Fps.convert fps_converter frame (fun ~time_base:_ frame ->
-        Avcodec.encode encoder
-          (fun packet ->
-            let pts = Avcodec.Packet.get_pts packet in
-            let duration =
-              match (Avcodec.Packet.get_duration packet, pts, !last_pts) with
-                | Some d, _, _ -> d
-                | None, Some current_pts, Some last_pts ->
-                    let d = Int64.sub current_pts last_pts in
-                    Avcodec.Packet.set_duration packet (Some d);
-                    d
-                | _ -> 0L
-            in
-            last_pts := pts;
-            let packet =
-              { Ffmpeg_copy_content.packet; time_base = encoder_time_base }
-            in
-            let data =
-              {
-                Ffmpeg_content_base.params = Some (Avcodec.params encoder);
-                data = [(0, packet)];
-              }
-            in
-            let data = Ffmpeg_copy_content.Video.lift_data data in
-            Producer_consumer.(
-              Generator.put_video c.generator data 0
-                (get_duration (Some duration))))
-          frame)
+        write_frame frame)
   in
 
   let nb_frames = ref 0L in
@@ -169,36 +253,100 @@ let write_video_frame ~opts ~codec ~format c =
 
 let () =
   Lang.add_module "ffmpeg";
-  Lang.add_module "ffmpeg.encode"
+  Lang.add_module "ffmpeg.encode";
+  Lang.add_module "ffmpeg.raw"
 
 let mk_encoder mode =
+  let has_audio =
+    List.mem mode [`Audio_encoded; `Audio_raw; `Both_encoded; `Both_raw]
+  in
+  let has_video =
+    List.mem mode [`Video_encoded; `Video_raw; `Both_encoded; `Both_raw]
+  in
+  let has_encoded_audio = List.mem mode [`Audio_encoded; `Both_encoded] in
+  let has_raw_audio = List.mem mode [`Audio_raw; `Both_raw] in
+  let has_encoded_video = List.mem mode [`Video_encoded; `Both_encoded] in
+  let has_raw_video = List.mem mode [`Video_raw; `Both_raw] in
   let source_kind =
     Frame.
       {
-        audio = (if mode = `Audio || mode = `Both then audio_pcm else none);
-        video = (if mode = `Video || mode = `Both then video_yuv420p else none);
+        audio = (if has_audio then audio_pcm else none);
+        video = (if has_video then video_yuv420p else none);
         midi = none;
       }
   in
   let source_t = Lang.kind_type_of_kind_format source_kind in
+  let source_kind_t = Lang.of_frame_kind_t source_t in
+  let format_kind =
+    Frame.
+      {
+        audio =
+          ( match mode with
+            | `Audio_encoded | `Both_encoded -> source_kind.Frame.audio
+            | `Audio_raw | `Both_raw -> `Kind Ffmpeg_raw_content.Audio.kind
+            | _ -> none );
+        video =
+          ( match mode with
+            | `Video_encoded | `Both_encoded -> source_kind.Frame.video
+            | `Video_raw | `Both_raw -> `Kind Ffmpeg_raw_content.Video.kind
+            | _ -> none );
+        midi = none;
+      }
+  in
+  let format_t =
+    Lang.frame_kind_t
+      ~audio:
+        ( match mode with
+          | `Audio_encoded | `Both_encoded -> source_kind_t.Frame.audio
+          | `Audio_raw | `Both_raw ->
+              Lang.kind_t (`Kind Ffmpeg_raw_content.Audio.kind)
+          | _ -> Lang.kind_none_t )
+      ~video:
+        ( match mode with
+          | `Video_encoded | `Both_encoded -> source_kind_t.Frame.video
+          | `Video_raw | `Both_raw ->
+              Lang.kind_t (`Kind Ffmpeg_raw_content.Video.kind)
+          | _ -> Lang.kind_none_t )
+      ~midi:Lang.kind_none_t
+  in
+  let format_kind_t = Lang.of_frame_kind_t format_t in
   let return_kind =
     Frame.
       {
         audio =
-          ( if mode = `Audio || mode = `Both then
-            `Kind Ffmpeg_copy_content.Audio.kind
-          else none );
+          ( match mode with
+            | `Audio_encoded | `Both_encoded ->
+                `Kind Ffmpeg_copy_content.Audio.kind
+            | `Audio_raw | `Both_raw -> format_kind.Frame.audio
+            | _ -> none );
         video =
-          ( if mode = `Video || mode = `Both then
-            `Kind Ffmpeg_copy_content.Video.kind
-          else none );
+          ( match mode with
+            | `Video_encoded | `Both_encoded ->
+                `Kind Ffmpeg_copy_content.Video.kind
+            | `Video_raw | `Both_raw -> format_kind.Frame.video
+            | _ -> none );
         midi = none;
       }
   in
-  let return_t = Lang.kind_type_of_kind_format return_kind in
+  let return_t =
+    Lang.frame_kind_t
+      ~audio:
+        ( match mode with
+          | `Audio_encoded | `Both_encoded ->
+              Lang.kind_t (`Kind Ffmpeg_copy_content.Audio.kind)
+          | `Audio_raw | `Both_raw -> format_kind_t.Frame.audio
+          | _ -> Lang.kind_none_t )
+      ~video:
+        ( match mode with
+          | `Video_encoded | `Both_encoded ->
+              Lang.kind_t (`Kind Ffmpeg_copy_content.Video.kind)
+          | `Video_raw | `Both_raw -> format_kind_t.Frame.video
+          | _ -> Lang.kind_none_t )
+      ~midi:Lang.kind_none_t
+  in
   let proto =
     [
-      ("", Lang.format_t source_t, None, Some "Encoding format.");
+      ("", Lang.format_t format_t, None, Some "Encoding format.");
       ("", Lang.source_t source_t, None, None);
       ( "buffer",
         Lang.float_t,
@@ -212,13 +360,15 @@ let mk_encoder mode =
   in
   let extension =
     match mode with
-      | `Audio -> "audio"
-      | `Video -> "video"
-      | `Both -> "audio_video"
+      | `Audio_encoded -> "encode.audio"
+      | `Audio_raw -> "raw.audio"
+      | `Video_encoded -> "encode.video"
+      | `Video_raw -> "raw.video"
+      | `Both_encoded -> "encode.audio_video"
+      | `Both_raw -> "raw.audio_video"
   in
-  Lang.add_operator ("ffmpeg.encode." ^ extension)
-    proto ~return_t ~category:Lang.Conversions
-    ~descr:"Encode a source's content" (fun p ->
+  Lang.add_operator ("ffmpeg." ^ extension) proto ~return_t
+    ~category:Lang.Conversions ~descr:"Convert a source's content" (fun p ->
       let pre_buffer = Lang.to_float (List.assoc "buffer" p) in
       let max_buffer = Lang.to_float (List.assoc "max" p) in
       let max_buffer = max max_buffer (pre_buffer *. 1.1) in
@@ -238,9 +388,9 @@ let mk_encoder mode =
             generator =
               Generator.create
                 ( match mode with
-                  | `Audio -> `Audio
-                  | `Video -> `Video
-                  | `Both -> `Both );
+                  | `Audio_raw | `Audio_encoded -> `Audio
+                  | `Video_raw | `Video_encoded -> `Video
+                  | `Both_raw | `Both_encoded -> `Both );
             lock = Mutex.create ();
             buffering = true;
             abort = false;
@@ -248,7 +398,9 @@ let mk_encoder mode =
       in
       let producer =
         new Producer_consumer.producer
-          ~kind:return_kind ~name:"ffmpeg.encode.producer" control
+          ~kind:return_kind
+          ~name:("ffmpeg." ^ extension ^ ".producer")
+          control
       in
 
       if Hashtbl.length format.Ffmpeg_format.other_opts > 0 then
@@ -271,37 +423,61 @@ let mk_encoder mode =
 
       let original_opts = Hashtbl.create 10 in
 
-      if mode = `Audio || mode = `Both then
-        Hashtbl.iter (Hashtbl.add original_opts) format.Ffmpeg_format.audio_opts;
+      if has_audio then
+        Hashtbl.iter
+          (fun name value -> Hashtbl.add original_opts ("audio: " ^ name) value)
+          format.Ffmpeg_format.audio_opts;
 
-      if mode = `Video || mode = `Both then
-        Hashtbl.iter (Hashtbl.add original_opts) format.Ffmpeg_format.video_opts;
+      if has_video then
+        Hashtbl.iter
+          (fun name value -> Hashtbl.add original_opts ("video: " ^ name) value)
+          format.Ffmpeg_format.video_opts;
 
       let write_frame =
         let write_audio_frame =
-          if mode = `Audio || mode = `Both then (
-            let codec =
-              match format.Ffmpeg_format.audio_codec with
-                | Some (`Internal codec) -> Avcodec.Audio.find_encoder codec
-                | _ ->
-                    raise
-                      (Lang_errors.Invalid_value
-                         (format_val, "Operator expects a %audio encoder"))
-            in
-            Some (write_audio_frame ~opts:audio_opts ~codec ~format control) )
+          if has_audio then (
+            match format.Ffmpeg_format.audio_codec with
+              | Some (`Raw "none") when has_raw_audio ->
+                  Some
+                    (write_audio_frame ~mode:`Raw ~opts:audio_opts ~format
+                       control)
+              | Some (`Internal codec) when has_encoded_audio ->
+                  let codec = Avcodec.Audio.find_encoder codec in
+                  Some
+                    (write_audio_frame ~mode:`Encoded ~opts:audio_opts ~codec
+                       ~format control)
+              | _ ->
+                  let encoder =
+                    if has_encoded_audio then "%audio"
+                    else "%audio.raw(codec=\"none\")"
+                  in
+                  raise
+                    (Lang_errors.Invalid_value
+                       (format_val, "Operator expects a " ^ encoder ^ " encoder"))
+            )
           else None
         in
         let write_video_frame =
-          if mode = `Video || mode = `Both then (
-            let codec =
-              match format.Ffmpeg_format.video_codec with
-                | Some (`Internal codec) -> Avcodec.Video.find_encoder codec
-                | _ ->
-                    raise
-                      (Lang_errors.Invalid_value
-                         (format_val, "Operator expects a %video encoder"))
-            in
-            Some (write_video_frame ~opts:video_opts ~codec ~format control) )
+          if has_video then (
+            match format.Ffmpeg_format.video_codec with
+              | Some (`Raw "none") when has_raw_video ->
+                  Some
+                    (write_video_frame ~mode:`Raw ~opts:video_opts ~format
+                       control)
+              | Some (`Internal codec) when has_encoded_video ->
+                  let codec = Avcodec.Video.find_encoder codec in
+                  Some
+                    (write_video_frame ~mode:`Encoded ~opts:video_opts ~codec
+                       ~format control)
+              | _ ->
+                  let encoder =
+                    if has_encoded_video then "%video"
+                    else "%video.raw(codec=\"none\")"
+                  in
+                  raise
+                    (Lang_errors.Invalid_value
+                       (format_val, "Operator expects a " ^ encoder ^ " encoder"))
+            )
           else None
         in
         fun frame ->
@@ -311,11 +487,17 @@ let mk_encoder mode =
 
       let () =
         let left_over_opts = Hashtbl.create 10 in
-        if mode = `Audio || mode = `Both then
-          Hashtbl.iter (Hashtbl.add left_over_opts) audio_opts;
+        if has_audio then
+          Hashtbl.iter
+            (fun name value ->
+              Hashtbl.add left_over_opts ("audio: " ^ name) value)
+            audio_opts;
 
-        if mode = `Video || mode = `Both then
-          Hashtbl.iter (Hashtbl.add left_over_opts) video_opts;
+        if has_video then
+          Hashtbl.iter
+            (fun name value ->
+              Hashtbl.add left_over_opts ("video: " ^ name) value)
+            video_opts;
 
         Hashtbl.filter_map_inplace
           (fun l v -> if Hashtbl.mem left_over_opts l then Some v else None)
@@ -331,10 +513,20 @@ let mk_encoder mode =
 
       let _ =
         new Producer_consumer.consumer
-          ~write_frame ~producer ~output_kind:"ffmpeg.encode.consumer"
+          ~write_frame ~producer
+          ~output_kind:("ffmpeg." ^ extension ^ ".consumer")
           ~kind:source_kind ~content:`Audio ~max_buffer ~pre_buffer ~source
           control
       in
       producer)
 
-let () = List.iter mk_encoder [`Audio; `Video; `Both]
+let () =
+  List.iter mk_encoder
+    [
+      `Audio_encoded;
+      `Audio_raw;
+      `Video_encoded;
+      `Video_raw;
+      `Both_encoded;
+      `Both_raw;
+    ]

--- a/src/lang/lang_parser.mly
+++ b/src/lang/lang_parser.mly
@@ -730,9 +730,13 @@ ffmpeg_list_elem:
   | AUDIO_NONE                        { `Audio_none }
   | AUDIO_COPY                        { `Audio_copy }
   | AUDIO_RAW LPAR ffmpeg_params RPAR { `Audio_raw $3 }
+  /* This is for inline encoders. */
+  | AUDIO_RAW                         { `Audio_raw [] }
   | AUDIO LPAR ffmpeg_params RPAR     { `Audio  $3 }
   | VIDEO_NONE                        { `Video_none }
   | VIDEO_COPY                        { `Video_copy }
+  /* This is for inline encoders. */
+  | VIDEO_RAW                         { `Video_raw [] }
   | VIDEO_RAW LPAR ffmpeg_params RPAR { `Video_raw  $3 }
   | VIDEO LPAR ffmpeg_params RPAR     { `Video  $3 }
   | ffmpeg_param                      { `Option $1 }

--- a/src/lang_encoders/lang_ffmpeg.ml
+++ b/src/lang_encoders/lang_ffmpeg.ml
@@ -82,13 +82,13 @@ let ffmpeg_gen params =
         let f =
           match (mode, format) with
             | `Audio, `Internal ->
-                { f with Ffmpeg_format.audio_codec = Some (`Internal c) }
+                { f with Ffmpeg_format.audio_codec = Some (`Internal (Some c)) }
             | `Audio, `Raw ->
-                { f with Ffmpeg_format.audio_codec = Some (`Raw c) }
+                { f with Ffmpeg_format.audio_codec = Some (`Raw (Some c)) }
             | `Video, `Internal ->
-                { f with Ffmpeg_format.video_codec = Some (`Internal c) }
+                { f with Ffmpeg_format.video_codec = Some (`Internal (Some c)) }
             | `Video, `Raw ->
-                { f with Ffmpeg_format.video_codec = Some (`Raw c) }
+                { f with Ffmpeg_format.video_codec = Some (`Raw (Some c)) }
         in
         parse_args ~format ~mode f l
     | (k, { term = Ground (String s); _ }) :: l ->
@@ -112,12 +112,24 @@ let ffmpeg_gen params =
     (fun f -> function
       | `Audio_none -> { f with Ffmpeg_format.audio_codec = None; channels = 0 }
       | `Audio_copy -> { f with Ffmpeg_format.audio_codec = Some `Copy }
-      | `Audio_raw l -> parse_args ~format:`Raw ~mode:`Audio f l
-      | `Audio l -> parse_args ~format:`Internal ~mode:`Audio f l
+      | `Audio_raw l ->
+          let f = { f with Ffmpeg_format.audio_codec = Some (`Raw None) } in
+          parse_args ~format:`Raw ~mode:`Audio f l
+      | `Audio l ->
+          let f =
+            { f with Ffmpeg_format.audio_codec = Some (`Internal None) }
+          in
+          parse_args ~format:`Internal ~mode:`Audio f l
       | `Video_none -> { f with Ffmpeg_format.video_codec = None }
       | `Video_copy -> { f with Ffmpeg_format.video_codec = Some `Copy }
-      | `Video_raw l -> parse_args ~format:`Raw ~mode:`Video f l
-      | `Video l -> parse_args ~format:`Internal ~mode:`Video f l
+      | `Video_raw l ->
+          let f = { f with Ffmpeg_format.video_codec = Some (`Raw None) } in
+          parse_args ~format:`Raw ~mode:`Video f l
+      | `Video l ->
+          let f =
+            { f with Ffmpeg_format.video_codec = Some (`Internal None) }
+          in
+          parse_args ~format:`Internal ~mode:`Video f l
       | `Option ("format", { term = Ground (String s); _ })
       | `Option ("format", { term = Var s; _ })
         when s = "none" ->

--- a/src/stream/generator.mli
+++ b/src/stream/generator.mli
@@ -48,7 +48,7 @@ module type S = sig
   val remove : t -> int -> unit
 
   (** Add metadata. *)
-  val add_metadata : t -> Frame.metadata -> unit
+  val add_metadata : ?pos:int -> t -> Frame.metadata -> unit
 end
 
 (** Content-agnostic generator. *)
@@ -134,10 +134,10 @@ module From_frames : sig
   val remaining : t -> int
 
   (** Add metadata at the current position. *)
-  val add_metadata : t -> Frame.metadata -> unit
+  val add_metadata : ?pos:int -> t -> Frame.metadata -> unit
 
   (** Add a break at the current position. *)
-  val add_break : t -> unit
+  val add_break : ?pos:int -> t -> unit
 
   (** Remove data. *)
   val remove : t -> int -> unit
@@ -173,8 +173,8 @@ module type S_Asio = sig
 
   val clear : t -> unit
   val fill : t -> Frame.t -> unit
-  val add_metadata : t -> Frame.metadata -> unit
-  val add_break : ?sync:bool -> t -> unit
+  val add_metadata : ?pos:int -> t -> Frame.metadata -> unit
+  val add_break : ?sync:bool -> ?pos:int -> t -> unit
   val put_audio : ?pts:int64 -> t -> Frame_content.data -> int -> int -> unit
   val put_video : ?pts:int64 -> t -> Frame_content.data -> int -> int -> unit
   val set_mode : t -> [ `Audio | `Video | `Both | `Undefined ] -> unit
@@ -228,12 +228,13 @@ module From_audio_video : sig
   (** Duration of data (in ticks) before the next break, -1 if there's none. *)
   val remaining : t -> int
 
-  (** Add metadata at the minimum position of audio and video. You probably want
-      to call this when there is as much audio as video. *)
-  val add_metadata : t -> Frame.metadata -> unit
+  (** Add metadata at the minimum position of audio and video. [pos] is an
+      offset from the current buffer's length and defaults to [0]. *)
+  val add_metadata : ?pos:int -> t -> Frame.metadata -> unit
 
-  (** Add a track limit. Audio and video length should be equal. *)
-  val add_break : ?sync:bool -> t -> unit
+  (** Add a track limit. [pos] is an offset from the current buffer's length and
+      defaults to [0]. *)
+  val add_break : ?sync:bool -> ?pos:int -> t -> unit
 
   (* [put_audio ?pts buffer data offset length]: offset and length
    * are in master ticks ! *)
@@ -283,8 +284,8 @@ module From_audio_video_plus : sig
   val length : t -> int
   val remaining : t -> int
   val set_rewrite_metadata : t -> (Frame.metadata -> Frame.metadata) -> unit
-  val add_metadata : t -> Frame.metadata -> unit
-  val add_break : ?sync:bool -> t -> unit
+  val add_metadata : ?pos:int -> t -> Frame.metadata -> unit
+  val add_break : ?sync:bool -> ?pos:int -> t -> unit
 
   (* [put_audio ?pts buffer data offset length]:
    * offset and length are in master ticks! *)

--- a/tests/media/Makefile
+++ b/tests/media/Makefile
@@ -3,7 +3,7 @@
 DISTFILES = Makefile $(wildcard *.sh) $(wildcard *.liq *.liq.in)
 top_srcdir = $(shell realpath ../..)
 
-test: test_encoder test_stereo test_mono test_ffmpeg_audio_decoder test_ffmpeg_video_decoder test_ffmpeg_filter test_ffmpeg_copy_decoder test_ffmpeg_copy_and_encode_decoder test_ffmpeg_raw_decoder test_ffmpeg_raw_and_encode_decoder test_ffmpeg_raw_and_copy_decoder test_ffmpeg_distributed_hls test_gstreamer_audio_decoder test_gstreamer_video_decoder # test_stream_audio test_stream_video
+test: test_encoder test_stereo test_mono test_ffmpeg_audio_decoder test_ffmpeg_video_decoder test_ffmpeg_filter test_ffmpeg_copy_decoder test_ffmpeg_copy_and_encode_decoder test_ffmpeg_raw_decoder test_ffmpeg_raw_and_encode_decoder test_ffmpeg_raw_and_copy_decoder test_ffmpeg_raw_hls test_ffmpeg_distributed_hls test_gstreamer_audio_decoder test_gstreamer_video_decoder # test_stream_audio test_stream_video
 
 AUDIO_TEST_FORMATS = \
   @flac(stereo).flac \
@@ -131,5 +131,8 @@ test_gstreamer_video_decoder: $(ENCODED_VIDEO_FILES) $(top_srcdir)/src/liquidsoa
 
 test_ffmpeg_distributed_hls:
 	../run_test.sh "$(top_srcdir)/src/liquidsoap --no-pervasives $(top_srcdir)/libs/pervasives.liq -" media/test_ffmpeg_distributed_hls.liq
+
+test_ffmpeg_raw_hls:
+	../run_test.sh "$(top_srcdir)/src/liquidsoap --no-pervasives $(top_srcdir)/libs/pervasives.liq -" media/test_ffmpeg_raw_hls.liq
 
 include $(top_srcdir)/Makefile.rules

--- a/tests/media/test_ffmpeg_distributed_hls.liq
+++ b/tests/media/test_ffmpeg_distributed_hls.liq
@@ -4,6 +4,12 @@
 set("log.level", 5)
 set("frame.audio.samplerate",48000)
 
+debian_version = process.run("cat /etc/os-release | grep VERSION_ID | cut -d'=' -f 2")
+
+if "#{debian_version}" == "\"10\"" then
+  test.skip()
+end
+
 main_encoder =
   %ffmpeg(
     %audio(

--- a/tests/media/test_ffmpeg_distributed_hls.liq
+++ b/tests/media/test_ffmpeg_distributed_hls.liq
@@ -4,9 +4,9 @@
 set("log.level", 5)
 set("frame.audio.samplerate",48000)
 
-debian_version = process.run("cat /etc/os-release | grep VERSION_ID | cut -d'=' -f 2")
+debian_version = string.trim(process.run("cat /etc/os-release | grep VERSION_ID | cut -d'=' -f 2 | xargs").stdout)
 
-if "#{debian_version}" == "\"10\"" then
+if debian_version == "10" then
   test.skip()
 end
 

--- a/tests/media/test_ffmpeg_raw_hls.liq
+++ b/tests/media/test_ffmpeg_raw_hls.liq
@@ -4,7 +4,7 @@
 set("log.level", 5)
 set("frame.audio.samplerate",48000)
 
-raw_encoder = %ffmpeg(%audio.raw(codec="none"),%video.raw(codec="none"))
+raw_encoder = %ffmpeg(%audio.raw,%video.raw)
 
 mpegts = %ffmpeg(
   format="mpegts",

--- a/tests/media/test_ffmpeg_raw_hls.liq
+++ b/tests/media/test_ffmpeg_raw_hls.liq
@@ -4,6 +4,12 @@
 set("log.level", 5)
 set("frame.audio.samplerate",48000)
 
+debian_version = process.run("cat /etc/os-release | grep VERSION_ID | cut -d'=' -f 2")
+
+if "#{debian_version}" == "\"10\"" then
+  test.skip()
+end
+
 raw_encoder = %ffmpeg(%audio.raw,%video.raw)
 
 mpegts = %ffmpeg(

--- a/tests/media/test_ffmpeg_raw_hls.liq
+++ b/tests/media/test_ffmpeg_raw_hls.liq
@@ -1,0 +1,128 @@
+#!../../src/liquidsoap ../../libs/pervasives.liq
+%include "test.liq"
+
+set("log.level", 5)
+set("frame.audio.samplerate",48000)
+
+raw_encoder = %ffmpeg(%audio.raw(codec="none"),%video.raw(codec="none"))
+
+mpegts = %ffmpeg(
+  format="mpegts",
+  %audio.raw(
+    codec="aac",
+    b="128k",
+    channels=2,
+    ar=44100
+  ),
+  %video.raw(
+    codec="libx264",
+    b="5M",
+    flags="+global_header"
+  )
+)
+
+mp4 = %ffmpeg(
+  format="mp4",
+  movflags="+dash+skip_sidx+skip_trailer+frag_custom",
+  frag_duration=2,
+  %audio.raw(
+    codec="aac",
+    b="128k",
+    channels=2,
+    ar=44100
+  ),
+  %video.raw(
+    codec="libx264",
+    b="5M",
+    flags="+global_header"
+  )
+)
+
+s = noise(duration=1.)
+
+raw = ffmpeg.raw.audio_video(raw_encoder, s)
+
+streams = [
+  ("mp4", mp4),
+  ("mpegts",mpegts)
+]
+
+is_ready = ref(false)
+
+def segment_name(~position,~extname,stream_name) =
+  is_ready := position > 2
+  timestamp = int_of_float(time())
+  "#{stream_name}_#{timestamp}_#{position}.#{extname}"
+end
+
+output_dir = file.temp_dir("liq","hls")
+
+def cleanup() =
+  file.rmdir(output_dir)
+end
+
+on_shutdown(cleanup)
+
+def check_stream(_) =
+  if !is_ready then
+    ojson = process.read("ffprobe -v quiet -print_format json -show_streams #{output_dir}/mp4.m3u8")
+
+    output_format = of_json(default=[("streams", [[("samplerate", "0")]])], ojson)
+
+    output_streams = list.assoc(default=[], "streams", output_format)
+
+    params = ["channel_layout", "sample_rate",
+              "sample_fmt", "codec_name", "pix_fmt"]
+
+    def m(s) =
+      def f(e) =
+        let (p, _) = e
+        list.mem(p, params)
+      end
+      list.filter(f, s)
+    end
+
+    output_streams = list.map(m, output_streams)
+
+    def cmp(c, c') =
+      if c < c' then
+        -1
+      elsif c' < c then
+        1
+      else
+        0
+      end
+    end
+
+    output_streams = list.map(list.sort(cmp), output_streams)
+
+    def cmd_l(l, l') =
+      cmp(list.assoc("codec_name", l), list.assoc("codec_name", l'))
+    end
+
+    output_streams = list.sort(cmd_l, output_streams)
+
+    expected = [
+      [("channel_layout", "stereo"), ("codec_name", "aac"), ("sample_fmt", "fltp"), ("sample_rate", "44100")],
+      [("codec_name", "h264"), ("pix_fmt", "yuv420p")]
+    ]
+
+    if output_streams == expected then
+      test.pass()
+    else
+      test.fail()
+    end
+  end
+end
+
+s.on_track(check_stream)
+
+output.file.hls(playlist="live.m3u8",
+                segment_duration=2.0,
+                segments=5,
+                segments_overhead=5,
+                segment_name=segment_name,
+                output_dir,
+                streams,
+                fallible=true,
+                raw)

--- a/tests/media/test_ffmpeg_raw_hls.liq
+++ b/tests/media/test_ffmpeg_raw_hls.liq
@@ -4,9 +4,9 @@
 set("log.level", 5)
 set("frame.audio.samplerate",48000)
 
-debian_version = process.run("cat /etc/os-release | grep VERSION_ID | cut -d'=' -f 2")
+debian_version = string.trim(process.run("cat /etc/os-release | grep VERSION_ID | cut -d'=' -f 2 | xargs").stdout)
 
-if "#{debian_version}" == "\"10\"" then
+if debian_version == "10" then
   test.skip()
 end
 

--- a/tests/run_test.sh
+++ b/tests/run_test.sh
@@ -33,7 +33,7 @@ fi
 
 if [ "${STATUS}" == "2" ]; then
     echo -e "\033[1;33m[skipped]\033[0m"
-    exit 2
+    exit 0
 fi
 
 echo -e "\033[0;31m[failed]\033[0m"


### PR DESCRIPTION
Test script:
```ruby
raw_encoder = %ffmpeg(%audio.raw,%video.raw)

mpegts = %ffmpeg(
  format="mpegts",
  %audio.raw(
    codec="aac",
    b="128k",
    channels=2,
    ar=44100
  ),
  %video.raw(
    codec="libx264",
    b="5M",
    flags="+global_header"
  )
)

mp4 = %ffmpeg(
  format="mp4",
  movflags="+dash+skip_sidx+skip_trailer+frag_custom",
  frag_duration=2,
  %audio.raw(
    codec="aac",
    b="128k",
    channels=2,
    ar=44100
  ),
  %video.raw(
    codec="libx264",
    b="5M",
    flags="+global_header"
  )
)

s = ....

raw = ffmpeg.raw.audio_video(raw_encoder, s)

streams = [
  ("mp4", mp4),
  ("mpegts",mpegts)
]

def segment_name(~position,~extname,stream_name) =
  timestamp = int_of_float(time())
  "#{stream_name}_#{timestamp}_#{position}.#{extname}"
end

output.file.hls(playlist="live.m3u8",
                segment_duration=2.0,
                segments=5,
                segments_overhead=5,
                segment_name=segment_name,
                "/tmp/hls",
                streams,
                fallible=true,
                raw)
```