### PR TITLE
Use clock patterns for legacy inputs

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -68,7 +68,6 @@ sources = \
 	sources/audio_gen.ml sources/request_source.ml sources/latest_metadata.ml \
 	sources/request_simple.ml \
 	sources/generated.ml \
-        $(if $(W_CURL),sources/http_source.ml) \
 	harbor/harbor_base.ml harbor/harbor.ml sources/harbor_input.ml \
 	$(if $(W_SSL),harbor/harbor_ssl.ml sources/harbor_input_ssl.ml) \
 	$(if $(W_OSX_SECURE_TRANSPORT),harbor/harbor_secure_transport.ml sources/harbor_input_secure_transport.ml) \
@@ -257,6 +256,7 @@ liquidsoap_sources += \
 	tools/icecast_utils.ml tools/avi.ml \
 	$(video_converters) $(audio_converters) $(protocols) \
 	$(sources) $(outputs) tools/producer_consumer.ml \
+        $(if $(W_CURL),sources/http_source.ml) \
 	$(conversions) $(operators) \
 	$(encoders) $(decoders) $(ogg_demuxer) $(ogg_muxer) \
 	$(playlists) $(visualization) $(synth) $(io) \

--- a/src/io/srt_io.ml
+++ b/src/io/srt_io.ml
@@ -29,7 +29,6 @@ exception Not_connected
 
 module G = Generator
 module Generator = Generator.From_audio_video_plus
-module Generated = Generated.Make (Generator)
 
 let mode_of_value v =
   match Lang.to_string v with

--- a/src/lang/builtins_http.ml
+++ b/src/lang/builtins_http.ml
@@ -132,7 +132,9 @@ let add_http_request ~stream_body ~descr ~request name =
           let ans =
             Liqcurl.http_request ~follow_redirect:redirect ~timeout ~headers
               ~url
-              ~on_body_data:(fun s -> on_body_data (Some s))
+              ~on_body_data:(fun s ->
+                on_body_data (Some s);
+                `Continue)
               ~request ?http_version ()
           in
           on_body_data None;

--- a/src/lang/lang.ml
+++ b/src/lang/lang.ml
@@ -474,6 +474,10 @@ let to_num t =
 let to_list t = match (demeth t).value with List l -> l | _ -> assert false
 let to_tuple t = match (demeth t).value with Tuple l -> l | _ -> assert false
 let to_option t = match (demeth t).value with Null -> None | _ -> Some t
+let to_valued_option convert v = Option.map convert (to_option v)
+
+let to_default_option ~default convert v =
+  Option.value ~default (to_valued_option convert v)
 
 let to_product t =
   match (demeth t).value with Tuple [a; b] -> (a, b) | _ -> assert false

--- a/src/lang/lang.mli
+++ b/src/lang/lang.mli
@@ -209,6 +209,8 @@ val to_int_getter : value -> unit -> int
 val to_num : value -> [ `Int of int | `Float of float ]
 val to_list : value -> value list
 val to_option : value -> value option
+val to_valued_option : (value -> 'a) -> value -> 'a option
+val to_default_option : default:'a -> (value -> 'a) -> value -> 'a
 val to_product : value -> value * value
 val to_tuple : value -> value list
 val to_ref : value -> value ref

--- a/src/outputs/output.mli
+++ b/src/outputs/output.mli
@@ -109,3 +109,22 @@ class virtual encoded :
 
        method virtual private output_stop : unit
      end
+
+class dummy :
+  infallible:bool
+  -> on_start:(unit -> unit)
+  -> on_stop:(unit -> unit)
+  -> autostart:bool
+  -> kind:Source.Kind.t
+  -> Lang.value
+  -> object
+       inherit output
+
+       method private output_reset : unit
+
+       method private output_start : unit
+
+       method private output_stop : unit
+
+       method private output_send : Frame.t -> unit
+     end

--- a/src/source.ml
+++ b/src/source.ml
@@ -407,6 +407,8 @@ class virtual operator ?(name = "src") ?audio_in ?video_in ?midi_in out_kind
 
     val mutex = Mutex.create ()
 
+    method mutex = mutex
+
     method mutexify : 'a 'b. ('a -> 'b) -> 'a -> 'b = Tutils.mutexify mutex
 
     (** Is the source infallible, i.e. is it always guaranteed that there

--- a/src/source.mli
+++ b/src/source.mli
@@ -86,6 +86,8 @@ class virtual source :
   -> ?midi_in:Frame.kind
   -> Kind.t
   -> object
+       method mutex : Mutex.t
+
        method mutexify : 'a 'b. ('a -> 'b) -> 'a -> 'b
 
        (** {1 Naming} *)

--- a/src/tools/liqcurl.mli
+++ b/src/tools/liqcurl.mli
@@ -23,6 +23,8 @@
 val parse_response_headers :
   string -> string * int * string * (string * string) list
 
+type after_write = [ `Continue | `Pause ]
+
 val http_connection :
   ?headers:(string * string) list ->
   ?http_version:string ->
@@ -31,7 +33,7 @@ val http_connection :
   url:string ->
   request:[< `Delete | `Get | `Head | `Post of string | `Put of string ] ->
   on_response_header_data:(string -> unit) ->
-  on_body_data:(string -> unit) ->
+  on_body_data:(string -> after_write) ->
   unit ->
   Curl.handle
 
@@ -43,6 +45,6 @@ val http_request :
   follow_redirect:bool ->
   url:string ->
   request:[< `Delete | `Get | `Head | `Post of string | `Put of string ] ->
-  on_body_data:(string -> 'a) ->
+  on_body_data:(string -> after_write) ->
   unit ->
   string * int * string * (string * string) list

--- a/src/tools/liqfm.ml
+++ b/src/tools/liqfm.ml
@@ -45,7 +45,10 @@ module Liq_http = struct
       let data = Buffer.create 1024 in
       let x, code, y, _ =
         Liqcurl.http_request ?headers ~follow_redirect:true
-          ~on_body_data:(Buffer.add_string data) ~timeout ~url ~request ()
+          ~on_body_data:(fun s ->
+            Buffer.add_string data s;
+            `Continue)
+          ~timeout ~url ~request ()
       in
       if code <> 200 then
         raise (Http (Printf.sprintf "Http request failed: %s %i %s" x code y));


### PR DESCRIPTION
This PR intents to cleanup the input logic and implement the proper low-level `clock` logic.

Some operators (`input.http`, `input.udp` and `input.ffmpeg`) are using legacy patterns that predate the introduction of clocks. These patterns spin up a feeding thread that keeps decoding as much as possible, ignoring potential clock issues and creating large amount of buffered data.

This PR intents to clean this up by applying to these operators the modern clock patterns that have for instance been applied in `input.srt` and co. It will also tentatively factor out what can or should be re-used across operators.