### PR TITLE
Build apk package, add alpine docker images

### DIFF
--- a/.github/alpine/APKBUILD.in
+++ b/.github/alpine/APKBUILD.in
@@ -1,0 +1,27 @@
+pkgname=@APK_PACKAGE@
+subpackages="$pkgname-dbg"
+pkgver=@APK_VERSION@
+pkgrel=0
+pkgdesc="Swiss-army knife for multimedia streaming"
+url="https://github.com/savonet/liquidsoap"
+arch="all"
+license="GPL-2.0-only"
+install="@APK_PACKAGE@.pre-install"
+options="!check"
+
+package() {
+	eval $(opam env)
+	cd liquidsoap
+
+	make install \
+	  DESTDIR="$pkgdir" \
+	  OCAMLFIND_DESTDIR="$pkgdir/$OCAML_STDLIB_DIR" \
+	  prefix="$pkgdir/usr" \
+	  sysconfdir="$pkgdir/etc" \
+	  INSTALL_DAEMON=no \
+	  OCAMLFIND_LDCONF=ignore
+
+	mkdir -p "$pkgdir/usr/share/liquidsoap"
+
+	cp -rf "$(ocamlfind ocamlc -where)/../../share/camomile" "$pkgdir/usr/share/liquidsoap"
+}

--- a/.github/alpine/liquidsoap.pre-install
+++ b/.github/alpine/liquidsoap.pre-install
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+addgroup -S liquidsoap 2>/dev/null
+adduser -S -D -h /var/liquidsoap -s /sbin/nologin -G liquidsoap -g liquidsoap liquidsoap 2>/dev/null
+addgroup liquidsoap audio 2>/dev/null
+
+exit 0

--- a/.github/docker/Dockerfile.production-alpine
+++ b/.github/docker/Dockerfile.production-alpine
@@ -1,0 +1,20 @@
+FROM alpine:latest
+
+ARG APK_FILE
+
+ARG APK_DBG_FILE
+
+USER root
+
+COPY $APK_FILE /tmp/liquidsoap.apk
+
+COPY $APK_DBG_FILE /tmp/liquidsoap-dbg.apk
+
+RUN apk add --allow-untrusted --no-cache \
+      -X http://dl-cdn.alpinelinux.org/alpine/edge/testing \
+      tini /tmp/liquidsoap.apk /tmp/liquidsoap-dbg.apk && \
+      rm -rf /tmp/liquidsoap.apk /tmp/liquidsoap-dbg.apk
+
+USER liquidsoap
+
+ENTRYPOINT ["/sbin/tini", "--", "/usr/bin/liquidsoap"]

--- a/.github/scripts/build-apk.sh
+++ b/.github/scripts/build-apk.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+
+set -e
+
+BRANCH=$1
+ARCH=$2
+
+cd /tmp/liquidsoap-full/liquidsoap
+
+APK_VERSION=`opam show -f version .`
+
+TAG=`echo "${BRANCH}" | tr '[:upper:]' '[:lower:]' | sed -e 's#[^0-9^a-z^A-Z^.^-]#-#g'`
+
+if [ "${ARCH}" = "amd64" ]; then
+  ALPINE_ARCH=x86_64
+else
+  ALPINE_ARCH=aarch64
+fi
+
+APK_PACKAGE="liquidsoap-${TAG}-${ALPINE_ARCH}"
+
+echo "Building ${APK_PACKAGE}.."
+
+cd /tmp/liquidsoap-full
+
+cat liquidsoap/.github/alpine/APKBUILD.in | \
+  sed -e "s#@APK_PACKAGE@#${APK_PACKAGE}#" | \
+  sed -e "s#@APK_VERSION@#${APK_VERSION}#" \
+  > APKBUILD
+
+cp liquidsoap/.github/alpine/liquidsoap.pre-install ${APK_PACKAGE}.pre-install
+
+abuild-keygen -a -n
+abuild
+
+mv /home/opam/packages/tmp/${ALPINE_ARCH}/${APK_PACKAGE}-${APK_VERSION}-r0.apk /tmp/alpine
+mv /home/opam/packages/tmp/${ALPINE_ARCH}/${APK_PACKAGE}-dbg-${APK_VERSION}-r0.apk /tmp/alpine
+
+echo "##[set-output name=basename;]${APK_PACKAGE}-${APK_VERSION}-r0.apk"

--- a/.github/scripts/build-details.sh
+++ b/.github/scripts/build-details.sh
@@ -45,3 +45,5 @@ else
 fi
 
 echo "##[set-output name=should_build_code;]${SHOULD_BUILD_CODE}"
+
+echo "##[set-output name=s3-artifact-basepath;]s3://liquidsoap-artifacts/${GITHUB_WORKFLOW}/${GITHUB_RUN_NUMBER}"

--- a/.github/scripts/build-docker-alpine.sh
+++ b/.github/scripts/build-docker-alpine.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+set -e
+
+APK_FILE=$1
+APK_DBG_FILE=$2
+TAG=$3
+USER=$4
+PASSWORD=$5
+ARCHITECTURE=$6
+
+cp $APK_FILE $APK_DBG_FILE .
+
+docker build --no-cache  --build-arg "APK_FILE=$APK_FILE" --build-arg "APK_DBG_FILE=$APK_DBG_FILE" -f .github/docker/Dockerfile.production-alpine -t savonet/liquidsoap-ci-build:${TAG}_alpine_${ARCHITECTURE} .
+
+docker login -u "$USER" -p "$PASSWORD" 
+
+docker push savonet/liquidsoap-ci-build:${TAG}_alpine_${ARCHITECTURE}

--- a/.github/scripts/push-docker.sh
+++ b/.github/scripts/push-docker.sh
@@ -15,3 +15,5 @@ docker login -u "$USER" -p "$PASSWORD"
 docker manifest create savonet/liquidsoap:$TAG --amend savonet/liquidsoap-ci-build:${TAG}_amd64 --amend savonet/liquidsoap-ci-build:${TAG}_arm64
 docker manifest push savonet/liquidsoap:$TAG
 
+docker manifest create savonet/liquidsoap-alpine:$TAG --amend savonet/liquidsoap-ci-build:${TAG}_alpine_amd64 --amend savonet/liquidsoap-ci-build:${TAG}_alpine_arm64
+docker manifest push savonet/liquidsoap-alpine:$TAG

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ jobs:
       is_release: ${{ steps.build_details.outputs.is_release }}
       docker_release: ${{ steps.build_details.outputs.docker_release }}
       should_build_code: ${{ steps.build_details.outputs.should_build_code }}
+      s3-artifact-basepath: ${{ steps.build_details.outputs.s3-artifact-basepath }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -111,7 +112,7 @@ jobs:
             runs-on: self-hosted
     container:
       image: savonet/liquidsoap-ci:${{ matrix.os }}_${{ matrix.platform }}
-      options: --user root --privileged --ulimit core=-1 --security-opt seccomp=unconfined -v ${{ github.workspace }}/core:/tmp/core -v ${{ github.workspace }}/debian:/tmp/debian
+      options: --user root --privileged --ulimit core=-1 --security-opt seccomp=unconfined -v ${{ github.workspace }}/core:/tmp/core -v ${{ github.workspace }}/debian:/tmp/debian -v ${{ github.workspace }}/alpine:/tmp/alpine
     env:
       HOME: /home/opam
     steps:
@@ -156,12 +157,91 @@ jobs:
           name: ${{ steps.build_deb.outputs.basename }}
           path: ${{ github.workspace }}/debian
           if-no-files-found: error
+      - name: Build alpine package
+        if: matrix.os == 'alpine'
+        id: build_apk
+        run: |
+          cd /tmp/liquidsoap-full/liquidsoap
+          apk add alpine-sdk
+          adduser opam abuild
+          mkdir -p /tmp/alpine
+          rm -rf /tmp/alpine/*
+          chown -R opam /tmp/alpine 
+          sudo -u opam -E ./.github/scripts/build-apk.sh ${{ needs.build_details.outputs.branch }} ${{ matrix.platform }}
+      - name: Upload alpine packages artifacts
+        if: matrix.os == 'alpine'
+        uses: savonet/aws-s3-docker-action@master
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          SOURCE: ${{ github.workspace }}/alpine
+          TARGET: ${{ needs.build_details.outputs.s3-artifact-basepath }}
       - name: Export potential core dumps
         if: ${{ failure() }}
         uses: actions/upload-artifact@v2
         with:
           name: core-dump-${{ matrix.os }}-${{ matrix.platform }}
           path: ${{ github.workspace }}/core
+
+  fetch_s3_artifacts:
+    runs-on: ubuntu-latest
+    needs: [build_details, build_posix]
+    steps:
+      - name: Prepare directory
+        run: |
+          rm -rf ${{ github.workspace }}/s3-artifacts
+          mkdir -p ${{ github.workspace }}/s3-artifacts
+      - name: Fetch S3 artifacts
+        uses: savonet/aws-s3-docker-action@master
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          SOURCE: ${{ needs.build_details.outputs.s3-artifact-basepath }}
+          TARGET: ${{ github.workspace }}/s3-artifacts
+      - name: Get alpine amd64 package name
+        id: apk_amd64
+        run: |
+          echo "##[set-output name=path;]$(find ${{ github.workspace }}/s3-artifacts -type f | grep 'apk$' | grep -v dbg | grep x86_64)"
+          echo "##[set-output name=name;]$(find ${{ github.workspace }}/s3-artifacts -type f | grep 'apk$' | grep -v dbg | grep x86_64 | xargs basename)"
+      - name: Upload alpine amd64 package
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ steps.apk_amd64.outputs.name }}
+          path: ${{ steps.apk_amd64.outputs.path }}
+          if-no-files-found: error
+      - name: Get alpine amd64 debug package name
+        id: apk_amd64_dbg
+        run: |
+          echo "##[set-output name=path;]$(find ${{ github.workspace }}/s3-artifacts -type f | grep 'apk$' | grep dbg | grep x86_64)"
+          echo "##[set-output name=name;]$(find ${{ github.workspace }}/s3-artifacts -type f | grep 'apk$' | grep dbg | grep x86_64 | xargs basename)"
+      - name: Upload alpine amd64 debug package
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ steps.apk_amd64_dbg.outputs.name }}
+          path: ${{ steps.apk_amd64_dbg.outputs.path }}
+          if-no-files-found: error
+      - name: Get alpine arm64 package name
+        id: apk_arm64
+        run: |
+          echo "##[set-output name=path;]$(find ${{ github.workspace }}/s3-artifacts -type f | grep 'apk$' | grep -v dbg | grep aarch64)"
+          echo "##[set-output name=name;]$(find ${{ github.workspace }}/s3-artifacts -type f | grep 'apk$' | grep -v dbg | grep aarch64 | xargs basename)"
+      - name: Upload alpine amd64 package
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ steps.apk_arm64.outputs.name }}
+          path: ${{ steps.apk_arm64.outputs.path }}
+          if-no-files-found: error
+      - name: Get alpine arm64 debug package name
+        id: apk_arm64_dbg
+        run: |
+          echo "##[set-output name=path;]$(find ${{ github.workspace }}/s3-artifacts -type f | grep 'apk$' | grep dbg | grep aarch64)"
+          echo "##[set-output name=name;]$(find ${{ github.workspace }}/s3-artifacts -type f | grep 'apk$' | grep dbg | grep aarch64 | xargs basename)"
+      - name: Upload alpine amd64 debug package
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ steps.apk_arm64_dbg.outputs.name }}
+          path: ${{ steps.apk_arm64_dbg.outputs.path }}
+          if-no-files-found: error
 
   build_win32:
     runs-on: ubuntu-latest
@@ -249,9 +329,41 @@ jobs:
       - name: Build docker image
         run: .github/scripts/build-docker.sh ${{ steps.debian_package.outputs.deb-file }} ${{ steps.debian_debug_package.outputs.deb-file }} ${{ needs.build_details.outputs.branch }} ${{ secrets.DOCKERHUB_USER }} ${{ secrets.DOCKERHUB_PASSWORD }} ${{ matrix.platform }}
 
+  build_docker_alpine:
+    runs-on: ${{ matrix.runs-on }}
+    needs: [build_details, fetch_s3_artifacts]
+    strategy:
+      matrix:
+        platform: [amd64, arm64]
+        include:
+          - platform: amd64
+            runs-on: ubuntu-latest
+            alpine-arch: x86_64
+          - platform: arm64
+            runs-on: self-hosted
+            alpine-arch: aarch64
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+      - name: Download all artifact
+        uses: actions/download-artifact@v2
+        with:
+          path: artifacts/${{ needs.build_details.outputs.sha }}
+      - name: Get alpine package
+        run: echo "##[set-output name=apk-file;]$(find artifacts/${{ needs.build_details.outputs.sha }} -type f | grep 'apk$' | grep -v dbg | grep ${{ matrix.alpine-arch }})"
+        id: alpine_package
+      - name: Get alpine debug package
+        run: echo "##[set-output name=apk-file;]$(find artifacts/${{ needs.build_details.outputs.sha }} -type f | grep 'apk$' | grep dbg | grep ${{ matrix.alpine-arch }})"
+        id: alpine_dbg_package
+      - name: Build docker image
+        run: .github/scripts/build-docker-alpine.sh ${{ steps.alpine_package.outputs.apk-file }} ${{ steps.alpine_dbg_package.outputs.apk-file }} ${{ needs.build_details.outputs.branch }} ${{ secrets.DOCKERHUB_USER }} ${{ secrets.DOCKERHUB_PASSWORD }} ${{ matrix.platform }}
+
   build_docker_release:
     runs-on: ubuntu-latest
-    needs: [build_details, build_docker]
+    needs: [build_details, build_docker, build_docker_alpine]
     if: ${{ needs.build_details.outputs.docker_release }}
     steps:
       - name: Checkout code

--- a/doc/content/install.md
+++ b/doc/content/install.md
@@ -89,6 +89,11 @@ These images contain a minimal `debian/testing` image with the liquidsoap debian
 Installed packages are those generated during our CI process, not the official debian package! Images are tagged
 by the branch that was used to generate them. 
 
+We also provide images based on [Aline Linux](https://hub.docker.com/re/savonet/liquidsoap-alpine). These images
+are much smaller in size, due to the particularity of the standard C library [musl](https://www.musl-libc.org/)
+used to build them and can be useful in situations where size matters. However, because `musl` is not as widespread
+as the GNU libc, we have not (yet?) made those images our default production images.
+
 Windows
 -------
 

--- a/src/main.ml
+++ b/src/main.ml
@@ -76,8 +76,8 @@ let deprecated = ref true
 let interactive = ref false
 
 (** [load_libs] should be called before loading a script or looking up
-  * the documentation, to make sure that pervasive libraries have been loaded,
-  * unless the user explicitly opposed to it. *)
+  * the documentation, to make sure that pervasive libraries have been
+  * loaded, unless the user explicitly opposed to it. *)
 let load_libs =
   let loaded = ref false in
   fun () ->


### PR DESCRIPTION
This PR adds `alpine` packages to the generated artifacts and also adds production docker images for alpine. With all features enabled, the image size goes from ~250MB to ~50MB! Default production images will remain on debian/testing for now but the alpine images will be available at: https://hub.docker.com/repository/docker/savonet/liquidsoap-alpine

The only annoying thing is that, for some reason, github's artifact upload/download does not work on alpine on arm64 so I had to do a temporary upload to S3 to get the built packages out of the job run..