### PR TITLE
Refactor Start_stop

### DIFF
--- a/libs/io.liq
+++ b/libs/io.liq
@@ -35,10 +35,10 @@ let output.video = output.dummy
 %ifdef output.sdl
   def output.video(%argsof(output.sdl), s)
     if output.sdl.has_video() then
-      output.sdl(%argsof(output.sdl), s)
+      (output.sdl(%argsof(output.sdl), s):source)
     else
       # Avoid using SDL when there is no video output.
-      output.dummy(fallible=fallible, s)
+      (output.dummy(fallible=fallible, s):source)
     end
   end
 %endif

--- a/src/io/ffmpeg_filter_io.ml
+++ b/src/io/ffmpeg_filter_io.ml
@@ -50,13 +50,13 @@ class audio_output ~name ~kind source_val =
 
     method set_init v = init <- v
 
-    method output_start = Lazy.force init
+    method start = Lazy.force init
 
-    method output_stop = ()
+    method stop = ()
 
-    method output_reset = ()
+    method reset = ()
 
-    method output_send memo =
+    method send_frame memo =
       let frames =
         Ffmpeg_raw_content.(
           (Audio.get_data Frame.(memo.content.audio)).VideoSpecs.data)
@@ -93,13 +93,13 @@ class video_output ~kind ~name source_val =
 
     method set_init v = init <- v
 
-    method output_start = Lazy.force init
+    method start = Lazy.force init
 
-    method output_stop = ()
+    method stop = ()
 
-    method output_reset = ()
+    method reset = ()
 
-    method output_send memo =
+    method send_frame memo =
       let frames =
         Ffmpeg_raw_content.(
           (Video.get_data Frame.(memo.content.video)).VideoSpecs.data)
@@ -215,12 +215,6 @@ class audio_input ~bufferize kind =
         self#log#important "Buffer emptied..."
 
     method abort_track = ()
-
-    val mutable init = lazy ()
-
-    method set_init v = init <- v
-
-    method output_start = Lazy.force init
   end
 
 type video_config = {

--- a/src/io/gstreamer_io.ml
+++ b/src/io/gstreamer_io.ml
@@ -197,7 +197,7 @@ class output ~kind ~clock_safe ~on_error ~infallible ~on_start ~on_stop
         Clock.unify self#clock
           (Clock.create_known (gst_clock () :> Clock.clock))
 
-    method output_start =
+    method start =
       let el = self#get_element in
       self#log#info "Playing.";
       started <- true;
@@ -209,7 +209,7 @@ class output ~kind ~clock_safe ~on_error ~infallible ~on_start ~on_stop
       (* ignore (Element.get_state el.bin); *)
       self#register_task ~priority:Tutils.Blocking Tutils.scheduler
 
-    method output_stop =
+    method stop =
       self#stop_task;
       started <- false;
       let todo =
@@ -269,7 +269,7 @@ class output ~kind ~clock_safe ~on_error ~infallible ~on_start ~on_stop
 
     val mutable presentation_time = Int64.zero
 
-    method output_send frame =
+    method send_frame frame =
       let el = self#get_element in
       try
         if not (Frame.is_partial frame) then (
@@ -307,7 +307,7 @@ class output ~kind ~clock_safe ~on_error ~infallible ~on_start ~on_stop
              (Printexc.to_string e));
         self#on_error e
 
-    method output_reset = ()
+    method reset = ()
   end
 
 let output_proto ~return_t ~pipeline =
@@ -596,8 +596,6 @@ class audio_video_input p kind (pipeline, audio_pipeline, video_pipeline) =
         else None
       in
       { bin; audio = audio_sink; video = video_sink }
-
-    method is_active = true
 
     method private is_generator_at_max = Generator.length gen >= max_ticks
 

--- a/src/io/oss_io.ml
+++ b/src/io/oss_io.ml
@@ -70,15 +70,11 @@ class output ~kind ~clock_safe ~on_start ~on_stop ~infallible ~start dev
             Unix.close x;
             fd <- None
 
-    method output_start = self#open_device
+    method start = self#open_device
 
-    method output_stop = self#close_device
+    method stop = self#close_device
 
-    method output_reset =
-      self#close_device;
-      self#open_device
-
-    method output_send memo =
+    method send_frame memo =
       let fd = Option.get fd in
       let buf = AFrame.pcm memo in
       let r = Audio.S16LE.size (Audio.channels buf) (Audio.length buf) in
@@ -92,20 +88,18 @@ class input ~kind ~clock_safe ~start ~on_stop ~on_start ~fallible dev =
   let samples_per_second = Lazy.force Frame.audio_rate in
   object (self)
     inherit
-      Start_stop.input
-        ~content_kind:(Source.Kind.of_kind kind) ~source_kind:"oss"
+      Start_stop.active_source
+        ~get_clock ~clock_safe ~content_kind:(Source.Kind.of_kind kind)
         ~name:(Printf.sprintf "oss_in(%s)" dev)
-        ~on_start ~on_stop ~fallible ~autostart:start as super
-
-    method private set_clock =
-      super#set_clock;
-      if clock_safe then
-        Clock.unify self#clock
-          (Clock.create_known (get_clock () :> Clock.clock))
+        ~on_start ~on_stop ~fallible ~autostart:start ()
 
     val mutable fd = None
 
     method self_sync = fd <> None
+
+    method abort_track = ()
+
+    method remaining = -1
 
     method private start = self#open_device
 
@@ -122,11 +116,7 @@ class input ~kind ~clock_safe ~start ~on_stop ~on_start ~fallible dev =
       Unix.close (Option.get fd);
       fd <- None
 
-    method output_reset =
-      self#close_device;
-      self#open_device
-
-    method input frame =
+    method get_frame frame =
       assert (0 = AFrame.position frame);
       let fd = Option.get fd in
       let buf = AFrame.pcm frame in
@@ -177,18 +167,15 @@ let () =
         :> Source.source ));
   let k = Lang.kind_type_of_kind_format Lang.audio_pcm in
   Lang.add_operator "input.oss" ~active:true
-    ( Start_stop.input_proto
+    ( Start_stop.active_source_proto ~fallible:true
     @ [
-        ( "clock_safe",
-          Lang.bool_t,
-          Some (Lang.bool true),
-          Some "Force the use of the dedicated OSS clock." );
         ( "device",
           Lang.string_t,
           Some (Lang.string "/dev/dsp"),
           Some "OSS device to use." );
       ] )
-    ~return_t:k ~category:Lang.Input ~descr:"Stream from an OSS input device."
+    ~meth:(Start_stop.meth ()) ~return_t:k ~category:Lang.Input
+    ~descr:"Stream from an OSS input device."
     (fun p ->
       let e f v = f (List.assoc v p) in
       let clock_safe = e Lang.to_bool "clock_safe" in
@@ -203,5 +190,4 @@ let () =
         let f = List.assoc "on_stop" p in
         fun () -> ignore (Lang.apply f [])
       in
-      ( new input ~kind ~start ~on_start ~on_stop ~fallible ~clock_safe device
-        :> Source.source ))
+      new input ~kind ~start ~on_start ~on_stop ~fallible ~clock_safe device)

--- a/src/lang/builtins_source.ml
+++ b/src/lang/builtins_source.ml
@@ -230,7 +230,6 @@ let () =
       let p = (("id", Lang.string "source_dumper") :: p) @ proto in
       let fo = Pipe_output.new_file_output p in
       fo#get_ready [s];
-      fo#output_get_ready;
       log#info "Start dumping source.";
       while s#is_ready do
         fo#output;

--- a/src/operators/noblank.ml
+++ b/src/operators/noblank.ml
@@ -158,11 +158,7 @@ class strip ~kind ~start_blank ~max_blank ~min_noise ~threshold ~track_sensitive
       if source#is_ready && self#is_blank && AFrame.is_partial self#memo then
         self#get_frame self#memo
 
-    method output_reset = ()
-
-    method output_get_ready = ()
-
-    method is_active = true
+    method reset = ()
   end
 
 class eat ~kind ~track_sensitive ~at_beginning ~start_blank ~max_blank

--- a/src/operators/time_warp.ml
+++ b/src/operators/time_warp.ml
@@ -81,15 +81,15 @@ module Buffer = struct
           ~output_kind:"buffer" ~content_kind:kind ~infallible ~on_start
             ~on_stop source_val autostart
 
-      method output_reset = ()
+      method reset = ()
 
-      method output_start = ()
+      method start = ()
 
-      method output_stop = ()
+      method stop = ()
 
       val source = Lang.to_source source_val
 
-      method output_send frame =
+      method send_frame frame =
         proceed c (fun () ->
             if c.abort then (
               c.abort <- false;
@@ -307,15 +307,15 @@ module AdaptativeBuffer = struct
           ~output_kind:"buffer" ~content_kind:kind ~infallible ~on_start
             ~on_stop source_val autostart
 
-      method output_reset = ()
+      method reset = ()
 
-      method output_start = ()
+      method start = ()
 
-      method output_stop = ()
+      method stop = ()
 
       val source = Lang.to_source source_val
 
-      method output_send frame =
+      method send_frame frame =
         proceed c (fun () ->
             if c.abort then (
               c.abort <- false;

--- a/src/outputs/alsa_out.ml
+++ b/src/outputs/alsa_out.ml
@@ -154,7 +154,7 @@ class output ~kind ~clock_safe ~infallible ~on_stop ~on_start ~start dev source
           Pcm.recover dev e )
         else Printexc.raise_with_backtrace e bt
 
-    method output_send buf =
+    method send_frame buf =
       let buf = AFrame.pcm buf in
       let ratio = float alsa_rate /. float samples_per_second in
       let buf =
@@ -163,7 +163,7 @@ class output ~kind ~clock_safe ~infallible ~on_stop ~on_start ~start dev source
       let f data = Audio.blit buf data in
       ioring#put_block f
 
-    method output_reset =
+    method reset =
       self#close;
       ignore self#get_device
   end

--- a/src/outputs/ao_out.ml
+++ b/src/outputs/ao_out.ml
@@ -92,7 +92,7 @@ class output ~kind ~clock_safe ~nb_blocks ~driver ~infallible ~on_start ~on_stop
       let dev = self#get_device in
       play dev (Bytes.unsafe_to_string data)
 
-    method output_send wav =
+    method send_frame wav =
       if not (Frame.is_partial wav) then (
         let push data =
           let pcm = AFrame.pcm wav in
@@ -101,7 +101,7 @@ class output ~kind ~clock_safe ~nb_blocks ~driver ~infallible ~on_start ~on_stop
         in
         ioring#put_block push )
 
-    method output_reset = ()
+    method reset = ()
   end
 
 let () =
@@ -132,7 +132,7 @@ let () =
           Some "List of parameters, depends on the driver." );
         ("", Lang.source_t return_t, None, None);
       ] )
-    ~category:Lang.Output
+    ~category:Lang.Output ~meth:Output.meth
     ~descr:"Output stream to local sound card using libao." ~return_t
     (fun p ->
       let clock_safe = Lang.to_bool (List.assoc "clock_safe" p) in
@@ -164,4 +164,4 @@ let () =
       ( new output
           ~kind ~clock_safe ~nb_blocks ~driver ~infallible ~on_start ~on_stop
           ?channels_matrix ~options source start
-        :> Source.source ))
+        :> Output.output ))

--- a/src/outputs/bjack_out.ml
+++ b/src/outputs/bjack_out.ml
@@ -100,11 +100,11 @@ class output ~kind ~clock_safe ~infallible ~on_stop ~on_start ~nb_blocks ~server
             device <- None
         | None -> ()
 
-    method output_send wav =
+    method send_frame wav =
       let push data = Audio.S16LE.of_audio (AFrame.pcm wav) data 0 in
       ioring#put_block push
 
-    method output_reset = ()
+    method reset = ()
   end
 
 let () =

--- a/src/outputs/graphics_out.ml
+++ b/src/outputs/graphics_out.ml
@@ -32,21 +32,21 @@ class output ~kind ~infallible ~autostart ~on_start ~on_stop source =
 
     val mutable sleep = false
 
-    method output_stop = sleep <- true
+    method stop = sleep <- true
 
-    method output_start =
+    method start =
       Graphics.open_graph "";
       Graphics.set_window_title "Liquidsoap";
       Graphics.resize_window video_width video_height;
       sleep <- false
 
-    method output_send buf =
+    method send_frame buf =
       let rgb = Video.get (VFrame.yuva420p buf) 0 in
       let img = Video.Image.to_int_image rgb in
       let img = Graphics.make_image img in
       Graphics.draw_image img 0 0
 
-    method output_reset = ()
+    method reset = ()
   end
 
 let () =

--- a/src/outputs/harbor_output.ml
+++ b/src/outputs/harbor_output.ml
@@ -600,7 +600,7 @@ module Make (T : T) = struct
             () )
         else ()
 
-      method output_start =
+      method start =
         assert (encoder = None);
         let enc = data.factory self#id in
         encoder <- Some (enc Meta_format.empty_metadata);
@@ -620,7 +620,7 @@ module Make (T : T) = struct
           | Some f -> dump <- Some (open_out_bin f)
           | None -> ()
 
-      method output_stop =
+      method stop =
         ignore ((Option.get encoder).Encoder.stop ());
         encoder <- None;
         Harbor.remove_http_handler ~port ~verb:`Get ~uri ();
@@ -642,9 +642,9 @@ module Make (T : T) = struct
           ();
         match dump with Some f -> close_out f | None -> ()
 
-      method output_reset =
-        self#output_stop;
-        self#output_start
+      method reset =
+        self#stop;
+        self#start
     end
 
   let () =

--- a/src/outputs/hls_output.ml
+++ b/src/outputs/hls_output.ml
@@ -631,7 +631,7 @@ class hls_output p =
       List.iter (fun s -> self#unlink (self#playlist_name s)) streams;
       self#unlink main_playlist_path
 
-    method output_start =
+    method start =
       ( match persist_at with
         | Some persist_at when Sys.file_exists persist_at -> (
             try
@@ -647,7 +647,7 @@ class hls_output p =
       List.iter self#open_segment streams;
       self#toggle_state `Streaming
 
-    method output_stop =
+    method stop =
       self#toggle_state `Stop;
       ( try
           let data =
@@ -664,7 +664,7 @@ class hls_output p =
             self#cleanup_streams;
             self#cleanup_playlists
 
-    method output_reset = self#toggle_state `Restart
+    method reset = self#toggle_state `Restart
 
     method private write_state persist_at =
       self#log#info "Reading state file at %S.." persist_at;

--- a/src/outputs/icecast2.ml
+++ b/src/outputs/icecast2.ml
@@ -515,13 +515,13 @@ class output ~kind p =
 
     (** It there's too much latency, we'll stop trying to catchup.
     * Reconnect to cancel the latency on the server's side too. *)
-    method output_reset =
-      self#output_stop;
-      self#output_start
+    method reset =
+      self#stop;
+      self#start
 
-    method output_start = self#icecast_start
+    method start = self#icecast_start
 
-    method output_stop = self#icecast_stop
+    method stop = self#icecast_stop
 
     method icecast_start =
       assert (encoder = None);

--- a/src/outputs/output.mli
+++ b/src/outputs/output.mli
@@ -43,44 +43,33 @@ class virtual output :
 
        method remaining : int
 
-       method output_get_ready : unit
-
        method output : unit
 
        method private get_frame : Frame.t -> unit
 
        method abort_track : unit
 
-       val mutable request_start : bool
-
-       val mutable request_stop : bool
-
-       (** An infallible (normal) output can always stream.
-    * Both fallible and infallible outputs may not always be outputting
-    * (sending data to the world using [#output_send]).
-    * Outputting can only be done when streaming.
-    * The following two methods give those two aspects of the current status,
-    * [#is_active] tells if the source is outputting and [#is_ready] tells
-    * whether it is streaming or can start streaming. *)
-       method is_active : bool
-
        method is_ready : bool
+
+       method state : Start_stop.state
+
+       method transition_to : Start_stop.state -> unit
 
        method private add_metadata : Request.metadata -> unit
 
        method private metadata_queue : Request.metadata Queue.t
 
-       (* TODO except for #output_reset those methods should be private
-        *   while we're at it I'm tempted to remove #is_active and let each
-        *   output deal with it *)
-       method virtual private output_reset : unit
+       method private reset : unit
 
-       method virtual private output_send : Frame.t -> unit
+       method virtual private send_frame : Frame.t -> unit
 
-       method virtual private output_start : unit
+       method virtual private start : unit
 
-       method virtual private output_stop : unit
+       method virtual private stop : unit
      end
+
+(** Default methods on output values. *)
+val meth : (string * Lang.scheme * string * (output -> Lang.value)) list
 
 class virtual encoded :
   content_kind:Source.Kind.t
@@ -94,7 +83,7 @@ class virtual encoded :
   -> object
        inherit output
 
-       method private output_send : Frame.t -> unit
+       method private send_frame : Frame.t -> unit
 
        method virtual private encode : Frame.t -> int -> int -> 'a
 
@@ -103,11 +92,11 @@ class virtual encoded :
 
        method virtual private send : 'a -> unit
 
-       method virtual private output_reset : unit
+       method private reset : unit
 
-       method virtual private output_start : unit
+       method virtual private start : unit
 
-       method virtual private output_stop : unit
+       method virtual private stop : unit
      end
 
 class dummy :
@@ -120,11 +109,11 @@ class dummy :
   -> object
        inherit output
 
-       method private output_reset : unit
+       method private reset : unit
 
-       method private output_start : unit
+       method private start : unit
 
-       method private output_stop : unit
+       method private stop : unit
 
-       method private output_send : Frame.t -> unit
+       method private send_frame : Frame.t -> unit
      end

--- a/src/outputs/pipe_output.ml
+++ b/src/outputs/pipe_output.ml
@@ -56,7 +56,7 @@ class virtual base ~kind ~source ~name p =
 
     method virtual private encoder_factory : Encoder.factory
 
-    method output_start =
+    method start =
       let enc = self#encoder_factory self#id in
       let meta =
         match current_metadata with
@@ -65,9 +65,9 @@ class virtual base ~kind ~source ~name p =
       in
       encoder <- Some (enc meta)
 
-    method output_stop = encoder <- None
+    method stop = encoder <- None
 
-    method output_reset = ()
+    method reset = ()
 
     val mutable need_reset = false
 
@@ -193,12 +193,12 @@ class virtual piped_output ~kind p =
       self#open_pipe;
       open_date <- Unix.gettimeofday ()
 
-    method output_stop =
+    method stop =
       if self#is_open then (
         let flush = (Option.get encoder).Encoder.stop () in
         self#send flush;
         self#close_pipe );
-      super#output_stop
+      super#stop
 
     val m = Mutex.create ()
 
@@ -207,10 +207,10 @@ class virtual piped_output ~kind p =
         (fun () ->
           self#log#important "Re-opening output pipe.";
 
-          (* #output_stop can trigger #send, the [reopening] flag avoids loops *)
+          (* #stop can trigger #send, the [reopening] flag avoids loops *)
           reopening <- true;
-          self#output_stop;
-          self#output_start;
+          self#stop;
+          self#start;
           reopening <- false;
           need_reset <- false)
         ()

--- a/src/outputs/sdl_out.ml
+++ b/src/outputs/sdl_out.ml
@@ -40,7 +40,7 @@ class output ~infallible ~on_start ~on_stop ~autostart ~kind source =
 
     val mutable window = None
 
-    method output_start =
+    method start =
       window <-
         Some
           (Sdl_utils.check
@@ -51,10 +51,10 @@ class output ~infallible ~on_start ~on_stop ~autostart ~kind source =
       self#log#info "Initialized SDL video surface."
 
     (** We don't care about latency. *)
-    method output_reset = ()
+    method reset = ()
 
     (** Stop SDL. We have to assume that there's only one SDL output anyway. *)
-    method output_stop = Sdl.quit ()
+    method stop = Sdl.quit ()
 
     method process_events =
       let e = Sdl.Event.create () in
@@ -65,8 +65,8 @@ class output ~infallible ~on_start ~on_stop ~autostart ~kind source =
                  do not cancel autostart. We should perhaps have a method in the
                  output class for that kind of thing, and try to get an uniform
                  behavior. *)
-              request_start <- false;
-              request_stop <- true
+              self#transition_to `Stopped;
+              self#transition_to `Started
           | `Key_down ->
               (let k = Sdl.Event.(get e keyboard_keycode) in
                match k with
@@ -86,7 +86,7 @@ class output ~infallible ~on_start ~on_stop ~autostart ~kind source =
               self#process_events
           | _ -> self#process_events )
 
-    method output_send buf =
+    method send_frame buf =
       self#process_events;
       let window = Option.get window in
       let surface = Sdl_utils.check Sdl.get_window_surface window in

--- a/src/source.ml
+++ b/src/source.ml
@@ -803,15 +803,7 @@ and virtual active_operator ?name ?audio_in ?video_in ?midi_in content_kind
     method virtual output : unit
 
     (** Do whatever needed when the latency gets too big and is reset. *)
-    method virtual output_reset : unit
-
-    (** Is the source active ? *)
-    method virtual is_active : bool
-
-    (** Special init phase for outputs. This method is called by Root after the
-    * standard get_ready propagation, after the Root clock is started.
-    * It allows enhancements of the initial latency. *)
-    method virtual output_get_ready : unit
+    method virtual reset : unit
   end
 
 (** Shortcuts for defining sources with no children *)

--- a/src/source.mli
+++ b/src/source.mli
@@ -230,23 +230,11 @@ and virtual active_source :
   -> object
        inherit source
 
-       (** Special init phase for outputs. This method is called by Root after the
-           standard get_ready propagation, after the Root clock is started.
-           It allows enhancements of the initial latency. *)
-       method virtual output_get_ready : unit
-
        (** Start a new output round, triggers computation of a new frame. *)
        method virtual output : unit
 
        (** Do whatever needed when the latency gets too big and is reset. *)
-       method virtual output_reset : unit
-
-       (** Is the source active ?
-           If the returned value is [false], then [output_reset]
-           should not be called on that source.
-           If [output_reset] does nothing, this function can return any value.
-           TODO that kind of detail could be left inside #output_reset *)
-       method virtual is_active : bool
+       method virtual reset : unit
      end
 
 (* This is for defining a source which has children *)

--- a/src/sources/bjack_in.ml
+++ b/src/sources/bjack_in.ml
@@ -21,27 +21,24 @@
  *****************************************************************************)
 
 open Mm
-open Source
 
 let log = Log.make ["input"; "jack"]
 let bjack_clock = Tutils.lazy_cell (fun () -> new Clock.clock "bjack")
 
-class jack_in ~kind ~clock_safe ~nb_blocks ~server =
+class jack_in ~kind ~clock_safe ~on_start ~on_stop ~fallible ~autostart
+  ~nb_blocks ~server =
   let samples_per_frame = AFrame.size () in
   let samples_per_second = Lazy.force Frame.audio_rate in
   let seconds_per_frame = float samples_per_frame /. float samples_per_second in
   let bytes_per_sample = 2 in
 
   object (self)
-    inherit active_source ~name:"input.jack" kind as active_source
+    inherit
+      Start_stop.active_source
+        ~name:"input.jack" ~content_kind:kind ~clock_safe ~on_start ~on_stop
+          ~fallible ~autostart () as active_source
 
     inherit [Bytes.t] IoRing.input ~nb_blocks as ioring
-
-    method set_clock =
-      active_source#set_clock;
-      if clock_safe then
-        Clock.unify self#clock
-          (Clock.create_known (bjack_clock () :> Clock.clock))
 
     method private wake_up l =
       active_source#wake_up l;
@@ -57,10 +54,6 @@ class jack_in ~kind ~clock_safe ~nb_blocks ~server =
     method private sleep =
       active_source#sleep;
       ioring#sleep
-
-    method stype = Infallible
-
-    method is_ready = true
 
     method abort_track = ()
 
@@ -122,37 +115,42 @@ class jack_in ~kind ~clock_safe ~nb_blocks ~server =
         (Audio.sub fbuf 0 samples_per_frame);
       AFrame.add_break buf samples_per_frame
 
-    method output =
-      let memo = self#memo in
-      if AFrame.is_partial memo then self#get_frame memo
-
-    method output_reset = ()
-
-    method is_active = true
+    method reset = ()
   end
 
 let () =
   let kind = Lang.audio_pcm in
   let return_t = Lang.kind_type_of_kind_format kind in
   Lang.add_operator "input.jack"
-    [
-      ( "clock_safe",
-        Lang.bool_t,
-        Some (Lang.bool true),
-        Some "Force the use of the dedicated bjack clock." );
-      ( "buffer_size",
-        Lang.int_t,
-        Some (Lang.int 2),
-        Some "Set buffer size, in frames. Must be >= 1." );
-      ( "server",
-        Lang.string_t,
-        Some (Lang.string ""),
-        Some "Jack server to connect to." );
-    ]
-    ~return_t ~category:Lang.Input ~descr:"Get stream from jack."
+    ( Start_stop.active_source_proto ~fallible:true
+    @ [
+        ( "buffer_size",
+          Lang.int_t,
+          Some (Lang.int 2),
+          Some "Set buffer size, in frames. Must be >= 1." );
+        ( "server",
+          Lang.string_t,
+          Some (Lang.string ""),
+          Some "Jack server to connect to." );
+      ] )
+    ~meth:(Start_stop.meth ()) ~return_t ~category:Lang.Input
+    ~descr:"Get stream from jack."
     (fun p ->
       let clock_safe = Lang.to_bool (List.assoc "clock_safe" p) in
+      let fallible = Lang.to_bool (List.assoc "fallible" p) in
+      let autostart = Lang.to_bool (List.assoc "start" p) in
+      let on_start =
+        let f = List.assoc "on_start" p in
+        fun () -> ignore (Lang.apply f [])
+      in
+      let on_stop =
+        let f = List.assoc "on_stop" p in
+        fun () -> ignore (Lang.apply f [])
+      in
       let nb_blocks = Lang.to_int (List.assoc "buffer_size" p) in
       let server = Lang.to_string (List.assoc "server" p) in
       let kind = Source.Kind.of_kind kind in
-      (new jack_in ~kind ~clock_safe ~nb_blocks ~server :> Source.source))
+      ( new jack_in
+          ~kind ~clock_safe ~nb_blocks ~server ~fallible ~on_start ~on_stop
+          ~autostart
+        :> Start_stop.active_source ))

--- a/src/synth/keyboard.ml
+++ b/src/synth/keyboard.ml
@@ -90,10 +90,7 @@ class keyboard ~kind =
 
     val lock = Mutex.create ()
 
-    method private sleep =
-      Tutils.mutexify lock (fun () -> run_id <- run_id + 1) ()
-
-    method private output_get_ready =
+    method private wake_up _ =
       let id = run_id in
       let rec task _ =
         if run_id <> id then []
@@ -124,9 +121,10 @@ class keyboard ~kind =
           events = [`Read Unix.stdin];
         }
 
-    method output_reset = ()
+    method private sleep =
+      Tutils.mutexify lock (fun () -> run_id <- run_id + 1) ()
 
-    method is_active = true
+    method reset = ()
 
     method private get_frame frame =
       assert (0 = MFrame.position frame);

--- a/src/synth/keyboard_sdl.ml
+++ b/src/synth/keyboard_sdl.ml
@@ -102,7 +102,7 @@ class keyboard ~kind velocity =
 
     val mutable window = None
 
-    method output_get_ready =
+    method wake_up _ =
       window <-
         Some
           (Sdl_utils.check
@@ -116,9 +116,7 @@ class keyboard ~kind velocity =
 
     val mutable velocity = velocity
 
-    method output_reset = ()
-
-    method is_active = true
+    method reset = ()
 
     method get_frame frame =
       assert (0 = MFrame.position frame);

--- a/src/tools/producer_consumer.ml
+++ b/src/tools/producer_consumer.ml
@@ -81,17 +81,17 @@ class consumer ?(write_frame : write_frame option) ~output_kind ~producer ~kind
         ~on_stop:(fun () -> write_frame `Flush)
         source autostart
 
-    method output_reset = ()
+    method reset = ()
 
-    method output_start = ()
+    method start = ()
 
-    method output_stop = ()
+    method stop = ()
 
     method private set_clock =
       Clock.unify self#clock producer#clock;
       Clock.unify self#clock s#clock
 
-    method output_send frame =
+    method send_frame frame =
       proceed c (fun () ->
           if c.abort then (
             c.abort <- false;

--- a/src/tools/start_stop.ml
+++ b/src/tools/start_stop.ml
@@ -20,138 +20,94 @@
 
  *****************************************************************************)
 
-(** Base class for sources with start/stop methods and server commands.
-  * That class provides #may/do_start/stop but does not hook them anywhere. *)
-class virtual base ~name ~(on_start : unit -> unit) ~(on_stop : unit -> unit)
-  ~autostart =
+type state = [ `Started | `Stopped ]
+
+(** Base class for sources with start/stop methods. Class ineheriting it should
+    declare their own [start]/[stop] method and users should call [#set_start]  *)
+class virtual base ~(on_start : unit -> unit) ~(on_stop : unit -> unit) =
   object (self)
-    method virtual private id : string
+    val mutable state : state = `Stopped
 
-    method virtual private set_id : ?definitive:bool -> string -> unit
-
-    method virtual private log : Log.t
+    method state = state
 
     method virtual private start : unit
 
     method virtual private stop : unit
 
-    val mutable is_started = false
+    method virtual stype : Source.source_t
 
-    (* Currently started *)
-    val mutable request_start = autostart
+    (* Default [reset] method. Can be overriden if necessary. *)
+    method reset =
+      self#stop;
+      self#start
 
-    (* Ask for startup *)
-    val mutable request_stop = false
-
-    method is_active = is_started
-
-    method private wake_up (_ : Source.source list) =
-      (* We prefer [name] as an ID over the default,
-       * but do not overwrite user-defined ID.
-       * Our ID will be used for the server interface. *)
-      if name <> "" then self#set_id ~definitive:false name
-
-    method private notify = ()
-
-    method private may_start = if request_start then self#do_start
-
-    method private may_stop = if request_stop then self#do_stop
-
-    method private do_start =
-      request_start <- autostart;
-      if not is_started then (
-        self#start;
-        on_start ();
-        is_started <- true )
-
-    method private do_stop =
-      if is_started then (
-        self#stop;
-        on_stop ();
-        is_started <- false;
-        request_stop <- false )
+    method transition_to (s : state) =
+      match (s, state) with
+        | `Started, `Stopped ->
+            self#start;
+            on_start ();
+            state <- `Started
+        | `Stopped, `Started ->
+            if self#stype = Source.Infallible then
+              raise
+                Lang_values.(
+                  Runtime_error
+                    {
+                      kind = "input";
+                      msg = Some "Input is infallible and cannot be stopped";
+                      pos = [];
+                    });
+            self#stop;
+            on_stop ();
+            state <- `Stopped
+        | _ -> ()
   end
 
-(* Takes care of calling #start/#stop in a well-parenthesized way,
- * but they may be called from any thread.
- * It is suitable for inactive inputs, where the #start/stop methods
- * should start some sort of feeding thread. *)
-class virtual async ~name ~(on_start : unit -> unit) ~(on_stop : unit -> unit)
-  ~autostart =
+class virtual active_source ?get_clock ~name ~content_kind ~clock_safe
+  ~(on_start : unit -> unit) ~(on_stop : unit -> unit) ~fallible ~autostart () =
+  let get_clock =
+    Option.value ~default:(fun () -> new Clock.clock name) get_clock
+  in
   object (self)
-    inherit base ~name ~on_start ~on_stop ~autostart as super
+    inherit Source.active_source ~name content_kind as super
 
-    method private wake_up activation =
-      super#wake_up activation;
-      self#may_start
-
-    method private sleep = self#do_stop
-
-    method private notify =
-      (* TODO we should avoid race conditions here *)
-      self#may_stop;
-      self#may_start
-  end
-
-(** The [input] class should be used for defining active inputs.
-  * It only requires #start, #stop and #input methods,
-  * and provides start/stop server commands.
-  * Currently the start/stop mechanism is always enabled, so the input
-  * is fallible.
-  * The code is similar to Output.output, with #may_(start/stop) called
-  * from the #output method. *)
-class virtual input ~name ~source_kind ~content_kind ~(on_start : unit -> unit)
-  ~(on_stop : unit -> unit) ~fallible ~autostart =
-  object (self)
-    inherit Source.active_source ~name:source_kind content_kind
-
-    inherit base ~name ~on_start ~on_stop ~autostart as super
+    inherit base ~on_start ~on_stop as base
 
     method stype = if fallible then Source.Fallible else Source.Infallible
 
-    method output_get_ready = if fallible then self#may_start else self#do_start
+    method private wake_up _ = if autostart then base#transition_to `Started
 
-    method private wake_up activation =
-      super#wake_up activation;
-      if fallible then self#may_start else self#do_start
+    method private sleep = base#transition_to `Stopped
 
-    method private sleep = self#do_stop
+    method is_ready = state = `Started
 
-    method is_ready =
-      if fallible then self#is_active
-      else (
-        assert self#is_active;
-        true )
+    val mutable clock = None
 
-    method remaining = if self#is_active then -1 else 0
+    method private get_clock =
+      match clock with
+        | Some c -> c
+        | None ->
+            let c = get_clock () in
+            clock <- Some c;
+            c
 
-    method abort_track = ()
+    method private set_clock =
+      super#set_clock;
+      if clock_safe then
+        Clock.unify self#clock
+          (Clock.create_known (self#get_clock :> Clock.clock))
+
+    method virtual private get_frame : Frame.t -> unit
+
+    method virtual private memo : Frame.t
 
     method private output =
-      self#may_start;
-      let memo = self#memo in
-      if is_started && AFrame.is_partial memo then self#get_frame memo;
-      if fallible then self#may_stop
-
-    method private get_frame frame =
-      (* Because we're an active source, the frame will actually be our memo.
-       * Hence we'll always start filling it at position 0, and we'll fill
-       * it completely. *)
-      assert (0 = AFrame.position frame);
-      if not is_started then Frame.add_break frame (Frame.position frame)
-      else self#input frame
-
-    method virtual private input : Frame.t -> unit
+      if self#is_ready && AFrame.is_partial self#memo then
+        self#get_frame self#memo
   end
 
-let input_proto =
+let output_proto =
   [
-    ( "fallible",
-      Lang.bool_t,
-      Some (Lang.bool false),
-      Some
-        "Allow the input to stop. When false, the source will be infallible \
-         but the stop command won't have any effect." );
     ( "on_start",
       Lang.fun_t [] Lang.unit_t,
       Some (Lang.val_cst_fun [] Lang.unit),
@@ -163,7 +119,52 @@ let input_proto =
     ( "start",
       Lang.bool_t,
       Some (Lang.bool true),
-      Some
-        "Start input as soon as it is created. Disabling it is only taken into \
-         account for a fallible input." );
+      Some "Start input as soon as it is available." );
   ]
+
+let active_source_proto ~fallible =
+  output_proto
+  @ [
+      ( "clock_safe",
+        Lang.bool_t,
+        Some (Lang.bool true),
+        Some "Force the use of a dedicated clock" );
+    ]
+  @
+  if fallible then
+    [
+      ( "fallible",
+        Lang.bool_t,
+        Some (Lang.bool true),
+        Some
+          "Allow the source to fail. If set to `false`, `start` must be `true` \
+           and `stop` method raises an error." );
+    ]
+  else []
+
+type 'a meth = string * Lang.scheme * string * ('a -> Lang.value)
+
+let meth :
+    unit -> < state : state ; transition_to : state -> unit ; .. > meth list =
+ fun () ->
+  Lang.
+    [
+      ( "is_started",
+        ([], fun_t [] bool_t),
+        "`true` if the output or source is started.",
+        fun s -> val_fun [] (fun _ -> bool (s#state = `Started)) );
+      ( "start",
+        ([], fun_t [] unit_t),
+        "Ask the source or output to start.",
+        fun s ->
+          val_fun [] (fun _ ->
+              s#transition_to `Started;
+              unit) );
+      ( "stop",
+        ([], fun_t [] unit_t),
+        "Ask the source or output to stop.",
+        fun s ->
+          val_fun [] (fun _ ->
+              s#transition_to `Stopped;
+              unit) );
+    ]


### PR DESCRIPTION
This PR cleans up `Start_stop`, following the TODO at #1171 More specifically it:
* Gets rid of `output_get_ready`
* Simplifies the `Start_stop` logic by using a state machine
* Delegates output start and stop to dedicated methods that are implicitly called during the `#output` call
* Creates a cleaned up & simplified facility to implement `active_source` with factored out protocol and methods
* Updates some sources to use the new facility.

