### PR TITLE
Add handler when source is leaving.

### DIFF
--- a/src/lang/builtins_source.ml
+++ b/src/lang/builtins_source.ml
@@ -140,6 +140,23 @@ let () =
       Lang.unit)
 
 let () =
+  add_builtin "source.on_leave" ~cat:Sys
+    [
+      ("", Lang.source_t (Lang.univ_t ()), None, None);
+      ("", Lang.fun_t [] Lang.unit_t, None, None);
+    ]
+    Lang.unit_t
+    ~descr:
+      "Register a function to be called when source is not used anymore by \
+       another souce."
+    (fun p ->
+      let s = Lang.to_source (Lang.assoc "" 1 p) in
+      let f = Lang.assoc "" 2 p in
+      let wrap_f () = ignore (Lang.apply f []) in
+      s#on_leave wrap_f;
+      Lang.unit)
+
+let () =
   add_builtin "source.on_shutdown" ~cat:Sys
     [
       ("", Lang.source_t (Lang.univ_t ()), None, None);

--- a/src/lang/lang.ml
+++ b/src/lang/lang.ml
@@ -202,9 +202,9 @@ let doc_of_prototype_item ~generalized t d doc =
   let item = new Doc.item doc in
   item#add_subsection "type" (T.doc_of_type ~generalized t);
   item#add_subsection "default"
-    (match d with
+    ( match d with
       | None -> Doc.trivial "None"
-      | Some d -> Doc.trivial (print_value d));
+      | Some d -> Doc.trivial (print_value d) );
   item
 
 type doc_flag = Hidden | Deprecated | Experimental | Extra
@@ -325,9 +325,9 @@ let iter_sources f v =
             let v = List.assoc v env in
             if Lazy.is_val v then (
               let v = Lazy.force v in
-              iter_value v)
+              iter_value v )
             else ()
-          with Not_found -> ())
+          with Not_found -> () )
       | Term.App (a, l) ->
           iter_term env a;
           List.iter (fun (_, v) -> iter_term env v) l
@@ -389,7 +389,7 @@ let iter_sources f v =
                   "WARNING! Found a reference, potentially containing sources, \
                    inside a dynamic source-producing function. Static analysis \
                    cannot be performed: make sure you are not sharing sources \
-                   contained in references!"))
+                   contained in references!" ) )
   in
   iter_value v
 
@@ -409,7 +409,7 @@ let to_bool_getter t =
         fun () ->
           match (apply t []).value with
             | Ground (Bool b) -> b
-            | _ -> assert false)
+            | _ -> assert false )
     | _ -> assert false
 
 let to_fun f =
@@ -427,7 +427,7 @@ let to_string_getter t =
         fun () ->
           match (apply t []).value with
             | Ground (String s) -> s
-            | _ -> assert false)
+            | _ -> assert false )
     | _ -> assert false
 
 let to_float t =
@@ -440,7 +440,7 @@ let to_float_getter t =
         fun () ->
           match (apply t []).value with
             | Ground (Float s) -> s
-            | _ -> assert false)
+            | _ -> assert false )
     | _ -> assert false
 
 let to_source t =
@@ -462,7 +462,7 @@ let to_int_getter t =
         fun () ->
           match (apply t []).value with
             | Ground (Int n) -> n
-            | _ -> assert false)
+            | _ -> assert false )
     | _ -> assert false
 
 let to_num t =
@@ -726,6 +726,15 @@ let source_methods =
         val_fun [("", "", None)] (fun p ->
             let f = assoc "" 1 p in
             s#on_shutdown (fun () -> ignore (apply f []));
+            unit) );
+    ( "on_leave",
+      ([], fun_t [(false, "", fun_t [] unit_t)] unit_t),
+      "Register a function to be called when source is not used anymore by \
+       another source.",
+      fun s ->
+        val_fun [("", "", None)] (fun p ->
+            let f = assoc "" 1 p in
+            s#on_leave (fun () -> ignore (apply f []));
             unit) );
     ( "on_track",
       ([], fun_t [(false, "", fun_t [(false, "", metadata_t)] unit_t)] unit_t),

--- a/src/source.ml
+++ b/src/source.ml
@@ -261,7 +261,7 @@ module Kind = struct
             match t with
               | `Audio -> Frame_content.default_audio ()
               | `Video -> Frame_content.default_video ()
-              | `Midi -> Frame_content.default_midi ())
+              | `Midi -> Frame_content.default_midi () )
         | `Format f -> f
         | `Kind k -> Frame_content.default_format k
     in
@@ -395,7 +395,7 @@ class virtual operator ?(name = "src") ?audio_in ?video_in ?midi_in out_kind
       let s = Pcre.substitute ~pat:"[ \t\n]" ~subst:(fun _ -> "_") s in
       if not definitive_id then (
         id <- s;
-        definitive_id <- definitive);
+        definitive_id <- definitive );
 
       (* Sometimes the ID is changed during initialization,
        * in order to make it equal to the server name,
@@ -529,16 +529,16 @@ class virtual operator ?(name = "src") ?audio_in ?video_in ?midi_in out_kind
                     dynamic_activations
                 then Some "possible dynamic activation"
                 else None
-            | _ -> Some "two static activations")
+            | _ -> Some "two static activations" )
       with
         | None ->
             if caching then (
               caching <- false;
-              self#log#debug "Disabling caching mode.")
+              self#log#debug "Disabling caching mode." )
         | Some msg ->
             if not caching then (
               caching <- true;
-              self#log#debug "Enabling caching mode: %s." msg)
+              self#log#debug "Enabling caching mode: %s." msg )
 
     (* Ask for initialization.
      * The current implementation makes it dangerous to call #get_ready from
@@ -549,7 +549,7 @@ class virtual operator ?(name = "src") ?audio_in ?video_in ?midi_in out_kind
       if static_activations = [] && dynamic_activations = [] then (
         source_log#info "Source %s gets up with content kind: %s." id
           (Kind.to_string self#kind);
-        self#wake_up activation);
+        self#wake_up activation );
       if dynamic then dynamic_activations <- activation :: dynamic_activations
       else static_activations <- activation :: static_activations;
       self#update_caching_mode;
@@ -562,11 +562,18 @@ class virtual operator ?(name = "src") ?audio_in ?video_in ?midi_in out_kind
           w.get_ready ~stype:self#stype ~is_output:self#is_output ~id:self#id
             ~ctype:self#ctype ~clock_id ~clock_sync_mode)
 
+    val mutable on_leave = []
+
+    method on_leave = self#mutexify (fun fn -> on_leave <- fn :: on_leave)
+
     (* Release the source, which will shutdown if possible.
      * The current implementation makes it dangerous to call #leave from
      * another thread than the Root one, as interleaving with #get is
      * forbidden. *)
     method leave ?(dynamic = false) src =
+      self#mutexify
+        (fun () -> List.iter (fun fn -> try fn () with _ -> ()) on_leave)
+        ();
       let rec remove acc = function
         | [] ->
             self#log#critical "Got ill-balanced activations (from %s)!" src#id;
@@ -584,7 +591,7 @@ class virtual operator ?(name = "src") ?audio_in ?video_in ?midi_in out_kind
             List.iter (fun fn -> try fn () with _ -> ()) on_shutdown;
             on_shutdown <- [])
           ();
-        self#sleep);
+        self#sleep );
       self#iter_watchers (fun w -> w.leave ())
 
     method is_up = static_activations <> [] || dynamic_activations <> []
@@ -676,7 +683,7 @@ class virtual operator ?(name = "src") ?audio_in ?video_in ?midi_in out_kind
                 | None -> Hashtbl.create 0
                 | Some m -> m
             in
-            List.iter (fun fn -> fn m) on_track);
+            List.iter (fun fn -> fn m) on_track );
           was_partial <- is_partial)
         ();
       self#iter_watchers (fun w ->
@@ -720,7 +727,7 @@ class virtual operator ?(name = "src") ?audio_in ?video_in ?midi_in out_kind
           self#instrumented_get_frame buf;
           if List.length b + 1 <> List.length (Frame.breaks buf) then (
             self#log#severe "#get_frame didn't add exactly one break!";
-            assert false))
+            assert false ) )
       else (
         let memo = self#memo in
         try Frame.get_chunk buf memo
@@ -733,9 +740,9 @@ class virtual operator ?(name = "src") ?audio_in ?video_in ?midi_in out_kind
             self#instrumented_get_frame memo;
             if List.length b + 1 <> List.length (Frame.breaks memo) then (
               self#log#severe "#get_frame didn't add exactly one break!";
-              assert false)
+              assert false )
             else if p < Frame.position memo then self#get buf
-            else Frame.add_break buf (Frame.position buf)))
+            else Frame.add_break buf (Frame.position buf) ) )
 
     (* That's the way the source produces audio data.
      * It cannot be called directly, but [#get] should be used instead, for

--- a/src/source.mli
+++ b/src/source.mli
@@ -134,6 +134,9 @@ class virtual source :
            [get_ready] and not called externally. *)
        method private wake_up : source list -> unit
 
+       (** Register a callback when leave is called. *)
+       method on_leave : (unit -> unit) -> unit
+
        (** Opposite of [get_ready] : the operator no longer needs the source. *)
        method leave : ?dynamic:bool -> source -> unit
 


### PR DESCRIPTION
A common problem consists in skipping a source when it is not used anymore in a `switch`.  When `switch` changes sources is "leaves" the old source. The current patch allows registering a callback on this situation. We can thus do something like:

```
m = playlist("~/Music")
m.on_leave({print("leaving!"); m.skip()})
s = sine()
s = switch(track_sensitive=false, [({time () mod 10. <= 1.}, s), ({true}, m)])
output(s)
```

Each time `s` kicks in `m` is left and thus skipped.