### PR TITLE
Unified kind

### DIFF
--- a/src/conversions/audio_to_stereo.ml
+++ b/src/conversions/audio_to_stereo.ml
@@ -36,8 +36,9 @@ class basic source =
   object
     inherit
       Source.operator
-        ~audio_in:Frame.audio_pcm Lang.audio_stereo [source]
-          ~name:"audio_to_stereo"
+        ~audio_in:Frame.audio_pcm
+        (Source.Kind.of_kind Lang.audio_stereo)
+        [source] ~name:"audio_to_stereo"
 
     inherit
       Conversion.base

--- a/src/conversions/drop.ml
+++ b/src/conversions/drop.ml
@@ -32,6 +32,7 @@ class drop ?(audio = false) ?(video = false) ?(midi = false) ~name source =
       midi = (if midi then Frame.none else `Any);
     }
   in
+  let kind = Source.Kind.of_kind kind in
   object
     inherit Source.operator ?audio_in ?video_in ?midi_in kind [source] ~name
 

--- a/src/conversions/mean.ml
+++ b/src/conversions/mean.ml
@@ -25,7 +25,10 @@ open Source
 class mean ~normalize source =
   object
     inherit
-      operator ~audio_in:Frame.audio_pcm Lang.audio_mono [source] ~name:"mean"
+      operator
+        ~audio_in:Frame.audio_pcm
+        (Source.Kind.of_kind Lang.audio_mono)
+        [source] ~name:"mean"
 
     inherit
       Conversion.base

--- a/src/conversions/mux.ml
+++ b/src/conversions/mux.ml
@@ -37,14 +37,17 @@ let create ~name ~pre_buffer ~max_buffer ~main_source ~main_content ~aux_source
       abort = false;
     }
   in
-  let producer = new producer ~kind:Lang.any ~name control in
+  let producer =
+    new producer ~kind:(Source.Kind.of_kind Lang.any) ~name control
+  in
   let main_kind =
-    Frame.
-      {
-        audio = (if main_content = `Audio then `Any else none);
-        video = (if main_content = `Video then `Any else none);
-        midi = `Any;
-      }
+    Source.Kind.of_kind
+      Frame.
+        {
+          audio = (if main_content = `Audio then `Any else none);
+          video = (if main_content = `Video then `Any else none);
+          midi = `Any;
+        }
   in
   let main_output_kind =
     match main_content with
@@ -58,12 +61,13 @@ let create ~name ~pre_buffer ~max_buffer ~main_source ~main_content ~aux_source
       ~content:main_content ~max_buffer ~pre_buffer ~source:main_source control
   in
   let aux_kind =
-    Frame.
-      {
-        audio = (if aux_content = `Audio then `Any else none);
-        video = (if aux_content = `Video then `Any else none);
-        midi = none;
-      }
+    Source.Kind.of_kind
+      Frame.
+        {
+          audio = (if aux_content = `Audio then `Any else none);
+          video = (if aux_content = `Video then `Any else none);
+          midi = none;
+        }
   in
   let aux_output_kind =
     match aux_content with

--- a/src/conversions/swap.ml
+++ b/src/conversions/swap.ml
@@ -65,4 +65,5 @@ let () =
     ~descr:"Swap two channels of a stereo source."
     (fun p ->
       let s = Lang.to_source (Lang.assoc "" 1 p) in
+      let kind = Source.Kind.of_kind kind in
       new swap ~kind s)

--- a/src/harbor/harbor.ml
+++ b/src/harbor/harbor.ml
@@ -106,7 +106,7 @@ module type T = sig
   (* Source input *)
 
   class virtual source :
-    kind:Frame.content_kind
+    kind:Source.Kind.t
     -> object
          inherit Source.source
 

--- a/src/io/alsa_io.ml
+++ b/src/io/alsa_io.ml
@@ -176,8 +176,8 @@ class output ~kind ~clock_safe ~start ~infallible ~on_stop ~on_start dev
   object (self)
     inherit
       Output.output
-        ~infallible ~on_stop ~on_start ~content_kind:kind ~name
-          ~output_kind:"output.alsa" val_source start as super
+        ~infallible ~on_stop ~on_start ~content_kind:(Source.Kind.of_kind kind)
+          ~name ~output_kind:"output.alsa" val_source start as super
 
     inherit base dev [Pcm.Playback]
 
@@ -244,7 +244,7 @@ class input ~kind ~clock_safe ~start ~on_stop ~on_start ~fallible dev =
 
     inherit
       Start_stop.input
-        ~content_kind:kind ~source_kind:"alsa"
+        ~content_kind:(Source.Kind.of_kind kind) ~source_kind:"alsa"
         ~name:(Printf.sprintf "alsa_in(%s)" dev)
         ~on_start ~on_stop ~fallible ~autostart:start as super
 

--- a/src/io/ffmpeg_io.ml
+++ b/src/io/ffmpeg_io.ml
@@ -199,6 +199,7 @@ let () =
       let bufferize = Lang.to_float (List.assoc "buffer" p) in
       let log_overfull = Lang.to_bool (List.assoc "log_overfull" p) in
       let url = Lang.to_string (Lang.assoc "" 1 p) in
+      let kind = Source.Kind.of_kind kind in
       ( new input
           ~kind ~start ~on_start ~on_stop ~bufferize ~log_overfull ?format ~opts
           url

--- a/src/io/gstreamer_io.ml
+++ b/src/io/gstreamer_io.ml
@@ -361,6 +361,7 @@ let () =
         fun () -> ignore (Lang.apply f [])
       in
       let source = List.assoc "" p in
+      let kind = Source.Kind.of_kind kind in
       ( new output
           ~kind ~clock_safe ~on_error ~infallible ~on_start ~on_stop source
           start ("", Some pipeline, None)
@@ -391,6 +392,7 @@ let () =
         fun () -> ignore (Lang.apply f [])
       in
       let source = List.assoc "" p in
+      let kind = Source.Kind.of_kind kind in
       ( new output
           ~kind ~clock_safe ~infallible ~on_error ~on_start ~on_stop source
           start ("", None, Some pipeline)
@@ -441,6 +443,7 @@ let () =
         fun () -> ignore (Lang.apply f [])
       in
       let source = List.assoc "" p in
+      let kind = Source.Kind.of_kind kind in
       ( new output
           ~kind ~clock_safe ~infallible ~on_error ~on_start ~on_stop ~blocking
           source start
@@ -733,6 +736,7 @@ let () =
       let video_pipeline =
         Lang.to_string_getter (List.assoc "video_pipeline" p)
       in
+      let kind = Source.Kind.of_kind kind in
       new audio_video_input
         p kind
         (pipeline, Some audio_pipeline, Some video_pipeline))
@@ -752,6 +756,7 @@ let () =
   Lang.add_operator "input.gstreamer.audio" proto ~return_t ~category:Lang.Input
     ~flags:[] ~descr:"Stream audio from a GStreamer pipeline." (fun p ->
       let pipeline = Lang.to_string_getter (List.assoc "pipeline" p) in
+      let kind = Source.Kind.of_kind kind in
       ( new audio_video_input p kind ((fun () -> ""), Some pipeline, None)
         :> Source.source ))
 
@@ -770,5 +775,6 @@ let () =
   Lang.add_operator "input.gstreamer.video" proto ~return_t ~category:Lang.Input
     ~flags:[] ~descr:"Stream video from a GStreamer pipeline." (fun p ->
       let pipeline = Lang.to_string_getter (List.assoc "pipeline" p) in
+      let kind = Source.Kind.of_kind kind in
       ( new audio_video_input p kind ((fun () -> ""), None, Some pipeline)
         :> Source.source ))

--- a/src/io/oss_io.ml
+++ b/src/io/oss_io.ml
@@ -43,8 +43,8 @@ class output ~kind ~clock_safe ~on_start ~on_stop ~infallible ~start dev
   object (self)
     inherit
       Output.output
-        ~infallible ~on_stop ~on_start ~content_kind:kind ~name
-          ~output_kind:"output.oss" val_source start as super
+        ~infallible ~on_stop ~on_start ~content_kind:(Source.Kind.of_kind kind)
+          ~name ~output_kind:"output.oss" val_source start as super
 
     method private set_clock =
       super#set_clock;
@@ -93,7 +93,7 @@ class input ~kind ~clock_safe ~start ~on_stop ~on_start ~fallible dev =
   object (self)
     inherit
       Start_stop.input
-        ~content_kind:kind ~source_kind:"oss"
+        ~content_kind:(Source.Kind.of_kind kind) ~source_kind:"oss"
         ~name:(Printf.sprintf "oss_in(%s)" dev)
         ~on_start ~on_stop ~fallible ~autostart:start as super
 

--- a/src/io/portaudio_io.ml
+++ b/src/io/portaudio_io.ml
@@ -213,6 +213,7 @@ let () =
       in
       let source = List.assoc "" p in
       let clock_safe = Lang.to_bool (List.assoc "clock_safe" p) in
+      let kind = Source.Kind.of_kind kind in
       ( new output
           ~kind ~start ~on_start ~on_stop ~infallible ~clock_safe buflen source
         :> Source.source ));
@@ -244,5 +245,6 @@ let () =
         let f = List.assoc "on_stop" p in
         fun () -> ignore (Lang.apply f [])
       in
+      let kind = Source.Kind.of_kind kind in
       ( new input ~kind ~clock_safe ~start ~on_start ~on_stop ~fallible buflen
         :> Source.source ))

--- a/src/io/pulseaudio_io.ml
+++ b/src/io/pulseaudio_io.ml
@@ -226,9 +226,11 @@ let () =
         let f = List.assoc "on_stop" p in
         fun () -> ignore (Lang.apply f [])
       in
+      let kind = Source.Kind.of_kind kind in
       (new output ~infallible ~on_start ~on_stop ~start ~kind p :> Source.source));
   Lang.add_operator "input.pulseaudio" ~active:true
     (Start_stop.input_proto @ proto)
     ~return_t:k ~category:Lang.Input
     ~descr:"Stream from a portaudio input device." (fun p ->
+      let kind = Source.Kind.of_kind kind in
       (new input ~kind p :> Source.source))

--- a/src/io/srt_io.ml
+++ b/src/io/srt_io.ml
@@ -755,7 +755,7 @@ class virtual input_base ~kind ~max ~log_overfull ~clock_safe ~on_connect
 
     inherit base
 
-    inherit Source.source ~name:"input.srt" kind as super
+    inherit Source.source ~name:"input.srt" (Source.Kind.of_kind kind) as super
 
     val mutable decoder_data = None
 
@@ -1067,9 +1067,9 @@ class output_caller ~kind ~payload_size ~messageapi ~on_start ~on_stop
   object
     inherit
       output_base
-        ~kind ~payload_size ~messageapi ~on_start ~on_stop ~infallible
-          ~autostart ~stats_interval ~on_connect ~on_disconnect ~encoder_factory
-          source
+        ~kind:(Source.Kind.of_kind kind) ~payload_size ~messageapi ~on_start
+          ~on_stop ~infallible ~autostart ~stats_interval ~on_connect
+          ~on_disconnect ~encoder_factory source
 
     inherit
       caller
@@ -1082,9 +1082,9 @@ class output_listener ~kind ~payload_size ~messageapi ~on_start ~on_stop
   object
     inherit
       output_base
-        ~kind ~payload_size ~messageapi ~on_start ~on_stop ~infallible
-          ~autostart ~stats_interval ~on_connect ~on_disconnect ~encoder_factory
-          source
+        ~kind:(Source.Kind.of_kind kind) ~payload_size ~messageapi ~on_start
+          ~on_stop ~infallible ~autostart ~stats_interval ~on_connect
+          ~on_disconnect ~encoder_factory source
 
     inherit
       listener

--- a/src/io/udp_io.ml
+++ b/src/io/udp_io.ml
@@ -220,6 +220,7 @@ let () =
                (fmt, "Cannot get a stream encoder for that format"))
       in
       let source = Lang.assoc "" 2 p in
+      let kind = Source.Kind.of_kind kind in
       ( new output
           ~kind ~on_start ~on_stop ~infallible ~autostart ~hostname ~port
           ~encoder_factory:fmt source
@@ -261,6 +262,7 @@ let () =
                      "Cannot get a stream decoder for this MIME" ))
           | Some decoder_factory -> decoder_factory
       in
+      let kind = Source.Kind.of_kind kind in
       ( new input
           ~kind ~hostname ~port ~bufferize ~log_overfull ~get_stream_decoder
         :> Source.source ))

--- a/src/lang/builtins_ffmpeg_decoder.ml
+++ b/src/lang/builtins_ffmpeg_decoder.ml
@@ -425,7 +425,7 @@ let mk_encoder mode =
       in
       let producer =
         new Producer_consumer.producer
-          ~kind:return_kind
+          ~kind:(Source.Kind.of_kind return_kind)
           ~name:("ffmpeg." ^ extension ^ ".producer")
           control
       in
@@ -480,8 +480,8 @@ let mk_encoder mode =
         new Producer_consumer.consumer
           ~write_frame:decode_frame ~producer
           ~output_kind:("ffmpeg." ^ extension ^ ".consumer")
-          ~kind:source_kind ~content:`Audio ~max_buffer ~pre_buffer ~source
-          control
+          ~kind:(Source.Kind.of_kind source_kind)
+          ~content:`Audio ~max_buffer ~pre_buffer ~source control
       in
       producer)
 

--- a/src/lang/builtins_ffmpeg_encoder.ml
+++ b/src/lang/builtins_ffmpeg_encoder.ml
@@ -484,7 +484,7 @@ let mk_encoder mode =
       in
       let producer =
         new Producer_consumer.producer
-          ~kind:return_kind
+          ~kind:(Source.Kind.of_kind return_kind)
           ~name:("ffmpeg." ^ extension ^ ".producer")
           control
       in
@@ -630,8 +630,8 @@ let mk_encoder mode =
         new Producer_consumer.consumer
           ~write_frame:encode_frame ~producer
           ~output_kind:("ffmpeg." ^ extension ^ ".consumer")
-          ~kind:source_kind ~content:`Audio ~max_buffer ~pre_buffer ~source
-          control
+          ~kind:(Source.Kind.of_kind source_kind)
+          ~content:`Audio ~max_buffer ~pre_buffer ~source control
       in
       producer)
 

--- a/src/lang/builtins_ffmpeg_filters.ml
+++ b/src/lang/builtins_ffmpeg_filters.ml
@@ -465,16 +465,17 @@ let () =
       let source_val = Lang.assoc "" 2 p in
 
       let kind =
-        Frame.
-          {
-            (* We need to make sure that we are using a format here to
-               ensure that its params are properly unified with the underlying source. *)
-            audio =
-              `Format
-                Ffmpeg_raw_content.Audio.(lift_params (default_params `Raw));
-            video = `Any;
-            midi = `Any;
-          }
+        Source.Kind.of_kind
+          Frame.
+            {
+              (* We need to make sure that we are using a format here to
+                 ensure that its params are properly unified with the underlying source. *)
+              audio =
+                `Format
+                  Ffmpeg_raw_content.Audio.(lift_params (default_params `Raw));
+              video = `Any;
+              midi = `Any;
+            }
       in
       let name = uniq_name "abuffer" in
       let pos = source_val.Lang.pos in
@@ -516,12 +517,13 @@ let () =
       let graph = Graph.of_value graph_v in
 
       let kind =
-        Frame.
-          {
-            audio = `Kind Ffmpeg_raw_content.Audio.kind;
-            video = none;
-            midi = none;
-          }
+        Source.Kind.of_kind
+          Frame.
+            {
+              audio = `Kind Ffmpeg_raw_content.Audio.kind;
+              video = none;
+              midi = none;
+            }
       in
       let bufferize = Lang.to_float (List.assoc "buffer" p) in
       let s = new Ffmpeg_filter_io.audio_input ~bufferize kind in
@@ -553,16 +555,17 @@ let () =
       let source_val = Lang.assoc "" 2 p in
 
       let kind =
-        Frame.
-          {
-            (* We need to make sure that we are using a format here to
-               ensure that its params are properly unified with the underlying source. *)
-            audio = `Any;
-            video =
-              `Format
-                Ffmpeg_raw_content.Video.(lift_params (default_params `Raw));
-            midi = `Any;
-          }
+        Source.Kind.of_kind
+          Frame.
+            {
+              (* We need to make sure that we are using a format here to
+                 ensure that its params are properly unified with the underlying source. *)
+              audio = `Any;
+              video =
+                `Format
+                  Ffmpeg_raw_content.Video.(lift_params (default_params `Raw));
+              midi = `Any;
+            }
       in
       let name = uniq_name "buffer" in
       let pos = source_val.Lang.pos in
@@ -616,12 +619,13 @@ let () =
       let fps = Option.value fps ~default:Frame.video_rate in
 
       let kind =
-        Frame.
-          {
-            audio = none;
-            video = `Kind Ffmpeg_raw_content.Video.kind;
-            midi = none;
-          }
+        Source.Kind.of_kind
+          Frame.
+            {
+              audio = none;
+              video = `Kind Ffmpeg_raw_content.Video.kind;
+              midi = none;
+            }
       in
       let bufferize = Lang.to_float (List.assoc "buffer" p) in
       let s = new Ffmpeg_filter_io.video_input ~bufferize ~fps kind in

--- a/src/operators/accelerate.ml
+++ b/src/operators/accelerate.ml
@@ -123,4 +123,5 @@ let () =
       let src = Lang.to_source (f "") in
       let ratio = Lang.to_float_getter (f "ratio") in
       let randomize = Lang.to_float_getter (f "randomize") in
+      let kind = Source.Kind.of_kind kind in
       new accelerate ~kind ~ratio ~randomize src)

--- a/src/operators/add.ml
+++ b/src/operators/add.ml
@@ -205,6 +205,7 @@ let () =
           (Lang_errors.Invalid_value
              ( List.assoc "weights" p,
                "there should be as many weights as sources" ));
+      let kind = Source.Kind.of_kind kind in
       ( new add
           ~kind ~renorm ~power
           (List.map2 (fun w s -> (w, s)) weights sources)
@@ -290,6 +291,7 @@ let () =
           (Lang_errors.Invalid_value
              ( List.assoc "weights" p,
                "there should be as many weights as sources" ));
+      let kind = Source.Kind.of_kind kind in
       ( new add
           ~kind ~renorm ~power
           (List.map2 (fun w s -> (w, s)) weights sources)

--- a/src/operators/amplify.ml
+++ b/src/operators/amplify.ml
@@ -96,4 +96,5 @@ let () =
       let s = Lang.to_source (Lang.assoc "" 2 p) in
       let o = Lang.to_option (Lang.assoc "override" 1 p) in
       let o = Option.map Lang.to_string o in
+      let kind = Source.Kind.of_kind kind in
       new amplify ~kind s o c)

--- a/src/operators/append.ml
+++ b/src/operators/append.ml
@@ -171,4 +171,5 @@ let register =
       let insert_missing = Lang.to_bool (Lang.assoc "insert_missing" 1 p) in
       let source = Lang.to_source (Lang.assoc "" 1 p) in
       let f = Lang.assoc "" 2 p in
+      let kind = Source.Kind.of_kind kind in
       new append ~kind ~insert_missing ~merge source f)

--- a/src/operators/available.ml
+++ b/src/operators/available.ml
@@ -83,4 +83,5 @@ let () =
       let override = List.assoc "override" p |> Lang.to_bool in
       let s = Lang.assoc "" 1 p |> Lang.to_source in
       let pred = Lang.assoc "" 2 p |> Lang.to_bool_getter in
+      let kind = Source.Kind.of_kind kind in
       new available ~kind ~track_sensitive ~override pred s)

--- a/src/operators/biquad_filter.ml
+++ b/src/operators/biquad_filter.ml
@@ -193,6 +193,7 @@ let () =
           Lang.to_float_getter (f "slope"),
           Lang.to_source (f "") )
       in
+      let kind = Source.Kind.of_kind kind in
       ( new biquad ~kind src `Low_shelf freq param (fun () -> 0.)
         :> Source.source ))
 
@@ -217,6 +218,7 @@ let () =
           Lang.to_float_getter (f "slope"),
           Lang.to_source (f "") )
       in
+      let kind = Source.Kind.of_kind kind in
       ( new biquad ~kind src `High_shelf freq param (fun () -> 0.)
         :> Source.source ))
 
@@ -237,6 +239,7 @@ let () =
           Lang.to_float_getter (f "q"),
           Lang.to_source (f "") )
       in
+      let kind = Source.Kind.of_kind kind in
       (new biquad ~kind src `Low_pass freq param (fun () -> 0.) :> Source.source))
 
 let () =
@@ -256,6 +259,7 @@ let () =
           Lang.to_float_getter (f "q"),
           Lang.to_source (f "") )
       in
+      let kind = Source.Kind.of_kind kind in
       ( new biquad ~kind src `High_pass freq param (fun () -> 0.)
         :> Source.source ))
 
@@ -276,6 +280,7 @@ let () =
           Lang.to_float_getter (f "q"),
           Lang.to_source (f "") )
       in
+      let kind = Source.Kind.of_kind kind in
       ( new biquad ~kind src `Band_pass freq param (fun () -> 0.)
         :> Source.source ))
 
@@ -299,6 +304,7 @@ let () =
           Lang.to_float_getter (f "bandwidth"),
           Lang.to_source (f "") )
       in
+      let kind = Source.Kind.of_kind kind in
       (new biquad ~kind src `All_pass freq param (fun () -> 0.) :> Source.source))
 
 let () =
@@ -318,6 +324,7 @@ let () =
           Lang.to_float_getter (f "q"),
           Lang.to_source (f "") )
       in
+      let kind = Source.Kind.of_kind kind in
       (new biquad ~kind src `Notch freq param (fun () -> 0.) :> Source.source))
 
 let () =
@@ -342,4 +349,5 @@ let () =
           Lang.to_float_getter (f "gain"),
           Lang.to_source (f "") )
       in
+      let kind = Source.Kind.of_kind kind in
       (new biquad ~kind src `Peaking freq param gain :> Source.source))

--- a/src/operators/chord.ml
+++ b/src/operators/chord.ml
@@ -140,4 +140,5 @@ let () =
       let f v = List.assoc v p in
       let src = Lang.to_source (f "") in
       let metadata = Lang.to_string (f "metadata") in
-      (new chord ~kind:Lang.any metadata src :> Source.source))
+      ( new chord ~kind:(Source.Kind.of_kind Lang.any) metadata src
+        :> Source.source ))

--- a/src/operators/clip.ml
+++ b/src/operators/clip.ml
@@ -59,4 +59,5 @@ let () =
     (fun p ->
       let f v = List.assoc v p in
       let src = Lang.to_source (f "") in
+      let kind = Source.Kind.of_kind kind in
       new clip ~kind src)

--- a/src/operators/comb.ml
+++ b/src/operators/comb.ml
@@ -86,4 +86,5 @@ let () =
           Lang.to_float_getter (f "feedback"),
           Lang.to_source (f "") )
       in
+      let kind = Source.Kind.of_kind kind in
       new comb ~kind src duration (fun () -> Audio.lin_of_dB (feedback ())))

--- a/src/operators/compand.ml
+++ b/src/operators/compand.ml
@@ -65,4 +65,5 @@ let () =
     (fun p ->
       let f v = List.assoc v p in
       let mu, src = (Lang.to_float (f "mu"), Lang.to_source (f "")) in
+      let kind = Source.Kind.of_kind kind in
       new compand ~kind src mu)

--- a/src/operators/compress.ml
+++ b/src/operators/compress.ml
@@ -258,6 +258,7 @@ let () =
       let window = List.assoc "window" p |> Lang.to_float_getter in
       let wet = List.assoc "wet" p |> Lang.to_float_getter in
       let s = List.assoc "" p |> Lang.to_source in
+      let kind = Source.Kind.of_kind kind in
       new compress
         ~kind ~attack ~release ~lookahead ~ratio ~knee ~threshold
         ~track_sensitive ~pre_gain ~make_up_gain ~window ~wet s)

--- a/src/operators/compress_exp.ml
+++ b/src/operators/compress_exp.ml
@@ -68,4 +68,5 @@ let () =
     (fun p ->
       let f v = List.assoc v p in
       let mu, src = (Lang.to_float (f "mu"), Lang.to_source (f "")) in
+      let kind = Source.Kind.of_kind kind in
       new compress ~kind src mu)

--- a/src/operators/compress_old.ml
+++ b/src/operators/compress_old.ml
@@ -117,6 +117,7 @@ let compress p =
       Lang.to_float_getter (f "gain"),
       Lang.to_source (f "") )
   in
+  let kind = Source.Kind.of_kind kind in
   new compress
     ~kind src
     (fun () -> attack () /. 1000.)

--- a/src/operators/cross.ml
+++ b/src/operators/cross.ml
@@ -507,6 +507,7 @@ let () =
       let conservative = Lang.to_bool (List.assoc "conservative" p) in
       let active = Lang.to_bool (List.assoc "active" p) in
       let source = Lang.to_source (Lang.assoc "" 2 p) in
+      let kind = Source.Kind.of_kind kind in
       let c =
         new cross
           ~kind source transition ~conservative ~active ~cross_length ~rms_width

--- a/src/operators/cuepoint.ml
+++ b/src/operators/cuepoint.ml
@@ -293,4 +293,5 @@ let () =
       let on_cue_out = Lang.assoc "on_cue_out" 1 p in
       let on_cue_out () = ignore (Lang.apply on_cue_out []) in
       let s = Lang.to_source (Lang.assoc "" 1 p) in
+      let kind = Source.Kind.of_kind kind in
       new cue_cut ~kind ~m_cue_in ~m_cue_out ~on_cue_in ~on_cue_out s)

--- a/src/operators/delay.ml
+++ b/src/operators/delay.ml
@@ -83,4 +83,5 @@ let () =
       let d = Lang.to_float (f 1) in
       let s = Lang.to_source (f 2) in
       let initial = Lang.to_bool (List.assoc "initial" p) in
+      let kind = Source.Kind.of_kind kind in
       new delay ~kind ~initial s d)

--- a/src/operators/delay_line.ml
+++ b/src/operators/delay_line.ml
@@ -95,4 +95,5 @@ let () =
     (fun p ->
       let duration = Lang.assoc "" 1 p |> Lang.to_float_getter in
       let s = Lang.assoc "" 2 p |> Lang.to_source in
+      let kind = Source.Kind.of_kind kind in
       new delay ~kind s duration)

--- a/src/operators/dyn_op.ml
+++ b/src/operators/dyn_op.ml
@@ -145,5 +145,6 @@ let () =
       let track_sensitive = List.assoc "track_sensitive" p |> Lang.to_bool in
       let infallible = List.assoc "infallible" p |> Lang.to_bool in
       let resurection_time = List.assoc "resurection_time" p |> Lang.to_float in
+      let kind = Source.Kind.of_kind kind in
       new dyn
         ~kind ~track_sensitive ~infallible ~resurection_time (List.assoc "" p))

--- a/src/operators/echo.ml
+++ b/src/operators/echo.ml
@@ -98,4 +98,5 @@ let () =
                (f "feedback", "feedback should be negative"));
         fun () -> Audio.lin_of_dB (feedback ())
       in
+      let kind = Source.Kind.of_kind kind in
       new echo ~kind src duration feedback pp)

--- a/src/operators/filter.ml
+++ b/src/operators/filter.ml
@@ -145,4 +145,5 @@ let () =
                 (Lang_errors.Invalid_value
                    (mode, "valid values are low|high|band|notch"))
       in
+      let kind = Source.Kind.of_kind kind in
       (new filter ~kind src freq q wet mode :> Source.source))

--- a/src/operators/filter_rc.ml
+++ b/src/operators/filter_rc.ml
@@ -125,4 +125,5 @@ let () =
               raise
                 (Lang_errors.Invalid_value (mode, "valid values are low|high"))
       in
+      let kind = Source.Kind.of_kind kind in
       (new filter ~kind src freq wet mode :> Source.source))

--- a/src/operators/fir_filter.ml
+++ b/src/operators/fir_filter.ml
@@ -186,4 +186,5 @@ let () =
           Lang.to_int (f "coeffs"),
           Lang.to_source (f "") )
       in
+      let kind = Source.Kind.of_kind kind in
       (new fir ~kind src freq beta num :> Source.source))

--- a/src/operators/flanger.ml
+++ b/src/operators/flanger.ml
@@ -110,4 +110,5 @@ let () =
           Lang.to_source (f "") )
       in
       let feedback () = Audio.lin_of_dB (feedback ()) in
+      let kind = Source.Kind.of_kind kind in
       (new flanger ~kind src duration freq feedback phase :> Source.source))

--- a/src/operators/frei0r_op.ml
+++ b/src/operators/frei0r_op.ml
@@ -345,6 +345,7 @@ let register_plugin fname =
       in
       let f v = List.assoc v p in
       let params = params instance p in
+      let kind = Source.Kind.of_kind kind in
       if inputs = 1 then (
         let source = Lang.to_source (f "") in
         new frei0r_filter ~kind ~name bgra instance params source )

--- a/src/operators/gate.ml
+++ b/src/operators/gate.ml
@@ -160,4 +160,5 @@ let () =
       let window = List.assoc "window" p |> Lang.to_float_getter in
       let window () = window () /. 1000. in
       let src = List.assoc "" p |> Lang.to_source in
+      let kind = Source.Kind.of_kind kind in
       new gate ~kind ~threshold ~attack ~release ~hold ~range ~window src)

--- a/src/operators/iir_filter.ml
+++ b/src/operators/iir_filter.ml
@@ -475,6 +475,7 @@ let () =
           Lang.to_int (f "order"),
           Lang.to_source (f "") )
       in
+      let kind = Source.Kind.of_kind kind in
       new iir ~kind src Butterworth High_pass order freq 0. 0.);
   Lang.add_operator "filter.iir.butterworth.low"
     [
@@ -490,6 +491,7 @@ let () =
           Lang.to_int (f "order"),
           Lang.to_source (f "") )
       in
+      let kind = Source.Kind.of_kind kind in
       new iir ~kind src Butterworth Low_pass order freq 0. 0.);
   Lang.add_operator "filter.iir.butterworth.bandpass"
     [
@@ -507,6 +509,7 @@ let () =
           Lang.to_int (f "order"),
           Lang.to_source (f "") )
       in
+      let kind = Source.Kind.of_kind kind in
       new iir ~kind src Butterworth Band_pass order freq1 freq2 0.);
   Lang.add_operator "filter.iir.butterworth.bandstop"
     [
@@ -524,6 +527,7 @@ let () =
           Lang.to_int (f "order"),
           Lang.to_source (f "") )
       in
+      let kind = Source.Kind.of_kind kind in
       new iir ~kind src Butterworth Band_stop order freq1 freq2 0.);
   Lang.add_operator "filter.iir.resonator.bandpass"
     [
@@ -539,6 +543,7 @@ let () =
           Lang.to_float (f "q"),
           Lang.to_source (f "") )
       in
+      let kind = Source.Kind.of_kind kind in
       new iir ~kind src Resonator Band_pass 0 freq 0. q);
   Lang.add_operator "filter.iir.resonator.bandstop"
     [
@@ -554,6 +559,7 @@ let () =
           Lang.to_float (f "q"),
           Lang.to_source (f "") )
       in
+      let kind = Source.Kind.of_kind kind in
       new iir ~kind src Resonator Band_pass 0 freq 0. q);
   Lang.add_operator "filter.iir.resonator.allpass"
     [
@@ -569,4 +575,5 @@ let () =
           Lang.to_float (f "q"),
           Lang.to_source (f "") )
       in
+      let kind = Source.Kind.of_kind kind in
       new iir ~kind src Resonator Band_pass 0 freq 0. q)

--- a/src/operators/insert_metadata.ml
+++ b/src/operators/insert_metadata.ml
@@ -121,6 +121,7 @@ let () =
     (fun p ->
       let s = Lang.to_source (List.assoc "" p) in
       let id = Lang.to_string (List.assoc "id" p) in
+      let kind = Source.Kind.of_kind kind in
       let s = new insert_metadata ~kind s in
       if id <> "" then s#set_id id;
       s)

--- a/src/operators/ladspa_op.ml
+++ b/src/operators/ladspa_op.ml
@@ -340,6 +340,7 @@ let register_descr plugin_name descr_n d inputs outputs =
       let f v = List.assoc v p in
       let source = try Some (Lang.to_source (f "")) with Not_found -> None in
       let params = params p in
+      let output_kind = Source.Kind.of_kind output_kind in
       if ni = 0 then
         new ladspa_nosource ~kind:output_kind plugin_name descr_n outputs params
       else if mono then

--- a/src/operators/lilv_op.ml
+++ b/src/operators/lilv_op.ml
@@ -346,16 +346,18 @@ let register_plugin plugin =
       else if no = 0 then
         (* TODO: can we really use such a type? *)
         ( new lilv_noout
-            ~kind:(Lang.audio_n 0) (Option.get source) plugin inputs params
+            ~kind:(Source.Kind.of_kind (Lang.audio_n 0))
+            (Option.get source) plugin inputs params
           :> Source.source )
       else if mono then
         ( new lilv_mono
-            ~kind:Lang.any (Option.get source) plugin inputs.(0) outputs.(0)
-            params
+            ~kind:(Source.Kind.of_kind Lang.any)
+            (Option.get source) plugin inputs.(0) outputs.(0) params
           :> Source.source )
       else
         ( new lilv
-            ~kind:Lang.any (Option.get source) plugin inputs outputs params
+            ~kind:(Source.Kind.of_kind Lang.any)
+            (Option.get source) plugin inputs outputs params
           :> Source.source ))
 
 let register_plugin plugin =

--- a/src/operators/lilv_op.ml
+++ b/src/operators/lilv_op.ml
@@ -35,7 +35,7 @@ let lilv_enabled =
 
 class virtual base ~kind source =
   object
-    inherit operator ~name:"lilv" kind [source]
+    inherit operator ~name:"lilv" (Source.Kind.of_kind kind) [source]
 
     method stype = source#stype
 
@@ -342,22 +342,22 @@ let register_plugin plugin =
       let source = try Some (Lang.to_source (f "")) with Not_found -> None in
       let params = params p in
       if ni = 0 then
-        new lilv_nosource ~kind:(Lang.audio_n no) plugin outputs params
+        new lilv_nosource
+          ~kind:(Source.Kind.of_kind (Lang.audio_n no))
+          plugin outputs params
       else if no = 0 then
         (* TODO: can we really use such a type? *)
         ( new lilv_noout
-            ~kind:(Source.Kind.of_kind (Lang.audio_n 0))
-            (Option.get source) plugin inputs params
+            ~kind:(Lang.audio_n 0) (Option.get source) plugin inputs params
           :> Source.source )
       else if mono then
         ( new lilv_mono
-            ~kind:(Source.Kind.of_kind Lang.any)
-            (Option.get source) plugin inputs.(0) outputs.(0) params
+            ~kind:Lang.any (Option.get source) plugin inputs.(0) outputs.(0)
+            params
           :> Source.source )
       else
         ( new lilv
-            ~kind:(Source.Kind.of_kind Lang.any)
-            (Option.get source) plugin inputs outputs params
+            ~kind:Lang.any (Option.get source) plugin inputs outputs params
           :> Source.source ))
 
 let register_plugin plugin =

--- a/src/operators/lufs.ml
+++ b/src/operators/lufs.ml
@@ -225,4 +225,5 @@ let () =
       let f v = List.assoc v p in
       let src = Lang.to_source (f "") in
       let window = Lang.to_float_getter (f "window") in
+      let kind = Source.Kind.of_kind kind in
       new lufs ~kind window src)

--- a/src/operators/map_metadata.ml
+++ b/src/operators/map_metadata.ml
@@ -114,4 +114,5 @@ let register =
       let update = Lang.to_bool (List.assoc "update" p) in
       let strip = Lang.to_bool (List.assoc "strip" p) in
       let missing = Lang.to_bool (List.assoc "insert_missing" p) in
+      let kind = Source.Kind.of_kind kind in
       new map_metadata ~kind source f missing update strip)

--- a/src/operators/map_op.ml
+++ b/src/operators/map_op.ml
@@ -65,4 +65,5 @@ let () =
     (fun p ->
       let f = to_fun_float (Lang.assoc "" 1 p) in
       let src = Lang.to_source (Lang.assoc "" 2 p) in
+      let kind = Source.Kind.of_kind kind in
       new map ~kind src f)

--- a/src/operators/max_duration.ml
+++ b/src/operators/max_duration.ml
@@ -103,4 +103,5 @@ let () =
         Frame.main_of_seconds (Lang.to_float (Lang.assoc "" 1 p))
       in
       let s = Lang.to_source (Lang.assoc "" 2 p) in
+      let kind = Source.Kind.of_kind kind in
       new max_duration ~kind ~override_meta ~duration s)

--- a/src/operators/midi_routing.ml
+++ b/src/operators/midi_routing.ml
@@ -77,6 +77,7 @@ let () =
       let f v = List.assoc v p in
       let out = Lang.to_int (f "track_out") in
       let src = Lang.to_source (f "") in
+      let kind = Source.Kind.of_kind kind in
       new merge ~kind src out)
 
 let () =
@@ -92,4 +93,5 @@ let () =
       (* let f v = List.assoc v p in *)
       let t = List.map Lang.to_int (Lang.to_list (Lang.assoc "" 1 p)) in
       let src = Lang.to_source (Lang.assoc "" 2 p) in
+      let kind = Source.Kind.of_kind kind in
       new remove ~kind src t)

--- a/src/operators/ms_stereo.ml
+++ b/src/operators/ms_stereo.ml
@@ -73,6 +73,7 @@ let () =
     ~descr:"Encode left+right stereo to mid+side stereo (M/S)."
     (fun p ->
       let s = Lang.to_source (Lang.assoc "" 1 p) in
+      let kind = Source.Kind.of_kind kind in
       new msstereo ~kind s Encode 0.);
   Lang.add_operator "stereo.ms.decode"
     [
@@ -87,6 +88,7 @@ let () =
     (fun p ->
       let s = Lang.to_source (Lang.assoc "" 1 p) in
       let w = Lang.to_float (Lang.assoc "width" 1 p) in
+      let kind = Source.Kind.of_kind kind in
       new msstereo ~kind s Decode w)
 
 class spatializer ~kind ~width (source : source) =
@@ -143,4 +145,5 @@ let () =
     (fun p ->
       let width = Lang.assoc "" 1 p |> Lang.to_float_getter in
       let s = Lang.assoc "" 2 p |> Lang.to_source in
+      let kind = Source.Kind.of_kind kind in
       new spatializer ~kind ~width s)

--- a/src/operators/noblank.ml
+++ b/src/operators/noblank.ml
@@ -298,6 +298,7 @@ let () =
       let start_blank, max_blank, min_noise, threshold, track_sensitive, s =
         extract p
       in
+      let kind = Source.Kind.of_kind kind in
       new detect
         ~kind ~start_blank ~max_blank ~min_noise ~threshold ~track_sensitive
         ~on_blank ~on_noise s);
@@ -315,6 +316,7 @@ let () =
       let start_blank, max_blank, min_noise, threshold, track_sensitive, s =
         extract p
       in
+      let kind = Source.Kind.of_kind kind in
       new strip
         ~kind ~track_sensitive ~start_blank ~max_blank ~min_noise ~threshold s);
   Lang.add_operator "blank.eat" ~return_t ~category:Lang.TrackProcessing
@@ -338,6 +340,7 @@ let () =
       let start_blank, max_blank, min_noise, threshold, track_sensitive, s =
         extract p
       in
+      let kind = Source.Kind.of_kind kind in
       new eat
         ~kind ~at_beginning ~track_sensitive ~start_blank ~max_blank ~min_noise
         ~threshold s)

--- a/src/operators/normalize.ml
+++ b/src/operators/normalize.ml
@@ -191,6 +191,7 @@ let () =
           Lang.to_source (f "") )
       in
       let track_sensitive = Lang.to_bool (f "track_sensitive") in
+      let kind = Source.Kind.of_kind kind in
       new normalize
         ~kind ~track_sensitive src
         (fun () -> Audio.lin_of_dB (target ()))

--- a/src/operators/on_end.ml
+++ b/src/operators/on_end.ml
@@ -89,4 +89,5 @@ let () =
       let delay = Lang.to_float_getter (List.assoc "delay" p) in
       let s = Lang.assoc "" 1 p |> Lang.to_source in
       let f = Lang.assoc "" 2 p in
+      let kind = Source.Kind.of_kind kind in
       new on_end ~kind ~delay f s)

--- a/src/operators/on_frame.ml
+++ b/src/operators/on_frame.ml
@@ -59,6 +59,7 @@ let () =
     (fun p ->
       let s = Lang.assoc "" 1 p |> Lang.to_source in
       let f = Lang.assoc "" 2 p in
+      let kind = Source.Kind.of_kind kind in
       new on_frame ~kind f s)
 
 (** Operations on frames. *)
@@ -101,6 +102,7 @@ let op name descr f_t f default =
     ~meth:[("frame_" ^ name, ([], f_t), descr, fun s -> s#value)]
     (fun p ->
       let s = List.assoc "" p |> Lang.to_source in
+      let kind = Source.Kind.of_kind kind in
       new frame_op ~name ~kind f default s)
 
 let () =

--- a/src/operators/on_offset.ml
+++ b/src/operators/on_offset.ml
@@ -135,4 +135,5 @@ let () =
       let override = Lang.to_string (List.assoc "override" p) in
       let f = Lang.assoc "" 1 p in
       let s = Lang.to_source (Lang.assoc "" 2 p) in
+      let kind = Source.Kind.of_kind kind in
       new on_offset ~kind ~offset ~force ~override f s)

--- a/src/operators/pan.ml
+++ b/src/operators/pan.ml
@@ -74,4 +74,5 @@ let () =
       let s = Lang.to_source (Lang.assoc "" 1 p) in
       let phi_0 = Lang.to_float_getter (Lang.assoc "field" 1 p) in
       let phi = Lang.to_float_getter (Lang.assoc "pan" 1 p) in
+      let kind = Source.Kind.of_kind kind in
       new pan ~kind s phi phi_0)

--- a/src/operators/pipe.ml
+++ b/src/operators/pipe.ml
@@ -345,6 +345,7 @@ let () =
           Lang.to_bool (f "restart_on_error"),
           Lang.to_source (f "") )
       in
+      let kind = Source.Kind.of_kind kind in
       ( new pipe
           ~kind ~replay_delay ~data_len ~bufferize ~max ~log_overfull ~restart
           ~restart_on_error ~process src

--- a/src/operators/pitch.ml
+++ b/src/operators/pitch.ml
@@ -144,4 +144,5 @@ let () =
       let freq_min = Lang.to_float (f "freq_min") in
       let freq_max = Lang.to_float (f "freq_max") in
       let src = Lang.to_source (f "") in
+      let kind = Source.Kind.of_kind kind in
       (new pitch ~kind 10 length freq_min freq_max src :> Source.source))

--- a/src/operators/prepend.ml
+++ b/src/operators/prepend.ml
@@ -168,4 +168,5 @@ let register =
       let merge = Lang.to_bool (Lang.assoc "merge" 1 p) in
       let source = Lang.to_source (Lang.assoc "" 1 p) in
       let f = Lang.assoc "" 2 p in
+      let kind = Source.Kind.of_kind kind in
       new prepend ~kind ~merge source f)

--- a/src/operators/resample.ml
+++ b/src/operators/resample.ml
@@ -195,4 +195,5 @@ let () =
       let src = Lang.to_source (f "") in
       let ratio = Lang.to_float_getter (f "ratio") in
       let active = Lang.to_bool (f "active") in
+      let kind = Source.Kind.of_kind kind in
       new resample ~kind ~active ~ratio src)

--- a/src/operators/rms_smooth.ml
+++ b/src/operators/rms_smooth.ml
@@ -91,4 +91,5 @@ let () =
     (fun p ->
       let duration = List.assoc "duration" p |> Lang.to_float_getter in
       let src = List.assoc "" p |> Lang.to_source in
+      let kind = Source.Kind.of_kind kind in
       new rms ~kind ~tau:duration src)

--- a/src/operators/sequence.ml
+++ b/src/operators/sequence.ml
@@ -146,6 +146,7 @@ let () =
        which is played as much as available."
     ~return_t:k
     (fun p ->
+      let kind = Source.Kind.of_kind kind in
       new sequence
         ~kind
         ~merge:(Lang.to_bool (List.assoc "merge" p))
@@ -161,4 +162,6 @@ let () =
       "Merge consecutive tracks from the input source. They will be considered \
        as one big track, so `on_track()` will not trigger for example."
     ~return_t:k
-    (fun p -> new merge_tracks ~kind (Lang.to_source (List.assoc "" p)))
+    (fun p ->
+      let kind = Source.Kind.of_kind kind in
+      new merge_tracks ~kind (Lang.to_source (List.assoc "" p)))

--- a/src/operators/sleeper.ml
+++ b/src/operators/sleeper.ml
@@ -86,4 +86,5 @@ let () =
       let random = AFrame.duration () *. random in
       let freeze = Lang.to_float (List.assoc "freeze" p) in
       let src = Lang.to_source (List.assoc "" p) in
+      let kind = Source.Kind.of_kind kind in
       new map ~kind src delay random freeze)

--- a/src/operators/soundtouch_op.ml
+++ b/src/operators/soundtouch_op.ml
@@ -127,4 +127,5 @@ let () =
       let tempo = Lang.to_float_getter (f "tempo") in
       let pitch = Lang.to_float_getter (f "pitch") in
       let s = Lang.to_source (f "") in
+      let kind = Source.Kind.of_kind kind in
       (new soundtouch ~kind s rate tempo pitch :> Source.source))

--- a/src/operators/st_bpm.ml
+++ b/src/operators/st_bpm.ml
@@ -81,4 +81,5 @@ let () =
       ]
     (fun p ->
       let s = Lang.to_source (List.assoc "" p) in
+      let kind = Source.Kind.of_kind kind in
       new bpm ~kind s)

--- a/src/operators/switch.ml
+++ b/src/operators/switch.ml
@@ -430,6 +430,7 @@ let () =
                ( List.assoc "single" p,
                  "there should be exactly one flag per children" ))
       in
+      let kind = Source.Kind.of_kind kind in
       new lang_switch
         ~kind ~replay_meta ~override_meta ~all_predicates ~transition_length:tl
         ts children)

--- a/src/operators/time_warp.ml
+++ b/src/operators/time_warp.ml
@@ -149,6 +149,7 @@ let () =
       let pre_buffer = Lang.to_float (List.assoc "buffer" p) in
       let max_buffer = Lang.to_float (List.assoc "max" p) in
       let max_buffer = max max_buffer (pre_buffer *. 1.1) in
+      let kind = Source.Kind.of_kind kind in
       Buffer.create ~infallible ~autostart ~on_start ~on_stop ~pre_buffer
         ~max_buffer ~kind s)
 
@@ -399,5 +400,6 @@ let () =
       let limit = if limit < 1. then 1. /. limit else limit in
       let reset = Lang.to_bool (List.assoc "reset" p) in
       let max_buffer = max max_buffer (pre_buffer *. 1.1) in
+      let kind = Source.Kind.of_kind kind in
       AdaptativeBuffer.create ~infallible ~autostart ~on_start ~on_stop
         ~pre_buffer ~max_buffer ~averaging ~limit ~reset ~kind s)

--- a/src/operators/video_effects.ml
+++ b/src/operators/video_effects.ml
@@ -60,6 +60,7 @@ let () =
     (fun p ->
       let f v = List.assoc v p in
       let src = Lang.to_source (f "") in
+      let kind = Source.Kind.of_kind kind in
       new effect ~name ~kind Video.Image.Effect.greyscale src)
 
 let () =
@@ -70,6 +71,7 @@ let () =
     (fun p ->
       let f v = List.assoc v p in
       let src = Lang.to_source (f "") in
+      let kind = Source.Kind.of_kind kind in
       new effect ~name ~kind Video.Image.Effect.sepia src)
 
 let () =
@@ -80,6 +82,7 @@ let () =
     (fun p ->
       let f v = List.assoc v p in
       let src = Lang.to_source (f "") in
+      let kind = Source.Kind.of_kind kind in
       new effect ~name ~kind Video.Image.Effect.invert src)
 
 let () =
@@ -96,6 +99,7 @@ let () =
     (fun p ->
       let a = Lang.to_float_getter (Lang.assoc "" 1 p) in
       let src = Lang.to_source (Lang.assoc "" 2 p) in
+      let kind = Source.Kind.of_kind kind in
       new effect
         ~name ~kind
         (fun buf -> Video.Image.Effect.Alpha.scale buf (a ()))
@@ -119,6 +123,7 @@ let () =
       let color () =
         Image.Pixel.yuv_of_rgb (Image.RGB8.Color.of_int (color ()))
       in
+      let kind = Source.Kind.of_kind kind in
       new effect
         ~name ~kind
         (fun buf ->
@@ -148,7 +153,8 @@ let () =
     (fun p ->
        let f v = List.assoc v p in
        let src = Lang.to_source (f "") in
-         new effect ~kind Image.Effect.lomo src)
+       let kind = Source.Kind.of_kind kind in
+       new effect ~kind Image.Effect.lomo src)
 
 let () =
   Lang.add_operator "video.transparent"
@@ -174,7 +180,8 @@ let () =
        in
        let prec = int_of_float (prec *. 255.) in
        let color = Image.RGB8.Color.of_int color in
-         new effect ~kind (fun buf -> Image.Effect.Alpha.of_color buf color prec) src)
+       let kind = Source.Kind.of_kind kind in
+       new effect ~kind (fun buf -> Image.Effect.Alpha.of_color buf color prec) src)
 
 let () =
   Lang.add_operator "video.rotate"
@@ -212,6 +219,7 @@ let () =
           angle := !angle +. da ();
         Image.Effect.rotate buf !angle
       in
+      let kind = Source.Kind.of_kind kind in
       new effect ~kind effect src)
  *)
 
@@ -240,6 +248,7 @@ let () =
       let height = Lang.to_int_getter (f "height") in
       let ox = Lang.to_int_getter (f "x") in
       let oy = Lang.to_int_getter (f "y") in
+      let kind = Source.Kind.of_kind kind in
       new effect
         ~name ~kind
         (fun buf ->
@@ -284,6 +293,7 @@ let () =
       let ox = Lang.to_int_getter (f "x") in
       let oy = Lang.to_int_getter (f "y") in
       let alpha = Lang.to_float_getter (f "alpha") in
+      let kind = Source.Kind.of_kind kind in
       new effect
         ~name ~kind
         (fun buf ->
@@ -322,6 +332,7 @@ let () =
           Lang.to_int_getter (f "x"),
           Lang.to_int_getter (f "y") )
       in
+      let kind = Source.Kind.of_kind kind in
       new effect
         ~name ~kind
         (fun buf ->

--- a/src/operators/video_fade.ml
+++ b/src/operators/video_fade.ml
@@ -295,6 +295,7 @@ let () =
     (fun p ->
       let d, f, t, s = extract p in
       let meta = Lang.to_string (List.assoc "override" p) in
+      let kind = Source.Kind.of_kind kind in
       new fade_in ~kind ~meta d f t s);
   Lang.add_operator "video.fade.out"
     ( ( "override",
@@ -309,4 +310,5 @@ let () =
     (fun p ->
       let d, f, t, s = extract p in
       let meta = Lang.to_string (List.assoc "override" p) in
+      let kind = Source.Kind.of_kind kind in
       new fade_out ~kind ~meta d f t s)

--- a/src/operators/video_text.ml
+++ b/src/operators/video_text.ml
@@ -164,6 +164,7 @@ let register name init render_text =
         in
         let speed = speed / Lazy.force Frame.video_rate in
         let meta = if meta = "" then None else Some meta in
+        let kind = Source.Kind.of_kind kind in
         ( new text
             ~kind init render_text ttf ttf_size color x y speed cycle meta txt
             source

--- a/src/operators/window_op.ml
+++ b/src/operators/window_op.ml
@@ -128,6 +128,7 @@ let declare mode suffix kind fun_ret_t f_ans =
       let f v = List.assoc v p in
       let src = Lang.to_source (f "") in
       let duration = Lang.to_float_getter (f "duration") in
+      let kind = Source.Kind.of_kind kind in
       new window ~kind mode duration src)
 
 let () =

--- a/src/outputs/alsa_out.ml
+++ b/src/outputs/alsa_out.ml
@@ -37,8 +37,8 @@ class output ~kind ~clock_safe ~infallible ~on_stop ~on_start ~start dev source
   object (self)
     inherit
       Output.output
-        ~infallible ~on_stop ~on_start ~content_kind:kind ~name
-          ~output_kind:"output.alsa" source start as super
+        ~infallible ~on_stop ~on_start ~content_kind:(Source.Kind.of_kind kind)
+          ~name ~output_kind:"output.alsa" source start as super
 
     inherit [Frame_content.Audio.data] IoRing.output ~nb_blocks as ioring
 

--- a/src/outputs/ao_out.ml
+++ b/src/outputs/ao_out.ml
@@ -160,6 +160,7 @@ let () =
         fun () -> ignore (Lang.apply f [])
       in
       let source = List.assoc "" p in
+      let kind = Source.Kind.of_kind kind in
       ( new output
           ~kind ~clock_safe ~nb_blocks ~driver ~infallible ~on_start ~on_stop
           ?channels_matrix ~options source start

--- a/src/outputs/bjack_out.ml
+++ b/src/outputs/bjack_out.ml
@@ -142,6 +142,7 @@ let () =
         let f = List.assoc "on_stop" p in
         fun () -> ignore (Lang.apply f [])
       in
+      let kind = Source.Kind.of_kind kind in
       ( new output
           ~kind ~clock_safe ~infallible ~on_start ~on_stop ~nb_blocks ~server
           source

--- a/src/outputs/graphics_out.ml
+++ b/src/outputs/graphics_out.ml
@@ -68,5 +68,6 @@ let () =
         fun () -> ignore (Lang.apply f [])
       in
       let source = List.assoc "" p in
+      let kind = Source.Kind.of_kind kind in
       ( new output ~kind ~infallible ~autostart ~on_start ~on_stop source
         :> Source.source ))

--- a/src/outputs/harbor_output.ml
+++ b/src/outputs/harbor_output.ml
@@ -650,7 +650,9 @@ module Make (T : T) = struct
     let return_t = Lang.kind_type_of_kind_format kind in
     Lang.add_operator ~category:Lang.Output ~active:true
       ~descr:T.source_description T.source_name (proto return_t) ~return_t
-      (fun p -> (new output ~kind p :> Source.source))
+      (fun p ->
+        let kind = Source.Kind.of_kind kind in
+        (new output ~kind p :> Source.source))
 end
 
 module Unix_output = struct

--- a/src/outputs/hls_output.ml
+++ b/src/outputs/hls_output.ml
@@ -428,7 +428,9 @@ class hls_output p =
     segments_per_playlist + Lang.to_int (List.assoc "segments_overhead" p)
   in
   let file_perm = Lang.to_int (List.assoc "perm" p) in
-  let kind = Encoder.kind_of_format (List.hd streams).format in
+  let kind =
+    Source.Kind.of_kind (Encoder.kind_of_format (List.hd streams).format)
+  in
   object (self)
     inherit
       Output.encoded

--- a/src/outputs/icecast2.ml
+++ b/src/outputs/icecast2.ml
@@ -398,8 +398,8 @@ class output ~kind p =
   object (self)
     inherit
       Output.encoded
-        ~content_kind:kind ~output_kind:"output.icecast" ~infallible ~autostart
-          ~on_start ~on_stop ~name source
+        ~content_kind:(Source.Kind.of_kind kind) ~output_kind:"output.icecast"
+          ~infallible ~autostart ~on_start ~on_stop ~name source
 
     (** In this operator, we don't exactly follow the start/stop
     * mechanism of Output.encoded because we want to control

--- a/src/outputs/output.ml
+++ b/src/outputs/output.ml
@@ -228,6 +228,7 @@ let () =
       let on_stop = List.assoc "on_stop" p in
       let on_start () = ignore (Lang.apply on_start []) in
       let on_stop () = ignore (Lang.apply on_stop []) in
+      let kind = Source.Kind.of_kind kind in
       ( new dummy
           ~kind ~on_start ~on_stop ~infallible ~autostart (List.assoc "" p)
         :> Source.source ))

--- a/src/outputs/output.mli
+++ b/src/outputs/output.mli
@@ -26,7 +26,7 @@
 val proto : (string * Lang.t * Lang.value option * string option) list
 
 class virtual output :
-  content_kind:Frame.content_kind
+  content_kind:Source.Kind.t
   -> output_kind:string
   -> ?name:string
   -> infallible:bool
@@ -83,7 +83,7 @@ class virtual output :
      end
 
 class virtual encoded :
-  content_kind:Frame.content_kind
+  content_kind:Source.Kind.t
   -> output_kind:string
   -> name:string
   -> infallible:bool

--- a/src/outputs/pipe_output.ml
+++ b/src/outputs/pipe_output.ml
@@ -104,7 +104,7 @@ class url_output p =
            (format_val, "Encoding format does not support output url!"))
   in
   let format = Encoder.with_url_output format url in
-  let kind = Encoder.kind_of_format format in
+  let kind = Source.Kind.of_kind (Encoder.kind_of_format format) in
   let source = Lang.assoc "" 2 p in
   let name = "output.url" in
   object
@@ -378,7 +378,7 @@ let file_proto kind =
 let new_file_output p =
   let format_val = Lang.assoc "" 1 p in
   let format = Lang.to_format format_val in
-  let kind = Encoder.kind_of_format format in
+  let kind = Source.Kind.of_kind (Encoder.kind_of_format format) in
   if Encoder.file_output format then
     (new file_output_using_encoder ~format_val ~kind p :> piped_output)
   else (new file_output ~format_val ~kind p :> piped_output)
@@ -394,7 +394,7 @@ let () =
 class external_output p =
   let format_val = Lang.assoc "" 1 p in
   let format = Lang.to_format format_val in
-  let kind = Encoder.kind_of_format format in
+  let kind = Source.Kind.of_kind (Encoder.kind_of_format format) in
   let process = Lang.to_string_getter (Lang.assoc "" 2 p) in
   let self_sync = Lang.to_bool (List.assoc "self_sync" p) in
   object (self)

--- a/src/outputs/sdl_out.ml
+++ b/src/outputs/sdl_out.ml
@@ -34,7 +34,7 @@ class output ~infallible ~on_start ~on_stop ~autostart ~kind source =
     inherit
       Output.output
         ~name:"sdl" ~output_kind:"output.sdl" ~infallible ~on_start ~on_stop
-          ~content_kind:kind source autostart
+          ~content_kind:(Source.Kind.of_kind kind) source autostart
 
     val mutable fullscreen = false
 

--- a/src/source.ml
+++ b/src/source.ml
@@ -355,7 +355,6 @@ let add_new_output, iterate_new_outputs =
 
 class virtual operator ?(name = "src") ?audio_in ?video_in ?midi_in out_kind
   sources =
-  let out_kind = Kind.of_kind out_kind in
   let f kind (fn, el) = match el with None -> kind | Some v -> fn kind v in
   let in_kind =
     List.fold_left f out_kind

--- a/src/source.mli
+++ b/src/source.mli
@@ -84,7 +84,7 @@ class virtual source :
   -> ?audio_in:Frame.kind
   -> ?video_in:Frame.kind
   -> ?midi_in:Frame.kind
-  -> Frame.content_kind
+  -> Kind.t
   -> object
        method mutexify : 'a 'b. ('a -> 'b) -> 'a -> 'b
 
@@ -221,7 +221,7 @@ and virtual active_source :
   -> ?audio_in:Frame.kind
   -> ?video_in:Frame.kind
   -> ?midi_in:Frame.kind
-  -> Frame.content_kind
+  -> Kind.t
   -> object
        inherit source
 
@@ -250,7 +250,7 @@ class virtual operator :
   -> ?audio_in:Frame.kind
   -> ?video_in:Frame.kind
   -> ?midi_in:Frame.kind
-  -> Frame.content_kind
+  -> Kind.t
   -> source list
   -> object
        inherit source
@@ -263,7 +263,7 @@ class virtual active_operator :
   -> ?audio_in:Frame.kind
   -> ?video_in:Frame.kind
   -> ?midi_in:Frame.kind
-  -> Frame.content_kind
+  -> Kind.t
   -> source list
   -> object
        inherit active_source

--- a/src/sources/alsa_in.ml
+++ b/src/sources/alsa_in.ml
@@ -36,7 +36,8 @@ class mic ~kind ~clock_safe device =
   let alsa_device = device in
   let nb_blocks = Alsa_settings.conf_buffer_length#get in
   object (self)
-    inherit active_source ~name:"input.alsa" kind as active_source
+    inherit
+      active_source ~name:"input.alsa" (Source.Kind.of_kind kind) as active_source
 
     inherit [Frame_content.Audio.data] IoRing.input ~nb_blocks as ioring
 

--- a/src/sources/audio_gen.ml
+++ b/src/sources/audio_gen.ml
@@ -61,6 +61,7 @@ let add name g =
         Some ("Frequency of the " ^ name ^ ".") );
     ]
     (fun p ->
+      let kind = Source.Kind.of_kind kind in
       ( new gen
           ~seek:true ~kind name g
           (Lang.to_float_getter (List.assoc "" p))

--- a/src/sources/bjack_in.ml
+++ b/src/sources/bjack_in.ml
@@ -154,4 +154,5 @@ let () =
       let clock_safe = Lang.to_bool (List.assoc "clock_safe" p) in
       let nb_blocks = Lang.to_int (List.assoc "buffer_size" p) in
       let server = Lang.to_string (List.assoc "server" p) in
+      let kind = Source.Kind.of_kind kind in
       (new jack_in ~kind ~clock_safe ~nb_blocks ~server :> Source.source))

--- a/src/sources/blank.ml
+++ b/src/sources/blank.ml
@@ -84,6 +84,7 @@ let () =
     ]
     (fun p ->
       let d = Lang.to_float (List.assoc "duration" p) in
+      let kind = Source.Kind.of_kind kind in
       (new blank ~kind d :> source))
 
 class fail ~kind =
@@ -112,4 +113,7 @@ let () =
   Lang.add_operator "fail" ~category:Lang.Input
     ~descr:
       "A source that does not produce anything. No silence, no track at all."
-    ~return_t [] (fun _ -> (new fail ~kind :> source))
+    ~return_t [] (fun _ ->
+      ( let kind = Source.Kind.of_kind kind in
+        new fail ~kind
+        :> source ))

--- a/src/sources/external_input_audio.ml
+++ b/src/sources/external_input_audio.ml
@@ -118,6 +118,7 @@ let () =
         Lang.audio_params
           { Frame_content.Contents.channel_layout = lazy channel_layout }
       in
+      let kind = Source.Kind.of_kind kind in
       let samplerate = Lang.to_int (List.assoc "samplerate" p) in
       let resampler = Decoder_utils.samplerate_converter () in
       let convert =
@@ -159,6 +160,7 @@ let () =
       let restart = Lang.to_bool (List.assoc "restart" p) in
       let restart_on_error = Lang.to_bool (List.assoc "restart_on_error" p) in
       let max = Lang.to_float (List.assoc "max" p) in
+      let kind = Source.Kind.of_kind kind in
       ( new external_input
           ~kind ~restart ~bufferize ~log_overfull ~read_header ~restart_on_error
           ~max ~name:"input.external.wav" ~converter command

--- a/src/sources/external_input_video.ml
+++ b/src/sources/external_input_video.ml
@@ -239,6 +239,7 @@ let () =
       let restart = Lang.to_bool (List.assoc "restart" p) in
       let restart_on_error = Lang.to_bool (List.assoc "restart_on_error" p) in
       let max = Lang.to_float (List.assoc "max" p) in
+      let kind = Source.Kind.of_kind kind in
       new video
         ~name:"input.external.avi" ~kind ~restart ~bufferize ~log_overfull
         ~restart_on_error ~max ~read_header ~on_data command)
@@ -311,6 +312,7 @@ let () =
       let restart = Lang.to_bool (List.assoc "restart" p) in
       let restart_on_error = Lang.to_bool (List.assoc "restart_on_error" p) in
       let max = Lang.to_float (List.assoc "max" p) in
+      let kind = Source.Kind.of_kind kind in
       new video
         ~name:"input.external.rawvideo" ~kind ~restart ~bufferize ~log_overfull
         ~restart_on_error ~max ~on_data command)

--- a/src/sources/harbor_input.ml
+++ b/src/sources/harbor_input.ml
@@ -491,7 +491,7 @@ module Make (Harbor : T) = struct
         let on_disconnect () =
           ignore (Lang.apply (List.assoc "on_disconnect" p) [])
         in
-        let kind = Lang.any in
+        let kind = Source.Kind.of_kind Lang.any in
         new http_input_server
           ~kind ~timeout ~bufferize ~max ~login ~mountpoint ~dumpfile ~logfile
           ~icy ~port ~icy_charset ~meta_charset ~replay_meta ~on_connect

--- a/src/sources/http_source.ml
+++ b/src/sources/http_source.ml
@@ -713,7 +713,7 @@ module Make (Config : Config_t) = struct
           ignore (Lang.apply (List.assoc "on_disconnect" p) [])
         in
         let poll_delay = Lang.to_float (List.assoc "poll_delay" p) in
-        let kind = Lang.any in
+        let kind = Source.Kind.of_kind Lang.any in
         new http
           ~kind ~protocol ~playlist_mode ~autostart ~track_on_meta ~force_mime
           ~bind_address ~poll_delay ~timeout ~on_connect ~on_disconnect

--- a/src/sources/noise.ml
+++ b/src/sources/noise.ml
@@ -55,4 +55,6 @@ let () =
         Some "Duration in seconds (negative means infinite)." );
     ]
     ~return_t
-    (fun p -> new noise ~kind (Lang.to_float (List.assoc "duration" p)))
+    (fun p ->
+      let kind = Source.Kind.of_kind kind in
+      new noise ~kind (Lang.to_float (List.assoc "duration" p)))

--- a/src/sources/request_simple.ml
+++ b/src/sources/request_simple.ml
@@ -48,6 +48,7 @@ let () =
     (fun p ->
       let timeout = List.assoc "timeout" p |> Lang.to_float in
       let r = List.assoc "" p |> Lang.to_request in
+      let kind = Source.Kind.of_kind kind in
       new once ~kind ~name:"request.once" ~timeout r)
 
 exception Invalid_URI of string
@@ -107,6 +108,7 @@ let () =
       let fallible = Lang.to_bool (List.assoc "fallible" p) in
       let l, d, t, c = extract_queued_params p in
       let uri = Lang.to_string val_uri in
+      let kind = Source.Kind.of_kind kind in
       if (not fallible) && Request.is_static uri then (
         let request = Request.create ~persistent:true uri in
         (new unqueued ~kind request :> source) )
@@ -122,6 +124,7 @@ let () =
        WARNING: if used uncarefully, it can crash your application!"
     [("", Lang.request_t, None, None)] ~return_t:t (fun p ->
       let request = Lang.to_request (List.assoc "" p) in
+      let kind = Source.Kind.of_kind kind in
       (new unqueued ~kind request :> source))
 
 class dynamic ~kind ~retry_delay ~available (f : Lang.value) length
@@ -226,4 +229,5 @@ let () =
       let available = Lang.to_bool_getter (List.assoc "available" p) in
       let retry_delay = Lang.to_float_getter (List.assoc "retry_delay" p) in
       let l, d, t, c = extract_queued_params p in
+      let kind = Source.Kind.of_kind kind in
       new dynamic ~kind ~available ~retry_delay f l d t c)

--- a/src/sources/request_source.mli
+++ b/src/sources/request_source.mli
@@ -23,7 +23,7 @@
 (** General classes for streaming files. *)
 
 class once :
-  kind:Frame.content_kind
+  kind:Source.Kind.t
   -> name:string
   -> timeout:float
   -> Request.t
@@ -46,7 +46,7 @@ class once :
      end
 
 class virtual unqueued :
-  kind:Frame.content_kind
+  kind:Source.Kind.t
   -> name:string
   -> object
        (** [get_next_file] is the only thing you've got to define,
@@ -69,7 +69,7 @@ class virtual unqueued :
      end
 
 class virtual queued :
-  kind:Frame.content_kind
+  kind:Source.Kind.t
   -> name:string
   -> ?length:float
   -> ?default_duration:float

--- a/src/synth/dssi_op.ml
+++ b/src/synth/dssi_op.ml
@@ -50,7 +50,7 @@ let all_chans = 16
 (* chan = None means synth all channels *)
 class dssi ~kind ?chan plugin descr outputs params source =
   object
-    inherit operator ~name:"dssi" kind [source]
+    inherit operator ~name:"dssi" (Source.Kind.of_kind kind) [source]
 
     method stype = source#stype
 

--- a/src/synth/keyboard.ml
+++ b/src/synth/keyboard.ml
@@ -144,4 +144,5 @@ let () =
   Lang.add_operator "input.keyboard" [] ~return_t ~category:Lang.Input
     ~flags:[Lang.Hidden; Lang.Experimental]
     ~descr:"Play notes from the keyboard." (fun _ ->
+      let kind = Source.Kind.of_kind kind in
       (new keyboard ~kind :> Source.source))

--- a/src/synth/keyboard_sdl.ml
+++ b/src/synth/keyboard_sdl.ml
@@ -85,7 +85,8 @@ let note_of_char c =
 class keyboard ~kind velocity =
   let () = Sdl_utils.init [Sdl.Init.events; Sdl.Init.video] in
   object (self)
-    inherit Source.active_source ~name:"input.keyboard.sdl" kind
+    inherit
+      Source.active_source ~name:"input.keyboard.sdl" (Source.Kind.of_kind kind)
 
     method stype = Source.Infallible
 

--- a/src/synth/synth_op.ml
+++ b/src/synth/synth_op.ml
@@ -101,6 +101,7 @@ let register obj name descr =
         else None
       in
       let src = Lang.to_source (f "") in
+      let kind = Source.Kind.of_kind kind in
       (new synth ~kind (obj adsr) src chan volume :> Source.source));
   let kind =
     { Frame.audio = Frame.audio_mono; video = `Any; midi = Frame.midi_n 16 }
@@ -145,9 +146,12 @@ let register obj name descr =
       in
       let synths =
         Array.init (Lazy.force Frame.midi_channels) (fun c ->
-            ((fun () -> 1.), new synth ~kind (obj adsr) src c 1.))
+            ( (fun () -> 1.),
+              let kind = Source.Kind.of_kind kind in
+              new synth ~kind (obj adsr) src c 1. ))
       in
       let synths = Array.to_list synths in
+      let kind = Source.Kind.of_kind kind in
       ( new Add.add
           ~kind
           ~renorm:(fun () -> false)

--- a/src/visualization/midimeter.ml
+++ b/src/visualization/midimeter.ml
@@ -70,4 +70,5 @@ let () =
     (fun p ->
       let f v = List.assoc v p in
       let src = Lang.to_source (f "") in
+      let kind = Source.Kind.of_kind kind in
       (new midimeter ~kind src :> Source.source))

--- a/src/visualization/video_volume.ml
+++ b/src/visualization/video_volume.ml
@@ -166,4 +166,5 @@ let () =
     (fun p ->
       let f v = List.assoc v p in
       let src = Lang.to_source (f "") in
+      let kind = Source.Kind.of_kind kind in
       (new visu ~kind src :> Source.source))

--- a/src/visualization/vis_volume.ml
+++ b/src/visualization/vis_volume.ml
@@ -131,4 +131,5 @@ let () =
     (fun p ->
       let f v = List.assoc v p in
       let src = Lang.to_source (f "") in
+      let kind = Source.Kind.of_kind kind in
       new vumeter ~kind src)


### PR DESCRIPTION
This PR fixes #1584 by making sure that source content `kind` is unified across different targets, typically between `consumer` and `producer` in the `buffer` operator.

Fixes: #1584