### PR TITLE
Use an explicit cast in the language

### DIFF
--- a/src/lang/lang.ml
+++ b/src/lang/lang.ml
@@ -310,6 +310,7 @@ let iter_sources f v =
       | Term.List l -> List.iter (iter_term env) l
       | Term.Tuple l -> List.iter (iter_term env) l
       | Term.Null -> ()
+      | Term.Cast (a, _) -> iter_term env a
       | Term.Meth (_, a, b) ->
           iter_term env a;
           iter_term env b

--- a/src/lang/lang_parser.mly
+++ b/src/lang/lang_parser.mly
@@ -125,7 +125,7 @@ exprss:
 
 /* General expressions. */
 expr:
-  | LPAR expr COLON ty RPAR          { Lang_types.(<:) $2.Lang_values.t $4 ; $2 }
+  | LPAR expr COLON ty RPAR          { mk ~pos:$loc (Cast ($2, $4)) }
   | UMINUS FLOAT                     { mk ~pos:$loc (Ground (Float (-. $2))) }
   | UMINUS INT                       { mk ~pos:$loc (Ground (Int (- $2))) }
   | UMINUS LPAR expr RPAR            { mk ~pos:$loc (App (mk ~pos:$loc($1) (Var "~-"), ["", $3])) }

--- a/src/lang/lang_values.ml
+++ b/src/lang/lang_values.ml
@@ -988,19 +988,19 @@ let rec eval ~env tm =
   let mk v =
     ( (* Ensure that the kind computed at runtime for sources will agree with
          the typing. *)
-      (* TODO: cover more cases of casting *)
       match (T.deref tm.t).T.descr with
       | T.Constr { T.name = "source"; params = [(T.Invariant, k)] } -> (
           let frame_content_of_t t =
-            Printf.printf "frame_content_of_t: %s\n%!" (T.print t);
             match (T.deref t).T.descr with
-              | T.Ground (T.Format fmt) -> `Format fmt
               | T.EVar _ -> `Any
-              | T.Constr { T.name = "pcm"; params = [(_, t)] } -> (
+              | T.Constr { T.name; params = [(_, t)] } -> (
                   match (T.deref t).T.descr with
                     | T.Ground (T.Format fmt) -> `Format fmt
-                    | _ -> assert false )
-              | _ -> assert false
+                    | T.EVar _ -> `Kind (Frame_content.kind_of_string name)
+                    | _ -> failwith ("Unhandled content: " ^ T.print tm.t) )
+              | T.Constr { T.name = "none" } ->
+                  `Kind (Frame_content.kind_of_string "none")
+              | _ -> failwith ("Unhandled content: " ^ T.print tm.t)
           in
           let k = of_frame_kind_t k in
           let k =

--- a/src/outputs/alsa_out.ml
+++ b/src/outputs/alsa_out.ml
@@ -113,8 +113,9 @@ class output ~kind ~clock_safe ~infallible ~on_stop ~on_start ~start dev source
               (bufsize, fst (Pcm.get_periods_max params))
             in
             self#log#important
-              "Samplefreq=%dHz, Bufsize=%dB, Frame=%dB, Periods=%d" alsa_rate
-              bufsize
+              "channels=%d, samplerate=%dHz, buffer size=%dB, frame size=%dB, \
+               periods=%d"
+              self#audio_channels alsa_rate bufsize
               (Pcm.get_frame_size params)
               periods;
             Pcm.set_params dev params;

--- a/src/outputs/alsa_out.ml
+++ b/src/outputs/alsa_out.ml
@@ -82,6 +82,7 @@ class output ~kind ~clock_safe ~infallible ~on_stop ~on_start ~start dev source
             self#log#important "Using ALSA %s." (Alsa.get_version ());
             let dev = Pcm.open_pcm dev [Pcm.Playback] [] in
             let params = Pcm.get_params dev in
+            let channels = self#audio_channels in
             let bufsize, periods =
               ( try
                   Pcm.set_access dev params Pcm.Access_rw_noninterleaved;
@@ -93,10 +94,12 @@ class output ~kind ~clock_safe ~infallible ~on_stop ~on_start ~start dev source
                   Pcm.set_format dev params Pcm.Format_s16_le;
                   alsa_write <-
                     (fun pcm buf ofs len ->
-                      let sbuf = Bytes.create (2 * len * Array.length buf) in
+                      let sbuf =
+                        Bytes.create (Audio.S16LE.size (Array.length buf) len)
+                      in
                       Audio.S16LE.of_audio (Audio.sub buf ofs len) sbuf 0;
                       Pcm.writei pcm sbuf 0 len) );
-              Pcm.set_channels dev params self#audio_channels;
+              Pcm.set_channels dev params channels;
               alsa_rate <-
                 Pcm.set_rate_near dev params samples_per_second Dir_eq;
 
@@ -115,7 +118,7 @@ class output ~kind ~clock_safe ~infallible ~on_stop ~on_start ~start dev source
             self#log#important
               "channels=%d, samplerate=%dHz, buffer size=%dB, frame size=%dB, \
                periods=%d"
-              self#audio_channels alsa_rate bufsize
+              channels alsa_rate bufsize
               (Pcm.get_frame_size params)
               periods;
             Pcm.set_params dev params;
@@ -140,15 +143,16 @@ class output ~kind ~clock_safe ~infallible ~on_stop ~on_start ~start dev source
         in
         f 0
       with e ->
+        let bt = Printexc.get_raw_backtrace () in
         begin
           match e with
           | Buffer_xrun -> self#log#severe "Underrun!"
           | _ -> self#log#severe "Alsa error: %s" (string_of_error e)
         end;
         if e = Buffer_xrun || e = Suspended || e = Interrupted then (
-          self#log#severe "Trying to recover..";
+          self#log#severe "Trying to recover.";
           Pcm.recover dev e )
-        else raise e
+        else Printexc.raise_with_backtrace e bt
 
     method output_send buf =
       let buf = AFrame.pcm buf in

--- a/tests/language/typing.liq
+++ b/tests/language/typing.liq
@@ -140,6 +140,7 @@ def f() =
   ignore(sum_eq)
 
   (noise():source(audio=pcm,video=yuva420p,midi=none))
+  (noise():source(audio=none,video=none,midi=none))
 
   (single("annotate:foo=\"bla\":/nonexistent"):source(audio=ffmpeg.audio.copy,video=ffmpeg.video.copy,midi=midi))
   (single("annotate:foo=\"bla\":/nonexistent"):source(audio=ffmpeg.audio.raw,video=ffmpeg.video.raw,midi=midi))

--- a/tests/language/typing.liq
+++ b/tests/language/typing.liq
@@ -140,6 +140,7 @@ def f() =
   ignore(sum_eq)
 
   (noise():source(audio=pcm,video=yuva420p,midi=none))
+  (noise():source(audio=pcm(mono)))
   (noise():source(audio=none,video=none,midi=none))
 
   (single("annotate:foo=\"bla\":/nonexistent"):source(audio=ffmpeg.audio.copy,video=ffmpeg.video.copy,midi=midi))


### PR DESCRIPTION
In this way the cast is correctly propagated to the runtime kind for sources, which fixes #1522.