### PR TITLE
Switch to using the number of requests when queueing new requests.

### DIFF
--- a/doc/content/migrating.md
+++ b/doc/content/migrating.md
@@ -115,6 +115,15 @@ s.insert_metadata([("artist", "Bob")])
 output.pulseaudio(s)
 ```
 
+### Request-based queueing
+
+Queueing for request-based sources has been simplified. The `default_duration` and `length` have been removed in favor of
+a simpler implementation. You can now pass a `prefetch` parameter which tells the source how many requests should be queued
+in advance.
+
+Should you need more advanced queueing strategy, `request.dynamic.list` and `request.dynamic` now export functions to retrieve 
+and set their own queue of requests.
+
 ### Deprecated operators
 
 Some operators have been deprecated. For most of them, we provide a backward-compatible support 

--- a/libs/deprecations.liq
+++ b/libs/deprecations.liq
@@ -85,11 +85,10 @@ end
 # Deprecated: this function has been replaced with `playlist`, setting
 # `reload_mode` argument to `"never"` and `loop` to `false`.
 def playlist.once(~id=null(),~random=false,~reload_mode="",
-                  ~default_duration=30.,~length=10.,~conservative=false,
-                  ~filter=fun(_)->true,uri)
+                  ~length=2,~filter=fun(_)->true,uri)
   deprecated("playlist.once", "playlist")
   mode = if random then "randomize" else "normal" end
-  playlist(reload_mode="never", loop=false, id=id, mode=mode, conservative=conservative, default_duration=default_duration, check_next=filter, uri)
+  playlist(reload_mode="never", loop=false, id=id, mode=mode, length=length, check_next=filter, uri)
 end
 
 # Deprecated: this function has been replaced by `map_metadata`.

--- a/libs/deprecations.liq
+++ b/libs/deprecations.liq
@@ -85,10 +85,10 @@ end
 # Deprecated: this function has been replaced with `playlist`, setting
 # `reload_mode` argument to `"never"` and `loop` to `false`.
 def playlist.once(~id=null(),~random=false,~reload_mode="",
-                  ~length=2,~filter=fun(_)->true,uri)
+                  ~prefetch=2,~filter=fun(_)->true,uri)
   deprecated("playlist.once", "playlist")
   mode = if random then "randomize" else "normal" end
-  playlist(reload_mode="never", loop=false, id=id, mode=mode, length=length, check_next=filter, uri)
+  playlist(reload_mode="never", loop=false, id=id, mode=mode, prefetch=prefetch, check_next=filter, uri)
 end
 
 # Deprecated: this function has been replaced by `map_metadata`.

--- a/libs/deprecations.liq
+++ b/libs/deprecations.liq
@@ -85,7 +85,7 @@ end
 # Deprecated: this function has been replaced with `playlist`, setting
 # `reload_mode` argument to `"never"` and `loop` to `false`.
 def playlist.once(~id=null(),~random=false,~reload_mode="",
-                  ~prefetch=2,~filter=fun(_)->true,uri)
+                  ~prefetch=1,~filter=fun(_)->true,uri)
   deprecated("playlist.once", "playlist")
   mode = if random then "randomize" else "normal" end
   playlist(reload_mode="never", loop=false, id=id, mode=mode, prefetch=prefetch, check_next=filter, uri)

--- a/libs/hls.liq
+++ b/libs/hls.liq
@@ -79,7 +79,7 @@ def input.hls.native(~id=null(),~reload=10.,uri)
   end
   find_stream ()
 
-  source = request.dynamic.list(id=id,default_duration=0.5,length=5.,next)
+  source = request.dynamic.list(id=id,length=10,next)
 
   source = merge_tracks(source)
 

--- a/libs/hls.liq
+++ b/libs/hls.liq
@@ -79,7 +79,7 @@ def input.hls.native(~id=null(),~reload=10.,uri)
   end
   find_stream ()
 
-  source = request.dynamic.list(id=id,length=10,next)
+  source = request.dynamic.list(id=id,prefetch=10,next)
 
   source = merge_tracks(source)
 

--- a/libs/native.liq
+++ b/libs/native.liq
@@ -120,22 +120,31 @@ def native.request.dynamic(~id=null(), ~prefetch=1, ~polling_delay=1., ~timeout=
   end
 
   # Prefetch thread
-  def prefetch()
-    if list.length(!queue) < prefetch then
-      r = f()
-      if null.defined(r) then
-        r = null.get(r)
-        s = request.once(r)
-        if s.resolve() then
-          log.info("Added request on queue: #{request.uri(r)}.")
-          queue := [...!queue, s]
-        else
-          log.important("Failed to resolve request #{request.uri(r)}.")
-        end
+  def fetch()
+    r = f()
+    if null.defined(r) then
+      r = null.get(r)
+      s = request.once(r)
+      if s.resolve() then
+        log.info("Added request on queue: #{request.uri(r)}.")
+        queue := [...!queue, s]
+        true
+      else
+        log.important("Failed to resolve request #{request.uri(r)}.")
+        false
       end
+    else
+      false
     end
   end
-  thread.run(every=polling_delay, prefetch)
+
+  def fill() =
+    if list.length(!queue) < prefetch then
+      ignore(fetch())
+    end
+  end
+
+  thread.run(every=polling_delay, fill)
 
   # Source
   def s()
@@ -149,7 +158,7 @@ def native.request.dynamic(~id=null(), ~prefetch=1, ~polling_delay=1., ~timeout=
     end
   end
   source.dynamic(id=id, track_sensitive=true, s).{
-    prefetch=prefetch,
+    fetch=fetch,
     queue=get_queue,
     set_queue=set_queue,
     current=get_current

--- a/libs/native.liq
+++ b/libs/native.liq
@@ -88,37 +88,59 @@ let native.request = request
 def native.request.dynamic(~id=null(), ~prefetch=1, ~polling_delay=1., ~timeout=20., f)
   # Prepared requests
   queue = ref([])
-  def queue_size()
-    list.length(!queue)
+
+  def set_queue(q) =
+    queue := q
   end
-  # Filling thread
-  def filler()
+
+  current = ref(null())
+
+  def get_current() =
+    if null.defined(!current) then
+      s = null.get(!current)
+      def close() =
+        s.skip()
+      end
+      null({ request = s.request, close = close})
+    else
+      null()
+    end
+  end
+
+  # Prefetch thread
+  def prefetch()
     if list.length(!queue) < prefetch then
       r = f()
       if null.defined(r) then
         r = null.get(r)
-        s = request.once(r)
-        if s.resolve() then
+        if request.resolve(r) then
           log.info("Added request on queue: #{request.uri(r)}.")
-          queue := list.append(!queue, [s])
+          queue := [...!queue, r]
         else
           log.important("Failed to resolve request #{request.uri(r)}.")
         end
       end
     end
   end
-  thread.run(every=polling_delay, filler)
+  thread.run(every=polling_delay, prefetch)
+
   # Source
   def s()
     if not list.is_empty(!queue) then
-      s = list.hd(!queue)
-      queue := list.tl(!queue)
-      s
+      let [r, ...rest] = !queue
+      queue := rest
+      current := request.once(r)
+      null.get(!current)
     else
       source.fail()
     end
   end
-  source.dynamic(id=id, track_sensitive=true, s).{queue_size=queue_size}
+  source.dynamic(id=id, track_sensitive=true, s).{
+    prefetch=prefetch,
+    queue={!queue},
+    set_queue=set_queue,
+    current=get_current
+  }
 end
 
 # Play requests dynamically created by a given function.

--- a/libs/native.liq
+++ b/libs/native.liq
@@ -78,14 +78,8 @@ end
 # This allows doing `open native`
 let native.request = request
 
-# Play requests dynamically created by a given function.
-# @category Source / Input
-# @param ~id Force the value of the source ID.
-# @param ~polling_delay How often the queue should be checkelid and filled in seconds.
-# @param ~prefetch Number of tracks to prepare in advance.
-# @param ~timeout Timeout for resolving requests in seconds.
-# @param f Function returning the next request.
-def native.request.dynamic(~id=null(), ~prefetch=1, ~polling_delay=1., ~timeout=20., f)
+# @docof request.dynamic.list
+def native.request.dynamic(%argsof(request.dynamic.list), f)
   # Prepared requests
   queue = ref([])
 
@@ -144,7 +138,7 @@ def native.request.dynamic(~id=null(), ~prefetch=1, ~polling_delay=1., ~timeout=
     end
   end
 
-  thread.run(every=polling_delay, fill)
+  thread.run(every=retry_delay, fill)
 
   # Source
   def s()
@@ -165,24 +159,18 @@ def native.request.dynamic(~id=null(), ~prefetch=1, ~polling_delay=1., ~timeout=
   }
 end
 
-# Play requests dynamically created by a given function.
-# @category Source / Input
-# @param ~id Force the value of the source ID.
-# @param ~polling_delay How often the queue should be checkelid and filled in seconds.
-# @param ~prefetch Number of tracks to prepare in advance.
-# @param ~timeout Timeout for resolving requests in seconds.
-# @param f Function returning the list of next requests.
-def native.request.dynamic.list(~id=null(), ~prefetch=1, ~polling_delay=1., ~timeout=20., f)
-  l = ref([])
-  def f()
-    if !l == [] then l := f() end
-    if !l != [] then
-      r = list.hd(!l)
-      l := list.tl(!l)
-      r
-    else
-      null()
-    end
+# @docof request.dynamic.list
+def native.request.dynamic.list(%argsof(request.dynamic.list), f)
+  fn = ref({null()})
+
+  def next() =
+    fn = !fn
+    fn()
   end
-  native.request.dynamic(id=id, f)
+
+  s = native.request.dynamic(%argsof(request.dynamic.list), next)
+
+  fn := {s.set_queue(f()); null()}
+
+  s
 end

--- a/libs/native.liq
+++ b/libs/native.liq
@@ -89,8 +89,23 @@ def native.request.dynamic(~id=null(), ~prefetch=1, ~polling_delay=1., ~timeout=
   # Prepared requests
   queue = ref([])
 
+  def get_queue() =
+    def get_request(s) =
+      s.request
+    end
+    list.map(get_request, !queue)
+  end
+
   def set_queue(q) =
-    queue := q
+    def mk_source(result, r) =
+      s = request.once(r)
+      if s.resolve() then
+        [...result, s]
+      else
+        result
+      end
+    end
+    queue := list.fold(mk_source, [], q)
   end
 
   current = ref(null())
@@ -98,10 +113,7 @@ def native.request.dynamic(~id=null(), ~prefetch=1, ~polling_delay=1., ~timeout=
   def get_current() =
     if null.defined(!current) then
       s = null.get(!current)
-      def close() =
-        s.skip()
-      end
-      null({ request = s.request, close = close})
+      s.request
     else
       null()
     end
@@ -113,9 +125,10 @@ def native.request.dynamic(~id=null(), ~prefetch=1, ~polling_delay=1., ~timeout=
       r = f()
       if null.defined(r) then
         r = null.get(r)
-        if request.resolve(r) then
+        s = request.once(r)
+        if s.resolve() then
           log.info("Added request on queue: #{request.uri(r)}.")
-          queue := [...!queue, r]
+          queue := [...!queue, s]
         else
           log.important("Failed to resolve request #{request.uri(r)}.")
         end
@@ -127,17 +140,17 @@ def native.request.dynamic(~id=null(), ~prefetch=1, ~polling_delay=1., ~timeout=
   # Source
   def s()
     if not list.is_empty(!queue) then
-      let [r, ...rest] = !queue
+      let [s, ...rest] = !queue
       queue := rest
-      current := request.once(r)
-      null.get(!current)
+      current := s
+      s
     else
       source.fail()
     end
   end
   source.dynamic(id=id, track_sensitive=true, s).{
     prefetch=prefetch,
-    queue={!queue},
+    queue=get_queue,
     set_queue=set_queue,
     current=get_current
   }

--- a/libs/native.liq
+++ b/libs/native.liq
@@ -90,16 +90,19 @@ def native.request.dynamic(%argsof(request.dynamic.list), f)
     list.map(get_request, !queue)
   end
 
-  def set_queue(q) =
-    def mk_source(result, r) =
-      s = request.once(r)
-      if s.resolve() then
-        [...result, s]
-      else
-        result
-      end
+  def add(r) =
+    s = request.once(r)
+    if s.resolve() then
+      queue := [...!queue, s]
+      true
+    else
+      false
     end
-    queue := list.fold(mk_source, [], q)
+  end
+
+  def set_queue(l) =
+    queue := []
+    list.iter(fun (r) -> ignore(add(r)), l)
   end
 
   current = ref(null())
@@ -154,6 +157,7 @@ def native.request.dynamic(%argsof(request.dynamic.list), f)
   source.dynamic(id=id, track_sensitive=true, s).{
     fetch=fetch,
     queue=get_queue,
+    add=add,
     set_queue=set_queue,
     current=get_current
   }
@@ -170,7 +174,7 @@ def native.request.dynamic.list(%argsof(request.dynamic.list), f)
 
   s = native.request.dynamic(%argsof(request.dynamic.list), next)
 
-  fn := {s.set_queue(f()); null()}
+  fn := {list.iter(fun (r) -> ignore(s.add(r)), f()); null()}
 
   s
 end

--- a/libs/playlist.liq
+++ b/libs/playlist.liq
@@ -62,7 +62,7 @@ let stdlib_native = native
 # @param ~timeout Timeout (in sec.) for a single download.
 # @param playlist Playlist.
 # @method reload Reload the playlist with given list of songs.
-def playlist.list(~id=null(), ~check_next=null(), ~prefetch=2, ~loop=true, ~mime_type=null(),
+def playlist.list(~id=null(), ~check_next=null(), ~prefetch=1, ~loop=true, ~mime_type=null(),
                   ~mode="normal", ~native=false, ~on_done={()}, ~timeout=20., playlist)
   id = string.id.default(default="playlist.list", id)
   mode =
@@ -197,7 +197,7 @@ end
 # @method reload Reload the playlist.
 # @method length Length of the of the playlist (the number of songs it contains).
 def playlist.reloadable(
-  ~id=null(), ~check_next=null(), ~prefetch=2, ~loop=true, ~mime_type=null(),
+  ~id=null(), ~check_next=null(), ~prefetch=1, ~loop=true, ~mime_type=null(),
   ~mode="randomize", ~native=false, ~on_done={()}, ~on_reload=(fun (_) -> ()),
   ~prefix="", ~timeout=20., uri) =
   id = string.id.default(default="playlist.reloadable", id)
@@ -275,7 +275,7 @@ end
 # @method reload Reload the playlist.
 # @method length Length of the of the playlist (the number of songs it contains).
 def replaces playlist(
-  ~id=null(), ~check_next=null(), ~prefetch=2, ~loop=true, 
+  ~id=null(), ~check_next=null(), ~prefetch=1, ~loop=true, 
   ~mime_type=null(), ~mode="randomize", ~native=false, ~on_reload=(fun (_) -> ()),
   ~prefix="", ~reload=0, ~reload_mode="seconds", ~timeout=20., uri) =
   id = string.id.default(default="playlist", id)

--- a/libs/playlist.liq
+++ b/libs/playlist.liq
@@ -49,7 +49,7 @@ let stdlib_native = native
 #   corresponding to local files. This is typically used to avoid repetitions, \
 #   but be careful: if the function rejects all attempts, the playlist will \
 #   enter into a consuming loop and stop playing anything.
-# @param ~length How many requests should be queued in advance.
+# @param ~prefetch How many requests should be queued in advance.
 # @param ~loop Loop on the playlist.
 # @param ~mime_type Default MIME type for the playlist. Empty string means \
 #  automatic detection.
@@ -62,7 +62,7 @@ let stdlib_native = native
 # @param ~timeout Timeout (in sec.) for a single download.
 # @param playlist Playlist.
 # @method reload Reload the playlist with given list of songs.
-def playlist.list(~id=null(), ~check_next=null(), ~length=2, ~loop=true, ~mime_type=null(),
+def playlist.list(~id=null(), ~check_next=null(), ~prefetch=2, ~loop=true, ~mime_type=null(),
                   ~mode="normal", ~native=false, ~on_done={()}, ~timeout=20., playlist)
   id = string.id.default(default="playlist.list", id)
   mode =
@@ -102,7 +102,7 @@ def playlist.list(~id=null(), ~check_next=null(), ~length=2, ~loop=true, ~mime_t
     if native then
       stdlib_native.request.dynamic.list(id=id, next)
     else
-      (request.dynamic.list(id=id, length=length, timeout=timeout, retry_delay=1., available={not !has_stopped}, next):source_methods)
+      (request.dynamic.list(id=id, prefetch=prefetch, timeout=timeout, retry_delay=1., available={not !has_stopped}, next):source_methods)
     end
   source.set_name(s, "playlist.list.reloadable")
 
@@ -178,7 +178,7 @@ end
 #   corresponding to local files. This is typically used to avoid repetitions, \
 #   but be careful: if the function rejects all attempts, the playlist will \
 #   enter into a consuming loop and stop playing anything.
-# @param ~length How many requests should be queued in advance.
+# @param ~prefetch How many requests should be queued in advance.
 # @param ~loop Loop on the playlist.
 # @param ~mime_type Default MIME type for the playlist. `null` means \
 #  automatic detection.
@@ -197,7 +197,7 @@ end
 # @method reload Reload the playlist.
 # @method length Length of the of the playlist (the number of songs it contains).
 def playlist.reloadable(
-  ~id=null(), ~check_next=null(), ~length=2, ~loop=true, ~mime_type=null(),
+  ~id=null(), ~check_next=null(), ~prefetch=2, ~loop=true, ~mime_type=null(),
   ~mode="randomize", ~native=false, ~on_done={()}, ~on_reload=(fun (_) -> ()),
   ~prefix="", ~timeout=20., uri) =
   id = string.id.default(default="playlist.reloadable", id)
@@ -218,7 +218,7 @@ def playlist.reloadable(
   files := load_playlist()
 
   s = playlist.list(
-    id=id, check_next=check_next, length=length,
+    id=id, check_next=check_next, prefetch=prefetch,
     loop=loop, mime_type=mime_type, mode=mode,
     native=native, on_done=on_done, timeout=timeout,
     !files)
@@ -252,7 +252,7 @@ end
 #   corresponding to local files. This is typically used to avoid repetitions, \
 #   but be careful: if the function rejects all attempts, the playlist will \
 #   enter into a consuming loop and stop playing anything.
-# @param ~length How many requests should be queued in advance.
+# @param ~prefetch How many requests should be queued in advance.
 # @param ~loop Loop on the playlist.
 # @param ~mime_type Default MIME type for the playlist. `null` means automatic \
 #  detection.
@@ -275,7 +275,7 @@ end
 # @method reload Reload the playlist.
 # @method length Length of the of the playlist (the number of songs it contains).
 def replaces playlist(
-  ~id=null(), ~check_next=null(), ~length=2, ~loop=true, 
+  ~id=null(), ~check_next=null(), ~prefetch=2, ~loop=true, 
   ~mime_type=null(), ~mode="randomize", ~native=false, ~on_reload=(fun (_) -> ()),
   ~prefix="", ~reload=0, ~reload_mode="seconds", ~timeout=20., uri) =
   id = string.id.default(default="playlist", id)
@@ -314,7 +314,7 @@ def replaces playlist(
   end 
 
   s = playlist.reloadable(
-    id=id, check_next=check_next, length=length, loop=loop,
+    id=id, check_next=check_next, prefetch=prefetch, loop=loop,
     mime_type=mime_type, mode=mode, native=native, on_done=on_done,
     prefix=prefix, timeout=timeout, on_reload=on_reload, !uri)
 

--- a/libs/playlist.liq
+++ b/libs/playlist.liq
@@ -49,10 +49,7 @@ let stdlib_native = native
 #   corresponding to local files. This is typically used to avoid repetitions, \
 #   but be careful: if the function rejects all attempts, the playlist will \
 #   enter into a consuming loop and stop playing anything.
-# @param ~conservative If true, estimated remaining time on the current track \
-#   is not considered when computing queue length.
-# @param ~default_duration When unknown, assume this duration (in sec.) for files.
-# @param ~length How much audio (in sec.) should be queued in advance.
+# @param ~length How many requests should be queued in advance.
 # @param ~loop Loop on the playlist.
 # @param ~mime_type Default MIME type for the playlist. Empty string means \
 #  automatic detection.
@@ -65,7 +62,8 @@ let stdlib_native = native
 # @param ~timeout Timeout (in sec.) for a single download.
 # @param playlist Playlist.
 # @method reload Reload the playlist with given list of songs.
-def playlist.list(~id=null(), ~check_next=null(), ~conservative=false, ~default_duration=30., ~length=10., ~loop=true, ~mime_type=null(), ~mode="normal", ~native=false, ~on_done={()}, ~timeout=20., playlist)
+def playlist.list(~id=null(), ~check_next=null(), ~length=2, ~loop=true, ~mime_type=null(),
+                  ~mode="normal", ~native=false, ~on_done={()}, ~timeout=20., playlist)
   id = string.id.default(default="playlist.list", id)
   mode =
     if not list.mem(mode, ["normal", "random", "randomize"]) then
@@ -104,7 +102,7 @@ def playlist.list(~id=null(), ~check_next=null(), ~conservative=false, ~default_
     if native then
       stdlib_native.request.dynamic.list(id=id, next)
     else
-      (request.dynamic.list(id=id, conservative=conservative, default_duration=default_duration, length=length, timeout=timeout, retry_delay=1., available={not !has_stopped}, next):source_methods)
+      (request.dynamic.list(id=id, length=length, timeout=timeout, retry_delay=1., available={not !has_stopped}, next):source_methods)
     end
   source.set_name(s, "playlist.list.reloadable")
 
@@ -180,10 +178,7 @@ end
 #   corresponding to local files. This is typically used to avoid repetitions, \
 #   but be careful: if the function rejects all attempts, the playlist will \
 #   enter into a consuming loop and stop playing anything.
-# @param ~conservative If true, estimated remaining time on the current track \
-#   is not considered when computing queue length.
-# @param ~default_duration When unknown, assume this duration (in sec.) for files.
-# @param ~length How much audio (in sec.) should be queued in advance.
+# @param ~length How many requests should be queued in advance.
 # @param ~loop Loop on the playlist.
 # @param ~mime_type Default MIME type for the playlist. `null` means \
 #  automatic detection.
@@ -202,9 +197,9 @@ end
 # @method reload Reload the playlist.
 # @method length Length of the of the playlist (the number of songs it contains).
 def playlist.reloadable(
-  ~id=null(), ~check_next=null(), ~conservative=false, ~default_duration=30.,
-  ~length=10., ~loop=true, ~mime_type=null(), ~mode="randomize", ~native=false,
-  ~on_done={()}, ~on_reload=(fun (_) -> ()), ~prefix="", ~timeout=20., uri) =
+  ~id=null(), ~check_next=null(), ~length=2, ~loop=true, ~mime_type=null(),
+  ~mode="randomize", ~native=false, ~on_done={()}, ~on_reload=(fun (_) -> ()),
+  ~prefix="", ~timeout=20., uri) =
   id = string.id.default(default="playlist.reloadable", id)
   # URI of the current playlist
   playlist_uri=ref(uri)
@@ -223,10 +218,10 @@ def playlist.reloadable(
   files := load_playlist()
 
   s = playlist.list(
-    id=id, check_next=check_next, conservative=conservative,
-    default_duration=default_duration, length=length, loop=loop,
-    mime_type=mime_type, mode=mode, native=native, on_done=on_done,
-    timeout=timeout, !files)
+    id=id, check_next=check_next, length=length,
+    loop=loop, mime_type=mime_type, mode=mode,
+    native=native, on_done=on_done, timeout=timeout,
+    !files)
 
   source.set_name(s, "playlist.reloadable")
 
@@ -257,10 +252,7 @@ end
 #   corresponding to local files. This is typically used to avoid repetitions, \
 #   but be careful: if the function rejects all attempts, the playlist will \
 #   enter into a consuming loop and stop playing anything.
-# @param ~conservative If true, estimated remaining time on the current track \
-#   is not considered when computing queue length.
-# @param ~default_duration When unknown, assume this duration (in sec.) for files.
-# @param ~length How much audio (in sec.) should be queued in advance.
+# @param ~length How many requests should be queued in advance.
 # @param ~loop Loop on the playlist.
 # @param ~mime_type Default MIME type for the playlist. `null` means automatic \
 #  detection.
@@ -283,9 +275,9 @@ end
 # @method reload Reload the playlist.
 # @method length Length of the of the playlist (the number of songs it contains).
 def replaces playlist(
-  ~id=null(), ~check_next=null(), ~conservative=false, ~default_duration=30.,
-  ~length=10., ~loop=true, ~mime_type=null(), ~mode="randomize", ~native=false,
-  ~on_reload=(fun (_) -> ()), ~prefix="", ~reload=0, ~reload_mode="seconds", ~timeout=20., uri) =
+  ~id=null(), ~check_next=null(), ~length=2, ~loop=true, 
+  ~mime_type=null(), ~mode="randomize", ~native=false, ~on_reload=(fun (_) -> ()),
+  ~prefix="", ~reload=0, ~reload_mode="seconds", ~timeout=20., uri) =
   id = string.id.default(default="playlist", id)
 
   reload_mode =
@@ -322,11 +314,9 @@ def replaces playlist(
   end 
 
   s = playlist.reloadable(
-    id=id, check_next=check_next, conservative=conservative,
-    default_duration=default_duration, length=length, loop=loop,
+    id=id, check_next=check_next, length=length, loop=loop,
     mime_type=mime_type, mode=mode, native=native, on_done=on_done,
-    prefix=prefix, timeout=timeout, on_reload=on_reload,
-    !uri)
+    prefix=prefix, timeout=timeout, on_reload=on_reload, !uri)
 
   reloader_ref := s.reload
 

--- a/libs/request.liq
+++ b/libs/request.liq
@@ -2,20 +2,13 @@ let request.queue = ()
 
 let stdlib_native = native
 
-# Play requests dynamically created by a given function.
-# @category Source / Input
-# @param ~id Force the value of the source ID.
-# @param ~available Whether some new requests are available (when set to false, it stops after current playing request).
-# @param ~prefetch How many requests should be queued in advance.
+# @docof request.dynamic.list
 # @param ~native Use native implementation.
-# @param ~retry_delay Retry after a given time (in seconds) when callback returns an empty list.
-# @param ~timeout Timeout (in sec.) for a single download.
-# @param f Function producing requests.
-def replaces request.dynamic(~id=null(), ~available={true}, ~retry_delay=0.1, ~prefetch=1, ~timeout=20., ~native=false, f) =
+def replaces request.dynamic(%argsof(request.dynamic.list), ~native=false, f) =
   if native then
-    stdlib_native.request.dynamic(id=id, timeout=timeout, f)
+    stdlib_native.request.dynamic(id=id, timeout=timeout, prefetch=prefetch, f)
   else
-    request.dynamic.list(id=id, available=available, retry_delay=retry_delay, prefetch=prefetch, timeout=timeout, {null.to_list(f())})
+    request.dynamic.list(%argsof(request.dynamic.list), {null.to_list(f())})
   end
 end
 

--- a/libs/request.liq
+++ b/libs/request.liq
@@ -13,7 +13,7 @@ let stdlib_native = native
 # @param f Function producing requests.
 def replaces request.dynamic(~id=null(), ~available={true}, ~retry_delay=0.1, ~prefetch=2, ~timeout=20., ~native=false, f) =
   if native then
-    stdlib_native.request.dynamic(id=id, timeout=timeout, f).{prefetch = fun() -> (), queue_length = fun() -> 0.}
+    stdlib_native.request.dynamic(id=id, timeout=timeout, f).{prefetch = fun() -> true}
   else
     request.dynamic.list(id=id, available=available, retry_delay=retry_delay, prefetch=prefetch, timeout=timeout, {null.to_list(f())})
   end

--- a/libs/request.liq
+++ b/libs/request.liq
@@ -6,16 +6,16 @@ let stdlib_native = native
 # @category Source / Input
 # @param ~id Force the value of the source ID.
 # @param ~available Whether some new requests are available (when set to false, it stops after current playing request).
-# @param ~length How many requests should be queued in advance.
+# @param ~prefetch How many requests should be queued in advance.
 # @param ~native Use native implementation.
 # @param ~retry_delay Retry after a given time (in seconds) when callback returns an empty list.
 # @param ~timeout Timeout (in sec.) for a single download.
 # @param f Function producing requests.
-def replaces request.dynamic(~id=null(), ~available={true}, ~retry_delay=0.1, ~length=2, ~timeout=20., ~native=false, f) =
+def replaces request.dynamic(~id=null(), ~available={true}, ~retry_delay=0.1, ~prefetch=2, ~timeout=20., ~native=false, f) =
   if native then
     stdlib_native.request.dynamic(id=id, timeout=timeout, f).{prefetch = fun() -> (), queue_length = fun() -> 0.}
   else
-    request.dynamic.list(id=id, available=available, retry_delay=retry_delay, length=length, timeout=timeout, {null.to_list(f())})
+    request.dynamic.list(id=id, available=available, retry_delay=retry_delay, prefetch=prefetch, timeout=timeout, {null.to_list(f())})
   end
 end
 
@@ -23,13 +23,13 @@ end
 # @category Source / Track Processing
 # @param ~id Force the value of the source ID.
 # @param ~interactive Should the queue be controllable via telnet?
-# @param ~length How many requests should be queued in advance.
+# @param ~prefetch How many requests should be queued in advance.
 # @param ~native Use native implementation.
 # @param ~queue Initial queue of requests.
 # @param ~timeout Timeout (in sec.) for a single download.
 # @method push Push a request on the request queue.
 # @method length Length of the queue.
-def request.queue(~id=null(), ~interactive=true, ~length=2, ~native=false, ~queue=[], ~timeout=20.)
+def request.queue(~id=null(), ~interactive=true, ~prefetch=2, ~native=false, ~queue=[], ~timeout=20.)
   id = string.id.default(default="request.queue", id)
   queue = ref(queue)
   def next()
@@ -49,7 +49,7 @@ def request.queue(~id=null(), ~interactive=true, ~length=2, ~native=false, ~queu
     if native then
       stdlib_native.request.dynamic.list(id=id, timeout=timeout, next)
     else
-      (request.dynamic.list(id=id, length=length, timeout=timeout, available={not list.is_empty(!queue)}, next) : source_methods)
+      (request.dynamic.list(id=id, prefetch=prefetch, timeout=timeout, available={not list.is_empty(!queue)}, next) : source_methods)
     end
   source.set_name(s, "request.queue")
   if interactive then

--- a/libs/request.liq
+++ b/libs/request.liq
@@ -11,7 +11,7 @@ let stdlib_native = native
 # @param ~retry_delay Retry after a given time (in seconds) when callback returns an empty list.
 # @param ~timeout Timeout (in sec.) for a single download.
 # @param f Function producing requests.
-def replaces request.dynamic(~id=null(), ~available={true}, ~retry_delay=0.1, ~prefetch=2, ~timeout=20., ~native=false, f) =
+def replaces request.dynamic(~id=null(), ~available={true}, ~retry_delay=0.1, ~prefetch=1, ~timeout=20., ~native=false, f) =
   if native then
     stdlib_native.request.dynamic(id=id, timeout=timeout, f).{prefetch = fun() -> true}
   else
@@ -29,7 +29,7 @@ end
 # @param ~timeout Timeout (in sec.) for a single download.
 # @method push Push a request on the request queue.
 # @method length Length of the queue.
-def request.queue(~id=null(), ~interactive=true, ~prefetch=2, ~native=false, ~queue=[], ~timeout=20.)
+def request.queue(~id=null(), ~interactive=true, ~prefetch=1, ~native=false, ~queue=[], ~timeout=20.)
   id = string.id.default(default="request.queue", id)
   queue = ref(queue)
   def next()

--- a/libs/request.liq
+++ b/libs/request.liq
@@ -13,7 +13,7 @@ let stdlib_native = native
 # @param f Function producing requests.
 def replaces request.dynamic(~id=null(), ~available={true}, ~retry_delay=0.1, ~prefetch=1, ~timeout=20., ~native=false, f) =
   if native then
-    stdlib_native.request.dynamic(id=id, timeout=timeout, f).{prefetch = fun() -> true}
+    stdlib_native.request.dynamic(id=id, timeout=timeout, f)
   else
     request.dynamic.list(id=id, available=available, retry_delay=retry_delay, prefetch=prefetch, timeout=timeout, {null.to_list(f())})
   end

--- a/libs/request.liq
+++ b/libs/request.liq
@@ -6,34 +6,30 @@ let stdlib_native = native
 # @category Source / Input
 # @param ~id Force the value of the source ID.
 # @param ~available Whether some new requests are available (when set to false, it stops after current playing request).
-# @param ~conservative If true, estimated remaining time on the current track is not considered when computing queue length.
-# @param ~default_duration When unknown, assume this duration (in sec.) for files.
-# @param ~length How much audio (in sec.) should be queued in advance.
+# @param ~length How many requests should be queued in advance.
 # @param ~native Use native implementation.
 # @param ~retry_delay Retry after a given time (in seconds) when callback returns an empty list.
 # @param ~timeout Timeout (in sec.) for a single download.
 # @param f Function producing requests.
-def replaces request.dynamic(~id=null(), ~available={true}, ~retry_delay=0.1, ~conservative=false, ~default_duration=30., ~length=10., ~timeout=20., ~native=false, f) =
+def replaces request.dynamic(~id=null(), ~available={true}, ~retry_delay=0.1, ~length=2, ~timeout=20., ~native=false, f) =
   if native then
     stdlib_native.request.dynamic(id=id, timeout=timeout, f).{prefetch = fun() -> (), queue_length = fun() -> 0.}
   else
-    request.dynamic.list(id=id, available=available, retry_delay=retry_delay, conservative=conservative, default_duration=default_duration, length=length, timeout=timeout, {null.to_list(f())})
+    request.dynamic.list(id=id, available=available, retry_delay=retry_delay, length=length, timeout=timeout, {null.to_list(f())})
   end
 end
 
 # Play a queue of uris. Returns a function to push new uris in the queue as well as the resulting source.
 # @category Source / Track Processing
 # @param ~id Force the value of the source ID.
-# @param ~conservative If true, estimated remaining time on the current track is not considered when computing queue length.
-# @param ~default_duration When unknown, assume this duration (in sec.) for files.
 # @param ~interactive Should the queue be controllable via telnet?
-# @param ~length How much audio (in sec.) should be queued in advance.
+# @param ~length How many requests should be queued in advance.
 # @param ~native Use native implementation.
 # @param ~queue Initial queue of requests.
 # @param ~timeout Timeout (in sec.) for a single download.
 # @method push Push a request on the request queue.
 # @method length Length of the queue.
-def request.queue(~id=null(), ~conservative=false, ~default_duration=30., ~interactive=true, ~length=40., ~native=false, ~queue=[], ~timeout=20.)
+def request.queue(~id=null(), ~interactive=true, ~length=2, ~native=false, ~queue=[], ~timeout=20.)
   id = string.id.default(default="request.queue", id)
   queue = ref(queue)
   def next()
@@ -53,7 +49,7 @@ def request.queue(~id=null(), ~conservative=false, ~default_duration=30., ~inter
     if native then
       stdlib_native.request.dynamic.list(id=id, timeout=timeout, next)
     else
-      (request.dynamic.list(id=id, conservative=conservative, default_duration=default_duration, length=length, timeout=timeout, available={not list.is_empty(!queue)}, next) : source_methods)
+      (request.dynamic.list(id=id, length=length, timeout=timeout, available={not list.is_empty(!queue)}, next) : source_methods)
     end
   source.set_name(s, "request.queue")
   if interactive then

--- a/src/sources/request_simple.ml
+++ b/src/sources/request_simple.ml
@@ -73,10 +73,10 @@ class unqueued ~kind ~timeout request =
     method get_next_file = Some request
   end
 
-class queued ~kind uri length timeout =
+class queued ~kind uri prefetch timeout =
   object (self)
     inherit
-      Request_source.queued ~name:"single" ~kind ~length ~timeout () as super
+      Request_source.queued ~name:"single" ~kind ~prefetch ~timeout () as super
 
     method wake_up x =
       if String.length uri < 15 then self#set_id uri;
@@ -127,11 +127,11 @@ let () =
       let kind = Source.Kind.of_kind kind in
       (new unqueued ~kind ~timeout:60. request :> source))
 
-class dynamic ~kind ~retry_delay ~available (f : Lang.value) length timeout =
+class dynamic ~kind ~retry_delay ~available (f : Lang.value) prefetch timeout =
   object (self)
     inherit
       Request_source.queued
-        ~kind ~name:"request.dynamic.list" ~length ~timeout () as super
+        ~kind ~name:"request.dynamic.list" ~prefetch ~timeout () as super
 
     val mutable retry_status = None
 

--- a/src/sources/request_simple.ml
+++ b/src/sources/request_simple.ml
@@ -206,20 +206,20 @@ let () =
      :: queued_proto)
     ~meth:
       [
-        ( "prefetch",
+        ( "fetch",
           ([], Lang.fun_t [] Lang.bool_t),
           "Try feeding the queue with a new request. Returns `true` if \
            successful. This method can take long to return and should usually \
            be run in a separate thread.",
           fun s ->
             Lang.val_fun [] (fun _ ->
-                match s#prefetch with
+                match s#fetch with
                   | `Finished -> Lang.bool true
                   | `Retry ->
-                      log#important "Prefetch failed: retry.";
+                      log#important "Fetch failed: retry.";
                       Lang.bool false
                   | `Empty ->
-                      log#important "Prefetch failed: empty.";
+                      log#important "Fetch failed: empty.";
                       Lang.bool false) );
         ( "queue",
           ([], Lang.fun_t [] (Lang.list_t Lang.request_t)),

--- a/src/sources/request_simple.ml
+++ b/src/sources/request_simple.ml
@@ -230,6 +230,18 @@ let () =
                   (Queue.fold
                      (fun c i -> Lang.request i.request :: c)
                      [] s#queue)) );
+        ( "add",
+          ([], Lang.fun_t [(false, "", Lang.request_t)] Lang.bool_t),
+          "Add a request ot the queue. Requests are resolved before being \
+           added. Returns `true` if the request was successfully added.",
+          fun s ->
+            Lang.val_fun [("", "", None)] (fun p ->
+                Lang.bool
+                  (s#add
+                     {
+                       request = Lang.to_request (List.assoc "" p);
+                       expired = false;
+                     })) );
         ( "set_queue",
           ([], Lang.fun_t [(false, "", Lang.list_t Lang.request_t)] Lang.unit_t),
           "Set the queue of requests. Requests are resolved before being added \

--- a/src/sources/request_source.ml
+++ b/src/sources/request_source.ml
@@ -248,7 +248,6 @@ class virtual unqueued ~kind ~name =
 
 type queue_item = {
   request : Request.t;
-  duration : float;
   (* in seconds *)
   mutable expired : bool;
 }
@@ -259,47 +258,20 @@ let priority = Tutils.Maybe_blocking
 (** Same thing, with a queue in which we prefetch files, which requests are
     given by [get_next_request]. Heuristical settings determining how the source
     feeds its queue:
-    - the source tries to have more than [length] seconds in queue
-    - if the duration of a file is unknown we use [default_duration] seconds
+    - the source tries to have more than [length] requests in queue
     - downloading a file is required to take less than [timeout] seconds
    *)
-class virtual queued ~kind ~name ?(length = 10.) ?(default_duration = 30.)
-  ?(conservative = false) ?(timeout = 20.) () =
+class virtual queued ~kind ~name ?(length = 2) ?(timeout = 20.) () =
   object (self)
     inherit unqueued ~kind ~name as super
     method stype = Fallible
     method virtual get_next_request : Request.t option
-
-    (** Management of the queue of files waiting to be played. *)
-    val min_queue_length = length
-
     val qlock = Mutex.create ()
     val retrieved : queue_item Queue.t = Queue.create ()
-    val mutable queue_length = 0.
-    method queue_length = queue_length
     method queue_size = Queue.length retrieved
 
     (* Seconds *)
     val mutable resolving = None
-
-    (** [available_length] is the length of the queue plus the remaining time in
-      the current track (0 in conservative mode). Although [queue_length]
-      should be accessed under [qlock] we don't do it here, and more
-      importantly, all the instances of "if self#available_length <
-      min_queue_length then ..." are not run within [qlock]'s critical
-      section. The potential race condition (there seems to be enough, then the
-      length decreases but we have already decided to take no action) is
-      harmless because all the portions of the code that decrease the length
-      trigger the appropriate action (feeding) themselves. *)
-    method private available_length =
-      if conservative then queue_length
-      else (
-        let remaining = self#remaining in
-        if remaining < 0 then
-          (* There is a track available but we don't know its duration at this
-             point. Hence, using default_duration. *)
-          queue_length +. default_duration
-        else queue_length +. Frame.seconds_of_main remaining)
 
     (** State should be `Sleeping on awakening, and is then turned to `Running.
       Eventually #sleep puts it to `Tired, then waits for it to be `Sleeping,
@@ -417,13 +389,11 @@ class virtual queued ~kind ~name ?(length = 10.) ?(default_duration = 30.)
                    *    emptied, but Sleeping saves us). *)
                   false)
           ()
-        && self#available_length < min_queue_length
+        && self#queue_size < length
       then (
         match self#prefetch with
           | `Finished ->
-              (* Retry again in order to make sure that we have enough data (in
-                 particular, when being conservative and starting on empty we need
-                 to fetch two requests). *)
+              (* Retry again in order to make sure that we have enough data *)
               0.5
           | `Retry -> adaptative_delay ()
           | `Empty -> -1.)
@@ -440,12 +410,6 @@ class virtual queued ~kind ~name ?(length = 10.) ?(default_duration = 30.)
             resolving <- Some req;
             match Request.resolve ~ctype:(Some self#ctype) req timeout with
               | Request.Resolved ->
-                  let len =
-                    match Request.get_metadata req "duration" with
-                      | Some f -> (
-                          try float_of_string f with _ -> default_duration)
-                      | None -> default_duration
-                  in
                   let rec remove_expired n =
                     if n = 0 then ()
                     else (
@@ -458,14 +422,8 @@ class virtual queued ~kind ~name ?(length = 10.) ?(default_duration = 30.)
                   in
                   Mutex.lock qlock;
                   remove_expired (Queue.length retrieved);
-                  Queue.add
-                    { request = req; duration = len; expired = false }
-                    retrieved;
-                  self#log#info
-                    "Remaining: %.1fs, queued: %.1fs, adding: %.1fs (RID %d)"
-                    (Frame.seconds_of_main self#remaining)
-                    queue_length len (Request.get_id req);
-                  queue_length <- queue_length +. len;
+                  Queue.add { request = req; expired = false } retrieved;
+                  self#log#info "Queued %d requests" self#queue_size;
                   Mutex.unlock qlock;
                   resolving <- None;
                   `Finished
@@ -481,10 +439,7 @@ class virtual queued ~kind ~name ?(length = 10.) ?(default_duration = 30.)
       let ans =
         try
           let r = Queue.take retrieved in
-          self#log#info "Remaining: %.1fs, queued: %.1fs, taking: %.1fs"
-            (Frame.seconds_of_main self#remaining)
-            queue_length r.duration;
-          if not r.expired then queue_length <- queue_length -. r.duration;
+          self#log#info "Remaining %d requests" self#queue_size;
           Some r.request
         with Queue.Empty ->
           self#log#debug "Queue is empty!";
@@ -494,24 +449,17 @@ class virtual queued ~kind ~name ?(length = 10.) ?(default_duration = 30.)
 
       (* A request has been taken off the queue, there is a chance that the
          queue should be refilled: awaken the feeding task. However, we can wait
-         that this file is played, and this need will be noticed in #get_frame.
-         This is critical in non-conservative mode because at this point
-         remaining is still 0 (we're inside #begin_track) which would lead to
-         too early prefetching; if we wait that a frame has been produced, we'll
-         get the first non-infinite remaining time estimations. *)
+         that this file is played, and this need will be noticed in #get_frame. *)
       ans
 
     method private expire test =
-      let already_short = self#available_length < min_queue_length in
+      let already_short = self#queue_size < length in
       Mutex.lock qlock;
       Queue.iter
-        (fun r ->
-          if test r.request && not r.expired then (
-            r.expired <- true;
-            queue_length <- queue_length -. r.duration))
+        (fun r -> if test r.request && not r.expired then r.expired <- true)
         retrieved;
       Mutex.unlock qlock;
-      if self#available_length < min_queue_length then (
+      if self#queue_size < length then (
         if not already_short then
           self#log#info "Expirations made the queue too short, feeding...";
 
@@ -523,7 +471,7 @@ class virtual queued ~kind ~name ?(length = 10.) ?(default_duration = 30.)
 
       (* At an end of track, we always have unqueued#remaining=0, so there's
          nothing special to do. *)
-      if self#available_length < min_queue_length then self#notify_new_request
+      if self#queue_size < length then self#notify_new_request
 
     method copy_queue =
       Mutex.lock qlock;
@@ -537,19 +485,9 @@ class virtual queued ~kind ~name ?(length = 10.) ?(default_duration = 30.)
 let queued_proto =
   [
     ( "length",
-      Lang.float_t,
-      Some (Lang.float 40.),
-      Some "How much audio (in sec.) should be queued in advance." );
-    ( "default_duration",
-      Lang.float_t,
-      Some (Lang.float 30.),
-      Some "When unknown, assume this duration (in sec.) for files." );
-    ( "conservative",
-      Lang.bool_t,
-      Some (Lang.bool false),
-      Some
-        "If true, estimated remaining time on the current track is not \
-         considered when computing queue length." );
+      Lang.int_t,
+      Some (Lang.int 2),
+      Some "How many requests should be queued in advance." );
     ( "timeout",
       Lang.float_t,
       Some (Lang.float 20.),
@@ -557,8 +495,6 @@ let queued_proto =
   ]
 
 let extract_queued_params p =
-  let l = Lang.to_float (List.assoc "length" p) in
-  let d = Lang.to_float (List.assoc "default_duration" p) in
+  let l = Lang.to_int (List.assoc "length" p) in
   let t = Lang.to_float (List.assoc "timeout" p) in
-  let c = Lang.to_bool (List.assoc "conservative" p) in
-  (l, d, t, c)
+  (l, t)

--- a/src/sources/request_source.ml
+++ b/src/sources/request_source.ml
@@ -408,7 +408,7 @@ class virtual queued ~kind ~name ?(prefetch = 1) ?(timeout = 20.) () =
           ()
         && self#queue_size < prefetch
       then (
-        match self#prefetch with
+        match self#fetch with
           | `Finished ->
               (* Retry again in order to make sure that we have enough data *)
               0.5
@@ -420,7 +420,7 @@ class virtual queued ~kind ~name ?(prefetch = 1) ?(timeout = 20.) () =
       Empty if there was no new request to try,
       Retry if there was a new one but it failed to be resolved,
       Finished if all went OK. *)
-    method prefetch =
+    method fetch =
       match self#get_next_request with
         | None -> `Empty
         | Some req -> (

--- a/src/sources/request_source.ml
+++ b/src/sources/request_source.ml
@@ -262,7 +262,7 @@ let priority = Tutils.Maybe_blocking
     - the source tries to have more than [prefetch] requests in queue
     - downloading a file is required to take less than [timeout] seconds
    *)
-class virtual queued ~kind ~name ?(prefetch = 2) ?(timeout = 20.) () =
+class virtual queued ~kind ~name ?(prefetch = 1) ?(timeout = 20.) () =
   object (self)
     inherit unqueued ~kind ~name as super
     method stype = Fallible
@@ -484,7 +484,7 @@ let queued_proto =
   [
     ( "prefetch",
       Lang.int_t,
-      Some (Lang.int 2),
+      Some (Lang.int 1),
       Some "How many requests should be queued in advance." );
     ( "timeout",
       Lang.float_t,

--- a/src/sources/request_source.mli
+++ b/src/sources/request_source.mli
@@ -58,7 +58,7 @@ class virtual unqueued :
 class virtual queued :
   kind:Source.Kind.t
   -> name:string
-  -> ?length:int
+  -> ?prefetch:int
   -> ?timeout:float
   -> unit
   -> object

--- a/src/sources/request_source.mli
+++ b/src/sources/request_source.mli
@@ -101,6 +101,7 @@ class virtual queued :
 
        method queue : queue_item Queue.t
        method set_queue : queue_item Queue.t -> unit
+       method add : queue_item -> bool
      end
 
 val queued_proto : Lang.proto

--- a/src/sources/request_source.mli
+++ b/src/sources/request_source.mli
@@ -97,7 +97,7 @@ class virtual queued :
 
        (** Try to add a new request in the queue. This should be used in usual
            situations. *)
-       method prefetch : [ `Finished | `Retry | `Empty ]
+       method fetch : [ `Finished | `Retry | `Empty ]
 
        method queue : queue_item Queue.t
        method set_queue : queue_item Queue.t -> unit

--- a/src/sources/request_source.mli
+++ b/src/sources/request_source.mli
@@ -29,19 +29,12 @@ class once :
   -> Request.t
   -> object
        inherit Source.source
-
        method stype : Source.source_t
-
        method self_sync : Source.self_sync
-
        method is_ready : bool
-
        method remaining : int
-
        method private get_frame : Frame.t -> unit
-
        method resolve : bool
-
        method abort_track : unit
      end
 
@@ -54,31 +47,22 @@ class virtual unqueued :
        method virtual get_next_file : Request.t option
 
        inherit Source.source
-
        method is_ready : bool
-
        method private get_frame : Frame.t -> unit
-
        method abort_track : unit
-
        method copy_queue : Request.t list
-
        method remaining : int
-
        method self_sync : Source.self_sync
      end
 
 class virtual queued :
   kind:Source.Kind.t
   -> name:string
-  -> ?length:float
-  -> ?default_duration:float
-  -> ?conservative:bool
+  -> ?length:int
   -> ?timeout:float
   -> unit
   -> object
        method copy_queue : Request.t list
-
        method stype : Source.source_t
 
        (** You should only define this. *)
@@ -104,10 +88,7 @@ class virtual queued :
 
        (** Number of requests in the queue. *)
        method queue_size : int
-
-       (** Size of the queue. *)
-       method queue_length : float
      end
 
 val queued_proto : Lang.proto
-val extract_queued_params : Lang.env -> float * float * float * bool
+val extract_queued_params : Lang.env -> int * float

--- a/tests/streams/request.liq
+++ b/tests/streams/request.liq
@@ -18,6 +18,10 @@ def f() =
   if not r.is_ready() then
     0.1
   else
+    if not r.add(request.create("file2.mp3")) then
+      test.fail()
+    end
+
     r.set_queue([
       request.create("file2.mp3"),
       request.create("file3.mp3")

--- a/tests/streams/request.liq
+++ b/tests/streams/request.liq
@@ -1,0 +1,49 @@
+#!../../src/liquidsoap ../../libs/stdlib.liq ../../libs/deprecations.liq
+
+# Basic request tests
+
+%include "test.liq"
+
+settings.log.level.set(4)
+
+def next() =
+  [request.create("file1.mp3")]
+end
+
+r = request.dynamic.list(prefetch=1, next)
+
+output.dummy(fallible=true, r)
+
+def f() =
+  if not r.is_ready() then
+    0.1
+  else
+    r.set_queue([
+      request.create("file2.mp3"),
+      request.create("file3.mp3")
+    ])
+  
+    q = r.queue()
+
+    if list.length(q) != 2 then
+      test.fail()
+    end
+
+    c = r.current()
+
+    if not null.defined(c) then
+      test.fail()
+    end
+
+    c = null.get(c)
+    if request.filename(c) != "file1.mp3" then
+      test.fail()
+    end
+
+    test.pass()
+
+    (-1.)
+  end
+end
+
+thread.run.recurrent(f)


### PR DESCRIPTION
This is probably one of the most confusing aspect of liquidsoap: how requests are queued.

The current schema uses a combination of:
* `length`, to express how much media length, in seconds should be available in the queue
* `default_duration` to assign a default duration to newly queued requests when not provided. Historically, because computing requests length used to be very costly, this is in practice the assigned duration of any new requests before it starts being played.
* `conservative` to enforce (?) strict duration computation.

The result is a very confusing algorithm where it becomes pretty tricky to say: "I want one/two/3 requests in the queue at all time".

This PR changes this behavior to simply implement that: let the user say, I want one, two, 3, .. requests in the queue at all time.

This is a breaking change but I believe it should make everyone's life MUCH easier.