### PR TITLE
Nice printing of internal dataypes

### DIFF
--- a/src/lang/lang_types.ml
+++ b/src/lang/lang_types.ml
@@ -496,6 +496,12 @@ let print_repr f t =
     | `UVar (_, [Getter a]) when !pretty_getters ->
         Format.fprintf f "{%s}" (print_ground a);
         vars
+    | `EVar (_, [InternalMedia]) ->
+        Format.fprintf f "?internal";
+        vars
+    | `UVar (_, [InternalMedia]) ->
+        Format.fprintf f "internal";
+        vars
     | `EVar (name, c) | `UVar (name, c) ->
         Format.fprintf f "%s" name;
         if c <> [] then DS.add (name, c) vars else vars

--- a/src/outputs/pipe_output.ml
+++ b/src/outputs/pipe_output.ml
@@ -136,10 +136,6 @@ let pipe_proto kind arg_doc =
         Lang.float_t,
         Some (Lang.float 120.),
         Some "Prevent re-opening within that delay, in seconds." );
-      ( "reopen_on_error",
-        Lang.bool_t,
-        Some (Lang.bool false),
-        Some "Re-open if some error occurs." );
       ( "reopen_on_metadata",
         Lang.bool_t,
         Some (Lang.bool false),
@@ -162,7 +158,6 @@ let pipe_proto kind arg_doc =
 class virtual piped_output ~kind p =
   let reload_predicate = List.assoc "reopen_when" p in
   let reload_delay = Lang.to_float (List.assoc "reopen_delay" p) in
-  let reload_on_error = Lang.to_bool (List.assoc "reopen_on_error" p) in
   let reload_on_metadata = Lang.to_bool (List.assoc "reopen_on_metadata" p) in
   let name = Lang.to_string_getter (Lang.assoc "" 2 p) in
   let name = name () in
@@ -217,10 +212,7 @@ class virtual piped_output ~kind p =
 
     method send b =
       if not self#is_open then self#prepare_pipe;
-      ( try super#send b
-        with e when reload_on_error ->
-          self#log#important "Reopening on error: %s." (Printexc.to_string e);
-          need_reset <- true );
+      super#send b;
       if not reopening then
         if
           need_reset


### PR DESCRIPTION
For instance, this patch changes the type of `blank` fom

```
(?id : string, ?duration : float) -> source(audio='a, video='b, midi=none)
where
  'a, 'b is an internal media type (none, pcm, yuva420p or midi)
```

to 

```
(?id : string, ?duration : float) -> source(audio=internal, video=internal, midi=none)
```

**Question**. Before we merge the above patch I'd like to understand what it the difference between the two above types and

```
(?id : string, ?duration : float) -> source(audio=pcm('a), video=yuva420p('b), midi=none)
```

and thus, do we really need/want the "internal type" constraint for type variables? Is it thtat *internal = pcm or none*?

PS: we could easily generate blank midi I think...