### PR TITLE
Add support for documenting methods.

### DIFF
--- a/libs/playlist.liq
+++ b/libs/playlist.liq
@@ -11,6 +11,7 @@
 # @param ~on_done Function executed when the playlist is finished.
 # @param ~timeout Timeout (in sec.) for a single download.
 # @param playlist Playlist.
+# @method reload Reload the playlist with given songs.
 def playlist.list(~id="playlist.list.reloadable", ~check_next=fun(_)->true, ~conservative=false, ~default_duration=30., ~length=10., ~loop=true, ~mime_type="", ~mode="normal", ~on_done={()}, ~timeout=20., playlist)
   mode = if not list.mem(mode, ["normal", "random", "randomize"]) then log.severe(label=id, "Invalid mode: #{mode}"); "randomize" else mode end
 
@@ -101,6 +102,7 @@ end
 # @param ~prefix Add a constant prefix to all requests. Useful for passing extra information using annotate, or for resolution through a particular protocol, such as replaygain.
 # @param ~timeout Timeout (in sec.) for a single download.
 # @param uri Playlist URI.
+# @method reload Reload the playlist.
 def playlist.reloadable(~id="playlist.reloadable", ~check_next=fun(_)->true, ~conservative=false, ~default_duration=30., ~length=10., ~loop=true, ~mime_type="", ~mode="randomize", ~on_done={()}, ~prefix="", ~timeout=20., uri)
   # URI of the current playlist
   playlist_uri=ref(uri)

--- a/libs/request.liq
+++ b/libs/request.liq
@@ -1,4 +1,3 @@
-# TODO: use a record to push........
 let request.queue = ()
 
 # Play request dynamically created by a given function.
@@ -24,6 +23,7 @@ end
 # @param ~length How much audio (in sec.) should be queued in advance.
 # @param ~queue Initial queue of requests.
 # @param ~timeout Timeout (in sec.) for a single download.
+# @method push Push an uri on the request queue.
 def request.queue(~id="", ~conservative=false, ~default_duration=30., ~interactive=true, ~length=40., ~queue=[], ~timeout=20.)
   queue = ref(queue)
   def next()

--- a/src/lang/lang_parser.mly
+++ b/src/lang/lang_parser.mly
@@ -166,7 +166,7 @@
     let list_var_name = "_" in
     let list_var () = mk ~pos (Var list_var_name) in
     let mk_let ~pos var def body =
-       mk_let ~pos ((Doc.none (), []), false, PVar [var], def) body
+       mk_let ~pos ((Doc.none (), [], []), false, PVar [var], def) body
     in
     let body =
       match dots with
@@ -331,7 +331,8 @@
 %token WAV AVI FDKAAC MP3 MP3_VBR MP3_ABR SHINE EXTERNAL
 %token EOF
 %token BEGIN END REC GETS TILD QUESTION LET
-%token <Doc.item * (string*string) list> DEF
+/* name, arguments, methods */
+%token <Doc.item * (string*string) list * (string*string) list> DEF
 %token REPLACES
 %token COALESCE
 %token TRY CATCH IN DO
@@ -622,9 +623,9 @@ pattern_list:
   | pattern COMMA pattern_list { $1::$3 }
 
 binding:
-  | bindvar GETS expr { (Doc.none (),[]),false,PVar [$1],$3 }
-  | LET replaces pattern GETS expr { (Doc.none (),[]),$2,$3,$5 }
-  | LET replaces subfield GETS expr { (Doc.none (),[]),$2,PVar $3,$5 }
+  | bindvar GETS expr { (Doc.none (),[],[]),false,PVar [$1],$3 }
+  | LET replaces pattern GETS expr { (Doc.none (),[],[]),$2,$3,$5 }
+  | LET replaces subfield GETS expr { (Doc.none (),[],[]),$2,PVar $3,$5 }
   | DEF replaces pattern g exprs END {
       let body = $5 in
       $1,$2,$3,body

--- a/src/lang/lang_types.ml
+++ b/src/lang/lang_types.ml
@@ -880,11 +880,12 @@ let doc_of_type ~generalized t =
   Format.pp_set_margin Format.str_formatter margin;
   Doc.trivial (Format.flush_str_formatter ())
 
-let doc_of_meths m =
+let doc_of_meths ?(description = []) m =
   let items = new Doc.item "" in
   List.iter
     (fun (m, (generalized, t)) ->
-      let i = new Doc.item ~sort:false "" in
+      let description = try List.assoc m description with Not_found -> "" in
+      let i = new Doc.item ~sort:false description in
       i#add_subsection "type" (doc_of_type ~generalized t);
       items#add_subsection m i)
     m;

--- a/src/lang/lang_types.mli
+++ b/src/lang/lang_types.mli
@@ -86,7 +86,9 @@ val pp_type_generalized : var list -> Format.formatter -> t -> unit
 val print : ?generalized:var list -> t -> string
 val print_scheme : scheme -> string
 val doc_of_type : generalized:var list -> t -> Doc.item
-val doc_of_meths : (string * scheme) list -> Doc.item
+
+val doc_of_meths :
+  ?description:(string * string) list -> (string * scheme) list -> Doc.item
 
 exception Occur_check of t * t
 

--- a/src/lang/lang_values.ml
+++ b/src/lang/lang_values.ml
@@ -263,7 +263,8 @@ end
 type term = { mutable t : T.t; term : in_term }
 
 and let_t = {
-  doc : Doc.item * (string * string) list;
+  doc : Doc.item * (string * string) list * (string * string) list;
+  (* name, arguments, methods *)
   replace : bool;
   (* whether the definition replaces a previously existing one (keeping methods) *)
   pat : pattern;
@@ -1166,7 +1167,7 @@ let eval ?env tm =
 (** Add toplevel definitions to [builtins] so they can be looked during the
     evaluation of the next scripts. Also try to generate a structured
     documentation from the source code. *)
-let toplevel_add (doc, params) pat ~t v =
+let toplevel_add (doc, params, methods) pat ~t v =
   let generalized, t = t in
   let rec ptypes t =
     match (T.deref t).T.descr with
@@ -1225,7 +1226,8 @@ let toplevel_add (doc, params) pat ~t v =
        | _ -> (meths, t)
    in
    doc#add_subsection "_type" (T.doc_of_type ~generalized t);
-   if meths <> [] then doc#add_subsection "_methods" (T.doc_of_meths meths));
+   if meths <> [] then
+     doc#add_subsection "_methods" (T.doc_of_meths ~description:methods meths));
   List.iter
     (fun (x, v) -> add_builtin ~override:true ~doc x ((generalized, t), v))
     (eval_pat pat v)

--- a/src/tools/doc.ml
+++ b/src/tools/doc.ml
@@ -158,7 +158,11 @@ let print_functions_md ~extra (doc : item) print_string =
               in
               let methods = List.filter (fun (n, _) -> n <> "_info") methods in
               List.map
-                (fun (l, m) -> (l, List.assoc "type" (to_assoc m) |> to_string))
+                (fun (l, m) ->
+                  let m = to_assoc m in
+                  ( l,
+                    List.assoc "_info" m |> to_string,
+                    List.assoc "type" m |> to_string ))
                 methods
             in
             let args =
@@ -193,8 +197,9 @@ let print_functions_md ~extra (doc : item) print_string =
             if methods <> [] then (
               print_string "\nMethods:\n\n";
               List.iter
-                (fun (l, t) ->
-                  Printf.ksprintf print_string "- `%s` (of type `%s`)\n" l t)
+                (fun (l, s, t) ->
+                  let s = if s = "" then "" else ": " ^ s in
+                  Printf.ksprintf print_string "- `%s` (of type `%s`)%s\n" l t s)
                 methods );
             if List.mem "experimental" flags then
               print_string "\nThis function is experimental.\n";
@@ -280,7 +285,10 @@ let print_lang (i : item) =
     Format.fprintf ff "@.Methods:@.";
     List.iter
       (fun (l, i) ->
-        Format.fprintf ff "@. * %s : %s@." l (i#get_subsection "type")#get_doc)
+        Format.fprintf ff "@. * %s : %s@." l (i#get_subsection "type")#get_doc;
+        let doc = i#get_doc in
+        if doc <> "(no doc)" && doc <> "" then
+          Format.fprintf ff "@[<5>     %a@]@." print_string_split doc)
       meths );
   Format.fprintf ff "@.";
   Format.pp_print_flush ff ();


### PR DESCRIPTION
Document methods in scripts with comments of the form
```
@method meth This documents the method
```