### PR TITLE
Source list

### DIFF
--- a/tests/language/record.liq
+++ b/tests/language/record.liq
@@ -55,11 +55,21 @@ def f() =
   t(counter(), 1)
 
   # Open
-
   r = ()
   def r.f(n) = 2*n end
   open r
   t(f(3), 6)
+
+  # Test subtyping in lists
+  a = "a"
+  b = "b"
+  let a.x = 5
+  let b.x = 3
+  let b.y = 1.
+  l = [a,b]
+  ignore(list.hd(l).x)
+  l = [b,a]
+  ignore(list.hd(l).x)
 
   if !success then test.pass() else test.fail() end
 end

--- a/tests/language/record.liq
+++ b/tests/language/record.liq
@@ -70,6 +70,7 @@ def f() =
   ignore(list.hd(l).x)
   l = [b,a]
   ignore(list.hd(l).x)
+  def f(c) = [a,c] end      
 
   if !success then test.pass() else test.fail() end
 end

--- a/tests/streams/radio2.liq
+++ b/tests/streams/radio2.liq
@@ -1,0 +1,26 @@
+#!../../src/liquidsoap -i ../../libs/pervasives.liq
+
+# Basic radio test
+
+%include "test.liq"
+
+day     = playlist("~/Music")
+night   = playlist("~/Music")
+jingles = playlist("~/Music")
+
+# Day / night switch
+radio = switch([({8h-20h}, day), ({20h-8h}, night)])
+# Crossfade
+radio = crossfade(fade_out=3., fade_in=3., duration=5., radio)
+l = [jingles, radio]
+# Add jingles
+radio = random(weights=[1, 4], l)
+
+output.dummy(fallible=true, radio)
+
+def on_done () =
+  test.pass()
+  shutdown()
+end
+
+thread.run(delay=1., on_done)


### PR DESCRIPTION
The following script fails:
```
night   = playlist("~/Music")
jingles = playlist("~/Music")

# Day / night switch
radio = switch([({8h-20h}, day), ({20h-8h}, night)])
# Crossfade
radio = crossfade(fade_out=3., fade_in=3., duration=5., radio)
l = [jingles, radio]
# Add jingles
radio = random(weights=[1, 4], l)
```
The problem comes from the fact that `l` has type
```
  [source(audio=pcm(?A), video=?B, midi=none)]
  where ?B is an internal media type (none, pcm, yuva420p or midi)
```
i.e. all the methods get lost, even though they are present for both `jingles` and `radio`:
```
jingles :
  source(audio=pcm(?A), video=?B, midi=none)
  .{
    time : () -> float,
    shutdown : () -> unit,
    fallible : () -> bool,
    skip : () -> unit,
    seek : (float) -> float,
    is_up : () -> bool,
    remaining : () -> float,
    on_track : ((([string * string]) -> unit)) -> unit,
    on_shutdown : ((() -> unit)) -> unit,
    on_metadata : ((([string * string]) -> unit)) -> unit,
    is_ready : () -> bool,
    id : () -> string,
    reload : ((?uri : string) -> unit)
  } where ?B is an internal media type (none, pcm, yuva420p or midi)
```
and
```
radio :
  source(audio=pcm(?A), video=?B, midi=none)
  .{
    time : () -> float,
    shutdown : () -> unit,
    fallible : () -> bool,
    skip : () -> unit,
    seek : (float) -> float,
    is_up : () -> bool,
    remaining : () -> float,
    on_track : ((([string * string]) -> unit)) -> unit,
    on_shutdown : ((() -> unit)) -> unit,
    on_metadata : ((([string * string]) -> unit)) -> unit,
    is_ready : () -> bool,
    id : (() -> string)
  } where ?B is an internal media type (none, pcm, yuva420p or midi)
```

The following simplified example (in record.liq test) works though:
```
  a = "a"
  b = "b"
  let a.x = 5
  let b.x = 3
  let b.y = 1.
  l = [a,b]
  ignore(list.hd(l).x)
  l = [b,a]
  ignore(list.hd(l).x)
```