### PR TITLE
Remove active_source type.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -94,6 +94,7 @@ Changed:
 - Implemented per-frame clock synchronization mechanism, should allow for more
   advanced flexibility when working with source synchronization while keeping
   the default safe behavior. (#1012)
+- Remove `active_source` type, make all output return `unit` type. (#1671)
 - Switch to YUV420 as internal image format, much more efficient (#848).
 - Use bigarrays for audio buffers (#950).
 - Re-implemented switch-derived operators (`fallback`, `rotate`, `random`) as

--- a/libs/io.liq
+++ b/libs/io.liq
@@ -35,10 +35,10 @@ let output.video = output.dummy
 %ifdef output.sdl
   def output.video(%argsof(output.sdl), s)
     if output.sdl.has_video() then
-      (output.sdl(%argsof(output.sdl), s):source)
+      (output.sdl(%argsof(output.sdl), s):unit)
     else
       # Avoid using SDL when there is no video output.
-      (output.dummy(fallible=fallible, s):source)
+      (output.dummy(fallible=fallible, s):unit)
     end
   end
 %endif

--- a/src/io/alsa_io.ml
+++ b/src/io/alsa_io.ml
@@ -290,7 +290,7 @@ class input ~kind ~clock_safe ~start ~on_stop ~on_start ~fallible dev =
 let () =
   let kind = Lang.audio_pcm in
   let k = Lang.kind_type_of_kind_format kind in
-  Lang.add_operator "output.alsa" ~active:true
+  Lang.add_operator "output.alsa"
     ( Output.proto
     @ [
         ( "bufferize",
@@ -339,7 +339,7 @@ let () =
 let () =
   let kind = Lang.audio_pcm in
   let k = Lang.kind_type_of_kind_format kind in
-  Lang.add_operator "input.alsa" ~active:true
+  Lang.add_operator "input.alsa"
     ( Start_stop.active_source_proto ~fallible:true
     @ [
         ("bufferize", Lang.bool_t, Some (Lang.bool true), Some "Bufferize input");

--- a/src/io/ffmpeg_io.ml
+++ b/src/io/ffmpeg_io.ml
@@ -285,7 +285,7 @@ let register_input is_http =
     if is_http then ("input.http", "Create a http stream using ffmpeg")
     else ("input.ffmpeg", "Create a stream using ffmpeg")
   in
-  Lang.add_operator name ~active:true ~descr ~category:Lang.Input
+  Lang.add_operator name ~descr ~category:Lang.Input
     ( List.filter
         (fun (lbl, _, _, _) -> lbl <> "clock_safe")
         (Start_stop.active_source_proto ~fallible:true)

--- a/src/io/gstreamer_io.ml
+++ b/src/io/gstreamer_io.ml
@@ -339,7 +339,7 @@ let () =
 let () =
   let kind = { Frame.audio = Frame.audio_pcm; video = `Any; midi = `Any } in
   let return_t = Lang.kind_type_of_kind_format kind in
-  Lang.add_operator "output.gstreamer.audio" ~active:true
+  Lang.add_operator "output.gstreamer.audio"
     (output_proto ~return_t ~pipeline:"autoaudiosink")
     ~category:Lang.Output ~descr:"Output stream to a GStreamer pipeline."
     ~return_t (fun p ->
@@ -370,7 +370,7 @@ let () =
 let () =
   let kind = { Frame.audio = Frame.audio_pcm; video = `Any; midi = `Any } in
   let return_t = Lang.kind_type_of_kind_format kind in
-  Lang.add_operator "output.gstreamer.video" ~active:true
+  Lang.add_operator "output.gstreamer.video"
     (output_proto ~return_t ~pipeline:"videoconvert ! autovideosink")
     ~category:Lang.Output ~descr:"Output stream to a GStreamer pipeline."
     ~return_t (fun p ->
@@ -403,7 +403,7 @@ let () =
     { Frame.audio = Frame.audio_pcm; video = Frame.video_yuva420p; midi = `Any }
   in
   let return_t = Lang.kind_type_of_kind_format kind in
-  Lang.add_operator "output.gstreamer.audio_video" ~active:true
+  Lang.add_operator "output.gstreamer.audio_video"
     ( output_proto ~return_t ~pipeline:""
     @ [
         ( "audio_pipeline",

--- a/src/io/oss_io.ml
+++ b/src/io/oss_io.ml
@@ -132,7 +132,7 @@ class input ~kind ~clock_safe ~start ~on_stop ~on_start ~fallible dev =
 let () =
   let kind = Lang.audio_pcm in
   let k = Lang.kind_type_of_kind_format kind in
-  Lang.add_operator "output.oss" ~active:true
+  Lang.add_operator "output.oss"
     ( Output.proto
     @ [
         ( "clock_safe",
@@ -166,7 +166,7 @@ let () =
           ~start ~on_start ~on_stop ~infallible ~kind ~clock_safe device source
         :> Source.source ));
   let k = Lang.kind_type_of_kind_format Lang.audio_pcm in
-  Lang.add_operator "input.oss" ~active:true
+  Lang.add_operator "input.oss"
     ( Start_stop.active_source_proto ~fallible:true
     @ [
         ( "device",

--- a/src/io/portaudio_io.ml
+++ b/src/io/portaudio_io.ml
@@ -177,7 +177,7 @@ class input ~kind ~clock_safe ~start ~on_start ~on_stop ~fallible buflen =
 let () =
   let kind = Lang.audio_pcm in
   let k = Lang.kind_type_of_kind_format kind in
-  Lang.add_operator "output.portaudio" ~active:true
+  Lang.add_operator "output.portaudio"
     ( Output.proto
     @ [
         ( "clock_safe",

--- a/src/io/pulseaudio_io.ml
+++ b/src/io/pulseaudio_io.ml
@@ -204,7 +204,7 @@ let () =
         Some "Force the use of the dedicated Pulseaudio clock." );
     ]
   in
-  Lang.add_operator "output.pulseaudio" ~active:true
+  Lang.add_operator "output.pulseaudio"
     (Output.proto @ proto @ [("", Lang.source_t k, None, None)])
     ~return_t:k ~category:Lang.Output ~meth:Output.meth
     ~descr:"Output the source's stream to a portaudio output device."
@@ -221,7 +221,7 @@ let () =
       in
       let kind = Source.Kind.of_kind kind in
       (new output ~infallible ~on_start ~on_stop ~start ~kind p :> Output.output));
-  Lang.add_operator "input.pulseaudio" ~active:true
+  Lang.add_operator "input.pulseaudio"
     (Start_stop.active_source_proto ~fallible:true @ proto)
     ~return_t:k ~category:Lang.Input ~meth:(Start_stop.meth ())
     ~descr:"Stream from a portaudio input device."

--- a/src/io/srt_io.ml
+++ b/src/io/srt_io.ml
@@ -1106,7 +1106,7 @@ let () =
       (fun (a, b, c, fn) -> (a, b, c, fun s -> fn (s :> Output.output)))
       Output.meth
   in
-  Lang.add_operator "output.srt" ~active:true ~return_t ~category:Lang.Output
+  Lang.add_operator "output.srt" ~return_t ~category:Lang.Output
     ~meth:(meth () @ output_meth)
     ~descr:"Send a SRT stream to a distant agent."
     ( Output.proto

--- a/src/io/udp_io.ml
+++ b/src/io/udp_io.ml
@@ -204,7 +204,7 @@ class input ~kind ~hostname ~port ~get_stream_decoder ~bufferize ~log_overfull =
 let () =
   let kind = Lang.any in
   let k = Lang.kind_type_of_kind_format kind in
-  Lang.add_operator "output.udp" ~active:true
+  Lang.add_operator "output.udp"
     ~descr:"Output encoded data to UDP, without any control whatsoever."
     ~category:Lang.Output
     ~flags:[Lang.Hidden; Lang.Deprecated; Lang.Experimental]
@@ -249,7 +249,7 @@ let () =
 let () =
   let kind = Lang.any in
   let k = Lang.kind_type_of_kind_format kind in
-  Lang.add_operator "input.udp" ~active:true
+  Lang.add_operator "input.udp"
     ~descr:"Input encoded data from UDP, without any control whatsoever."
     ~category:Lang.Input
     ~flags:[Lang.Hidden; Lang.Deprecated; Lang.Experimental]

--- a/src/lang/builtins_ffmpeg_filters.ml
+++ b/src/lang/builtins_ffmpeg_filters.ml
@@ -381,7 +381,7 @@ let () =
           Printf.sprintf "Ffmpeg filter: %s%s" description
             (if explanation <> "" then " " ^ explanation else "")
         in
-        add_builtin ~cat:Liq ("ffmpeg.filter." ^ name) ~descr
+        add_builtin ~cat:FFmpegFilter ("ffmpeg.filter." ^ name) ~descr
           ~flags:[Lang.Extra] input_t output_t
           (apply_filter ~args_parser ~filter))
       filters)
@@ -456,7 +456,7 @@ let () =
     ]
   in
 
-  add_builtin ~cat:Liq "ffmpeg.filter.audio.input"
+  add_builtin ~cat:FFmpegFilter "ffmpeg.filter.audio.input"
     ~descr:"Attach an audio source to a filter's input"
     [("", Graph.t, None, None); ("", audio_t, None, None)] Audio.t (fun p ->
       let graph_v = Lang.assoc "" 1 p in
@@ -508,7 +508,7 @@ let () =
 
   let return_kind = Frame.{ audio_frame with video = none; midi = none } in
   let return_t = Lang.kind_type_of_kind_format return_kind in
-  Lang.add_operator "ffmpeg.filter.audio.output" ~category:Lang.Output
+  Lang.add_operator "ffmpeg.filter.audio.output" ~category:Lang.FFmpegFilter
     ~descr:"Return an audio source from a filter's output" ~return_t
     (output_base_proto @ [("", Graph.t, None, None); ("", Audio.t, None, None)])
     (fun p ->
@@ -546,7 +546,7 @@ let () =
 
       (s :> Source.source));
 
-  add_builtin ~cat:Liq "ffmpeg.filter.video.input"
+  add_builtin ~cat:FFmpegFilter "ffmpeg.filter.video.input"
     ~descr:"Attach a video source to a filter's input"
     [("", Graph.t, None, None); ("", video_t, None, None)] Video.t (fun p ->
       let graph_v = Lang.assoc "" 1 p in
@@ -598,7 +598,7 @@ let () =
 
   let return_kind = Frame.{ video_frame with audio = none; midi = none } in
   let return_t = Lang.kind_type_of_kind_format return_kind in
-  Lang.add_operator "ffmpeg.filter.video.output" ~category:Lang.Output
+  Lang.add_operator "ffmpeg.filter.video.output" ~category:Lang.FFmpegFilter
     ~descr:"Return a video source from a filter's output" ~return_t
     ( output_base_proto
     @ [
@@ -663,7 +663,7 @@ let () =
 
 let () =
   let univ_t = Lang.univ_t () in
-  add_builtin "ffmpeg.filter.create" ~cat:Liq
+  add_builtin "ffmpeg.filter.create" ~cat:FFmpegFilter
     ~descr:"Configure and launch a filter graph"
     [("", Lang.fun_t [(false, "", Graph.t)] univ_t, None, None)]
     univ_t

--- a/src/lang/builtins_prometheus.ml
+++ b/src/lang/builtins_prometheus.ml
@@ -162,7 +162,7 @@ let source_monitor ~prefix ~label_names ~labels ~window s =
   let last_start_time = ref 0. in
   let last_end_time = ref 0. in
   let last_data = Gauge.labels (get_last_data ~label_names) labels in
-  let get_ready ~stype:_ ~is_output:_ ~id:_ ~ctype:_ ~clock_id:_
+  let get_ready ~stype:_ ~is_active:_ ~id:_ ~ctype:_ ~clock_id:_
       ~clock_sync_mode:_ =
     ()
   in

--- a/src/lang/lang.mli
+++ b/src/lang/lang.mli
@@ -140,6 +140,7 @@ type category =
   | Input  (** Input. *)
   | Output  (** Output. *)
   | Conversions  (** Conversions of stream type *)
+  | FFmpegFilter  (** FFmpeg filter *)
   | TrackProcessing  (** Operations on tracks (e.g. mixing, etc.). *)
   | SoundProcessing  (** Operations on sound (e.g. compression, etc.). *)
   | VideoProcessing  (** Operations on video. *)
@@ -184,7 +185,6 @@ val add_operator :
   category:category ->
   descr:string ->
   ?flags:doc_flag list ->
-  ?active:bool ->
   ?meth:(< Source.source ; .. > as 'a) operator_method list ->
   string ->
   proto ->
@@ -242,7 +242,7 @@ val of_list_t : t -> t
 val nullable_t : t -> t
 val ref_t : t -> t
 val request_t : t
-val source_t : ?methods:bool -> ?active:bool -> t -> t
+val source_t : ?methods:bool -> t -> t
 val of_source_t : t -> t
 val format_t : t -> t
 val kind_t : Frame.kind -> t

--- a/src/lang/lang_builtins.ml
+++ b/src/lang/lang_builtins.ml
@@ -33,6 +33,7 @@ type category =
   | Control
   | Interaction
   | Other
+  | FFmpegFilter
 
 let string_of_category = function
   | Sys -> "System"
@@ -45,6 +46,7 @@ let string_of_category = function
   | Control -> "Control"
   | Interaction -> "Interaction"
   | Other -> "Other"
+  | FFmpegFilter -> "FFmpeg Filter"
 
 let add_builtin ~cat ~descr ?(meth = []) ?flags name proto ret_t f =
   let ret_t =

--- a/src/lang/lang_parser_helper.ml
+++ b/src/lang/lang_parser_helper.ml
@@ -314,7 +314,7 @@ let mk_kind ~pos (kind, params) =
       raise (Parse_error (pos, "Unknown type constructor: " ^ t ^ ".")) )
 
 let mk_source_ty ~pos name args =
-  if name <> "source" && name <> "active_source" then
+  if name <> "source" then
     raise (Parse_error (pos, "Unknown type constructor: " ^ name ^ "."));
 
   let audio = ref ("any", []) in
@@ -334,8 +334,7 @@ let mk_source_ty ~pos name args =
   let video = mk_kind ~pos !video in
   let midi = mk_kind ~pos !midi in
 
-  Lang_values.source_t ~active:(name <> "source")
-    (Lang_values.frame_kind_t audio video midi)
+  Lang_values.source_t (Lang_values.frame_kind_t audio video midi)
 
 let mk_ty ~pos name =
   match name with

--- a/src/lang/lang_types.ml
+++ b/src/lang/lang_types.ml
@@ -865,18 +865,12 @@ let doc_of_meths m =
  * optional argument; whereas with a mandatory argument it is expected to wait
  * for it. *)
 
-let constr_sub x y =
-  match (x, y) with
-    | _, _ when x = y -> true
-    | "active_source", "source" -> true
-    | _ -> false
-
 (** Ensure that a<:b, perform unification if needed.
   * In case of error, generate an explanation. *)
 let rec ( <: ) a b =
   if !debug then Printf.eprintf "%s <: %s\n%!" (print a) (print b);
   match ((deref a).descr, (deref b).descr) with
-    | Constr c1, Constr c2 when constr_sub c1.name c2.name ->
+    | Constr c1, Constr c2 when c1.name = c2.name ->
         let rec aux pre p1 p2 =
           match (p1, p2) with
             | (v, h1) :: t1, (_, h2) :: t2 ->

--- a/src/operators/noblank.ml
+++ b/src/operators/noblank.ml
@@ -298,7 +298,7 @@ let () =
       new detect
         ~kind ~start_blank ~max_blank ~min_noise ~threshold ~track_sensitive
         ~on_blank ~on_noise s);
-  Lang.add_operator "blank.strip" ~active:true ~return_t
+  Lang.add_operator "blank.strip" ~return_t
     ~meth:
       [
         ( "is_blank",

--- a/src/outputs/ao_out.ml
+++ b/src/outputs/ao_out.ml
@@ -107,7 +107,7 @@ class output ~kind ~clock_safe ~nb_blocks ~driver ~infallible ~on_start ~on_stop
 let () =
   let kind = Lang.audio_pcm in
   let return_t = Lang.kind_type_of_kind_format kind in
-  Lang.add_operator "output.ao" ~active:true
+  Lang.add_operator "output.ao"
     ( Output.proto
     @ [
         ( "clock_safe",

--- a/src/outputs/bjack_out.ml
+++ b/src/outputs/bjack_out.ml
@@ -110,7 +110,7 @@ class output ~kind ~clock_safe ~infallible ~on_stop ~on_start ~nb_blocks ~server
 let () =
   let kind = Lang.audio_pcm in
   let k = Lang.kind_type_of_kind_format kind in
-  Lang.add_operator "output.jack" ~active:true
+  Lang.add_operator "output.jack"
     ( Output.proto
     @ [
         ( "clock_safe",

--- a/src/outputs/graphics_out.ml
+++ b/src/outputs/graphics_out.ml
@@ -52,7 +52,7 @@ class output ~kind ~infallible ~autostart ~on_start ~on_stop source =
 let () =
   let kind = Lang.video_yuva420p in
   let k = Lang.kind_type_of_kind_format kind in
-  Lang.add_operator "output.graphics" ~active:true
+  Lang.add_operator "output.graphics"
     (Output.proto @ [("", Lang.source_t k, None, None)])
     ~return_t:k ~category:Lang.Output
     ~descr:"Display video stream using the Graphics library."

--- a/src/outputs/harbor_output.ml
+++ b/src/outputs/harbor_output.ml
@@ -650,9 +650,8 @@ module Make (T : T) = struct
   let () =
     let kind = Lang.any in
     let return_t = Lang.kind_type_of_kind_format kind in
-    Lang.add_operator ~category:Lang.Output ~active:true
-      ~descr:T.source_description T.source_name (proto return_t) ~return_t
-      (fun p ->
+    Lang.add_operator ~category:Lang.Output ~descr:T.source_description
+      T.source_name (proto return_t) ~return_t (fun p ->
         let kind = Source.Kind.of_kind kind in
         (new output ~kind p :> Source.source))
 end

--- a/src/outputs/hls_output.ml
+++ b/src/outputs/hls_output.ml
@@ -790,8 +790,8 @@ class hls_output p =
 
 let () =
   let return_t = Lang.univ_t () in
-  Lang.add_operator "output.file.hls" (hls_proto return_t) ~active:true
-    ~return_t ~category:Lang.Output
+  Lang.add_operator "output.file.hls" (hls_proto return_t) ~return_t
+    ~category:Lang.Output
     ~descr:
       "Output the source stream to an HTTP live stream served from a local \
        directory." (fun p -> (new hls_output p :> Source.source))

--- a/src/outputs/icecast2.ml
+++ b/src/outputs/icecast2.ml
@@ -600,7 +600,7 @@ class output ~kind p =
 
 let () =
   let return_t = Lang.univ_t () in
-  Lang.add_operator "output.icecast" ~active:true ~category:Lang.Output
+  Lang.add_operator "output.icecast" ~category:Lang.Output
     ~descr:"Encode and output the stream to an icecast2 or shoutcast server."
     (proto return_t) ~return_t (fun p ->
       let format_val = Lang.assoc "" 1 p in

--- a/src/outputs/output.ml
+++ b/src/outputs/output.ml
@@ -205,7 +205,7 @@ class dummy ~infallible ~on_start ~on_stop ~autostart ~kind source =
 let () =
   let kind = Lang.any in
   let return_t = Lang.kind_type_of_kind_format kind in
-  Lang.add_operator "output.dummy" ~active:true
+  Lang.add_operator "output.dummy"
     (proto @ [("", Lang.source_t return_t, None, None)])
     ~category:Lang.Output ~descr:"Dummy output for debugging purposes." ~meth
     ~return_t

--- a/src/outputs/pipe_output.ml
+++ b/src/outputs/pipe_output.ml
@@ -117,7 +117,7 @@ class url_output p =
 
 let () =
   let return_t = Lang.univ_t () in
-  Lang.add_operator "output.url" ~active:true (url_proto return_t) ~return_t
+  Lang.add_operator "output.url" (url_proto return_t) ~return_t
     ~category:Lang.Output
     ~descr:
       "Encode and let encoder handle data output. Useful with encoder with no \
@@ -385,7 +385,7 @@ let new_file_output p =
 
 let () =
   let return_t = Lang.univ_t () in
-  Lang.add_operator "output.file" (file_proto return_t) ~active:true ~return_t
+  Lang.add_operator "output.file" (file_proto return_t) ~return_t
     ~category:Lang.Output ~descr:"Output the source stream to a file." (fun p ->
       (new_file_output p :> Source.source))
 
@@ -428,7 +428,7 @@ let pipe_proto kind descr =
 
 let () =
   let return_t = Lang.univ_t () in
-  Lang.add_operator "output.external" ~active:true
+  Lang.add_operator "output.external"
     (pipe_proto return_t "Process to pipe data to.")
     ~return_t ~category:Lang.Output
     ~meth:

--- a/src/outputs/sdl_out.ml
+++ b/src/outputs/sdl_out.ml
@@ -99,7 +99,7 @@ class output ~infallible ~on_start ~on_stop ~autostart ~kind source =
 let () =
   let kind = Lang.video_yuva420p in
   let k = Lang.kind_type_of_kind_format kind in
-  Lang.add_operator "output.sdl" ~active:true
+  Lang.add_operator "output.sdl"
     (Output.proto @ [("", Lang.source_t k, None, None)])
     ~return_t:k ~category:Lang.Output ~descr:"Display a video using SDL."
     (fun p ->

--- a/src/source.ml
+++ b/src/source.ml
@@ -320,7 +320,7 @@ type clock_sync_mode = [ sync | `Unknown ]
 type watcher = {
   get_ready :
     stype:source_t ->
-    is_output:bool ->
+    is_active:bool ->
     id:string ->
     ctype:Frame.content_type ->
     clock_id:string ->
@@ -427,7 +427,7 @@ class virtual operator ?(name = "src") ?audio_in ?video_in ?midi_in out_kind
     method virtual stype : source_t
 
     (** Is the source active *)
-    method is_output = false
+    method is_active = false
 
     (** Children sources *)
     val mutable sources : operator list = sources
@@ -528,7 +528,7 @@ class virtual operator ?(name = "src") ?audio_in ?video_in ?midi_in out_kind
 
       (* Decide whether caching mode is needed, and why *)
       match
-        if self#is_output then Some "active source"
+        if self#is_active then Some "active source"
         else (
           match static_activations with
             | [] -> None
@@ -570,7 +570,7 @@ class virtual operator ?(name = "src") ?audio_in ?video_in ?midi_in out_kind
           | _ -> ("unknown", `Unknown)
       in
       self#iter_watchers (fun w ->
-          w.get_ready ~stype:self#stype ~is_output:self#is_output ~id:self#id
+          w.get_ready ~stype:self#stype ~is_active:self#is_active ~id:self#id
             ~ctype:self#ctype ~clock_id ~clock_sync_mode)
 
     val mutable on_leave = []
@@ -797,7 +797,7 @@ and virtual active_operator ?name ?audio_in ?video_in ?midi_in content_kind
       (unify self#clock
          (create_unknown ~sources:[(self :> active_operator)] ~sub_clocks:[]))
 
-    method is_output = true
+    method is_active = true
 
     (** Start a new output round, may trigger the computation of a frame. *)
     method virtual output : unit

--- a/src/source.mli
+++ b/src/source.mli
@@ -47,7 +47,7 @@ type clock_sync_mode = [ sync | `Unknown ]
 type watcher = {
   get_ready :
     stype:source_t ->
-    is_output:bool ->
+    is_active:bool ->
     id:string ->
     ctype:Frame.content_type ->
     clock_id:string ->
@@ -193,7 +193,7 @@ class virtual source :
        (** Tells the source to finish the reading of current track. *)
        method virtual abort_track : unit
 
-       method is_output : bool
+       method is_active : bool
 
        (** Wait for output round to finish.
            Typically, output nodes compute an audio frame (a full buffer),

--- a/tests/language/list.liq
+++ b/tests/language/list.liq
@@ -79,10 +79,6 @@ def f() =
   l = [ "a".{b = true, k = 0} , "b".{b = true, l = 1} ]
   t(list.for_all(fun (x) -> x.b, l), true)
 
-  # Ensure that we can have active sources and sources
-  ignore([output.dummy(noise()), blank()])
-  ignore([blank(), output.dummy(noise())])
-
   # There used to be a bug where [x] would loose all its methods.
   x = 1
   let x.foo = "bla"

--- a/tests/streams/195.liq
+++ b/tests/streams/195.liq
@@ -4,4 +4,5 @@
 
 s = playlist(mode="randomize",reload=1,reload_mode="rounds","playlist")
 s = test.check_non_repeating(nb_files=3,nb_rounds=10,s)
-clock(sync="none", output.dummy(fallible=true,s))
+clock(sync="none", s)
+output.dummy(fallible=true,s)

--- a/tests/streams/197.liq
+++ b/tests/streams/197.liq
@@ -15,4 +15,5 @@ end
 
 s = playlist(check_next=filter, mode="randomize", reload_mode="rounds", "playlist")
 s = test.check_non_repeating(nb_files=2, nb_rounds=10, s)
-clock(sync="none", output.dummy(fallible=true,s))
+clock(sync="none", s)
+output.dummy(fallible=true,s)


### PR DESCRIPTION
The notion of `active_source` is mostly internal. It means that this a source (output or not) that will always be animated by its clock once it is available. This is useful for sources such as `input.http` that need to maintain an active connection, and outputs, of course.

However, this notion does not provide anything to the end user and complicates the typing system, in particular when joining sources in a list and etc.

Thus, this PR removes the `active_source` type. The only blind spot is output and warnings for top-level unused variables:
* Either we accept to not warn on any source left unused at top-level
* Or we change the type of outputs.

I suggest that we should use `unit` type for outputs, which would effectively make them leaf nodes in the streaming graph, which seems like what we always thought of them as anyways.