### PR TITLE
Support for hardware acceleration.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@ New:
 - Add support for `x ? y : z` syntax (#1266).
 - Added support for list spread and deconstruction syntax (#1269).
 - Added support for video encoding and decoding using `ffmpeg` (#1038).
+- Added support for hardware-accelerated video encoding using `ffmpeg` (#1380)
 - Added support for ffmpeg filters (#1038).
 - Added video support to `output.hls` (#1391).
 - Added mp4 support to `output.hls` (#1391).

--- a/src/encoder/ffmpeg_internal_encoder.ml
+++ b/src/encoder/ffmpeg_internal_encoder.ml
@@ -29,7 +29,7 @@ module RawResampler = Swresample.Make (Swresample.Frame) (Swresample.Frame)
 module InternalScaler = Swscale.Make (Swscale.BigArray) (Swscale.Frame)
 module RawScaler = Swscale.Make (Swscale.Frame) (Swscale.Frame)
 
-let log = Log.make ["ffmpeg"; "decoder"; "internal"]
+let log = Log.make ["ffmpeg"; "encoder"; "internal"]
 
 (* mk_stream is used for the copy encoder, where stream creation has to be
    delayed until the first packet is passed. This is not needed here. *)
@@ -241,6 +241,9 @@ let mk_video ~ffmpeg ~options output =
   let target_video_frame_time_base = { Avutil.num = 1; den = target_fps } in
   let target_width = Lazy.force ffmpeg.Ffmpeg_format.width in
   let target_height = Lazy.force ffmpeg.Ffmpeg_format.height in
+  let target_pixel_format =
+    Avutil.Pixel_format.of_string ffmpeg.Ffmpeg_format.pixel_format
+  in
 
   let flag =
     match Ffmpeg_utils.conf_scaling_algorithm#get with
@@ -254,10 +257,14 @@ let mk_video ~ffmpeg ~options output =
   Hashtbl.iter (Hashtbl.add opts) ffmpeg.Ffmpeg_format.video_opts;
   Hashtbl.iter (Hashtbl.add opts) options;
 
+  let hardware_context, target_pixel_format =
+    Ffmpeg_utils.mk_hardware_context ~opts ~target_pixel_format ~target_width
+      ~target_height codec
+  in
+
   let stream =
     Av.new_video_stream ~time_base:target_video_frame_time_base
-      ~pixel_format:
-        (Avutil.Pixel_format.of_string ffmpeg.Ffmpeg_format.pixel_format)
+      ~pixel_format:target_pixel_format ?hardware_context
       ~frame_rate:{ Avutil.num = target_fps; den = 1 }
       ~width:target_width ~height:target_height ~opts ~codec output
   in

--- a/src/encoder/ffmpeg_internal_encoder.ml
+++ b/src/encoder/ffmpeg_internal_encoder.ml
@@ -257,9 +257,12 @@ let mk_video ~ffmpeg ~options output =
   Hashtbl.iter (Hashtbl.add opts) ffmpeg.Ffmpeg_format.video_opts;
   Hashtbl.iter (Hashtbl.add opts) options;
 
+  let hwaccel = ffmpeg.Ffmpeg_format.hwaccel in
+  let hwaccel_device = ffmpeg.Ffmpeg_format.hwaccel_device in
+
   let hardware_context, target_pixel_format =
-    Ffmpeg_utils.mk_hardware_context ~opts ~target_pixel_format ~target_width
-      ~target_height codec
+    Ffmpeg_utils.mk_hardware_context ~hwaccel ~hwaccel_device ~opts
+      ~target_pixel_format ~target_width ~target_height codec
   in
 
   let stream =

--- a/src/lang/builtins_ffmpeg.ml
+++ b/src/lang/builtins_ffmpeg.ml
@@ -180,10 +180,17 @@ let write_video_frame ~kind_t ~mode ~opts ?codec ~format c =
       | `Encoded -> (
           let stream_idx = Ffmpeg_copy_content.new_stream_idx () in
 
+          let codec = Option.get codec in
+
+          let hardware_context, target_pixel_format =
+            Ffmpeg_utils.mk_hardware_context ~opts ~target_pixel_format
+              ~target_width ~target_height codec
+          in
+
           let encoder =
-            Avcodec.Video.create_encoder ~opts ~frame_rate:target_frame_rate
-              ~pixel_format:target_pixel_format ~width:target_width
-              ~height:target_height ~time_base (Option.get codec)
+            Avcodec.Video.create_encoder ?hardware_context ~opts
+              ~frame_rate:target_frame_rate ~pixel_format:target_pixel_format
+              ~width:target_width ~height:target_height ~time_base codec
           in
 
           let params = Some (Avcodec.params encoder) in

--- a/src/lang/builtins_ffmpeg.ml
+++ b/src/lang/builtins_ffmpeg.ml
@@ -182,9 +182,12 @@ let write_video_frame ~kind_t ~mode ~opts ?codec ~format c =
 
           let codec = Option.get codec in
 
+          let hwaccel = format.Ffmpeg_format.hwaccel in
+          let hwaccel_device = format.Ffmpeg_format.hwaccel_device in
+
           let hardware_context, target_pixel_format =
-            Ffmpeg_utils.mk_hardware_context ~opts ~target_pixel_format
-              ~target_width ~target_height codec
+            Ffmpeg_utils.mk_hardware_context ~hwaccel ~hwaccel_device ~opts
+              ~target_pixel_format ~target_width ~target_height codec
           in
 
           let encoder =

--- a/src/lang_encoders/lang_ffmpeg.ml
+++ b/src/lang_encoders/lang_ffmpeg.ml
@@ -37,6 +37,8 @@ let ffmpeg_gen params =
       pixel_format = "yuv420p";
       audio_codec = None;
       video_codec = None;
+      hwaccel = `Auto;
+      hwaccel_device = None;
       audio_opts = Hashtbl.create 0;
       video_opts = Hashtbl.create 0;
       other_opts = Hashtbl.create 0;
@@ -77,6 +79,19 @@ let ffmpeg_gen params =
     | ("pixel_format", { term = Ground (String p); _ }) :: l when mode = `Video
       ->
         parse_args ~format ~mode { f with Ffmpeg_format.pixel_format = p } l
+    | ("hwaccel", { term = Var "auto"; _ }) :: l when mode = `Video ->
+        parse_args ~format ~mode { f with Ffmpeg_format.hwaccel = `Auto } l
+    | ("hwaccel", { term = Var "none"; _ }) :: l when mode = `Video ->
+        parse_args ~format ~mode { f with Ffmpeg_format.hwaccel = `None } l
+    | ("hwaccel_device", { term = Var "none"; _ }) :: l when mode = `Video ->
+        parse_args ~format ~mode
+          { f with Ffmpeg_format.hwaccel_device = None }
+          l
+    | ("hwaccel_device", { term = Ground (String d); _ }) :: l
+      when mode = `Video ->
+        parse_args ~format ~mode
+          { f with Ffmpeg_format.hwaccel_device = Some d }
+          l
     (* Shared options *)
     | ("codec", { term = Ground (String c); _ }) :: l ->
         let f =

--- a/src/tools/ffmpeg_utils.ml
+++ b/src/tools/ffmpeg_utils.ml
@@ -188,6 +188,7 @@ let mk_hardware_context ~hwaccel ~hwaccel_device ~opts ~target_pixel_format
   let codec_name = Avcodec.name codec in
   let no_hardware_context = (None, target_pixel_format) in
   try
+    if hwaccel = `None then raise (Found no_hardware_context);
     let hw_configs = Avcodec.hw_configs codec in
     let find hw_method cb =
       ignore

--- a/src/tools/ffmpeg_utils.mli
+++ b/src/tools/ffmpeg_utils.mli
@@ -34,6 +34,14 @@ val liq_frame_time_base : unit -> Avutil.rational
 val convert_time_base :
   src:Avutil.rational -> dst:Avutil.rational -> int64 -> int64
 
+val mk_hardware_context :
+  opts:Avutil.opts ->
+  target_pixel_format:Avutil.Pixel_format.t ->
+  target_width:int ->
+  target_height:int ->
+  ([< `Audio | `Video ], Avcodec.encode) Avcodec.codec ->
+  Avcodec.Video.hardware_context option * Avutil.Pixel_format.t
+
 module Fps : sig
   type t
 

--- a/src/tools/ffmpeg_utils.mli
+++ b/src/tools/ffmpeg_utils.mli
@@ -35,6 +35,8 @@ val convert_time_base :
   src:Avutil.rational -> dst:Avutil.rational -> int64 -> int64
 
 val mk_hardware_context :
+  hwaccel:Ffmpeg_format.hwaccel ->
+  hwaccel_device:string option ->
   opts:Avutil.opts ->
   target_pixel_format:Avutil.Pixel_format.t ->
   target_width:int ->


### PR DESCRIPTION
Should be automatic whenever using a hardware-enabled codec, e.g. `h264_nvenc`

Test script:
```
s =  single("/tmp/bla.mkv")

# Default, automatic detection
e = %ffmpeg(%video(codec="h264_nvenc"))

# Disable
%ffmpeg(%video(codec="h264_nvenc", hwaccel=none))

# Specify a device
%ffmpeg(%video(codec="h264_nvenc", hwaccel_device="1"))

output.file(e, "/tmp/blo.mkv", single("/tmp/bla.mkv"))
```