### PR TITLE
Print methods separately

### DIFF
--- a/src/lang/lang.ml
+++ b/src/lang/lang.ml
@@ -228,6 +228,26 @@ let builtin_type p t =
 
 let to_plugin_doc category flags main_doc proto return_t =
   let item = new Doc.item ~sort:false main_doc in
+  let meths, return_t =
+    let rec aux t =
+      match (T.deref t).T.descr with
+        | T.Meth (l, mt, t) ->
+            let m, t = aux t in
+            ((l, mt) :: m, t)
+        | _ -> ([], t)
+    in
+    aux return_t
+  in
+  let meths =
+    let meths_items = new Doc.item "" in
+    List.iter
+      (fun (m, (generalized, t)) ->
+        let i = new Doc.item "" in
+        i#add_subsection "type" (T.doc_of_type ~generalized t);
+        meths_items#add_subsection m i)
+      meths;
+    meths_items
+  in
   let t = builtin_type proto return_t in
   let generalized = T.filter_vars (fun _ -> true) t in
   item#add_subsection "_category" (Doc.trivial category);
@@ -235,6 +255,7 @@ let to_plugin_doc category flags main_doc proto return_t =
   List.iter
     (fun f -> item#add_subsection "_flag" (Doc.trivial (string_of_flag f)))
     flags;
+  item#add_subsection "_methods" meths;
   List.iter
     (fun (l, t, d, doc) ->
       item#add_subsection

--- a/src/lang/lang.ml
+++ b/src/lang/lang.ml
@@ -238,16 +238,6 @@ let to_plugin_doc category flags main_doc proto return_t =
     in
     aux return_t
   in
-  let meths =
-    let meths_items = new Doc.item "" in
-    List.iter
-      (fun (m, (generalized, t)) ->
-        let i = new Doc.item "" in
-        i#add_subsection "type" (T.doc_of_type ~generalized t);
-        meths_items#add_subsection m i)
-      meths;
-    meths_items
-  in
   let t = builtin_type proto return_t in
   let generalized = T.filter_vars (fun _ -> true) t in
   item#add_subsection "_category" (Doc.trivial category);
@@ -255,7 +245,15 @@ let to_plugin_doc category flags main_doc proto return_t =
   List.iter
     (fun f -> item#add_subsection "_flag" (Doc.trivial (string_of_flag f)))
     flags;
-  item#add_subsection "_methods" meths;
+  if meths <> [] then (
+    let items = new Doc.item ~sort:false "" in
+    List.iter
+      (fun (m, (generalized, t)) ->
+        let i = new Doc.item ~sort:false "" in
+        i#add_subsection "type" (T.doc_of_type ~generalized t);
+        items#add_subsection m i)
+      meths;
+    item#add_subsection "_methods" items );
   List.iter
     (fun (l, t, d, doc) ->
       item#add_subsection

--- a/src/lang/lang_types.ml
+++ b/src/lang/lang_types.ml
@@ -208,8 +208,10 @@ let rec invoke t l =
     | Meth (_, _, t) -> invoke t l
     | _ -> raise Not_found
 
+(** Add a method. *)
 let meth ?pos ?level l v t = make ?pos ?level (Meth (l, v, t))
 
+(** Add methods. *)
 let rec meths ?pos ?level l v t =
   match l with
     | [] -> assert false

--- a/src/tools/doc.ml
+++ b/src/tools/doc.ml
@@ -254,6 +254,12 @@ let print_lang (i : item) =
       List.remove_assoc "_category" sub
     with Not_found -> sub
   in
+  let meths, sub =
+    try
+      ( (List.assoc "_methods" sub)#get_subsections,
+        List.remove_assoc "_methods" sub )
+    with Not_found -> ([], sub)
+  in
   let rec print_flags sub =
     try
       Format.fprintf ff "Flag: %s@." (List.assoc "_flag" sub)#get_doc;
@@ -270,6 +276,12 @@ let print_lang (i : item) =
         if i#get_doc <> "(no doc)" then
           Format.fprintf ff "@[<5>     %a@]@." print_string_split i#get_doc)
       sub );
+  if meths <> [] then (
+    Format.fprintf ff "@.Methods:@.";
+    List.iter
+      (fun (l, i) ->
+        Format.fprintf ff "@. * %s : %s@." l (i#get_subsection "type")#get_doc)
+      meths );
   Format.fprintf ff "@.";
   Format.pp_print_flush ff ();
   Utils.print_string ~pager:true (Buffer.contents b)

--- a/src/tools/doc.ml
+++ b/src/tools/doc.ml
@@ -105,11 +105,19 @@ let print_functions (doc : item) print_string =
   let add (f, _) = functions := f :: !functions in
   List.iter add doc;
   let functions = List.sort compare !functions in
-  List.iter print_string functions
+  List.iter
+    (fun s ->
+      print_string s;
+      print_string "\n")
+    functions
 
 let print_functions_md ~extra (doc : item) print_string =
   let doc = to_json doc in
-  let to_assoc = function `Assoc l -> l | _ -> assert false in
+  let to_assoc = function
+    | `Assoc l -> l
+    | `String "" -> []
+    | _ -> assert false
+  in
   let to_string = function `String s -> s | _ -> assert false in
   let doc = List.assoc "scripting values" (to_assoc doc) in
   let doc = List.tl (to_assoc doc) in
@@ -143,11 +151,21 @@ let print_functions_md ~extra (doc : item) print_string =
               (to_string (List.assoc "_info" desc));
             Printf.ksprintf print_string "Type:\n```\n%s\n```\n\n"
               (to_string (List.assoc "_type" desc));
+            let methods =
+              let methods =
+                try List.assoc "_methods" desc |> to_assoc
+                with Not_found -> []
+              in
+              let methods = List.filter (fun (n, _) -> n <> "_info") methods in
+              List.map
+                (fun (l, m) -> (l, List.assoc "type" (to_assoc m) |> to_string))
+                methods
+            in
             let args =
               List.filter
                 (fun (n, _) ->
                   n <> "_info" && n <> "_category" && n <> "_type"
-                  && n <> "_flag")
+                  && n <> "_flag" && n <> "_methods")
                 desc
             in
             let args =
@@ -172,6 +190,12 @@ let print_functions_md ~extra (doc : item) print_string =
                 Printf.ksprintf print_string "- `%s` (of type `%s`%s)%s\n" n t d
                   s)
               args;
+            if methods <> [] then (
+              print_string "\nMethods:\n\n";
+              List.iter
+                (fun (l, t) ->
+                  Printf.ksprintf print_string "- `%s` (of type `%s`)\n" l t)
+                methods );
             if List.mem "experimental" flags then
               print_string "\nThis function is experimental.\n";
             print_string "\n" ))


### PR DESCRIPTION
Documents returned methods outside the type. For instance, the doc of `amplify` was
```
Multiply the amplitude of the signal.

Type: (?id : string, ?override : string?, {float},
 source(audio='b, video='c, midi='d)) -> source(audio='b, video='c, midi='d)
.{
  time : () -> float,
  shutdown : () -> unit,
  fallible : () -> bool,
  skip : () -> unit,
  seek : (float) -> float,
  is_up : () -> bool,
  remaining : () -> float,
  on_track : ((([string * string]) -> unit)) -> unit,
  on_shutdown : ((() -> unit)) -> unit,
  on_metadata : ((([string * string]) -> unit)) -> unit,
  is_ready : () -> bool,
  id : (() -> string)}

Category: Source / Sound Processing

Parameters:

 * id : string (default: "")
     Force the value of the source ID.

 * override : string? (default: "liq_amplify")
     Specify the name of a metadata field that, when present and well-formed,
     overrides the amplification factor for the current track. Well-formed
     values are floats in decimal notation (e.g. `0.7`) which are taken as
     normal/linear multiplicative factors; values can be passed in decibels
     with the suffix `dB` (e.g. `-8.2 dB`, but the spaces do not matter).

 * (unlabeled) : {float} (default: None)
     Multiplicative factor.

 * (unlabeled) : source(audio='b, video='c, midi='d) (default: None)
```
and with this PR it becomes
```
Multiply the amplitude of the signal.

Type: (?id : string, ?override : string?, {float},
 source(audio='b, video='c, midi='d)) -> source(audio='b, video='c, midi='d)

Category: Source / Sound Processing

Parameters:

 * id : string (default: "")
     Force the value of the source ID.

 * override : string? (default: "liq_amplify")
     Specify the name of a metadata field that, when present and well-formed,
     overrides the amplification factor for the current track. Well-formed
     values are floats in decimal notation (e.g. `0.7`) which are taken as
     normal/linear multiplicative factors; values can be passed in decibels
     with the suffix `dB` (e.g. `-8.2 dB`, but the spaces do not matter).

 * (unlabeled) : {float} (default: None)
     Multiplicative factor.

 * (unlabeled) : source(audio='b, video='c, midi='d) (default: None)

Methods:

 * id : () -> string

 * is_ready : () -> bool

 * on_metadata : ((([string * string]) -> unit)) -> unit

 * on_shutdown : ((() -> unit)) -> unit

 * on_track : ((([string * string]) -> unit)) -> unit

 * remaining : () -> float

 * is_up : () -> bool

 * seek : (float) -> float

 * skip : () -> unit

 * fallible : () -> bool

 * shutdown : () -> unit

 * time : () -> float
```
(the above example supposes that #1465 has been merged).

Next step would be to add proper documentation for methods, but this PR gets readability of documentation back to acceptable I think.