### PR TITLE
Add handlers for asynchronous errors.

### DIFF
--- a/src/lang/builtins_thread.ml
+++ b/src/lang/builtins_thread.ml
@@ -80,7 +80,7 @@ let () =
         (false, "queue_name", Lang.string_t);
         (false, "", Builtins_error.Error.t);
       ]
-      Lang.bool_t
+      Lang.unit_t
   in
   add_builtin "thread.on_error" ~cat:Liq
     ~descr:
@@ -96,9 +96,10 @@ let () =
             let error = Builtins_error.(Error.to_value { kind; msg }) in
             let bt = Lang.string bt in
             let name = Lang.string name in
-            Lang.to_bool
+            ignore
               (Lang.apply fn
-                 [("backtrace", bt); ("queue_name", name); ("", error)])
+                 [("backtrace", bt); ("queue_name", name); ("", error)]);
+            true
         | _ -> false
       in
       Queue.push handler Tutils.error_handlers;

--- a/src/lang/builtins_thread.ml
+++ b/src/lang/builtins_thread.ml
@@ -84,12 +84,15 @@ let () =
   in
   add_builtin "thread.on_error" ~cat:Liq
     ~descr:
-      "Register a function to be called when an error is raised in a \
-       asynchronous thread. Returns `true` if the exception has been handled \
-       by the given callback." [("", fun_t, None, None)] Lang.unit_t (fun p ->
-      let fn = List.assoc "" p in
+      "Register a function to be called when an error of the given kind is \
+       raised in a asynchronous thread."
+    [("", Builtins_error.Error.t, None, None); ("", fun_t, None, None)]
+    Lang.unit_t (fun p ->
+      let err = Builtins_error.Error.of_value (Lang.assoc "" 1 p) in
+      let fn = Lang.assoc "" 2 p in
       let handler ~bt ~name = function
-        | Lang_values.(Runtime_error { kind; msg; _ }) ->
+        | Lang_values.(Runtime_error { kind; msg; _ })
+          when kind = err.Builtins_error.kind ->
             let error = Builtins_error.(Error.to_value { kind; msg }) in
             let bt = Lang.string bt in
             let name = Lang.string name in

--- a/src/tools/tutils.mli
+++ b/src/tools/tutils.mli
@@ -56,6 +56,10 @@ type priority =
 (** task scheduler *)
 val scheduler : priority Duppy.scheduler
 
+(** Register queue error handlers. Should return [true] if 
+    the exception was handler by the given callback. *)
+val error_handlers : (bt:string -> name:string -> exn -> bool) Queue.t
+
 (** {1 Misc} *)
 
 (** Waits for [f()] to become true on condition [c].

--- a/tests/language/error.liq
+++ b/tests/language/error.liq
@@ -105,7 +105,28 @@ def f() =
     end
   t(ret, "blo")
 
-  if !success then test.pass() else test.fail() end
+  def on_done() =
+    if !success then
+      test.pass()
+    else
+      test.fail()
+    end 
+  end
+
+  # Catches error in asynchronous tasks
+  def on_error(~backtrace, ~queue_name, e) =
+    if error.kind(e) == "foo" then
+      print("caught error #{e} from queue #{queue_name} and backtrace:\n#{backtrace}")
+      on_done()
+      true
+    else
+      test.fail()
+      false
+    end
+  end
+
+  thread.on_error(on_error)
+  thread.run(fun () -> error.raise(e, "Asynchronous error"))
 end
 
 test.check(f)

--- a/tests/language/error.liq
+++ b/tests/language/error.liq
@@ -115,17 +115,11 @@ def f() =
 
   # Catches error in asynchronous tasks
   def on_error(~backtrace, ~queue_name, e) =
-    if error.kind(e) == "foo" then
-      print("caught error #{e} from queue #{queue_name} and backtrace:\n#{backtrace}")
-      on_done()
-      true
-    else
-      test.fail()
-      false
-    end
+    print("caught error #{e} from queue #{queue_name} and backtrace:\n#{backtrace}")
+    on_done()
   end
 
-  thread.on_error(on_error)
+  thread.on_error(e, on_error)
   thread.run(fun () -> error.raise(e, "Asynchronous error"))
 end
 

--- a/tests/language/error.liq
+++ b/tests/language/error.liq
@@ -116,7 +116,11 @@ def f() =
   # Catches error in asynchronous tasks
   def on_error(~backtrace, ~queue_name, e) =
     print("caught error #{e} from queue #{queue_name} and backtrace:\n#{backtrace}")
-    on_done()
+    if error.kind(e) == "foo" then
+      on_done()
+    else
+      test.fail()
+    end
   end
 
   thread.on_error(e, on_error)


### PR DESCRIPTION
This PR ads support for catching runtime errors inside asynchronous queues. It should be recommended to ad such handlers every time one makes heavy use of asynchronous tasks.

Additionally, we should start visiting the code and see how much of the runtime OCaml exceptions that we raise should be converted to `Lang_value.Runtime_error` so that we can give the user more flexibility with how to handle errors.

Example:
```ruby
e = error.register("foo")

def on_error(~backtrace, ~queue_name, e) =
  print("caught error #{e} from queue #{queue_name} and backtrace:\n#{backtrace}")
end

thread.on_error(e, on_error)

thread.run(fun () -> error.raise(e, "Asynchronous error"))
```

Fixes: #1550