### PR TITLE
Generic error handler

### DIFF
--- a/libs/thread.liq
+++ b/libs/thread.liq
@@ -30,3 +30,9 @@ def thread.when(~fast=true, ~every=1., ~once=false, ~changed=true, p, f)
   end
   thread.run.recurrent(fast=fast, delay=0., check)
 end
+
+# @flag hidden
+def default_error_handler(~backtrace, ~thread_name, err) =
+  log(label="runtime", level=1, "Uncaught error #{err} in thread #{thread_name}!\n#{backtrace}")
+end
+thread.on_error(null(), default_error_handler)

--- a/src/lang/builtins_thread.ml
+++ b/src/lang/builtins_thread.ml
@@ -77,32 +77,46 @@ let () =
     Lang.fun_t
       [
         (false, "backtrace", Lang.string_t);
-        (false, "queue_name", Lang.string_t);
+        (false, "thread_name", Lang.string_t);
         (false, "", Builtins_error.Error.t);
       ]
       Lang.unit_t
   in
   add_builtin "thread.on_error" ~cat:Liq
     ~descr:
-      "Register a function to be called when an error of the given kind is \
-       raised in a asynchronous thread."
-    [("", Builtins_error.Error.t, None, None); ("", fun_t, None, None)]
-    Lang.unit_t (fun p ->
-      let err = Builtins_error.Error.of_value (Lang.assoc "" 1 p) in
+      "Register the function to be called when an error of the given kind is \
+       raised in a thread. Catches all errors if first argument is `null`."
+    [
+      ("", Lang.nullable_t Builtins_error.Error.t, None, None);
+      ("", fun_t, None, None);
+    ]
+    Lang.unit_t
+    (fun p ->
+      let on_err = Lang.to_option (Lang.assoc "" 1 p) in
+      let on_err = Option.map Builtins_error.Error.of_value on_err in
       let fn = Lang.assoc "" 2 p in
-      let handler ~bt ~name = function
-        | Lang_values.(Runtime_error { kind; msg; _ })
-          when kind = err.Builtins_error.kind ->
-            let error = Builtins_error.(Error.to_value { kind; msg }) in
-            let bt = Lang.string bt in
-            let name = Lang.string name in
-            ignore
-              (Lang.apply fn
-                 [("backtrace", bt); ("queue_name", name); ("", error)]);
-            true
-        | _ -> false
+      let handler ~bt ~name err =
+        match (err, on_err) with
+          | Lang_values.(Runtime_error { kind; msg; _ }), None ->
+              let error = Builtins_error.(Error.to_value { kind; msg }) in
+              let bt = Lang.string bt in
+              let name = Lang.string name in
+              ignore
+                (Lang.apply fn
+                   [("backtrace", bt); ("thread_name", name); ("", error)]);
+              true
+          | Lang_values.(Runtime_error { kind; msg; _ }), Some err
+            when kind = err.Builtins_error.kind ->
+              let error = Builtins_error.(Error.to_value { kind; msg }) in
+              let bt = Lang.string bt in
+              let name = Lang.string name in
+              ignore
+                (Lang.apply fn
+                   [("backtrace", bt); ("thread_name", name); ("", error)]);
+              true
+          | _ -> false
       in
-      Queue.push handler Tutils.error_handlers;
+      Stack.push handler Tutils.error_handlers;
       Lang.unit)
 
 let () =

--- a/src/tools/liqcurl.ml
+++ b/src/tools/liqcurl.ml
@@ -196,10 +196,12 @@ let rec http_request ?headers ?http_version ~follow_redirect ~timeout ~url
             List.fold_left
               (fun ret header ->
                 if header <> "" then (
-                  let res = Pcre.exec ~pat:"([^:]*):\\s*(.*)" header in
-                  ( String.lowercase_ascii (Pcre.get_substring res 1),
-                    Pcre.get_substring res 2 )
-                  :: ret )
+                  try
+                    let res = Pcre.exec ~pat:"([^:]*):\\s*(.*)" header in
+                    ( String.lowercase_ascii (Pcre.get_substring res 1),
+                      Pcre.get_substring res 2 )
+                    :: ret
+                  with Not_found -> ret )
                 else ret)
               [] (List.tl response_headers)
           in

--- a/src/tools/tutils.mli
+++ b/src/tools/tutils.mli
@@ -58,7 +58,7 @@ val scheduler : priority Duppy.scheduler
 
 (** Register queue error handlers. Should return [true] if 
     the exception was handler by the given callback. *)
-val error_handlers : (bt:string -> name:string -> exn -> bool) Queue.t
+val error_handlers : (bt:string -> name:string -> exn -> bool) Stack.t
 
 (** {1 Misc} *)
 

--- a/tests/language/error.liq
+++ b/tests/language/error.liq
@@ -113,9 +113,9 @@ def f() =
     end 
   end
 
-  # Catches error in asynchronous tasks
-  def on_error(~backtrace, ~queue_name, e) =
-    print("caught error #{e} from queue #{queue_name} and backtrace:\n#{backtrace}")
+  # Catches error
+  def on_error(~backtrace, ~thread_name, e) =
+    print("caught error #{e} from thread #{thread_name} and backtrace:\n#{backtrace}")
     if error.kind(e) == "foo" then
       on_done()
     else


### PR DESCRIPTION
This PR extends `thread.on_error` to work on all runtime exceptions, including exceptions thrown in the main streaming thread.

The idea is to provide users with a default handler for runtime errors so that they do not have to handle them unless they need/want to and also so that runtime errors never interrupt the streaming loop, which is most important to the application.

Errors handlers are registered as a stack that is, last registered handlers is the first one to be called. We register a default handler in the runtime library that will be called if the user hasn't registered their own afterward.

Lastly, it is still possible to catch a runtime error via the usual `try .. catch` syntax, but only when needed by the user.

This should, along with the `Not_found` fix, address #1616