### PR TITLE
DTMF detection.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -89,7 +89,7 @@ New:
   should be printed.
 - Added `input.rtmp` (#1640).
 - Added `%ifversion` and `%else` preprocessing commands (#1682).
-- Added `dtmf` to generate DTMF tones (#1796).
+- Added `dtmf` and `dtmf.detect` to generate and detect DTMF tones (#1796).
 
 Changed:
 

--- a/libs/sound.liq
+++ b/libs/sound.liq
@@ -202,7 +202,7 @@ end
 # @param ~duration Duration of a tone (in seconds).
 # @param ~delay Dealy between two successive tones (in seconds).
 # @param dtmf String describing DTMF tones to generates: it should contains characters 0 to 9, A to D, or * or #.
-def dtmf(~duration=0.1, ~delay=0.05, dtmf)
+def replaces dtmf(~duration=0.1, ~delay=0.05, dtmf)
   l = ref([])
   for i = 0 to string.length(dtmf) - 1 do
     c = string.sub(dtmf, start=i, length=1)

--- a/src/Makefile
+++ b/src/Makefile
@@ -95,7 +95,7 @@ operators = \
 	operators/chord.ml operators/video_text.ml operators/window_op.ml \
 	operators/rms_smooth.ml operators/delay_line.ml \
 	operators/video_text_native.ml operators/accelerate.ml \
-	operators/still_frame.ml \
+	operators/still_frame.ml operators/dtmf.ml \
 	$(if $(W_SOUNDTOUCH),operators/soundtouch_op.ml) \
 	$(if $(W_SOUNDTOUCH),operators/st_bpm.ml) \
 	$(if $(W_LADSPA),operators/ladspa_op.ml) \

--- a/src/operators/dtmf.ml
+++ b/src/operators/dtmf.ml
@@ -110,6 +110,8 @@ class dtmf ~kind (source : source) =
       done
   end
 
+let () = Lang.add_module "dtmf"
+
 let () =
   let kind = Lang.audio_pcm in
   let k = Lang.kind_type_of_kind_format kind in

--- a/src/operators/dtmf.ml
+++ b/src/operators/dtmf.ml
@@ -144,7 +144,7 @@ class dtmf ~kind ~duration ~bands ~threshold ~smoothing ~debug callback
               in
               b.band_x <- ((1. -. alpha) *. b.band_x) +. (alpha *. x);
               (* Apparently we need to reset values, otherwise some unexpected
-                 band get high values over time. *)
+                 bands get high values over time. *)
               b.band_v <- 0.;
               b.band_v' <- 0.;
               if debug then (
@@ -170,14 +170,8 @@ class dtmf ~kind ~duration ~bands ~threshold ~smoothing ~debug callback
                   let k = try String.make 1 (key f) with Not_found -> "???" in
                   Printf.printf "Signaled key %s.\n" k );
             print_newline () );
-          (* We are looking for bands threshold times higher than the lowest band. *)
+          (* Find relevant bands. *)
           let found =
-            let threshold =
-              let min =
-                List.fold_left (fun m b -> min m b.band_x) infinity bands
-              in
-              min *. threshold
-            in
             List.filter_map
               (fun b -> if b.band_x > threshold then Some b.band_f else None)
               bands
@@ -224,7 +218,7 @@ let () =
         Some "Number of frequency bands." );
       ( "threshold",
         Lang.getter_t Lang.float_t,
-        Some (Lang.float 100.),
+        Some (Lang.float 2500.),
         Some "Threshold for detecting a band." );
       ( "smoothing",
         Lang.getter_t Lang.float_t,

--- a/src/operators/dtmf.ml
+++ b/src/operators/dtmf.ml
@@ -1,0 +1,122 @@
+(*****************************************************************************
+
+  Liquidsoap, a programmable audio stream generator.
+  Copyright 2003-2021 Savonet team
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details, fully stated in the COPYING
+  file at the root of the liquidsoap distribution.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA
+
+ *****************************************************************************)
+
+open Source
+
+(* DFT lines *)
+type line = {
+  line_k : int;
+  line_cos : float;
+  (* precomputed 2cos(2πk/N) *)
+  mutable line_v : float;
+  (* current value *)
+  mutable line_v' : float;
+  (* previous value *)
+  mutable line_v'' : float; (* previous previous value *)
+}
+
+class dtmf ~kind (source : source) =
+  let samplerate = float (Lazy.force Frame.audio_rate) in
+  (* Size of the DFT (usually noted N). *)
+  let size = 256 in
+  object (self)
+    inherit operator ~name:"dtmf" kind [source] as super
+
+    method stype = source#stype
+
+    method remaining = source#remaining
+
+    method seek = source#seek
+
+    method is_ready = source#is_ready
+
+    method abort_track = source#abort_track
+
+    method self_sync = source#self_sync
+
+    (* TODO: only compute required v *)
+    val v =
+      List.init size (fun k ->
+          {
+            line_k = k;
+            line_cos = 2. *. cos (2. *. Float.pi *. float k /. float size);
+            line_v = 0.;
+            line_v' = 0.;
+            line_v'' = 0.;
+          })
+
+    val mutable n = size
+
+    method wake_up a = super#wake_up a
+
+    (* let channels = self#audio_channels in *)
+    (* low <- Array.make channels 0.; *)
+    (* high <- Array.make channels 0.; *)
+    (* band <- Array.make channels 0.; *)
+    (* notch <- Array.make channels 0. *)
+
+    (* See
+       https://en.wikipedia.org/wiki/Goertzel_algorithm
+       https://web.archive.org/web/20180628024641/http://en.dsplib.org/content/goertzel/goertzel.html
+       https://www.ti.com/lit/pdf/spra096
+    *)
+    method private get_frame buf =
+      let offset = AFrame.position buf in
+      source#get buf;
+      let b = AFrame.pcm buf in
+      let position = AFrame.position buf in
+      (* let channels = self#audio_channels in *)
+      for i = offset to position - 1 do
+        (* TODO: mean of all channels *)
+        let x = b.(0).{i} in
+        List.iter
+          (fun l ->
+            l.line_v'' <- l.line_v';
+            l.line_v' <- l.line_v;
+            l.line_v <- (l.line_cos *. l.line_v') -. l.line_v'' +. x)
+          v;
+        n <- n + 1;
+        if n mod size = 0 then (
+          n <- n - size;
+          List.iter
+            (fun l ->
+              (* square of the value for the DFT line *)
+              let v = l.line_v *. l.line_v in
+              let v' = l.line_v' *. l.line_v' in
+              let x = v +. v' -. (l.line_cos *. v *. v') in
+              let f = float l.line_k /. float size *. samplerate in
+              Printf.printf "%d / %f : %f\n" l.line_k f x)
+            v;
+          print_newline () )
+      done
+  end
+
+let () =
+  let kind = Lang.audio_pcm in
+  let k = Lang.kind_type_of_kind_format kind in
+  Lang.add_operator "dtmf.detect"
+    [("", Lang.source_t k, None, None)]
+    ~return_t:k ~category:Lang.SoundProcessing ~descr:"Detect DTMF tones."
+    (fun p ->
+      let s = List.assoc "" p |> Lang.to_source in
+      let kind = Source.Kind.of_kind kind in
+      (new dtmf ~kind s :> Source.source))

--- a/tests/streams/dtmf.liq
+++ b/tests/streams/dtmf.liq
@@ -1,0 +1,28 @@
+#!../../src/liquidsoap ../../libs/stdlib.liq ../../libs/deprecations.liq
+
+%include "test.liq"
+
+log.level.set(4)
+
+keys = "1234567890*#ABCD"
+detected = ref("")
+
+def f(k)
+  print("Detected key #{k}")
+  detected := !detected ^ k
+  if k == "D" then
+    if !detected == keys then
+      test.pass()
+    else
+      test.fail()
+    end
+    shutdown()
+  end
+end
+
+s = amplify(1., dtmf(duration=0.1, keys))
+# s = add([s, amplify(0.1, noise())])
+s = dtmf.detect(debug=false, s, f)
+
+# output.dummy(s)
+output(s)

--- a/tests/streams/dtmf.liq
+++ b/tests/streams/dtmf.liq
@@ -24,5 +24,4 @@ s = amplify(0.5, dtmf(duration=0.1, keys))
 s = add([s, amplify(0.5, noise())])
 s = dtmf.detect(debug=false, s, f)
 
-# output.dummy(s)
-output(s)
+output.dummy(s)

--- a/tests/streams/dtmf.liq
+++ b/tests/streams/dtmf.liq
@@ -20,8 +20,8 @@ def f(k)
   end
 end
 
-s = amplify(1., dtmf(duration=0.1, keys))
-# s = add([s, amplify(0.1, noise())])
+s = amplify(0.5, dtmf(duration=0.1, keys))
+s = add([s, amplify(0.5, noise())])
 s = dtmf.detect(debug=false, s, f)
 
 # output.dummy(s)


### PR DESCRIPTION
Add `dtmf.detect` to detect DTMF tones. Fixes #1796.