### PR TITLE
Self-sync and conversions improvements

### DIFF
--- a/.github/scripts/build-tarball.sh
+++ b/.github/scripts/build-tarball.sh
@@ -12,11 +12,12 @@ cd /tmp/liquidsoap-full
 git pull
 make clean
 make update
-./liquidsoap/.github/scripts/checkout-deps.sh
 
 cd liquidsoap
 git fetch origin $GITHUB_SHA
 git checkout $GITHUB_SHA
+
+./.github/scripts/checkout-deps.sh
 
 cd /tmp/liquidsoap-full
 

--- a/doc/content/build.md
+++ b/doc/content/build.md
@@ -42,7 +42,7 @@ Libraries not developed by Savonet are:
 | -------------- | ------------------------- |
 | OCaml compiler | >= 4.08.0     |
 | ocaml-dtools   |  >= 0.4.2    |
-| ocaml-duppy    |  >= 0.8.1     |
+| ocaml-duppy    |  >= 0.9.1     |
 | ocaml-mm       |  >= 0.7.0        |
 | ocaml-pcre     |       |
 | menhir         |  |

--- a/libs/clock.liq
+++ b/libs/clock.liq
@@ -3,7 +3,7 @@
 # allowing more concise scripts in some cases.
 # @category Liquidsoap
 # @param ~sync Synchronization mode. One of: `"auto"`, `"cpu"`, or `"none"`. Defaults to `"auto"`, which synchronizes with the CPU clock if none of the active sources are attached to their own clock (e.g. ALSA input, etc). `"cpu"` always synchronizes with the CPU clock. `"none"` removes all synchronization control.
-def replaces clock(~sync="auto",~id="",s)
+def replaces clock(~sync="auto",~id=null(),s)
   clock.assign_new(sync=sync,id=id,[s])
   s
 end

--- a/libs/deprecations.liq
+++ b/libs/deprecations.liq
@@ -52,7 +52,7 @@ end
 
 # Deprecated: use mksafe and playlist instead.
 # @flag deprecated
-def playlist.safe(~id="", ~mime_type="", ~mode="randomize", ~on_track={()}, ~prefix="", ~reload=0, ~reload_mode="seconds", uri)
+def playlist.safe(~id=null(), ~mime_type="", ~mode="randomize", ~on_track={()}, ~prefix="", ~reload=0, ~reload_mode="seconds", uri)
   deprecated("playlist.safe", "")
   mksafe(playlist(id=id, mime_type=mime_type, mode=mode, prefix=prefix, reload=reload, reload_mode=reload_mode, uri))
 end
@@ -103,7 +103,7 @@ end
 
 # Deprecated: this function has been replaced with `playlist`, setting
 # `reload_mode` argument to `"never"` and `loop` to `false`.
-def playlist.once(~id="",~random=false,~reload_mode="",
+def playlist.once(~id=null(),~random=false,~reload_mode="",
                   ~default_duration=30.,~length=10.,~conservative=false,
                   ~filter=fun(_)->true,uri)
   deprecated("playlist.once", "playlist")
@@ -128,7 +128,7 @@ end
 
 # Deprecated: this function will be removed in a future release
 # @flag deprecated
-def id(~id="",s)
+def id(~id=null(),s)
  deprecated("id","")
  s
 end 
@@ -239,7 +239,7 @@ end
 
 # Deprecated: this function has been replaced by `fail`.
 # @flag deprecated
-def empty(~id="")
+def empty(~id=null())
   fail()
 end
 
@@ -366,7 +366,7 @@ def gettimeofday()
 end
 
 # @flag deprecated
-def output.preferred(~id="",~fallible=false,
+def output.preferred(~id=null(),~fallible=false,
                     ~on_start={()},~on_stop={()},~start=true,s)
   deprecated("output.preferred","output")
   output(id=id,fallible=fallible,
@@ -383,7 +383,7 @@ end
 
 # Deprecated: use `input` instead.
 # @flag deprecated
-def in(~id="",~start=true,~on_start={()},~on_stop={()},~fallible=false)
+def in(~id=null(),~start=true,~on_start={()},~on_stop={()},~fallible=false)
   deprecated("in", "input")
   input(id=id,start=start,on_start=on_start,on_stop=on_stop,fallible=fallible)
 end

--- a/libs/ffmpeg.liq
+++ b/libs/ffmpeg.liq
@@ -4,7 +4,7 @@
 # @param ~id Force the value of the source ID.
 # @param ~max_buffer Maximum data buffer in seconds
 # @param ~device V4L2 device to use.
-def input.v4l2(~id="", ~max_buffer=0.5, ~device="/dev/video0")
+def input.v4l2(~id=null(), ~max_buffer=0.5, ~device="/dev/video0")
   (input.ffmpeg(format="v4l2", max_buffer=max_buffer, device):source(audio=none))
 end
 
@@ -13,7 +13,7 @@ end
 # @param ~pattern Pattern drawn in the video: `"testsrc"`, `"testsrc2"`, `"smptebars"` or `"rgbtestsrc"`.
 # @param ~max_buffer Maximum data buffer in seconds
 # @param ~duration Duration of the source.
-def video.testsrc(~id="", ~pattern="testsrc", ~max_buffer=0.5, ~duration=null())
+def video.testsrc(~id=null(), ~pattern="testsrc", ~max_buffer=0.5, ~duration=null())
   if not list.mem(pattern, ["testsrc", "testsrc2", "smptebars", "rgbtestsrc"]) then failwith("invalid pattern for video.testsrc.ffmpeg") end
   size = "size=#{video.frame.width()}x#{video.frame.height()}"
   rate = "rate=#{video.frame.rate()}"
@@ -66,7 +66,7 @@ let ffmpeg.filter.audio_video = ()
 # @param id Force the value of the source ID.
 # @param buffer Duration of the pre-buffered data.
 # @param fps Output frame per seconds. Defaults to global value.
-def ffmpeg.filter.audio_video.output(~id="", ~buffer=0.1, ~fps=null(), graph, audio, video)
+def ffmpeg.filter.audio_video.output(~id=null(), ~buffer=0.1, ~fps=null(), graph, audio, video)
   a = ffmpeg.filter.audio.output(id=id, buffer=buffer, graph, audio)
   v = ffmpeg.filter.video.output(id=id, buffer=buffer, fps=fps, graph, video)
   mux_audio(audio=a, v)

--- a/libs/gstreamer.liq
+++ b/libs/gstreamer.liq
@@ -6,7 +6,7 @@
 # @param ~id Force the value of the source ID.
 # @param ~device V4L2 device to use.
 # @param ~on_error Callback executed when an error happens.
-def input.v4l2(~id="",~device="/dev/video0",~on_error=fun(_)->3.)
+def input.v4l2(~id=null(),~device="/dev/video0",~on_error=fun(_)->3.)
   pipeline = "v4l2src device=#{device}"
   input.gstreamer.video(id=id, pipeline=pipeline, on_error=on_error)
 end
@@ -17,7 +17,7 @@ end
 # @param ~id Force the value of the source ID.
 # @param ~device V4L2 device to use.
 # @param ~on_error Callback executed when an error happens.
-def input.v4l2_with_audio(~id="",~device="/dev/video0",~on_error=fun(_)->3.)
+def input.v4l2_with_audio(~id=null(),~device="/dev/video0",~on_error=fun(_)->3.)
   audio_pipeline = "autoaudiosrc"
   video_pipeline = "v4l2src device=#{device}"
   input.gstreamer.audio_video(id=id, audio_pipeline=audio_pipeline, video_pipeline=video_pipeline, on_error=on_error)
@@ -32,7 +32,7 @@ let gstreamer.single = ()
 # @param ~id Force the value of the source ID.
 # @param ~on_error Callback executed when an error happens.
 # @param uri URI of the file to be played.
-def gstreamer.single.audio(~id="",~on_error=fun(_)->3.,uri) =
+def gstreamer.single.audio(~id=null(),~on_error=fun(_)->3.,uri) =
   uri = getter.function(uri)
   input.gstreamer.audio(pipeline={"filesrc location=\"#{uri()}\""})
 end
@@ -44,7 +44,7 @@ end
 # @param ~id Force the value of the source ID.
 # @param ~on_error Callback executed when an error happens.
 # @param uri URI of the HLS stream index.
-def output.file.hls.gstreamer(~id="",~on_error=fun(_)->3.,uri) =
+def output.file.hls.gstreamer(~id=null(),~on_error=fun(_)->3.,uri) =
   uri = getter.function(uri)
   pipeline = {"souphttpsrc location=\"#{uri()}\" ! tee name=t"}
   audio_pipeline = "t. ! queue"
@@ -58,7 +58,7 @@ end
 # @param ~id Force the value of the source ID.
 # @param ~on_error Callback executed when an error happens.
 # @param uri URI of the HLS stream index.
-def output.file.hls.gstreamer.audio(~id="",~on_error=fun(_)->3.,uri) =
+def output.file.hls.gstreamer.audio(~id=null(),~on_error=fun(_)->3.,uri) =
   uri = getter.function(uri)
   pipeline = {"souphttpsrc location=\"#{uri()}\""}
   input.gstreamer.audio(id=id, pipeline=pipeline, on_error=on_error)
@@ -117,7 +117,7 @@ end
 # @param source Source to stream
 # @category Source / Output
 # @flag extra
-def output.youtube.live(~id="",
+def output.youtube.live(~id=null(),
   ~video_bitrate=2000,
   ~audio_encoder="fdkaacenc",
   ~audio_bitrate=128000,
@@ -138,7 +138,7 @@ end
 # Test audio-video source using GStreamer.
 # @category Source / Input
 # @flag extra
-def video.testsrc.gstreamer(~id="")
+def video.testsrc.gstreamer(~id=null())
   video_pipeline="videotestsrc"
   audio_pipeline="audiotestsrc"
   input.gstreamer.audio_video(id=id,video_pipeline=video_pipeline, audio_pipeline=audio_pipeline)

--- a/libs/hls.liq
+++ b/libs/hls.liq
@@ -6,10 +6,11 @@ let input.hls = ()
 # @param ~reload How often (in seconds) the playlist should be reloaded.
 # @param uri Playlist URI.
 # @flag experimental
-def input.hls.native(~id="",~reload=10.,uri)
+def input.hls.native(~id=null(),~reload=10.,uri)
   playlistr = ref([])
   sequence = ref(0)
   playlist_uri = ref(uri)
+  id = string.id.default(default="input.hls.native", id)
 
   def load_playlist () =
     pl = request.create(!playlist_uri)
@@ -96,7 +97,7 @@ let replaces input.hls = input.ffmpeg
 # @category Source / Input
 # @param ~id Force the value of the source ID.
 # @param uri Playlist URI.
-def input.hls(~id="", uri)
+def input.hls(~id=null(), uri)
   input.hls(id=id, uri)
 end
 

--- a/libs/io.liq
+++ b/libs/io.liq
@@ -24,7 +24,7 @@ let replaces output=output.dummy
 # @param ~on_stop Callback executed when outputting stops.
 # @param ~start Automatically start outputting whenever possible. If `true`, an infallible (normal) output will start outputting as soon as it is created, and a fallible output will (re)start as soon as its source becomes available for streaming.
 # @param s Source to play.
-def replaces output(~id="",~fallible=true,
+def replaces output(~id=null(),~fallible=true,
            ~on_start={()},~on_stop={()},~start=true,s)
   output(id=id,fallible=fallible,
          start=start,on_start=on_start,on_stop=on_stop,
@@ -55,7 +55,7 @@ let output.video = output.dummy
 # @param ~on_stop Callback executed when outputting stops.
 # @param ~start Automatically start outputting whenever possible. If `true`, an infallible (normal) output will start outputting as soon as it is created, and a fallible output will (re)start as soon as its source becomes available for streaming.
 # @param s Source to play.
-def output.video(~id="",~fallible=true,~on_start={()},~on_stop={()},~start=true,s)
+def output.video(~id=null(),~fallible=true,~on_start={()},~on_stop={()},~start=true,s)
   output.video(id=id, fallible=fallible, start=start, on_start=on_start, on_stop=on_stop, s)
 end
 
@@ -69,12 +69,12 @@ end
 # @param ~on_stop Callback executed when outputting stops.
 # @param ~start Automatically start outputting whenever possible. If `true`, an infallible (normal) output will start outputting as soon as it is created, and a fallible output will (re)start as soon as its source becomes available for streaming.
 # @param s Source to play.
-def output.audio_video(~id="",~fallible=true,~on_start={()},~on_stop={()},~start=true,s)
+def output.audio_video(~id=null(),~fallible=true,~on_start={()},~on_stop={()},~start=true,s)
   output(id=id, fallible=fallible, start=start, on_start=on_start, on_stop=on_stop, drop_video(s))
   output.video(id=id, fallible=fallible, start=start, on_start=on_start, on_stop=on_stop, drop_audio(s))
 end
 
-def replaces input(~id="",~start=true,~on_start={()},~on_stop={()},~fallible=false)
+def replaces input(~id=null(),~start=true,~on_start={()},~on_stop={()},~fallible=false)
   blank(id=id)
 end
 %ifdef input.alsa
@@ -97,6 +97,6 @@ end
 # @param ~on_start Callback executed when outputting starts.
 # @param ~on_stop Callback executed when outputting stops.
 # @param ~start Automatically start outputting whenever possible. If `true`, an infallible (normal) output will start outputting as soon as it is created, and a fallible output will (re)start as soon as its source becomes available for streaming.
-def replaces input(~id="",~start=true,~on_start={()},~on_stop={()},~fallible=false)
+def replaces input(~id=null(),~start=true,~on_start={()},~on_stop={()},~fallible=false)
   input(id=id,start=start,on_start=on_start,on_stop=on_stop,fallible=fallible)
 end

--- a/libs/metadata.liq
+++ b/libs/metadata.liq
@@ -118,7 +118,7 @@ end
 # such information.
 # @category System
 # @param file File from which the cover should be obtained
-def file.cover(~id="", fname)
+def file.cover(~id=null(), fname)
   metadata.cover(file.metadata(fname))
 end
 

--- a/libs/native.liq
+++ b/libs/native.liq
@@ -17,7 +17,7 @@ end
 # @flag extra
 # @param ~id Force the value of the source ID.
 # @param ~track_sensitive Re-select only on end of tracks.
-def native.fallback(~id="", ~track_sensitive=true, sources)
+def native.fallback(~id=null(), ~track_sensitive=true, sources)
   fail = (fail():source)
 
   def s()
@@ -34,7 +34,7 @@ end
 # @flag extra
 # @param ~id Force the value of the source ID.
 # @param sources List of sources to play tracks from.
-def native.sequence(~id="", sources)
+def native.sequence(~id=null(), sources)
   len  = list.length(sources)
   n    = ref(0)
   fail = (fail():source)
@@ -70,7 +70,7 @@ end
 # @param ~id Force the value of the source ID.
 # @param ~track_sensitive Re-select only on end of tracks.
 # @param sources Sources with the predicate telling when they can be played.
-def native.switch(~id="", ~track_sensitive=true, sources)
+def native.switch(~id=null(), ~track_sensitive=true, sources)
   sources = list.map(fun(ps) -> source.available(snd(ps), fst(ps)), sources)
   native.fallback(id=id, track_sensitive=track_sensitive, sources)
 end
@@ -85,7 +85,7 @@ let native.request = request
 # @param ~prefetch Number of tracks to prepare in advance.
 # @param ~timeout Timeout for resolving requests in seconds.
 # @param f Function returning the next request.
-def native.request.dynamic(~id="", ~prefetch=1, ~polling_delay=1., ~timeout=20., f)
+def native.request.dynamic(~id=null(), ~prefetch=1, ~polling_delay=1., ~timeout=20., f)
   # Prepared requests
   queue = ref([])
   def queue_size()
@@ -128,7 +128,7 @@ end
 # @param ~prefetch Number of tracks to prepare in advance.
 # @param ~timeout Timeout for resolving requests in seconds.
 # @param f Function returning the list of next requests.
-def native.request.dynamic.list(~id="", ~prefetch=1, ~polling_delay=1., ~timeout=20., f)
+def native.request.dynamic.list(~id=null(), ~prefetch=1, ~polling_delay=1., ~timeout=20., f)
   l = ref([])
   def f()
     if !l == [] then l := f() end

--- a/libs/request.liq
+++ b/libs/request.liq
@@ -13,7 +13,7 @@ let stdlib_native = native
 # @param ~retry_delay Retry after a given time (in seconds) when callback returns an empty list.
 # @param ~timeout Timeout (in sec.) for a single download.
 # @param f Function producing requests.
-def replaces request.dynamic(~id="", ~available={true}, ~retry_delay=0.1, ~conservative=false, ~default_duration=30., ~length=10., ~timeout=20., ~native=false, f) =
+def replaces request.dynamic(~id=null(), ~available={true}, ~retry_delay=0.1, ~conservative=false, ~default_duration=30., ~length=10., ~timeout=20., ~native=false, f) =
   if native then
     stdlib_native.request.dynamic(id=id, timeout=timeout, f).{prefetch = fun() -> (), queue_length = fun() -> 0.}
   else

--- a/libs/server.liq
+++ b/libs/server.liq
@@ -7,7 +7,7 @@ end
 # Register a command that outputs the RMS of the returned source.
 # @category Source / Visualization
 # @param ~id Force the value of the source ID.
-def server.rms(~id="",s) =
+def server.rms(~id=null(),s) =
   let s = rms(id=id,s)
   id = s.id()
   def rms(_) =
@@ -26,7 +26,7 @@ end
 # format: insert key1="val1",key2="val2",...
 # @category Source / Track Processing
 # @param ~id Force the value of the source ID.
-def server.insert_metadata(~id="",s) =
+def server.insert_metadata(~id=null(),s) =
   s = insert_metadata(id=id,s)
   insert = s.insert_metadata
   def insert(s) =

--- a/libs/sound.liq
+++ b/libs/sound.liq
@@ -21,7 +21,7 @@
 # @method gain Current amplification coefficient (in linear scale).
 # @method target_gain Current target amplification coefficient (in linear scale).
 # @method rms Current rms (in linear scale).
-def replaces normalize(~id="", ~target=getter(-13.), ~up=getter(10.), ~down=getter(.1), ~gain_min=-12., ~gain_max=12., ~lookahead=getter(0.), ~window=getter(.5), ~threshold=getter(-40.), ~track_sensitive=true, ~debug=null(), s)
+def replaces normalize(~id=null(), ~target=getter(-13.), ~up=getter(10.), ~down=getter(.1), ~gain_min=-12., ~gain_max=12., ~lookahead=getter(0.), ~window=getter(.5), ~threshold=getter(-40.), ~track_sensitive=true, ~debug=null(), s)
   s = rms.smooth(duration=window, s)
   v = ref(1.)
   frame = frame.duration()
@@ -68,7 +68,7 @@ end
 # @param ~low Lower frequency of the bandpass filter.
 # @param ~high Higher frequency of the bandpass filter.
 # @param ~q Q factor.
-def filter.iir.eq.low_high(~id="", ~low, ~high, ~q=1., s)
+def filter.iir.eq.low_high(~id=null(), ~low, ~high, ~q=1., s)
   s = if not (getter.is_constant(high) and getter.get(high) == infinity) then filter.iir.eq.low(frequency=high, q=q, s) else s end
   s = if not (getter.is_constant(low) and getter.get(low) == 0.) then filter.iir.eq.high(frequency=low, q=q, s) else s end
   s

--- a/libs/source.liq
+++ b/libs/source.liq
@@ -41,7 +41,7 @@ end
 # @param ~id Force the value of the source ID.
 # @param fn The applied function.
 # @param s The input source.
-def map_first_track(~id="",fn,s)
+def map_first_track(~id=null(),fn,s)
   fallback(id=id,track_sensitive=true,[fn((once(s):source)),s])
 end
 
@@ -60,7 +60,7 @@ end
 # @param ~max_blank Maximum silence length allowed, in seconds.
 # @param ~min_noise Minimum duration of noise required to end silence, in seconds.
 # @param ~track_sensitive Reset blank counter at each track.
-def blank.skip(~id="",~threshold=-40.,~max_blank=20.,~min_noise=0.,~track_sensitive=true,s)
+def blank.skip(~id=null(),~threshold=-40.,~max_blank=20.,~min_noise=0.,~track_sensitive=true,s)
   blank.detect({s.skip()},threshold=threshold,max_blank=max_blank,min_noise=min_noise,track_sensitive=track_sensitive,s)
 end
 
@@ -72,7 +72,7 @@ end
 # @param ~transitions Transition functions, padded with `fun (x,y) -> y` functions.
 # @param ~weights Weights of the children (padded with 1), defining for each child how many tracks are played from it per round, if that many are actually available.
 # @param sources Sequence of sources to be merged
-def rotate.merge(~id="",~transitions=[],~weights=[],sources)
+def rotate.merge(~id=null(),~transitions=[],~weights=[],sources)
   ready = ref(true)
   duration = get(default=0.04,"frame.duration")
 
@@ -120,7 +120,7 @@ end
 # @param ~start_next Metadata field indicating when the next track should start, relative to current track's time.
 # @param ~weights Relative weight of the sources in the sum. The empty list stands for the homogeneous distribution.
 # @param sources Sources to toggle from
-def overlap_sources(~id="",~normalize=false,
+def overlap_sources(~id=null(),~normalize=false,
                     ~start_next="liq_start_next",
                     ~weights=[],sources) =
   position = ref(0)

--- a/libs/switches.liq
+++ b/libs/switches.liq
@@ -6,7 +6,7 @@
 # @param ~track_sensitive Re-select only on end of tracks.
 # @param ~transition_length Maximum transition duration.
 # @param ~transitions Transition functions, padded with `fun (x,y) -> y` functions.
-def fallback(~id="", ~override="liq_transition_length", ~replay_metadata=true,
+def fallback(~id=null(), ~override="liq_transition_length", ~replay_metadata=true,
            ~track_sensitive=true, ~transition_length=5., ~transitions=[],
            sources) =
   def add_condition(s) =
@@ -48,7 +48,7 @@ end
 # @param ~transition_length Maximum transition duration.
 # @param ~transitions Transition functions, padded with `fun (x,y) -> y` functions.
 # @param ~weights Weights of the children (padded with 1), defining for each child how many tracks are played from it per round, if that many are actually available.
-def rotate(~id="", ~override="liq_transition_length", ~replay_metadata=true,
+def rotate(~id=null(), ~override="liq_transition_length", ~replay_metadata=true,
            ~transition_length=5., ~transitions=[],
            ~weights=[], sources) =
   weights = list.map(getter.function, weights)
@@ -116,7 +116,7 @@ end
 # @param ~transition_length Maximum transition duration.
 # @param ~transitions Transition functions, padded with `fun (x,y) -> y` functions.
 # @param ~weights Weights of the children (padded with 1), defining for each child the probability that it is selected.
-def replaces random(~id="", ~override="liq_transition_length", ~replay_metadata=true,
+def replaces random(~id=null(), ~override="liq_transition_length", ~replay_metadata=true,
            ~transition_length=5., ~transitions=[],
            ~weights=[], sources) =
   weights = list.map(getter.function, weights)

--- a/libs/video.liq
+++ b/libs/video.liq
@@ -22,7 +22,7 @@ end
 # @param ~fallible Whether we are allowed to fail (in case the file is non-existent or invalid).
 # @param file Path to the image.
 # @method set Change the image.
-def image(~id="", ~fallible=false, file="")
+def image(~id=null(), ~fallible=false, file="")
   s = source.dynamic()
   def set(file)
     s.set(single(id=id, fallible=fallible, file))
@@ -40,7 +40,7 @@ end
 # @param ~x x position.
 # @param ~y y position.
 # @param ~file Path to the image file.
-def video.add_image(~id="", ~width=getter(-1), ~height=getter(-1), ~x=getter(0), ~y=getter(0), ~file, s)
+def video.add_image(~id=null(), ~width=getter(-1), ~height=getter(-1), ~x=getter(0), ~y=getter(0), ~file, s)
   image =
     if getter.is_constant(x) and getter.is_constant(y) and getter.is_constant(width) and getter.is_constant(height) then
       x      = getter.get(x)
@@ -149,7 +149,7 @@ end
 # @param ~reopen_on_metadata Re-open on every new metadata information.
 # @param ~reopen_when When should the output be re-opened.
 # @param ~start Automatically start outputting whenever possible. If true, an infallible (normal) output will start outputting as soon as it is created, and a fallible output will (re)start as soon as its source becomes available for streaming.
-def output.external.ffmpeg(~id="", ~show_command=false, ~flush=false, ~fallible=false, 
+def output.external.ffmpeg(~id=null(), ~show_command=false, ~flush=false, ~fallible=false, 
                            ~on_start={()}, ~on_stop={()}, ~reopen_delay=120.,
                            ~reopen_on_metadata=false, ~reopen_when={false},
                            ~start=true, outputopts, s)
@@ -174,7 +174,7 @@ end
 # @param ~start Automatically start outputting whenever possible. If true, an infallible (normal) output will start outputting as soon as it is created, and a fallible output will (re)start as soon as its source becomes available for streaming.
 # @param ~playlist Playlist name
 # @param ~directory Directory to write to
-def output.file.hls.ffmpeg(~id="", ~flush=false, ~fallible=false,
+def output.file.hls.ffmpeg(~id=null(), ~flush=false, ~fallible=false,
                            ~on_start={()}, ~on_stop={()}, ~reopen_delay=120.,
                            ~reopen_on_metadata=false, ~reopen_when={false},
                            ~start=true, ~playlist="stream.m3u8", ~directory, s)
@@ -202,7 +202,7 @@ let output.file.dash = ()
 # @param ~start Automatically start outputting whenever possible. If true, an infallible (normal) output will start outputting as soon as it is created, and a fallible output will (re)start as soon as its source becomes available for streaming.
 # @param ~playlist Playlist name
 # @param ~directory Directory to write to
-def output.file.dash.ffmpeg(~id="", ~flush=false, ~fallible=false,
+def output.file.dash.ffmpeg(~id=null(), ~flush=false, ~fallible=false,
                            ~on_start={()}, ~on_stop={()}, ~reopen_delay=120.,
                            ~reopen_on_metadata=false, ~reopen_when={false},
                            ~start=true, ~playlist="stream.mpd", ~directory, s)
@@ -232,7 +232,7 @@ let output.youtube.live = ()
 # @param ~bitrate Bitrate of the video (in kbps)
 # @param ~quality Quality of the video (low / medium / high)
 # @param ~key Your secret youtube key
-def output.youtube.live.ffmpeg(~id="",~flush=false, ~fallible=false,
+def output.youtube.live.ffmpeg(~id=null(),~flush=false, ~fallible=false,
                            ~on_start={()}, ~on_stop={()}, ~reopen_delay=120.,
                            ~reopen_on_metadata=false, ~reopen_when={false},
                            ~start=true, ~url="rtmp://a.rtmp.youtube.com/live2",
@@ -275,7 +275,7 @@ let video.add_text.best = video.add_text.sdl
 # @param ~x x offset.
 # @param ~y y offset.
 # @params d Text to display.
-def replaces video.add_text(~id="",~color=0xffffff,~cycle=true,~font="",
+def replaces video.add_text(~id=null(),~color=0xffffff,~cycle=true,~font="",
                    ~metadata="",~size=18,~speed=70,~x=getter(10),~y=getter(10),
                    d,s) =
   video.add_text.best(id=id,cycle=cycle,font=font,

--- a/liquidsoap.opam
+++ b/liquidsoap.opam
@@ -54,7 +54,7 @@ depends: [
   "ocaml" {>= "4.08.0"}
   "camomile" {>= "1.0.0"}
   "dtools" {>= "0.4.2"}
-  "duppy" {>= "0.8.1"}
+  "duppy" {>= "0.9.1"}
   "menhir"
   "mm" {>= "0.7.0"}
   "ocamlfind" {build}

--- a/src/Makefile
+++ b/src/Makefile
@@ -251,6 +251,7 @@ liquidsoap_sources += \
 	lang/lang_types.ml lang/profiler.ml lang/lang_values.ml \
 	$(lang_encoders) lang/lang_parser_helper.ml lang/lang_parser.ml lang/lang_lexer.ml \
 	lang/lang_pp.ml lang/lang_errors.ml lang/lang.ml lang/modules.ml \
+        tools/child_support.ml \
         tools/start_stop.ml tools/ioRing.ml \
 	tools/icecast_utils.ml tools/avi.ml \
 	$(video_converters) $(audio_converters) $(protocols) \

--- a/src/clock.ml
+++ b/src/clock.ml
@@ -135,7 +135,7 @@ let sync_descr = function
   | `CPU -> "CPU sync"
   | `None -> "no sync"
 
-class clock ?(sync = `Auto) id =
+class clock ?(start = true) ?(sync = `Auto) id =
   object (self)
     initializer Clocks.add clocks (self :> Source.clock)
 
@@ -207,7 +207,7 @@ class clock ?(sync = `Auto) id =
         match sync with
           | `Auto ->
               List.exists
-                (fun (state, s) -> state = `Active && s#self_sync)
+                (fun (state, s) -> state = `Active && snd s#self_sync)
                 outputs
           | `CPU -> false
           | `None -> true
@@ -402,7 +402,10 @@ class clock ?(sync = `Auto) id =
         if leaving <> [] then (
           log#info "Stopping %d sources..." (List.length leaving);
           List.iter (fun (s : active_source) -> leave s) leaving );
-        if List.exists (function `Active, _ -> true | _ -> false) outputs then
+        if
+          start
+          && List.exists (function `Active, _ -> true | _ -> false) outputs
+        then
           do_running (fun () ->
               if not running then (
                 running <- true;

--- a/src/clock.mli
+++ b/src/clock.mli
@@ -20,12 +20,99 @@
 
  *****************************************************************************)
 
+(* Some notes on clocks and streaming model after reworking it on June 21, 2021
+ * By: Romain
+ *
+ * - Sources are animated via their output
+ * - Each round of streaming is called a clock tick
+ * - A unit of data during a clock tick is called a frame
+ * - Frames contain breaks which indicate filling positions during the clock tick.
+ * - Sources implement a [#get_frame] method which fills a frame with as much data
+ *   as is available at each clock tick.
+ * - The source gets a frame at a given position, fills it with as much data it can
+ *   and add a break at the position last filled
+ * - Each call to [#get_frame] must add exactly one break, even if no data could be
+ *   added.
+ * - If [#get_frame] does not fill the frame entirely, it is considered that the
+ *   current track has ended. [#get_frame] can be called again if the source's
+ *   [#is_ready] is [true] to keep filling the frame.
+ * - Since sources can belong to multiple output, [#get_frame] result is cached.
+ *   [#get] is the public API to fill a frame and uses the cache if the source is
+ *   used by multiple outputs (called activations in the code).
+ * - Each output implements a [#output] method that takes care of calling its
+ *   underlying source's [#get] method as many times as possible to fill it during
+ *   a clock tick.
+ * - If a fallible output cannot fully fill the frame during a clock tick, it
+ *   considers that its underlying source has failed and stops. This should never
+ *   happen with infallible outputs.
+ * - [#output] is called unconditionally so outputs should know when to query the
+ *   underlying source and handle automatic restart there
+ * - [#output] is also the function responsible for detecting end-of-track, source
+ *   failures and etc. If an output fails to end and trigger its [on_stop]
+ *   callback, it is most likely because [#output] should have been called
+ * - Once done filling the frame, [#output] passes the frame to [#send_frame]
+ *
+ *
+ * Now the clocks!
+ * - Sources that are animated via clocks are called [active_source]. outputs are
+ *   the most common case but some sources can also be [active_source] if they
+ *   need to be actively animated, such as [input.http] for instance.
+ * - Clocks implement a [#end_tick] method which is responsible for animating all
+ *   its active source.
+ * - Each call to [#end_tick] calls [#output] on each of the active sources and
+ *   then [#after_output] on them.
+ * - [#after_output] is responsible for cleaning up things after a clock tick, in
+ *   particular clearing the frame cache for [#get]
+ * - The best way to get the result of a clock tick for a given source is to plug
+ *   it into an output and use the [#send_frame] method. There is no way currently
+ *   to call [#get] on the underlying source between [#output] and [#after_output].
+ *   Each call to [#end_tick] performs both operations at once.
+ * - When running, a clock creates its own thread that executes [#end_tick] in a
+ *   loop, implemented in the [#run] function.
+ * - Latency during a clock tick run by [#run] can be controlled by the clock
+ *   itself, if all the active sources report [#self_sync] as [false]. If any of
+ *   the active outputs report [true] for [#self_sync] then the clock delegates
+ *   latency control to its active sources, expecting the call to [#output] to last
+ *   as long as needed to maintain correct latency. Otherwise, [#run] uses the CPU
+ *   clock (via calls to [gettimeofday]) to control latency, delaying or accelerating
+ *   accordingly depending on how long it takes to fill up a frame compared to the
+ *   duration of each frame.
+ *
+ * About dependent clocks:
+ * - The following is mostly implemented in [Child_resource] for reference.
+ * - In some operators such as [cross], [cue_cut], [soundtouch] and etc, the main
+ *   operator wants full control over the children's clock.
+ * - In this case, the children's source must all be statically non [self_sync]
+ * - A main clock and a children clock are created. All children are placed in the
+ *   children clock, which is marked as not running. It will not create its own
+ *   [#run] thread. The main source is placed on the main clock. This clock is
+ *   unknown and could possibly also not be running its own [#run] thread if the main
+ *   source is, in turn, controlled by another source (yey abstractions!)
+ * - During each of its clock tick, the main source may decide to call [#end_tick]
+ *   on the children clock, thus animating its own outputs.
+ * - If the operator needs more that one frame of data from its children during one
+ *   of the main clock tick, it can call [#end_tick] multiple times. For instance,
+ *   [soundtouch] when accelerating the rate or [cross] when buffering crossfade
+ *   data.
+ * - If the operator needs no more data, it can also not call [#end_tick] on the
+ *   children clock, for instance [soundtouch] when slowing down the rate.
+ * - However, one should remember that the children clock needs to be eventually
+ *   animated in order to allow the children outputs to detect source failure,
+ *   trigger [on_stop] events and etc.
+ * - Thus, the convention proposed in [Child_resource] is that, if the main source
+ *   is not available, it should always call [#end_tick] on each of the main clock
+ *   tick. This is implemented by using a [needs_tick] that is always set to [true]
+ *   on each [#after_output]. If [true], a [#end_tick] is executed on the children
+ *   clock during [#after_output]. [needs_tick] can optionally be set to [false]
+ *   during the call to [#get_frame] but, if the source is not ready, this call will
+ *   not be executed, leading to [#end_tick] being called on each main clock tick *)
+
 (** A clock represents the rate at which a source runs. In itself it does not
   * do much, except forcing that one source belongs to exactly one clock,
   * which prevents inconsistent uses of the source. Clocks are assigned to
   * sources at the end of the typing phase. *)
 
-class clock : ?sync:Source.sync -> string -> Source.clock
+class clock : ?start:bool -> ?sync:Source.sync -> string -> Source.clock
 
 (** Indicates whether the application has started to run or not. *)
 val running : unit -> bool

--- a/src/encoder/ffmpeg_internal_encoder.ml
+++ b/src/encoder/ffmpeg_internal_encoder.ml
@@ -105,7 +105,14 @@ let mk_audio ~ffmpeg ~options output =
   in
   let target_channels = ffmpeg.Ffmpeg_format.channels in
   let target_channel_layout = get_channel_layout target_channels in
-  let target_sample_format = Avcodec.Audio.find_best_sample_format codec `Dbl in
+  let target_sample_format =
+    match ffmpeg.Ffmpeg_format.sample_format with
+      | Some format -> Avutil.Sample_format.find format
+      | None -> `Dbl
+  in
+  let target_sample_format =
+    Avcodec.Audio.find_best_sample_format codec target_sample_format
+  in
 
   let opts = Hashtbl.create 10 in
   Hashtbl.iter (Hashtbl.add opts) ffmpeg.Ffmpeg_format.audio_opts;

--- a/src/encoder_formats/ffmpeg_format.ml
+++ b/src/encoder_formats/ffmpeg_format.ml
@@ -40,6 +40,7 @@ type t = {
   hwaccel : hwaccel;
   hwaccel_device : string option;
   audio_codec : codec option;
+  sample_format : string option;
   audio_opts : opts;
   video_codec : codec option;
   video_opts : opts;

--- a/src/io/alsa_io.ml
+++ b/src/io/alsa_io.ml
@@ -54,7 +54,7 @@ class virtual base dev mode =
         let buf = Array.map (fun buf -> Bigarray.Array1.sub buf ofs len) buf in
         Pcm.readn_float_ba pcm buf
 
-    method self_sync = pcm <> None
+    method self_sync : Source.self_sync = (`Static, true)
 
     method open_device =
       self#log#important "Using ALSA %s." (Alsa.get_version ());
@@ -340,7 +340,7 @@ let () =
   let kind = Lang.audio_pcm in
   let k = Lang.kind_type_of_kind_format kind in
   Lang.add_operator "input.alsa"
-    ( Start_stop.active_source_proto ~fallible_opt:(`Yep false)
+    ( Start_stop.active_source_proto ~clock_safe:true ~fallible_opt:(`Yep false)
     @ [
         ("bufferize", Lang.bool_t, Some (Lang.bool true), Some "Bufferize input");
         ( "device",

--- a/src/io/ffmpeg_filter_io.ml
+++ b/src/io/ffmpeg_filter_io.ml
@@ -38,7 +38,7 @@ class audio_output ~name ~kind source_val =
     inherit
       Output.output
         ~infallible:false ~on_stop:noop ~on_start:noop ~content_kind:kind ~name
-          ~output_kind:"ffmpeg.filter.input" source_val true
+          ~output_kind:"ffmpeg.filter.input" source_val true as super
 
     initializer Source.Kind.unify (Lang.to_source source_val)#kind self#kind
 
@@ -50,7 +50,11 @@ class audio_output ~name ~kind source_val =
 
     method set_init v = init <- v
 
-    method start = Lazy.force init
+    method private wake_up a =
+      super#wake_up a;
+      Lazy.force init
+
+    method start = ()
 
     method stop = ()
 
@@ -145,7 +149,7 @@ class audio_input ~bufferize kind =
         (Ffmpeg_raw_content.Audio.lift_params output_format);
       output <- Some v
 
-    method self_sync = false
+    method self_sync = (`Static, false)
 
     method stype = Source.Fallible
 
@@ -246,7 +250,7 @@ class video_input ~bufferize ~fps kind =
         (Ffmpeg_raw_content.Video.lift_params output_format);
       output <- Some v
 
-    method self_sync = false
+    method self_sync = (`Static, false)
 
     method stype = Source.Fallible
 

--- a/src/io/gstreamer_io.ml
+++ b/src/io/gstreamer_io.ml
@@ -187,9 +187,7 @@ class output ~kind ~clock_safe ~on_error ~infallible ~on_start ~on_stop
 
     inherit [App_src.t, App_src.t] element_factory ~on_error
 
-    val mutable started = false
-
-    method self_sync = started
+    method self_sync = (`Static, true)
 
     method private set_clock =
       super#set_clock;
@@ -200,7 +198,6 @@ class output ~kind ~clock_safe ~on_error ~infallible ~on_start ~on_stop
     method start =
       let el = self#get_element in
       self#log#info "Playing.";
-      started <- true;
       ignore (Element.set_state el.bin Element.State_playing);
 
       (* Don't uncomment the following line, it locks the program. I guess that
@@ -211,7 +208,6 @@ class output ~kind ~clock_safe ~on_error ~infallible ~on_start ~on_stop
 
     method stop =
       self#stop_task;
-      started <- false;
       let todo =
         Tutils.mutexify element_m
           (fun () ->
@@ -517,7 +513,7 @@ class audio_video_input p kind (pipeline, audio_pipeline, video_pipeline) =
           (Printexc.to_string e);
         false
 
-    method self_sync = self#is_ready
+    method self_sync = (`Static, true)
 
     method abort_track = ()
 

--- a/src/io/oss_io.ml
+++ b/src/io/oss_io.ml
@@ -54,7 +54,7 @@ class output ~kind ~clock_safe ~on_start ~on_stop ~infallible ~start dev
 
     val mutable fd = None
 
-    method self_sync = fd <> None
+    method self_sync = (`Static, true)
 
     method open_device =
       let descr = Unix.openfile dev [Unix.O_WRONLY; Unix.O_CLOEXEC] 0o200 in
@@ -95,7 +95,7 @@ class input ~kind ~clock_safe ~start ~on_stop ~on_start ~fallible dev =
 
     val mutable fd = None
 
-    method self_sync = fd <> None
+    method self_sync = (`Static, true)
 
     method abort_track = ()
 
@@ -167,7 +167,7 @@ let () =
         :> Source.source ));
   let k = Lang.kind_type_of_kind_format Lang.audio_pcm in
   Lang.add_operator "input.oss"
-    ( Start_stop.active_source_proto ~fallible_opt:(`Yep false)
+    ( Start_stop.active_source_proto ~clock_safe:true ~fallible_opt:(`Yep false)
     @ [
         ( "device",
           Lang.string_t,

--- a/src/io/portaudio_io.ml
+++ b/src/io/portaudio_io.ml
@@ -73,7 +73,7 @@ class output ~kind ~clock_safe ~start ~on_start ~on_stop ~infallible buflen
 
     val mutable stream = None
 
-    method self_sync = stream <> None
+    method self_sync = (`Static, true)
 
     method private open_device =
       self#handle "open_default_stream" (fun () ->
@@ -132,7 +132,7 @@ class input ~kind ~clock_safe ~start ~on_start ~on_stop ~fallible buflen =
 
     val mutable stream = None
 
-    method self_sync = stream <> None
+    method self_sync = (`Static, true)
 
     method abort_track = ()
 
@@ -212,7 +212,7 @@ let () =
           ~kind ~start ~on_start ~on_stop ~infallible ~clock_safe buflen source
         :> Output.output ));
   Lang.add_operator "input.portaudio"
-    ( Start_stop.active_source_proto ~fallible_opt:(`Yep false)
+    ( Start_stop.active_source_proto ~clock_safe:true ~fallible_opt:(`Yep false)
     @ [
         ( "buflen",
           Lang.int_t,

--- a/src/io/pulseaudio_io.ml
+++ b/src/io/pulseaudio_io.ml
@@ -45,7 +45,7 @@ class virtual base ~client ~device =
 
     method virtual log : Log.t
 
-    method self_sync = dev <> None
+    method self_sync : Source.self_sync = (`Static, true)
   end
 
 class output ~infallible ~start ~on_start ~on_stop ~kind p =
@@ -222,7 +222,8 @@ let () =
       let kind = Source.Kind.of_kind kind in
       (new output ~infallible ~on_start ~on_stop ~start ~kind p :> Output.output));
   Lang.add_operator "input.pulseaudio"
-    (Start_stop.active_source_proto ~fallible_opt:(`Yep false) @ proto)
+    ( Start_stop.active_source_proto ~clock_safe:true ~fallible_opt:(`Yep false)
+    @ proto )
     ~return_t:k ~category:Lang.Input ~meth:(Start_stop.meth ())
     ~descr:"Stream from a portaudio input device."
     (fun p ->

--- a/src/io/srt_io.ml
+++ b/src/io/srt_io.ml
@@ -806,7 +806,7 @@ class virtual input_base ~kind ~max ~log_overfull ~clock_safe ~on_connect
     method is_ready =
       super#is_ready && (not self#should_stop) && self#is_connected
 
-    method self_sync = self#is_connected
+    method self_sync = (`Static, true)
 
     method private create_decoder socket =
       let create_decoder =
@@ -905,7 +905,7 @@ let () =
     ~meth:(meth () @ Start_stop.meth ())
     ~descr:"Receive a SRT stream from a distant agent."
     ( common_options ~mode:`Listener
-    @ Start_stop.active_source_proto ~fallible_opt:`Nope
+    @ Start_stop.active_source_proto ~clock_safe:false ~fallible_opt:`Nope
     @ [
         ( "max",
           Lang.float_t,

--- a/src/lang/builtins_ffmpeg_decoder.ml
+++ b/src/lang/builtins_ffmpeg_decoder.ml
@@ -29,7 +29,7 @@ module InternalScaler = Swscale.Make (Swscale.Frame) (Swscale.BigArray)
 
 let log = Log.make ["ffmpeg"; "internal"; "decoder"]
 
-let decode_audio_frame ~mode c =
+let decode_audio_frame ~mode generator =
   let internal_channel_layout =
     Avutil.Channel_layout.get_default (Lazy.force Frame.audio_channels)
   in
@@ -72,7 +72,7 @@ let decode_audio_frame ~mode c =
       let len = Audio.length data in
       let data = Frame_content.Audio.lift_data data in
       Producer_consumer.(
-        Generator.put_audio c.generator ?pts data 0 (Frame.main_of_audio len))
+        Generator.put_audio generator ?pts data 0 (Frame.main_of_audio len))
   in
 
   let mk_copy_decoder () =
@@ -208,7 +208,7 @@ let decode_audio_frame ~mode c =
         convert ~get_data:Ffmpeg_raw_content.Audio.get_data
           ~decoder:(mk_raw_decoder ())
 
-let decode_video_frame ~mode c =
+let decode_video_frame ~mode generator =
   let internal_width = Lazy.force Frame.video_width in
   let internal_height = Lazy.force Frame.video_height in
   let target_fps = Lazy.force Frame.video_rate in
@@ -294,7 +294,7 @@ let decode_video_frame ~mode c =
           let data = Video.single img in
           let data = Frame_content.Video.lift_data data in
           Producer_consumer.(
-            Generator.put_video c.generator ?pts data 0 (Frame.main_of_video 1)))
+            Generator.put_video generator ?pts data 0 (Frame.main_of_video 1)))
   in
 
   let mk_copy_decoder () =
@@ -443,19 +443,6 @@ let mk_encoder mode =
       }
   in
   let return_t = Lang.kind_type_of_kind_format return_kind in
-  let proto =
-    [
-      ("", Lang.source_t source_t, None, None);
-      ( "buffer",
-        Lang.float_t,
-        Some (Lang.float 1.),
-        Some "Amount of data to pre-buffer, in seconds." );
-      ( "max",
-        Lang.float_t,
-        Some (Lang.float 10.),
-        Some "Maximum amount of buffered data, in seconds." );
-    ]
-  in
   let extension =
     match mode with
       | `Audio_encoded -> "decode.audio"
@@ -465,41 +452,33 @@ let mk_encoder mode =
       | `Both_encoded -> "decode.audio_video"
       | `Both_raw -> "raw.decode.audio_video"
   in
+  let name = "ffmpeg." ^ extension in
+  let proto = [("", Lang.source_t source_t, None, None)] in
   Lang.add_operator ("ffmpeg." ^ extension) proto ~return_t
     ~category:Lang.Conversions ~descr:"Convert a source's content" (fun p ->
-      let pre_buffer = Lang.to_float (List.assoc "buffer" p) in
-      let max_buffer = Lang.to_float (List.assoc "max" p) in
-      let max_buffer = max max_buffer (pre_buffer *. 1.1) in
+      let id =
+        Lang.to_default_option ~default:name Lang.to_string (List.assoc "id" p)
+      in
       let source = List.assoc "" p in
-      let generator =
-        Producer_consumer.Generator.create
-          ( match mode with
-            | `Audio_raw | `Audio_encoded -> `Audio
-            | `Video_raw | `Video_encoded -> `Video
-            | `Both_raw | `Both_encoded -> `Both )
+      let content =
+        match mode with
+          | `Audio_raw | `Audio_encoded -> `Audio
+          | `Video_raw | `Video_encoded -> `Video
+          | `Both_raw | `Both_encoded -> `Both
       in
-      let control =
-        Producer_consumer.
-          { generator; lock = Mutex.create (); buffering = true; abort = false }
-      in
-      let producer =
-        new Producer_consumer.producer
-          ~kind:(Source.Kind.of_kind return_kind)
-          ~name:("ffmpeg." ^ extension ^ ".producer")
-          control
-      in
+      let generator = Producer_consumer.Generator.create content in
 
       let mk_decode_frame () =
         let decode_audio_frame =
           if has_audio then (
             let mode = if has_encoded_audio then `Decode else `Raw in
-            Some (decode_audio_frame ~mode control) )
+            Some (decode_audio_frame ~mode generator) )
           else None
         in
         let decode_video_frame =
           if has_video then (
             let mode = if has_encoded_video then `Decode else `Raw in
-            Some (decode_video_frame ~mode control) )
+            Some (decode_video_frame ~mode generator) )
           else None
         in
         let size = Lazy.force Frame.size in
@@ -535,14 +514,17 @@ let mk_encoder mode =
             decode_frame_ref := mk_decode_frame ()
       in
 
-      let _ =
+      let consumer =
         new Producer_consumer.consumer
-          ~write_frame:decode_frame ~producer
-          ~output_kind:("ffmpeg." ^ extension ^ ".consumer")
+          ~write_frame:decode_frame ~name:(id ^ ".consumer")
           ~kind:(Source.Kind.of_kind source_kind)
-          ~content:`Audio ~max_buffer ~pre_buffer ~source control
+          ~source ()
       in
-      producer)
+      new Producer_consumer.producer
+        ~consumers_val:[Lang.source (consumer :> Source.source)]
+        ~name:(id ^ ".producer")
+        ~kind:(Source.Kind.of_kind return_kind)
+        generator)
 
 let () =
   List.iter mk_encoder

--- a/src/lang/lang.ml
+++ b/src/lang/lang.ml
@@ -771,7 +771,7 @@ let source_methods =
     ( "self_sync",
       ([], fun_t [] bool_t),
       "Is the source currently controling its own real-time loop.",
-      fun s -> val_fun [] (fun _ -> bool s#self_sync) );
+      fun s -> val_fun [] (fun _ -> bool (snd s#self_sync)) );
     ( "is_up",
       ([], fun_t [] bool_t),
       "Indicate that the source can be asked to produce some data at any time. \
@@ -875,21 +875,18 @@ let add_operator =
         | x, y -> Stdlib.compare x y
     in
     let proto =
-      let t = T.make (T.Ground T.String) in
       ( "id",
-        t,
-        Some { pos = t.T.pos; value = Ground (String "") },
+        nullable_t string_t,
+        Some null,
         Some "Force the value of the source ID." )
       :: List.stable_sort compare proto
     in
     let f env =
       let src : < Source.source ; .. > = f env in
-      let id =
-        match (List.assoc "id" env).value with
-          | Ground (String s) -> s
-          | _ -> assert false
-      in
-      if id <> "" then src#set_id id;
+      ignore
+        (Option.map
+           (fun id -> src#set_id id)
+           (to_valued_option to_string (List.assoc "id" env)));
       let v = source (src :> Source.source) in
       _meth v (List.map (fun (name, _, _, fn) -> (name, fn src)) meth)
     in

--- a/src/lang/lang_builtins.ml
+++ b/src/lang/lang_builtins.ml
@@ -141,8 +141,8 @@ let () =
   let proto =
     [
       ( "id",
-        Lang.string_t,
-        Some (Lang.string ""),
+        Lang.nullable_t Lang.string_t,
+        Some Lang.null,
         Some
           "Identifier for the new clock. The default empty string means that \
            the identifier of the first source will be used." );
@@ -161,7 +161,7 @@ let () =
     match l with
       | [] -> Lang.unit
       | hd :: _ as sources ->
-          let id = if id = "" then (Lang.to_source hd)#id else id in
+          let id = Option.value ~default:(Lang.to_source hd)#id id in
           let sync =
             match Lang.to_string sync with
               | s when s = "auto" -> `Auto
@@ -195,7 +195,7 @@ let () =
       ] )
     Lang.unit_t
     (fun p ->
-      let id = Lang.to_string (List.assoc "id" p) in
+      let id = Lang.to_valued_option Lang.to_string (List.assoc "id" p) in
       let sync = List.assoc "sync" p in
       let l = Lang.to_list (List.assoc "" p) in
       assign id sync l)

--- a/src/lang_encoders/lang_ffmpeg.ml
+++ b/src/lang_encoders/lang_ffmpeg.ml
@@ -53,6 +53,7 @@ let ffmpeg_gen params =
       height = Frame.video_height;
       pixel_format = None;
       audio_codec = None;
+      sample_format = None;
       video_codec = None;
       hwaccel = `Auto;
       hwaccel_device = None;
@@ -96,6 +97,10 @@ let ffmpeg_gen params =
     | ("ar", t) :: l when mode = `Audio ->
         parse_args ~format ~mode
           { f with Ffmpeg_format.samplerate = Lazy.from_val (to_int t) }
+          l
+    | ("sample_format", t) :: l when mode = `Audio ->
+        parse_args ~format ~mode
+          { f with Ffmpeg_format.sample_format = Some (to_string t) }
           l
     (* Video options *)
     | ("framerate", t) :: l when mode = `Video ->

--- a/src/operators/add.ml
+++ b/src/operators/add.ml
@@ -47,7 +47,10 @@ class add ~kind ~renorm ~power (sources : ((unit -> float) * source) list)
         Infallible
       else Fallible
 
-    method self_sync = List.exists (fun (_, s) -> s#self_sync) sources
+    method self_sync =
+      ( Utils.self_sync_type (List.map snd sources),
+        List.fold_left (fun cur (_, s) -> cur || snd s#self_sync) false sources
+      )
 
     method remaining =
       List.fold_left max 0

--- a/src/operators/append.ml
+++ b/src/operators/append.ml
@@ -110,7 +110,10 @@ class append ~kind ~insert_missing ~merge source f =
         | `Append s -> s#seek n
 
     method self_sync =
-      match state with `Append s -> s#self_sync | _ -> source#self_sync
+      ( `Dynamic,
+        match state with
+          | `Append s -> snd s#self_sync
+          | _ -> snd source#self_sync )
 
     (* Other behaviours could be wanted, but for now #abort_track won't cancel
      * any to-be-appended track. *)

--- a/src/operators/dyn_op.ml
+++ b/src/operators/dyn_op.ml
@@ -118,7 +118,8 @@ class dyn ~kind ~init ~track_sensitive ~infallible ~resurection_time f =
 
     method seek n = match source with Some s -> s#seek n | None -> 0
 
-    method self_sync = match source with Some s -> s#self_sync | None -> false
+    method self_sync =
+      (`Dynamic, match source with Some s -> snd s#self_sync | None -> false)
   end
 
 let () =

--- a/src/operators/frei0r_op.ml
+++ b/src/operators/frei0r_op.ml
@@ -101,7 +101,10 @@ class frei0r_mixer ~kind ~name bgra instance params (source : source) source2 =
 
     method is_ready = source#is_ready && source2#is_ready
 
-    method self_sync = source#self_sync || source2#self_sync
+    method self_sync =
+      match (source#self_sync, source2#self_sync) with
+        | (`Static, v), (`Static, v') when v = v' -> (`Static, v || v')
+        | (_, v), (_, v') -> (`Dynamic, v || v')
 
     method abort_track =
       source#abort_track;
@@ -167,7 +170,7 @@ class frei0r_source ~kind ~name bgra instance params =
 
     method is_ready = true
 
-    method self_sync = false
+    method self_sync = (`Static, false)
 
     val mutable must_fail = false
 

--- a/src/operators/insert_metadata.ml
+++ b/src/operators/insert_metadata.ml
@@ -120,10 +120,8 @@ let () =
     [("", Lang.source_t return_t, None, None)]
     (fun p ->
       let s = Lang.to_source (List.assoc "" p) in
-      let id = Lang.to_string (List.assoc "id" p) in
       let kind = Source.Kind.of_kind kind in
       let s = new insert_metadata ~kind s in
-      if id <> "" then s#set_id id;
       s)
 
 (** Insert metadata at the beginning if none is set. Currently used by the

--- a/src/operators/ladspa_op.ml
+++ b/src/operators/ladspa_op.ml
@@ -82,7 +82,7 @@ class virtual base_nosource ~kind =
 
     method is_ready = true
 
-    method self_sync = false
+    method self_sync = (`Static, false)
 
     val mutable must_fail = false
 

--- a/src/operators/lilv_op.ml
+++ b/src/operators/lilv_op.ml
@@ -168,7 +168,7 @@ class lilv_nosource ~kind plugin outputs params =
   object
     inherit base_nosource ~kind
 
-    method self_sync = false
+    method self_sync = (`Static, false)
 
     val inst =
       Plugin.instantiate plugin (float_of_int (Lazy.force Frame.audio_rate))

--- a/src/operators/sequence.ml
+++ b/src/operators/sequence.ml
@@ -34,7 +34,8 @@ class sequence ~kind ?(merge = false) sources =
     val mutable seq_sources = sources
 
     method self_sync =
-      match sources with hd :: _ -> hd#self_sync | [] -> false
+      ( Utils.self_sync_type sources,
+        match sources with hd :: _ -> snd hd#self_sync | [] -> false )
 
     method stype =
       match List.rev sources with hd :: _ -> hd#stype | [] -> Source.Fallible

--- a/src/operators/switch.ml
+++ b/src/operators/switch.ml
@@ -126,13 +126,15 @@ class virtual switch ~kind ~name ~override_meta ~transition_length
 
     method is_ready = need_eot || selected <> None || self#cached_select <> None
 
+    (* This is an approximation as it can be broken by transitions. *)
     method self_sync =
-      match selected with
-        | Some (_, source) -> source#self_sync
-        | None -> (
-            match self#cached_select with
-              | Some { source } -> source#self_sync
-              | None -> false )
+      ( Utils.self_sync_type (List.map (fun c -> c.source) cases),
+        match selected with
+          | Some (_, source) -> snd source#self_sync
+          | None -> (
+              match self#cached_select with
+                | Some { source } -> snd source#self_sync
+                | None -> false ) )
 
     method private get_frame ab =
       (* Choose the next child to be played.

--- a/src/operators/time_warp.ml
+++ b/src/operators/time_warp.ml
@@ -52,7 +52,7 @@ module Buffer = struct
     object (self)
       inherit Source.source kind ~name:"warp_prod"
 
-      method self_sync = false
+      method self_sync = (`Static, false)
 
       method stype = Source.Fallible
 
@@ -208,7 +208,7 @@ module AdaptativeBuffer = struct
 
       method stype = Source.Fallible
 
-      method self_sync = false
+      method self_sync = (`Static, false)
 
       method remaining = proceed c (fun () -> MG.remaining c.mg)
 

--- a/src/outputs/alsa_out.ml
+++ b/src/outputs/alsa_out.ml
@@ -57,7 +57,7 @@ class output ~kind ~clock_safe ~infallible ~on_stop ~on_start ~start dev source
 
     val mutable device = None
 
-    method self_sync = device <> None
+    method self_sync = (`Static, true)
 
     val mutable alsa_rate = samples_per_second
 

--- a/src/outputs/ao_out.ml
+++ b/src/outputs/ao_out.ml
@@ -60,7 +60,7 @@ class output ~kind ~clock_safe ~nb_blocks ~driver ~infallible ~on_start ~on_stop
 
     val mutable device = None
 
-    method self_sync = device <> None
+    method self_sync = (`Static, true)
 
     method get_device =
       match device with

--- a/src/outputs/bjack_out.ml
+++ b/src/outputs/bjack_out.ml
@@ -56,7 +56,7 @@ class output ~kind ~clock_safe ~infallible ~on_stop ~on_start ~nb_blocks ~server
 
     val mutable device = None
 
-    method self_sync = device <> None
+    method self_sync = (`Static, true)
 
     method get_device =
       match device with

--- a/src/outputs/output.mli
+++ b/src/outputs/output.mli
@@ -39,7 +39,7 @@ class virtual output :
 
        method stype : Source.source_t
 
-       method self_sync : bool
+       method self_sync : Source.self_sync
 
        method remaining : int
 

--- a/src/outputs/pipe_output.ml
+++ b/src/outputs/pipe_output.ml
@@ -404,7 +404,7 @@ class external_output p =
 
     method encoder_factory = encoder_factory format_val
 
-    method self_sync = self_sync
+    method self_sync = (`Static, self_sync)
 
     method open_chan =
       let process = process () in

--- a/src/source.ml
+++ b/src/source.ml
@@ -78,6 +78,7 @@ type source_t = Fallible | Infallible
   * are forced to clock. *)
 
 type sync = [ `Auto | `CPU | `None ]
+type self_sync = [ `Static | `Dynamic ] * bool
 
 class type ['a, 'b] proto_clock =
   object
@@ -445,7 +446,7 @@ class virtual operator ?(name = "src") ?audio_in ?video_in ?midi_in out_kind
 
     method clock = clock
 
-    method virtual self_sync : bool
+    method virtual self_sync : self_sync
 
     method private set_clock =
       List.iter (fun s -> unify self#clock s#clock) sources

--- a/src/source.mli
+++ b/src/source.mli
@@ -34,6 +34,10 @@ type clock_variable
   * protocol such as [input.srt]. *)
 type sync = [ `Auto | `CPU | `None ]
 
+(* Type for source's self_sync. A [`Static] self_sync should never change over
+   the source's lifetime. *)
+type self_sync = [ `Static | `Dynamic ] * bool
+
 (** The liveness type of a source indicates whether or not it can
   * fail to broadcast.
   * A Infallible source never fails; it is always ready. *)
@@ -125,7 +129,7 @@ class virtual source :
            clock), we simply decide based on whether there is one [self_sync]
            source or not. This logic should dictate how the method is
            implemented by the various operators. *)
-       method virtual self_sync : bool
+       method virtual self_sync : self_sync
 
        (** Choose your clock, by adjusting to your children source,
            or anything custom. *)

--- a/src/sources/alsa_in.ml
+++ b/src/sources/alsa_in.ml
@@ -45,7 +45,7 @@ class mic ~kind ~clock_safe ~fallible ~on_start ~on_stop ~start device =
 
     val mutable initialized = false
 
-    method self_sync = true
+    method self_sync = (`Static, true)
 
     method private wake_up l =
       active_source#wake_up l;

--- a/src/sources/bjack_in.ml
+++ b/src/sources/bjack_in.ml
@@ -63,7 +63,7 @@ class jack_in ~kind ~clock_safe ~on_start ~on_stop ~fallible ~autostart
 
     val mutable device = None
 
-    method self_sync = device <> None
+    method self_sync = (`Static, true)
 
     method close =
       match device with
@@ -122,7 +122,7 @@ let () =
   let kind = Lang.audio_pcm in
   let return_t = Lang.kind_type_of_kind_format kind in
   Lang.add_operator "input.jack"
-    ( Start_stop.active_source_proto ~fallible_opt:(`Yep false)
+    ( Start_stop.active_source_proto ~clock_safe:true ~fallible_opt:(`Yep false)
     @ [
         ( "buffer_size",
           Lang.int_t,

--- a/src/sources/blank.ml
+++ b/src/sources/blank.ml
@@ -37,7 +37,7 @@ class blank ~kind duration =
 
     method is_ready = true
 
-    method self_sync = false
+    method self_sync = (`Static, false)
 
     method seek x = x
 
@@ -95,7 +95,7 @@ class fail ~kind =
 
     method is_ready = false
 
-    method self_sync = false
+    method self_sync = (`Static, false)
 
     method remaining = 0
 

--- a/src/sources/generated.ml
+++ b/src/sources/generated.ml
@@ -49,7 +49,7 @@ module Make (Generator : Generator.S) = struct
 
       method virtual private log : Log.t
 
-      method self_sync = false
+      method self_sync : Source.self_sync = (`Static, false)
 
       method seek len =
         if (not seek) || len <= 0 then 0

--- a/src/sources/request_source.ml
+++ b/src/sources/request_source.ml
@@ -34,7 +34,7 @@ class once ~kind ~name ~timeout request =
   object (self)
     inherit source kind ~name as super
 
-    method self_sync = false
+    method self_sync = (`Static, false)
 
     method stype = Fallible
 
@@ -150,7 +150,7 @@ class virtual unqueued ~kind ~name =
 
     val plock = Mutex.create ()
 
-    method self_sync = false
+    method self_sync = (`Static, false)
 
     (** How to unload a request. *)
     method private end_track forced =

--- a/src/sources/request_source.mli
+++ b/src/sources/request_source.mli
@@ -32,7 +32,7 @@ class once :
 
        method stype : Source.source_t
 
-       method self_sync : bool
+       method self_sync : Source.self_sync
 
        method is_ready : bool
 
@@ -65,7 +65,7 @@ class virtual unqueued :
 
        method remaining : int
 
-       method self_sync : bool
+       method self_sync : Source.self_sync
      end
 
 class virtual queued :

--- a/src/sources/synthesized.ml
+++ b/src/sources/synthesized.ml
@@ -40,7 +40,7 @@ class virtual source ?name ~seek kind duration =
 
     method seek x = if seek then x else 0
 
-    method self_sync = false
+    method self_sync = (`Static, false)
 
     method remaining =
       match remaining with None -> -1 | Some remaining -> remaining

--- a/src/stream/generator.ml
+++ b/src/stream/generator.ml
@@ -580,7 +580,9 @@ module From_audio_video = struct
             (Frame_content.copy (AFrame.content frame))
             0 (Lazy.force Frame.size)
       | `Video ->
-          put_video ~pts t (VFrame.content frame) 0 (Lazy.force Frame.size)
+          put_video ~pts t
+            (Frame_content.copy (VFrame.content frame))
+            0 (Lazy.force Frame.size)
       | `Both ->
           put_audio ~pts t
             (Frame_content.copy (AFrame.content frame))

--- a/src/synth/keyboard.ml
+++ b/src/synth/keyboard.ml
@@ -64,7 +64,7 @@ class keyboard ~kind =
 
     method abort_track = ()
 
-    method self_sync = false
+    method self_sync = (`Static, false)
 
     method output = if AFrame.is_partial self#memo then self#get_frame self#memo
 

--- a/src/synth/keyboard_sdl.ml
+++ b/src/synth/keyboard_sdl.ml
@@ -96,7 +96,7 @@ class keyboard ~kind velocity =
 
     method abort_track = ()
 
-    method self_sync = false
+    method self_sync = (`Static, false)
 
     method output = if AFrame.is_partial self#memo then self#get_frame self#memo
 

--- a/src/tools/child_support.ml
+++ b/src/tools/child_support.ml
@@ -1,0 +1,83 @@
+(*****************************************************************************
+
+  Liquidsoap, a programmable audio stream generator.
+  Copyright 2003-2021 Savonet team
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details, fully stated in the COPYING
+  file at the root of the liquidsoap distribution.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA
+
+ *****************************************************************************)
+
+(** Utility for operators that need to control child source clocks. See [clock.mli]
+    for a more detailed description. *)
+
+let finalise_child_clock child_clock source =
+  Clock.forget source#clock child_clock
+
+class virtual base children_val =
+  let children = List.map Lang.to_source children_val in
+  object (self)
+    initializer
+    List.iter
+      (fun c ->
+        if (Lang.to_source c)#self_sync <> (`Static, false) then
+          raise
+            (Lang_errors.Invalid_value
+               ( c,
+                 "This source may control its own latency and cannot be used \
+                  with this operator." )))
+      children_val
+
+    val mutable child_clock = None
+
+    (* If [true] during [#after_output], issue a [#end_tick] call
+       on the child clock, which makes it perform a whole streaming
+       loop. *)
+    val mutable needs_tick = true
+
+    method virtual id : string
+
+    method virtual clock : Source.clock_variable
+
+    method private child_clock = Option.get child_clock
+
+    method private set_clock =
+      child_clock <-
+        Some
+          (Clock.create_known
+             (new Clock.clock ~start:false (Printf.sprintf "%s.child" self#id)));
+
+      Clock.unify self#clock
+        (Clock.create_unknown ~sources:[] ~sub_clocks:[self#child_clock]);
+
+      List.iter (fun c -> Clock.unify self#child_clock c#clock) children;
+
+      Gc.finalise (finalise_child_clock self#child_clock) self
+
+    method private child_tick =
+      (Clock.get self#child_clock)#end_tick;
+      needs_tick <- false
+
+    (* This methods always set [need_tick] to true. If the source is not
+       [#is_ready], only [#after_output] is called during a clock tick,
+       which means that the children clock is _always_ animated by the
+       main clock when the source becomes unavailable. Otherwise, we
+       expect the source to make a decision about executing a child clock
+       tick as part of its [#get_frame] implementation. See [cross.ml] or
+       [soundtouch.ml] as examples. *)
+    method after_output =
+      if needs_tick then self#child_tick;
+      needs_tick <- true
+  end

--- a/src/tools/tutils.ml
+++ b/src/tools/tutils.ml
@@ -231,10 +231,7 @@ let () =
   Lifecycle.on_scheduler_shutdown (fun () ->
       log#important "Shutting down scheduler...";
       Duppy.stop scheduler;
-      log#important "Scheduler shut down.";
-      log#important "Waiting for queue threads to terminate...";
-      join_all ~set:queues ();
-      log#important "Queues shut down")
+      log#important "Scheduler shut down.")
 
 let scheduler_log n =
   if scheduler_log#get then (

--- a/src/tools/utils.ml
+++ b/src/tools/utils.ml
@@ -736,3 +736,14 @@ module Version = struct
     in
     aux (num v) (num w)
 end
+
+let self_sync_type sources =
+  fst
+    (List.fold_left
+       (fun cur s ->
+         match (cur, s#self_sync) with
+           | (`Static, None), (`Static, v) -> (`Static, Some v)
+           | (`Static, Some v), (`Static, v') when v = v' -> (`Static, Some v)
+           | _ -> (`Dynamic, None))
+       (`Static, None)
+       sources)

--- a/tests/language/type_errors.pl
+++ b/tests/language/type_errors.pl
@@ -180,4 +180,11 @@ correct('%ffmpeg(
         %audio.copy,
         %video.copy)');
 
+# The following is not technically checking on type errors but runtime invalid values.
+section("INVALID VALUES");
+incorrect('crossfade(input.http(self_sync=true,"http://foo.bar"))');
+incorrect('crossfade(fallback([input.http("http://foo.bar"), input.http(self_sync=true,"http://foo.bar")]))');
+incorrect('crossfade(sequence([input.http("http://foo.bar"), input.http(self_sync=true,"http://foo.bar")]))');
+incorrect('crossfade(add([input.http("http://foo.bar"), input.http(self_sync=true,"http://foo.bar")]))');
+
 print "Everything's good!\n" ;

--- a/tests/media/test_ffmpeg_filter.liq
+++ b/tests/media/test_ffmpeg_filter.liq
@@ -35,55 +35,65 @@ s = sequence([s,s,s,s,s,fail()])
 
 s = f(s)
 
+started = ref(false)
+
+def on_track(_) =
+  started := true
+end
+
+s.on_track(on_track)
+
 clock.assign_new(id='test_clock',sync='none',[s])
 
 def on_done () =
-  ojson = process.read("ffprobe -v quiet -print_format json -show_streams '#{out}'")
+  if !started then
+    ojson = process.read("ffprobe -v quiet -print_format json -show_streams '#{out}'")
 
-  output_format = of_json(default=[("streams", [[("samplerate", "0")]])], ojson)
+    output_format = of_json(default=[("streams", [[("samplerate", "0")]])], ojson)
 
-  output_streams = list.assoc(default=[], "streams", output_format)
+    output_streams = list.assoc(default=[], "streams", output_format)
 
-  params = ["channel_layout", "sample_rate",
-            "sample_fmt", "codec_name", "pix_fmt"]
+    params = ["channel_layout", "sample_rate",
+              "sample_fmt", "codec_name", "pix_fmt"]
 
-  def m(s) =
-    def f(e) =
-      let (p, _) = e
-      list.mem(p, params)
+    def m(s) =
+      def f(e) =
+        let (p, _) = e
+        list.mem(p, params)
+      end
+      list.filter(f, s)
     end
-    list.filter(f, s)
-  end
 
-  output_streams = list.map(m, output_streams)
+    output_streams = list.map(m, output_streams)
 
-  def cmp(c, c') =
-    if c < c' then
-      -1
-    elsif c' < c then
-      1
+    def cmp(c, c') =
+      if c < c' then
+        -1
+      elsif c' < c then
+        1
+      else
+        0
+      end
+    end
+
+    output_streams = list.map(list.sort(cmp), output_streams)
+
+    def cmd_l(l, l') =
+      cmp(list.assoc("codec_name", l), list.assoc("codec_name", l'))
+    end
+
+    output_streams = list.sort(cmd_l, output_streams)
+
+    expected = [
+      [("channel_layout", "stereo"), ("codec_name", "aac"), ("sample_fmt", "fltp"), ("sample_rate", "44100")],
+      [("codec_name", "h264"), ("pix_fmt", "yuv420p")]
+    ]
+
+    if output_streams == expected then
+      test.pass()
     else
-      0
+      test.fail()
     end
-  end
-
-  output_streams = list.map(list.sort(cmp), output_streams)
-
-  def cmd_l(l, l') =
-    cmp(list.assoc("codec_name", l), list.assoc("codec_name", l'))
-  end
-
-  output_streams = list.sort(cmd_l, output_streams)
-
-  expected = [
-    [("channel_layout", "stereo"), ("codec_name", "aac"), ("sample_fmt", "fltp"), ("sample_rate", "44100")],
-    [("codec_name", "h264"), ("pix_fmt", "yuv420p")]
-  ]
-
-  if output_streams == expected then
-    test.pass()
-  else
-    test.fail()
   end
 end
 

--- a/tests/media/test_ffmpeg_inline_encode_decode.liq
+++ b/tests/media/test_ffmpeg_inline_encode_decode.liq
@@ -18,7 +18,7 @@ end
 
 s = once(blank(duration=10.))
 
-clock.assign_new(sync='none',[s])
+todo = ref(2)
 
 def on_done () =
   def check(out) =
@@ -49,14 +49,19 @@ def on_done () =
     streams == expected
   end
 
-  if check(out_copy) and check(out_encode) then
-    test.pass()
-  else
-    test.fail()
+  todo := !todo - 1
+
+  if !todo == 0 then
+    if check(out_copy) and check(out_encode) then
+      test.pass()
+    else
+      test.fail()
+    end
   end
 end
 
 s = ffmpeg.encode.audio_video(
+  id="encoder",
   %ffmpeg(
     %video(codec="libx264", b="5m"),
     %audio(codec="aac")
@@ -66,6 +71,7 @@ s = ffmpeg.encode.audio_video(
 
 output.file(
   fallible=true,
+  on_stop=on_done,
   %ffmpeg(
     %video.copy,
     %audio.copy,
@@ -74,7 +80,9 @@ output.file(
   s
 )
 
-s = ffmpeg.decode.audio_video(s)
+s = ffmpeg.decode.audio_video(id="decoder", s)
+
+clock.assign_new(sync='none',[s])
 
 output.file(
   fallible=true,

--- a/tests/media/test_ffmpeg_inline_encode_decode_audio.liq
+++ b/tests/media/test_ffmpeg_inline_encode_decode_audio.liq
@@ -18,7 +18,7 @@ end
 
 s = once(blank(duration=10.))
 
-clock.assign_new(sync='none',[s])
+todo = ref(2)
 
 def on_done () =
   def check(out) =
@@ -48,10 +48,14 @@ def on_done () =
     streams == expected
   end
 
-  if check(out_copy) and check(out_encode) then
-    test.pass()
-  else
-    test.fail()
+  todo := !todo - 1
+
+  if !todo == 0 then
+    if check(out_copy) and check(out_encode) then
+      test.pass()
+    else
+      test.fail()
+    end
   end
 end
 
@@ -64,6 +68,7 @@ s = ffmpeg.encode.audio(
 
 output.file(
   fallible=true,
+  on_stop=on_done,
   %ffmpeg(
     %audio.copy,
   ),
@@ -72,6 +77,8 @@ output.file(
 )
 
 s = ffmpeg.decode.audio(s)
+
+clock.assign_new(sync='none',[s])
 
 output.file(
   fallible=true,

--- a/tests/media/test_ffmpeg_inline_encode_decode_video.liq
+++ b/tests/media/test_ffmpeg_inline_encode_decode_video.liq
@@ -18,7 +18,7 @@ end
 
 s = once(blank(duration=10.))
 
-clock.assign_new(sync='none',[s])
+todo = ref(2)
 
 def on_done () =
   def check(out) =
@@ -48,10 +48,14 @@ def on_done () =
     streams == expected
   end
 
-  if check(out_copy) and check(out_encode) then
-    test.pass()
-  else
-    test.fail()
+  todo := !todo - 1
+
+  if !todo == 0 then
+    if check(out_copy) and check(out_encode) then
+      test.pass()
+    else
+      test.fail()
+    end
   end
 end
 
@@ -64,6 +68,7 @@ s = ffmpeg.encode.video(
 
 output.file(
   fallible=true,
+  on_stop=on_done,
   %ffmpeg(
     %video.copy,
   ),
@@ -72,6 +77,8 @@ output.file(
 )
 
 s = ffmpeg.decode.video(s)
+
+clock.assign_new(sync='none',[s])
 
 output.file(
   fallible=true,

--- a/tests/regression/infallible-shutdown.liq
+++ b/tests/regression/infallible-shutdown.liq
@@ -1,0 +1,9 @@
+#!../../src/liquidsoap ../../libs/stdlib.liq ../../libs/deprecations.liq
+
+# Make sure infallible output can shutdown properly.
+
+%include "test.liq"
+
+output.dummy(blank())
+
+thread.run(delay=1., test.pass)

--- a/tests/run_test.sh
+++ b/tests/run_test.sh
@@ -4,40 +4,66 @@ BASEPATH=$0
 BASEDIR=`dirname $0`
 PWD=`cd $BASEDIR && pwd`
 
-CMD=$1
-TEST=$2
-TEST_NAME=$3
+TIMEOUT=10m
 
-if [ -z "${TEST_NAME}" ]; then
-  TEST_NAME=${TEST}
-fi
+run_test() {
+  PWD=$1
+  CMD=$2
+  TEST=$3
+  TEST_NAME=$4
 
-LOG_FILE=`mktemp`
+  if [ -z "${TEST_NAME}" ]; then
+    TEST_NAME=${TEST}
+  fi
 
-trap cleanup 0 1 2
+  LOG_FILE=`mktemp`
 
-cleanup() {
-  rm -rf "${LOG_FILE}"
+  trap cleanup 0 1 2
+
+  cleanup() {
+    rm -rf "${LOG_FILE}"
+  }
+
+  on_timeout() {
+    echo -e "\033[1;34m[timeout]\033[0m"
+    cat "${LOG_FILE}"
+    exit 1
+  }
+
+  trap on_timeout 15
+
+  echo -en "Running test \033[1m${TEST_NAME}\033[0m... "
+
+  ${CMD} < "${PWD}/${TEST}"  > "${LOG_FILE}" 2>&1 &
+
+  PID=$!
+  wait $PID
+  STATUS=$?
+
+  if [ "${STATUS}" == "0" ]; then
+    echo -e "\033[0;32m[ok]\033[0m"
+    exit 0
+  fi
+
+  if [ "${STATUS}" == "2" ]; then
+      echo -e "\033[1;33m[skipped]\033[0m"
+      exit 0
+  fi
+
+  echo -e "\033[0;31m[failed]\033[0m"
+  cat "${LOG_FILE}"
+  exit 1
 }
 
-echo -en "Running test \033[1m${TEST_NAME}\033[0m... "
+export -f run_test
 
-${CMD} < "${PWD}/${TEST}"  > "${LOG_FILE}" 2>&1 &
+on_term() {
+  exit 1
+}
 
-PID=$!
-wait $PID
-STATUS=$?
+trap on_term INT
 
-if [ "${STATUS}" == "0" ]; then
-  echo -e "\033[0;32m[ok]\033[0m"
-  exit 0
-fi
+timeout -s 15 "${TIMEOUT}" bash -c "run_test \"$PWD\" \"$1\" \"$2\" \"$3\"" &
 
-if [ "${STATUS}" == "2" ]; then
-    echo -e "\033[1;33m[skipped]\033[0m"
-    exit 0
-fi
-
-echo -e "\033[0;31m[failed]\033[0m"
-cat "${LOG_FILE}"
-exit 1
+pid=$!
+wait $pid

--- a/tests/streams/197.liq
+++ b/tests/streams/197.liq
@@ -15,5 +15,5 @@ end
 
 s = playlist(check_next=filter, mode="randomize", reload_mode="rounds", "playlist")
 s = test.check_non_repeating(nb_files=2, nb_rounds=10, s)
-clock(sync="none", s)
+clock.assign_new(sync="none",[s])
 output.dummy(fallible=true,s)

--- a/tests/streams/autostart.liq
+++ b/tests/streams/autostart.liq
@@ -1,0 +1,31 @@
+#!../../src/liquidsoap ../../libs/stdlib.liq ../../libs/deprecations.liq
+
+%include "test.liq"
+
+test_no_autostart = ref(true)
+test_autostart = ref(false)
+
+def on_unwanted_autostart() =
+  test_no_autostart := false
+end
+
+def on_wanted_autostart() =
+  test_autostart := true
+end
+
+s = blank()
+
+clock.assign_new(sync="none",[s])
+
+output.dummy(id="no_autostart", start=false, on_start=on_unwanted_autostart, s)
+output.dummy(id="autostart", start=true, on_start=on_wanted_autostart, s)
+
+def on_done() =
+  if !test_no_autostart and !test_autostart then
+    test.pass()
+  else
+    test.fail()
+  end
+end
+
+thread.run(delay=1.,on_done) 

--- a/tests/streams/stretch-clock-propagation.liq
+++ b/tests/streams/stretch-clock-propagation.liq
@@ -1,0 +1,21 @@
+#!../../src/liquidsoap ../../libs/stdlib.liq ../../libs/deprecations.liq
+
+# Stretch (as well as soundtouch) uses the Child_support clock control
+# mechamism. We want to make sure that it properly propagates end-of-tracks
+# to its underlying outputs/sources.
+
+%include "test.liq"
+
+s = once(blank(duration=10.))
+
+def on_stop() =
+  test.pass()
+end
+
+output.dummy(fallible=true, on_stop=on_stop, s)
+
+s = stretch(ratio=2., s)
+
+clock.assign_new(sync="none",[s])
+
+output.dummy(fallible=true, s)


### PR DESCRIPTION
This is a rather large PR sorry!

* Make `Producer_consumer` infallible when possible, which includes inline `ffmpeg` encoder and decoder!
* Add static/dynamic annotation to `self_sync`
* Added `Child_support` to clarify logic when dealing with children sources in a clock driven by a parent source
* Added `~start:bool` to `new Clock` to allow dependent clocks without runtime thread when driven by a parent source
* Use new `self_sync` annotation to fail when underlying source is not statically `self_sync` in `Child_support`
* Use `Child_support` for all operators that control their underlying source clock (`cross`, `soundtouch`, `stretch` etc..)
* Factorized logic for `soundtouch` and `stretch` to use `Producer_consumer.consumer`, which gets complete `frame` per each clock tick.
* Add parameter for default `clock_safe` value in `Start_stop` protocol
* Unify ffmpeg's `clock_safe` with other operators, set to `false` by default
* Rewrote `cue_cut` to simplify its code
* Switch default `id` operator parameter to `string?`