### PR TITLE
Add sync API for input.ffmpeg.

### DIFF
--- a/src/io/ffmpeg_io.ml
+++ b/src/io/ffmpeg_io.ml
@@ -23,21 +23,21 @@
 module Generator = Generator.From_audio_video_plus
 module Generated = Generated.Make (Generator)
 
-class input ~bufferize ~log_overfull ~kind ~start ~on_start ~on_stop ?format
-  ~opts url =
+class input ~self_sync ~clock_safe ~bufferize ~log_overfull ~kind ~start
+  ~on_start ~on_stop ?format ~opts url =
   let max_ticks = 2 * Frame.main_of_seconds bufferize in
   (* A log function for our generator: start with a stub, and replace it
    * when we have a proper logger with our ID on it. *)
   let log_ref = ref (fun _ -> ()) in
   let log x = !log_ref x in
   object (self)
-    inherit Source.source ~name:"input.ffmpeg" kind
+    inherit Source.source ~name:"input.ffmpeg" kind as super
 
     inherit
       Generated.source
         (Generator.create ~log ~log_overfull ~overfull:(`Drop_old max_ticks)
            `Undefined)
-        ~empty_on_abort:false ~bufferize
+        ~self_sync ~clock_safe ~empty_on_abort:false ~bufferize as buffered
 
     inherit
       Start_stop.async ~name:"input.ffmpeg" ~on_start ~on_stop ~autostart:start
@@ -96,11 +96,15 @@ class input ~bufferize ~log_overfull ~kind ~start ~on_start ~on_stop ?format
 
     method private stype = Source.Fallible
 
+    method private set_clock =
+      super#set_clock;
+      buffered#set_buffered_clock
+
     method private feed (should_stop, has_stopped) =
       try
         let decoder = self#get_decoder in
         let buffer = Decoder.mk_buffer ~ctype:self#ctype generator in
-        while true do
+        while buffered#should_fill_buffer do
           if should_stop () then failwith "stop";
           decoder buffer
         done
@@ -153,6 +157,19 @@ let () =
         args ~t:Lang.int_t "int";
         args ~t:Lang.float_t "float";
         args ~t:Lang.string_t "string";
+        ( "self_sync",
+          Lang.bool_t,
+          Some (Lang.bool true),
+          Some
+            "Set to `true` if the input is a real-time stream, i.e. icecast, \
+             SRT, etc. and `false` is not, i.e. local file, etc.." );
+        ( "clock_safe",
+          Lang.bool_t,
+          Some (Lang.bool false),
+          Some
+            "Set to `true` if the source needs to be attached to its own \
+             clock. Should be set to `true` when `self_sync` is set to `true` \
+             in most cases." );
         ( "buffer",
           Lang.float_t,
           Some (Lang.float 5.),
@@ -172,6 +189,8 @@ let () =
     ~return_t:k
     (fun p ->
       let start = Lang.to_bool (List.assoc "start" p) in
+      let self_sync = Lang.to_bool (List.assoc "self_sync" p) in
+      let clock_safe = Lang.to_bool (List.assoc "clock_safe" p) in
       let on_start =
         let f = List.assoc "on_start" p in
         fun () -> ignore (Lang.apply f [])
@@ -203,6 +222,6 @@ let () =
       let url = Lang.to_string (Lang.assoc "" 1 p) in
       let kind = Source.Kind.of_kind kind in
       ( new input
-          ~kind ~start ~on_start ~on_stop ~bufferize ~log_overfull ?format ~opts
-          url
+          ~self_sync ~clock_safe ~kind ~start ~on_start ~on_stop ~bufferize
+          ~log_overfull ?format ~opts url
         :> Source.source ))

--- a/src/io/ffmpeg_io.ml
+++ b/src/io/ffmpeg_io.ml
@@ -164,8 +164,8 @@ let () =
             "Set to `true` if the input is a real-time stream, i.e. icecast, \
              SRT, etc. and `false` is not, i.e. local file, etc.." );
         ( "clock_safe",
-          Lang.bool_t,
-          Some (Lang.bool false),
+          Lang.nullable_t Lang.bool_t,
+          Some Lang.null,
           Some
             "Set to `true` if the source needs to be attached to its own \
              clock. Should be set to `true` when `self_sync` is set to `true` \
@@ -190,7 +190,11 @@ let () =
     (fun p ->
       let start = Lang.to_bool (List.assoc "start" p) in
       let self_sync = Lang.to_bool (List.assoc "self_sync" p) in
-      let clock_safe = Lang.to_bool (List.assoc "clock_safe" p) in
+      let clock_safe =
+        match Lang.to_option (List.assoc "clock_safe" p) with
+          | None -> self_sync
+          | Some v -> Lang.to_bool v
+      in
       let on_start =
         let f = List.assoc "on_start" p in
         fun () -> ignore (Lang.apply f [])

--- a/src/sources/generated.ml
+++ b/src/sources/generated.ml
@@ -146,7 +146,7 @@ module Make (Generator : Generator.S) = struct
             ();
         true
 
-      method private signal_frame_filled =
+      method private signal_get_frame =
         Tutils.mutexify frame_filled_m
           (fun () -> Condition.signal frame_filled)
           ()
@@ -157,6 +157,7 @@ module Make (Generator : Generator.S) = struct
             let was_buffering = buffering in
             let pos = Frame.position ab in
             buffering <- false;
+            self#signal_get_frame;
             if should_fail then (
               self#log#info "Performing skip.";
               should_fail <- false;
@@ -164,7 +165,6 @@ module Make (Generator : Generator.S) = struct
               Frame.add_break ab (Frame.position ab) )
             else (
               Generator.fill generator ab;
-              self#signal_frame_filled;
 
               (* Currently, we don't enter the buffering phase between tracks
                * even when there's not enough data in the buffer. This is mostly

--- a/src/sources/generated.ml
+++ b/src/sources/generated.ml
@@ -91,11 +91,13 @@ module Make (Generator : Generator.S) = struct
 
       val mutable clock = None
 
+      method virtual id : string
+
       method private get_clock =
         match clock with
           | Some c -> c
           | None ->
-              let c = new Clock.clock "srt" in
+              let c = new Clock.clock self#id in
               clock <- Some c;
               c
 


### PR DESCRIPTION
This PR adds the possibility to run a buffered source synchronously. We still need the buffer to simplify the process of queueing decoded data but we delegate the control of the clock and synchronization back to the source.

This should fix #1604 and introduce a pattern that could be re-used for other inputs, e.g. `input.http`