### PR TITLE
No need for file.write to return a boolean.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -144,7 +144,7 @@ Changed:
   output explicitly.
 - Implement `interactive.*` on script side (#1493).
 - `file.write` does not return a boolean anymore, exceptions are used for
-  exceptional cases.
+  exceptional cases (#1500).
 
 Fixed:
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -143,6 +143,8 @@ Changed:
 - Deprecated catch-all `input` and `output` in favor or setting your desired input or 
   output explicitly.
 - Implement `interactive.*` on script side (#1493).
+- `file.write` does not return a boolean anymore, exceptions are used for
+  exceptional cases.
 
 Fixed:
 

--- a/libs/interactive.liq
+++ b/libs/interactive.liq
@@ -127,7 +127,7 @@ def interactive.save(fname)
   bool = list.map(fun (nv) -> begin let (name, v) = nv; (name, !v.ref) end, !variables_bool)
   string = list.map(fun (nv) -> begin let (name, v) = nv; (name, !v.ref) end, !variables_string)
   vars = (int, float, bool, string)
-  ignore(file.write(data=json_of(vars), fname))
+  file.write(data=json_of(vars), fname)
 end
 
 # Load the value of interactive variables from a file.

--- a/libs/protocols.liq
+++ b/libs/protocols.liq
@@ -280,7 +280,7 @@ add_protocol("youtube-dl", youtube_dl_protocol,
 # @flag hidden
 def youtube_pl_protocol(~rlog,~maxtime,arg)
   tmp = file.temp("youtube-pl","")
-  ignore(file.write(data="youtube-pl:#{arg}",tmp))
+  file.write(data="youtube-pl:#{arg}",tmp)
   [tmp]
 end
 add_protocol("youtube-pl", youtube_pl_protocol,

--- a/libs/utils.liq
+++ b/libs/utils.liq
@@ -234,12 +234,12 @@ def clock.log(~delay=0., ~every=1., logfile)
   # Get the current clocks
   clocks = list.map(fst,clock.status())
   # Column headers
-  ignore(file.write(data="# #{string.concat(separator=' ', clocks)}", logfile))
+  file.write(data="# #{string.concat(separator=' ', clocks)}", logfile)
   def report()
     status = clock.status()
     status = list.map(fun (x) -> (fst(x),string_of(snd(x))), status)
     status = list.map(fun (c) -> status[c], clocks)
-    ignore(file.write(append=true, data="#{string.concat(separator=' ', status)}", logfile))
+    file.write(append=true, data="#{string.concat(separator=' ', status)}", logfile)
   end
   delay = if delay <= 0. then 0. else delay end
   thread.run(delay=delay, every=every, report)

--- a/src/lang/builtins_files.ml
+++ b/src/lang/builtins_files.ml
@@ -162,7 +162,7 @@ let () =
         Some "Default file rights if created" );
       ("", Lang.string_t, None, Some "Path to write to");
     ]
-    Lang.bool_t ~descr:"Write data to a file. Returns `true` if successful."
+    Lang.unit_t ~descr:"Write data to a file."
     (fun p ->
       let data = Lang.to_string (List.assoc "data" p) in
       let append = Lang.to_bool (List.assoc "append" p) in
@@ -174,7 +174,7 @@ let () =
         let oc = open_out_gen flags perms f in
         output_string oc data;
         close_out oc;
-        Lang.bool true
+        Lang.unit
       with e ->
         let message =
           Printf.sprintf "The file %s could not be written: %s" f


### PR DESCRIPTION
We drop backward compatibility on this one but I think it is worth it since we were always `ignore`ing the result anyway.