### PR TITLE
Add documentation for internal methods.

### DIFF
--- a/libs/playlist.liq
+++ b/libs/playlist.liq
@@ -11,7 +11,7 @@
 # @param ~on_done Function executed when the playlist is finished.
 # @param ~timeout Timeout (in sec.) for a single download.
 # @param playlist Playlist.
-# @method reload Reload the playlist with given songs.
+# @method reload Reload the playlist with given list of songs.
 def playlist.list(~id="playlist.list.reloadable", ~check_next=fun(_)->true, ~conservative=false, ~default_duration=30., ~length=10., ~loop=true, ~mime_type="", ~mode="normal", ~on_done={()}, ~timeout=20., playlist)
   mode = if not list.mem(mode, ["normal", "random", "randomize"]) then log.severe(label=id, "Invalid mode: #{mode}"); "randomize" else mode end
 

--- a/src/io/gstreamer_io.ml
+++ b/src/io/gstreamer_io.ml
@@ -704,18 +704,21 @@ let () =
       [
         ( "pause",
           ([], Lang.fun_t [] Lang.unit_t),
+          "Pause input.",
           fun s ->
             Lang.val_fun [] (fun _ ->
                 s#pause_cmd;
                 Lang.unit) );
         ( "play",
           ([], Lang.fun_t [] Lang.unit_t),
+          "Play input.",
           fun s ->
             Lang.val_fun [] (fun _ ->
                 s#play_cmd;
                 Lang.unit) );
         ( "restart",
           ([], Lang.fun_t [] Lang.unit_t),
+          "Restart input.",
           fun s ->
             Lang.val_fun [] (fun _ ->
                 s#restart_cmd;

--- a/src/io/srt_io.ml
+++ b/src/io/srt_io.ml
@@ -376,6 +376,7 @@ let meth :
         Lang.fun_t []
           (Lang.record_t
              (List.map (fun (name, typ, _, _) -> (name, typ)) stats_specs)) ),
+      "Statistics.",
       fun s ->
         Lang.val_fun [] (fun _ ->
             Lang.record

--- a/src/lang/builtins_http.ml
+++ b/src/lang/builtins_http.ml
@@ -43,10 +43,12 @@ let add_http_request http m name descr request =
   let request_return_t =
     Lang.method_t Lang.string_t
       [
-        ("protocol_version", ([], Lang.string_t));
-        ("status_code", ([], Lang.int_t));
-        ("status_message", ([], Lang.string_t));
-        ("headers", ([], headers_t));
+        ( "protocol_version",
+          ([], Lang.string_t),
+          "Version of the HTTP protocol." );
+        ("status_code", ([], Lang.int_t), "Status code.");
+        ("status_message", ([], Lang.string_t), "Status message.");
+        ("headers", ([], headers_t), "HTTP headers.");
       ]
   in
   let params =

--- a/src/lang/builtins_process.ml
+++ b/src/lang/builtins_process.ml
@@ -43,8 +43,12 @@ let () =
         ("stderr", Lang.string_t);
         ( "status",
           Lang.method_t Lang.string_t
-            [("code", ([], Lang.int_t)); ("description", ([], Lang.string_t))]
-        );
+            [
+              ("code", ([], Lang.int_t), "Returned status code.");
+              ( "description",
+                ([], Lang.string_t),
+                "Returned description (in case an exception was raised)." );
+            ] );
       ]
   in
   let env_t = Lang.product_t Lang.string_t Lang.string_t in

--- a/src/lang/lang.mli
+++ b/src/lang/lang.mli
@@ -175,7 +175,7 @@ val midi_n : int -> Frame.content_kind
 (* Conversion to format *)
 val kind_type_of_kind_format : Frame.content_kind -> t
 
-type 'a operator_method = string * scheme * ('a -> value)
+type 'a operator_method = string * scheme * string * ('a -> value)
 
 (** Add an operator to the language and to the documentation. *)
 val add_operator :
@@ -231,7 +231,7 @@ val of_product_t : t -> t * t
 val tuple_t : t list -> t
 val of_tuple_t : t -> t list
 val record_t : (string * t) list -> t
-val method_t : t -> (string * scheme) list -> t
+val method_t : t -> (string * scheme * string) list -> t
 val list_t : t -> t
 val of_list_t : t -> t
 val nullable_t : t -> t

--- a/src/lang/lang_parser.mly
+++ b/src/lang/lang_parser.mly
@@ -88,7 +88,7 @@
       in
       let get_meth_type () =
         match t.T.descr with
-          | T.Meth (_, _, t) -> t
+          | T.Meth (_, _, _, t) -> t
           | _ -> assert false
       in
       let term =

--- a/src/lang/lang_types.ml
+++ b/src/lang/lang_types.ml
@@ -151,7 +151,7 @@ and descr =
   | List of t
   | Tuple of t list
   | Nullable of t
-  | Meth of string * scheme * t
+  | Meth of string * scheme * string * t (* label, type, documentation, type to decorate *)
   | Arrow of (bool * string * t) list * t
   | EVar of var (* type variable *)
   | Link of t
@@ -188,28 +188,28 @@ let rec deref t = match t.descr with Link x -> deref x | _ -> t
 (** Remove methods. This function also removes links. *)
 let rec demeth t =
   let t = deref t in
-  match t.descr with Meth (_, _, t) -> demeth t | _ -> t
+  match t.descr with Meth (_, _, _, t) -> demeth t | _ -> t
 
 let rec remeth t u =
   let t = deref t in
   match t.descr with
-    | Meth (l, v, t) -> { t with descr = Meth (l, v, remeth t u) }
+    | Meth (l, v, d, t) -> { t with descr = Meth (l, v, d, remeth t u) }
     | _ -> u
 
 let rec hide_meth l a =
   match (deref a).descr with
-    | Meth (l', _, u) when l' = l -> hide_meth l u
-    | Meth (l', t, u) -> { a with descr = Meth (l', t, hide_meth l u) }
+    | Meth (l', _, _, u) when l' = l -> hide_meth l u
+    | Meth (l', t, d, u) -> { a with descr = Meth (l', t, d, hide_meth l u) }
     | _ -> a
 
 let rec invoke t l =
   match (deref t).descr with
-    | Meth (l', t, _) when l = l' -> t
-    | Meth (_, _, t) -> invoke t l
+    | Meth (l', t, _, _) when l = l' -> t
+    | Meth (_, _, _, t) -> invoke t l
     | _ -> raise Not_found
 
 (** Add a method. *)
-let meth ?pos ?level l v t = make ?pos ?level (Meth (l, v, t))
+let meth ?pos ?level l v ?(doc = "") t = make ?pos ?level (Meth (l, v, doc, t))
 
 (** Add methods. *)
 let rec meths ?pos ?level l v t =
@@ -225,9 +225,9 @@ let rec meths ?pos ?level l v t =
 let split_meths t =
   let rec aux hide t =
     match (deref t).descr with
-      | Meth (l, mt, t) ->
+      | Meth (l, v, d, t) ->
           let m, t = aux (l :: hide) t in
-          let m = if List.mem l hide then m else (l, mt) :: m in
+          let m = if List.mem l hide then m else (l, (v, d)) :: m in
           (m, t)
       | _ -> ([], t)
   in
@@ -302,7 +302,7 @@ let repr ?(filter_out = fun _ -> false) ?(generalized = []) t : repr =
         | List t -> `List (repr g t)
         | Tuple l -> `Tuple (List.map (repr g) l)
         | Nullable t -> `Nullable (repr g t)
-        | Meth (l, (g', u), v) ->
+        | Meth (l, (g', u), _, v) ->
             let gen =
               List.map
                 (fun ic -> match uvar (g' @ g) t.level ic with `UVar ic -> ic)
@@ -631,7 +631,7 @@ let rec occur_check a b =
     | Tuple l -> List.iter (occur_check a) l
     | List t -> occur_check a t
     | Nullable t -> occur_check a t
-    | Meth (_, (_, t), u) ->
+    | Meth (_, (_, t), _, u) ->
         (* We assume that a is not a generalized variable of t. *)
         occur_check a t;
         occur_check a u
@@ -773,7 +773,7 @@ let filter_vars f t =
       | Ground _ -> l
       | List t | Nullable t -> aux l t
       | Tuple aa -> List.fold_left aux l aa
-      | Meth (_, (g, t), u) ->
+      | Meth (_, (g, t), _, u) ->
           let l = List.filter (fun v -> not (List.mem v g)) (aux l t) in
           aux l u
       | Constr c -> List.fold_left (fun l (_, t) -> aux l t) l c.params
@@ -804,11 +804,11 @@ let copy_with (subst : Subst.t) t =
       | List t -> cp (List (aux t))
       | Nullable t -> cp (Nullable (aux t))
       | Tuple l -> cp (Tuple (List.map aux l))
-      | Meth (l, (g, t), u) ->
+      | Meth (l, (g, t), d, u) ->
           (* We assume that we don't substitute generalized variables. *)
           if !debug then
             assert (Subst.M.for_all (fun v _ -> not (List.mem v g)) subst);
-          cp (Meth (l, (g, aux t), aux u))
+          cp (Meth (l, (g, aux t), d, aux u))
       | Arrow (p, t) ->
           cp (Arrow (List.map (fun (o, l, t) -> (o, l, aux t)) p, aux t))
       | Link t ->
@@ -883,8 +883,8 @@ let doc_of_type ~generalized t =
 let doc_of_meths m =
   let items = new Doc.item "" in
   List.iter
-    (fun (m, (generalized, t)) ->
-      let i = new Doc.item ~sort:false "" in
+    (fun (m, ((generalized, t), doc)) ->
+      let i = new Doc.item ~sort:false doc in
       i#add_subsection "type" (doc_of_type ~generalized t);
       items#add_subsection m i)
     m;
@@ -1023,7 +1023,7 @@ let rec ( <: ) a b =
           raise (Error (repr a, repr b)) )
     | _, Nullable t2 -> (
         try a <: t2 with Error (a, b) -> raise (Error (a, `Nullable b)) )
-    | _, Meth (l, (g2, t2), u2) -> (
+    | _, Meth (l, (g2, t2), _, u2) -> (
         try
           let g1, t1 = invoke a l in
           ( try
@@ -1046,11 +1046,12 @@ let rec ( <: ) a b =
                      (Meth
                         ( l,
                           (g2, t2),
+                          "",
                           fresh ~level:(-1) ~constraints:[] ~pos:None ));
                 a <: b
             | _ -> raise (Error (repr a, `Meth (l, ([], `Ellipsis), `Ellipsis))) )
         )
-    | Meth (l, _, u1), _ -> hide_meth l u1 <: b
+    | Meth (l, _, _, u1), _ -> hide_meth l u1 <: b
     | Link _, _ | _, Link _ -> assert false (* thanks to deref *)
     | _, _ ->
         (* The superficial representation is enough for explaining the
@@ -1097,8 +1098,8 @@ let rec duplicate ?pos ?level t =
       | List t -> List (duplicate ?pos ?level t)
       | Tuple l -> Tuple (List.map (duplicate ?pos ?level) l)
       | Nullable t -> Nullable (duplicate ?pos ?level t)
-      | Meth (name, (v, g), t) ->
-          Meth (name, (v, duplicate ?pos ?level g), duplicate ?pos ?level t)
+      | Meth (name, (v, g), d, t) ->
+          Meth (name, (v, duplicate ?pos ?level g), d, duplicate ?pos ?level t)
       | Arrow (args, t) ->
           Arrow
             ( List.map (fun (b, n, t) -> (b, n, duplicate ?pos ?level t)) args,
@@ -1125,25 +1126,27 @@ let rec min_type ?(pos = None) ?(level = -1) a b =
     match ((deref a).descr, (deref b).descr) with
       | (Meth _ as da), (Meth _ as db) ->
           let rec methods m = function
-            | Meth (name, scheme, t) when not (List.mem_assoc name m) ->
-                methods ((name, scheme) :: m) (deref t).descr
+            | Meth (name, scheme, doc, t) when not (List.mem_assoc name m) ->
+                methods ((name, (scheme, doc)) :: m) (deref t).descr
             | _ -> m
           in
           let meths_a = methods [] da in
           let meths_b = methods [] db in
           let meths =
             List.fold_left
-              (fun cur (name, (g, t)) ->
+              (fun cur (name, ((g, t), doc)) ->
                 match List.assoc_opt name meths_b with
                   | None -> cur
-                  | Some (g', t') -> (
-                      try (name, (g @ g', min_type t t')) :: cur with _ -> cur ))
+                  | Some ((g', t'), _) -> (
+                      try (name, ((g @ g', min_type t t'), doc)) :: cur
+                      with _ -> cur ))
               [] meths_a
           in
           let t = min (demeth a) (demeth b) in
           let t =
             List.fold_left
-              (fun cur (name, s) -> make ~pos ~level (Meth (name, s, cur)))
+              (fun cur (name, (s, doc)) ->
+                make ~pos ~level (Meth (name, s, doc, cur)))
               t meths
           in
           duplicate ~pos ~level a <: t;

--- a/src/lang/lang_types.mli
+++ b/src/lang/lang_types.mli
@@ -58,7 +58,7 @@ and descr =
   | List of t
   | Tuple of t list
   | Nullable of t
-  | Meth of string * scheme * t
+  | Meth of string * scheme * string * t
   | Arrow of (bool * string * t) list * t
   | EVar of var
   | Link of t
@@ -86,7 +86,7 @@ val pp_type_generalized : var list -> Format.formatter -> t -> unit
 val print : ?generalized:var list -> t -> string
 val print_scheme : scheme -> string
 val doc_of_type : generalized:var list -> t -> Doc.item
-val doc_of_meths : (string * scheme) list -> Doc.item
+val doc_of_meths : (string * (scheme * string)) list -> Doc.item
 
 exception Occur_check of t * t
 
@@ -104,7 +104,8 @@ val bind : t -> t -> unit
 val deref : t -> t
 
 (** Add a method to a type. *)
-val meth : ?pos:pos option -> ?level:int -> string -> scheme -> t -> t
+val meth :
+  ?pos:pos option -> ?level:int -> string -> scheme -> ?doc:string -> t -> t
 
 (** Add a submethod to a type. *)
 val meths : ?pos:pos option -> ?level:int -> string list -> scheme -> t -> t
@@ -112,7 +113,7 @@ val meths : ?pos:pos option -> ?level:int -> string list -> scheme -> t -> t
 (** Remove all methods in a type. *)
 val demeth : t -> t
 
-val split_meths : t -> (string * scheme) list * t
+val split_meths : t -> (string * (scheme * string)) list * t
 
 (** Put the methods of the first type around the second type. *)
 val remeth : t -> t -> t

--- a/src/lang/lang_values.ml
+++ b/src/lang/lang_values.ml
@@ -598,7 +598,7 @@ let add_builtin ?(override = false) ?(register = true) ?doc name ((g, t), v) =
               let (lvg, lvt), lv = aux (l :: prefix) ll in
               (* Updated type for x.l1...li, obtained by changing the type of
                  the field li+1. *)
-              let t = T.make ~pos:t.T.pos (T.Meth (l, (lvg, lvt), vt)) in
+              let t = T.make ~pos:t.T.pos (T.Meth (l, (lvg, lvt), "", vt)) in
               (* Update value for x.l1...li. *)
               let value = V.Meth (l, lv, v) in
               ((vg, t), { V.pos = v.V.pos; value })
@@ -757,12 +757,12 @@ let rec check ?(print_toplevel = false) ~throw ~level ~(env : T.env) e =
     | Meth (l, a, b) ->
         check ~throw ~level ~env a;
         check ~throw ~level ~env b;
-        e.t >: mk (T.Meth (l, (T.generalizable ~level a.t, a.t), b.t))
+        e.t >: mk (T.Meth (l, (T.generalizable ~level a.t, a.t), "", b.t))
     | Invoke (a, l) ->
         check ~throw ~level ~env a;
         let rec aux t =
           match (T.deref t).T.descr with
-            | T.Meth (l', (generalized, b), c) ->
+            | T.Meth (l', (generalized, b), _, c) ->
                 if l = l' then T.instantiate ~level ~generalized b else aux c
             | _ ->
                 (* We did not find the method, the type we will infer is not the
@@ -770,7 +770,7 @@ let rec check ?(print_toplevel = false) ~throw ~level ~(env : T.env) e =
                    enough for records. *)
                 let x = T.fresh_evar ~level ~pos in
                 let y = T.fresh_evar ~level ~pos in
-                a.t <: mk (T.Meth (l, ([], x), y));
+                a.t <: mk (T.Meth (l, ([], x), "", y));
                 x
         in
         e.t >: aux a.t
@@ -779,7 +779,7 @@ let rec check ?(print_toplevel = false) ~throw ~level ~(env : T.env) e =
         a.t <: mk T.unit;
         let rec aux env t =
           match (T.deref t).T.descr with
-            | T.Meth (l, (g, u), t) -> aux ((l, (g, u)) :: env) t
+            | T.Meth (l, (g, u), _, t) -> aux ((l, (g, u)) :: env) t
             | _ -> env
         in
         let env = aux env a.t in
@@ -1171,7 +1171,7 @@ let toplevel_add (doc, params) pat ~t v =
   let rec ptypes t =
     match (T.deref t).T.descr with
       | T.Arrow (p, _) -> p
-      | T.Meth (_, _, t) -> ptypes t
+      | T.Meth (_, _, _, t) -> ptypes t
       | _ -> []
   in
   let ptypes = ptypes t in

--- a/src/operators/insert_metadata.ml
+++ b/src/operators/insert_metadata.ml
@@ -95,6 +95,8 @@ let () =
             Lang.fun_t
               [(true, "new_track", Lang.bool_t); (false, "", Lang.metadata_t)]
               Lang.unit_t ),
+          "Insert metadata in the source. The `new_track` parameter indicates \
+           whether a track boundary should also be inserted.",
           fun s ->
             Lang.val_fun
               [

--- a/src/operators/noblank.ml
+++ b/src/operators/noblank.ml
@@ -278,6 +278,7 @@ let () =
       [
         ( "is_blank",
           ([], Lang.fun_t [] Lang.bool_t),
+          "Indicate whether blank was detected.",
           fun s -> Lang.val_fun [] (fun _ -> Lang.bool s#is_blank) );
       ]
     ~descr:"Calls a given handler when detecting a blank."
@@ -305,6 +306,7 @@ let () =
       [
         ( "is_blank",
           ([], Lang.fun_t [] Lang.bool_t),
+          "Indicate whether blank was detected.",
           fun s -> Lang.val_fun [] (fun _ -> Lang.bool s#is_blank) );
       ]
     ~category:Lang.TrackProcessing
@@ -320,6 +322,7 @@ let () =
       [
         ( "is_blank",
           ([], Lang.fun_t [] Lang.bool_t),
+          "Indicate whether blank was detected.",
           fun s -> Lang.val_fun [] (fun _ -> Lang.bool s#is_blank) );
       ]
     ~descr:

--- a/src/operators/window_op.ml
+++ b/src/operators/window_op.ml
@@ -102,7 +102,13 @@ let declare mode suffix kind fun_ret_t f_ans =
   let doc = match mode with RMS -> "RMS volume" | Peak -> "peak volume" in
   let return_t = Lang.kind_type_of_kind_format kind in
   Lang.add_operator (name ^ suffix) ~category:Lang.Visualization
-    ~meth:[(name, ([], Lang.fun_t [] fun_ret_t), fun s -> f_ans s#value)]
+    ~meth:
+      [
+        ( name,
+          ([], Lang.fun_t [] fun_ret_t),
+          "Current value for the " ^ doc ^ ".",
+          fun s -> f_ans s#value );
+      ]
     ~return_t
     ~descr:
       ( "Get current " ^ doc

--- a/src/outputs/pipe_output.ml
+++ b/src/outputs/pipe_output.ml
@@ -427,6 +427,7 @@ let () =
       [
         ( "reopen",
           ([], Lang.fun_t [] Lang.unit_t),
+          "Reopen the pipe.",
           fun s ->
             Lang.val_fun [] (fun _ ->
                 s#reopen_cmd;

--- a/src/sources/external_input_video.ml
+++ b/src/sources/external_input_video.ml
@@ -103,6 +103,7 @@ let () =
           ( [],
             Lang.fun_t []
               (Lang.tuple_t [Lang.float_t; Lang.float_t; Lang.float_t]) ),
+          "Length of the buffer (in seconds).",
           fun s ->
             Lang.val_fun [] (fun _ ->
                 let x, y, z = s#buffer_length_cmd in
@@ -255,6 +256,7 @@ let () =
           ( [],
             Lang.fun_t []
               (Lang.tuple_t [Lang.float_t; Lang.float_t; Lang.float_t]) ),
+          "Length of the buffer (in seconds).",
           fun s ->
             Lang.val_fun [] (fun _ ->
                 let x, y, z = s#buffer_length_cmd in

--- a/src/sources/harbor_input.ml
+++ b/src/sources/harbor_input.ml
@@ -271,15 +271,18 @@ module Make (Harbor : T) = struct
         [
           ( "stop",
             ([], Lang.fun_t [] Lang.unit_t),
+            "Stop the input.",
             fun s ->
               Lang.val_fun [] (fun _ ->
                   s#stop_cmd;
                   Lang.unit) );
           ( "status",
             ([], Lang.fun_t [] Lang.string_t),
+            "Current statu of the input.",
             fun s -> Lang.val_fun [] (fun _ -> Lang.string s#status_cmd) );
           ( "buffer_length",
             ([], Lang.fun_t [] Lang.float_t),
+            "Length of the buffer (in seconds).",
             fun s -> Lang.val_fun [] (fun _ -> Lang.float s#buffer_length_cmd)
           );
         ]

--- a/src/sources/harbor_input.ml
+++ b/src/sources/harbor_input.ml
@@ -278,7 +278,7 @@ module Make (Harbor : T) = struct
                   Lang.unit) );
           ( "status",
             ([], Lang.fun_t [] Lang.string_t),
-            "Current statu of the input.",
+            "Current status of the input.",
             fun s -> Lang.val_fun [] (fun _ -> Lang.string s#status_cmd) );
           ( "buffer_length",
             ([], Lang.fun_t [] Lang.float_t),

--- a/src/sources/http_source.ml
+++ b/src/sources/http_source.ml
@@ -538,23 +538,27 @@ module Make (Config : Config_t) = struct
         [
           ( "start",
             ([], Lang.fun_t [] Lang.unit_t),
+            "Start reading input.",
             fun s ->
               Lang.val_fun [] (fun _ ->
                   s#start_cmd;
                   Lang.unit) );
           ( "stop",
             ([], Lang.fun_t [] Lang.unit_t),
+            "Stop reading input.",
             fun s ->
               Lang.val_fun [] (fun _ ->
                   s#stop_cmd;
                   Lang.unit) );
           ( "url",
             ([], Lang.fun_t [] Lang.string_t),
+            "URL of the input.",
             fun s -> Lang.val_fun [] (fun _ -> Lang.string s#url_cmd) );
           ( "set_url",
             ( [],
               Lang.fun_t [(false, "", Lang.fun_t [] Lang.string_t)] Lang.unit_t
             ),
+            "Set the url of the input.",
             fun s ->
               Lang.val_fun [("", "", None)] (fun p ->
                   let fn = List.assoc "" p in
@@ -563,9 +567,11 @@ module Make (Config : Config_t) = struct
                   Lang.unit) );
           ( "status",
             ([], Lang.fun_t [] Lang.string_t),
+            "Current status of the input.",
             fun s -> Lang.val_fun [] (fun _ -> Lang.string s#status_cmd) );
           ( "buffer_length",
             ([], Lang.fun_t [] Lang.float_t),
+            "Length of the buffer length (in seconds).",
             fun s -> Lang.val_fun [] (fun _ -> Lang.float s#buffer_length_cmd)
           );
         ]

--- a/src/test/types.ml
+++ b/src/test/types.ml
@@ -27,23 +27,23 @@ let () =
     (T.List (T.make (T.Ground T.Int)));
 
   let m =
-    T.Meth ("aa", ([], T.make (T.Ground T.Int)), T.make (T.Ground T.Bool))
+    T.Meth ("aa", ([], T.make (T.Ground T.Int)), "", T.make (T.Ground T.Bool))
   in
 
   should_work m (T.Ground T.Bool) (T.Ground T.Bool);
 
-  let n = T.Meth ("b", ([], T.make (T.Ground T.Bool)), T.make m) in
+  let n = T.Meth ("b", ([], T.make (T.Ground T.Bool)), "", T.make m) in
 
   should_work m n m;
 
   let n =
-    T.Meth ("aa", ([], T.make (T.Ground T.Int)), T.make (T.Ground T.Int))
+    T.Meth ("aa", ([], T.make (T.Ground T.Int)), "", T.make (T.Ground T.Int))
   in
 
   should_fail m n;
 
   let n =
-    T.Meth ("aa", ([], T.make (T.Ground T.Bool)), T.make (T.Ground T.Bool))
+    T.Meth ("aa", ([], T.make (T.Ground T.Bool)), "", T.make (T.Ground T.Bool))
   in
 
   should_fail m n;

--- a/src/tools/doc.ml
+++ b/src/tools/doc.ml
@@ -158,7 +158,11 @@ let print_functions_md ~extra (doc : item) print_string =
               in
               let methods = List.filter (fun (n, _) -> n <> "_info") methods in
               List.map
-                (fun (l, m) -> (l, List.assoc "type" (to_assoc m) |> to_string))
+                (fun (l, m) ->
+                  let m = to_assoc m in
+                  ( l,
+                    List.assoc "_info" m |> to_string,
+                    List.assoc "type" m |> to_string ))
                 methods
             in
             let args =
@@ -193,8 +197,9 @@ let print_functions_md ~extra (doc : item) print_string =
             if methods <> [] then (
               print_string "\nMethods:\n\n";
               List.iter
-                (fun (l, t) ->
-                  Printf.ksprintf print_string "- `%s` (of type `%s`)\n" l t)
+                (fun (l, s, t) ->
+                  let s = if s = "" then "" else ": " ^ s in
+                  Printf.ksprintf print_string "- `%s` (of type `%s`)%s\n" l t s)
                 methods );
             if List.mem "experimental" flags then
               print_string "\nThis function is experimental.\n";
@@ -280,7 +285,10 @@ let print_lang (i : item) =
     Format.fprintf ff "@.Methods:@.";
     List.iter
       (fun (l, i) ->
-        Format.fprintf ff "@. * %s : %s@." l (i#get_subsection "type")#get_doc)
+        Format.fprintf ff "@. * %s : %s@." l (i#get_subsection "type")#get_doc;
+        let doc = i#get_doc in
+        if doc <> "(no doc)" && doc <> "" then
+          Format.fprintf ff "@[<5>     %a@]@." print_string_split doc)
       meths );
   Format.fprintf ff "@.";
   Format.pp_print_flush ff ();


### PR DESCRIPTION
This add documentation for builtins. For instance:
```
Multiply the amplitude of the signal.

Type: (?id : string, ?override : string?, {float},
 source(audio='b, video='c, midi='d)) -> source(audio='b,
video='c, midi='d)

Category: Source / Sound Processing

Parameters:

 * id : string (default: "")
     Force the value of the source ID.

 * override : string? (default: "liq_amplify")
     Specify the name of a metadata field that, when present and well-formed,
     overrides the amplification factor for the current track. Well-formed
     values are floats in decimal notation (e.g. `0.7`) which are taken as
     normal/linear multiplicative factors; values can be passed in decibels
     with the suffix `dB` (e.g. `-8.2 dB`, but the spaces do not matter).

 * (unlabeled) : {float} (default: None)
     Multiplicative factor.

 * (unlabeled) : source(audio='b, video='c, midi='d) (default: None)

Methods:

 * fallible : () -> bool
     Indicate if a source may fail, i.e. may not be ready to stream.

 * id : () -> string
     Identifier of the source.

 * is_ready : () -> bool
     Indicate if a source is ready to stream, or currently streaming.

 * is_up : () -> bool
     Check whether a source is up.

 * on_metadata : ((([string * string]) -> unit)) -> unit
     Call a given handler on metadata packets.

 * on_shutdown : ((() -> unit)) -> unit
     Register a function to be called when source shuts down.

 * on_track : ((([string * string]) -> unit)) -> unit
     Call a given handler on new tracks.

 * remaining : () -> float
     Estimation of remaining time in the current track.

 * seek : (float) -> float
     Seek forward, in seconds (returns the amount of time effectively
     seeked).

 * shutdown : () -> unit
     Deactivate a source.

 * skip : () -> unit
     Skip to the next track.

 * time : () -> float
     Get a source's time, based on its assigned clock.
```

This is complementary to #1471 which add supports for adding documentation in scripts. Merging the two is expected to be non-trivial (although not very difficult).