### PR TITLE
Don't require source methods by default.

### DIFF
--- a/libs/fades.liq
+++ b/libs/fades.liq
@@ -8,6 +8,7 @@ fade = ()
 # @param ~duration Duration in seconds.
 # @param ~on_done Function to execute when the fade is finished
 def mkfade(~type="lin",~start=0.,~stop=1.,~duration=3.,~on_done={()},s) =
+  ignore((s : source_methods))
   log = log(label="mkfade")
 
   # Shape functions must map 0. -> 0. and 1. -> 1.
@@ -280,6 +281,8 @@ def crossfade(~duration=5.,~override_duration="liq_cross_duration",
   end
 
   def smart_transition(a,b,ma,mb,sa,sb)
+    ignore((sa : source_methods))
+    ignore((sb : source_methods))
 
     list.iter(fun(x)-> log(level=4,"Before: #{x}"),ma)
     list.iter(fun(x)-> log(level=4,"After : #{x}"),mb)

--- a/libs/switches.liq
+++ b/libs/switches.liq
@@ -142,6 +142,8 @@ def replaces random(~id="", ~override="liq_transition_length", ~replay_metadata=
   end
 
   def add_condition(index, s) =
+    ignore ((s : source_methods))
+
     def f(_) =
       next_index := -1
     end 

--- a/src/lang/lang.ml
+++ b/src/lang/lang.ml
@@ -796,6 +796,10 @@ let source_t ?(methods = false) ?active t =
     method_t t (List.map (fun (name, t, _) -> (name, t)) source_methods)
   else t
 
+let () =
+  Lang_values.source_methods_t :=
+    fun () -> source_t ~methods:true (kind_type_of_kind_format any)
+
 let source v =
   meth (source v) (List.map (fun (name, _, fn) -> (name, fn v)) source_methods)
 

--- a/src/lang/lang.ml
+++ b/src/lang/lang.ml
@@ -790,9 +790,11 @@ let source_methods =
             float (frame_position +. in_frame_position)) );
   ]
 
-let source_t ?active t =
-  method_t (source_t ?active t)
-    (List.map (fun (name, t, _) -> (name, t)) source_methods)
+let source_t ?(methods = false) ?active t =
+  let t = source_t ?active t in
+  if methods then
+    method_t t (List.map (fun (name, t, _) -> (name, t)) source_methods)
+  else t
 
 let source v =
   meth (source v) (List.map (fun (name, _, fn) -> (name, fn v)) source_methods)
@@ -851,7 +853,7 @@ let add_operator =
         | Source.Kind.Conflict (a, b) ->
             raise (Lang_errors.Kind_conflict (pos, a, b))
     in
-    let return_t = source_t ~active return_t in
+    let return_t = source_t ~methods:true ~active return_t in
     let return_t =
       method_t return_t (List.map (fun (name, typ, _) -> (name, typ)) meth)
     in

--- a/src/lang/lang.mli
+++ b/src/lang/lang.mli
@@ -237,7 +237,7 @@ val of_list_t : t -> t
 val nullable_t : t -> t
 val ref_t : t -> t
 val request_t : t
-val source_t : ?active:bool -> t -> t
+val source_t : ?methods:bool -> ?active:bool -> t -> t
 val of_source_t : t -> t
 val format_t : t -> t
 val kind_t : Frame.kind -> t

--- a/src/lang/lang_parser.mly
+++ b/src/lang/lang_parser.mly
@@ -314,6 +314,7 @@
       | "int" -> Lang_types.make (Lang_types.Ground Lang_types.Int)
       | "float" -> Lang_types.make (Lang_types.Ground Lang_types.Float)
       | "string" -> Lang_types.make (Lang_types.Ground Lang_types.String)
+      | "source_methods" -> !Lang_values.source_methods_t ()
       | _ -> raise (Parse_error (pos, "Unknown type constructor."))
 %}
 

--- a/src/lang/lang_types.ml
+++ b/src/lang/lang_types.ml
@@ -936,20 +936,17 @@ let rec ( <: ) a b =
               raise (Error (`Tuple (l @ [a] @ l'), `Tuple (l @ [b] @ l'))))
           l m
     | Arrow (l12, t), Arrow (l, t') ->
-        (* Here, it must be that l12 = l1@l2
-         * where l1 is essentially l modulo order
-         * and either l2 is erasable and t<:t'
-         *        or (l2)->t <: t'. *)
+        (* Here, it must be that l12 = l1@l2 where l1 is essentially l modulo
+           order and either l2 is erasable and t<:t' or (l2)->t <: t'. *)
         let ellipsis = (false, "", `Range_Ellipsis) in
         let elide (o, l, _) = (o, l, `Ellipsis) in
         let l1, l2 =
           List.fold_left
-            (* Start with [l2:=l12], [l1:=[]] and
-             * move each param [o,lbl] required by [l] from [l2] to [l1]. *)
+            (* Start with [l2:=l12], [l1:=[]] and move each param [o,lbl]
+               required by [l] from [l2] to [l1]. *)
               (fun (l1, l2) (o, lbl, t) ->
-              (* Search for a param with optionality o and label lbl.
-               * Returns the first matching parameter
-               * and the list without it. *)
+              (* Search for a param with optionality o and label lbl. Returns
+                 the first matching parameter and the list without it. *)
               let rec get_param acc = function
                 | [] ->
                     raise
@@ -967,7 +964,7 @@ let rec ( <: ) a b =
               let (o, lbl, t'), l2' = get_param [] l2 in
               (* Check on-the-fly that the types match. *)
               begin
-                try t <: t'
+                try t' <: t
                 with Error (t, t') ->
                   let make t =
                     `Arrow (List.rev (ellipsis :: (o, lbl, t) :: l1), `Ellipsis)
@@ -1032,8 +1029,8 @@ let rec ( <: ) a b =
     | Meth (l, _, u1), _ -> hide_meth l u1 <: b
     | Link _, _ | _, Link _ -> assert false (* thanks to deref *)
     | _, _ ->
-        (* The superficial representation is enough for explaining
-         * the mismatch. *)
+        (* The superficial representation is enough for explaining the
+           mismatch. *)
         let filter () =
           let already = ref false in
           function

--- a/src/lang/lang_values.ml
+++ b/src/lang/lang_values.ml
@@ -135,6 +135,9 @@ let source_t ?(active = false) ?pos ?level k =
   let name = if active then "active_source" else "source" in
   T.make ?pos ?level (T.Constr { T.name; T.params = [(T.Invariant, k)] })
 
+(* Filled in later to avoid dependency cycles. *)
+let source_methods_t = ref (fun () : Lang_types.t -> assert false)
+
 let of_source_t t =
   match (T.deref t).T.descr with
     | T.Constr { T.name = "source"; T.params = [(_, t)] } -> t

--- a/tests/language/typing.liq
+++ b/tests/language/typing.liq
@@ -117,11 +117,23 @@ def f() =
   # source is not an Ord
   # echo(blank()==blank())
 
-  # Ensure that we have correct subtyping for arguments (which should be
-  # contravariant, see #1465).
-  def f(x) = "" ^ x end
+  # Test record subtyping.
+  def f(x) =
+    "" ^ x
+  end
   ignore(f("a".{n = 3}))
-  
+  # Ensure that we have correct subtyping for arguments, which should be
+  # contravariant, see #1465.
+  # We have string.{l : int} < string
+  # Thus    (string) -> int  < (string.{l : int}) -> int
+  def g(f) =
+    f("a".{l = 3})
+  end
+  def f(x) =
+    0
+  end
+  ignore(g(f))
+
   def sum_eq(a,b)
     a+b == a
   end

--- a/tests/language/typing.liq
+++ b/tests/language/typing.liq
@@ -116,6 +116,11 @@ def f() =
   
   # source is not an Ord
   # echo(blank()==blank())
+
+  # Ensure that we have correct subtyping for arguments (which should be
+  # contravariant, see #1465).
+  def f(x) = "" ^ x end
+  ignore(f("a".{n = 3}))
   
   def sum_eq(a,b)
     a+b == a


### PR DESCRIPTION
By subtyping, it is not nececessary to require the methods for source arguments.

With this patch the type of `amplify` changes from
```
(?id : string, ?override : string?, {float},
 source(audio='b, video='c, midi='d)
 .{
   time : () -> float,
   shutdown : () -> unit,
   fallible : () -> bool,
   skip : () -> unit,
   seek : (float) -> float,
   is_up : () -> bool,
   remaining : () -> float,
   on_track : ((([string * string]) -> unit)) -> unit,
   on_shutdown : ((() -> unit)) -> unit,
   on_metadata : ((([string * string]) -> unit)) -> unit,
   is_ready : () -> bool,
   id : (() -> string)
 }) -> source(audio='b, video='c, midi='d)
.{
  time : () -> float,
  shutdown : () -> unit,
  fallible : () -> bool,
  skip : () -> unit,
  seek : (float) -> float,
  is_up : () -> bool,
  remaining : () -> float,
  on_track : ((([string * string]) -> unit)) -> unit,
  on_shutdown : ((() -> unit)) -> unit,
  on_metadata : ((([string * string]) -> unit)) -> unit,
  is_ready : () -> bool,
  id : (() -> string)}
```
to
```
(?id : string, ?override : string?, {float},
 source(audio='b, video='c, midi='d)) -> source(audio='b,
video='c, midi='d)
.{
  time : () -> float,
  shutdown : () -> unit,
  fallible : () -> bool,
  skip : () -> unit,
  seek : (float) -> float,
  is_up : () -> bool,
  remaining : () -> float,
  on_track : ((([string * string]) -> unit)) -> unit,
  on_shutdown : ((() -> unit)) -> unit,
  on_metadata : ((([string * string]) -> unit)) -> unit,
  is_ready : () -> bool,
  id : (() -> string)}
```
which is arguably more readable...