### PR TITLE
Detect unused arguments in functions.

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,4 +1,4 @@
-version=0.18.0
+version=0.19.0
 profile = conventional
 break-separators = after
 space-around-lists = false

--- a/libs/fades.liq
+++ b/libs/fades.liq
@@ -389,8 +389,8 @@ def crossfade(~id=null(), ~duration=5.,~override_duration="liq_cross_duration",
       simple_transition
     end
 
-  cross(id=id, width=width, duration=duration, conservative=conservative,
-        minimum=minimum,transition,s)
+  cross(id=id, width=width, duration=duration, override_duration=override_duration,
+        conservative=conservative, minimum=minimum, transition, s)
 end
 
 # Mixes two streams, with faded transitions between the state when only the
@@ -420,7 +420,7 @@ def smooth_add(~duration=1., ~p=getter(0.2), ~normal, ~special)
   normal_volume = ref(fun () -> 1.)
   normal = c(normal_volume,normal)
 
-  def to_special(b,special) =
+  def to_special(_,special) =
     last_p := p()
     q = 1. - !last_p
     normal_volume := mkfade(start=1.,stop=!last_p,duration=duration,normal)

--- a/libs/ffmpeg.liq
+++ b/libs/ffmpeg.liq
@@ -5,7 +5,7 @@
 # @param ~max_buffer Maximum data buffer in seconds
 # @param ~device V4L2 device to use.
 def input.v4l2(~id=null(), ~max_buffer=0.5, ~device="/dev/video0")
-  (input.ffmpeg(format="v4l2", max_buffer=max_buffer, device):source(audio=none))
+  (input.ffmpeg(id=id, format="v4l2", max_buffer=max_buffer, device):source(audio=none))
 end
 
 # A test video source, which generates various patterns.
@@ -19,7 +19,7 @@ def video.testsrc(~id=null(), ~pattern="testsrc", ~max_buffer=0.5, ~duration=nul
   rate = "rate=#{video.frame.rate()}"
   duration = if null.defined(duration) then ":duration=#{duration}" else "" end
   src = "#{pattern}=#{size}:#{rate}#{duration}"
-  (input.ffmpeg(max_buffer=max_buffer, format="lavfi", src):source(audio=none))
+  (input.ffmpeg(id=id, max_buffer=max_buffer, format="lavfi", src):source(audio=none))
 end
 
 # Read an RTMP stream.

--- a/libs/gstreamer.liq
+++ b/libs/gstreamer.liq
@@ -34,7 +34,7 @@ let gstreamer.single = ()
 # @param uri URI of the file to be played.
 def gstreamer.single.audio(~id=null(),~on_error=fun(_)->3.,uri) =
   uri = getter.function(uri)
-  input.gstreamer.audio(pipeline={"filesrc location=\"#{uri()}\""})
+  input.gstreamer.audio(id=id, on_error=on_error, pipeline={"filesrc location=\"#{uri()}\""})
 end
 
 

--- a/libs/http.liq
+++ b/libs/http.liq
@@ -123,7 +123,7 @@ def harbor.http.static.base(serve,~content_type,~basepath,~headers,~browse,direc
 
   responseHeaders = headers
 
-  def handler(~method,~protocol,~data,~headers,uri)
+  def handler(~method,~protocol,~data=_,~headers=_,uri)
     ret = string.extract(pattern="^#{basepath}([^?]*)", uri)
     match =
       if list.length(ret) == 0 then "."

--- a/libs/interactive.liq
+++ b/libs/interactive.liq
@@ -119,6 +119,8 @@ def interactive.create(~name, ~description="", ~osc="", ~type)
       error.raise(error.not_found)
     end
   end
+%else
+  ignore(osc)
 %endif
 end
 
@@ -216,7 +218,7 @@ end
 # @param ~port Port of the server.
 # @param ~uri URI of the server.
 def interactive.harbor(~port=8000, ~uri="/interactive")
-  def webpage(~protocol, ~data, ~headers, uri)
+  def webpage(~protocol=_, ~data, ~headers=_, _)
     form_data = data
     data = ref("")
     def add(s) =
@@ -330,7 +332,7 @@ def interactive.harbor(~port=8000, ~uri="/interactive")
 
   harbor.http.register(port=port, method="GET", uri, webpage)
 
-  def setter(~protocol, ~data, ~headers, uri)
+  def setter(~protocol=_, ~data, ~headers=_, _)
     data = url.split_args(data)
     def update(nv)
       let (name, v) = nv

--- a/libs/io.liq
+++ b/libs/io.liq
@@ -75,6 +75,10 @@ def output.audio_video(~id=null(),~fallible=true,~on_start={()},~on_stop={()},~s
 end
 
 def replaces input(~id=null(),~start=true,~on_start={()},~on_stop={()},~fallible=false)
+  ignore(start)
+  ignore(on_start)
+  ignore(on_stop)
+  ignore(fallible)
   blank(id=id)
 end
 %ifdef input.alsa

--- a/libs/list.liq
+++ b/libs/list.liq
@@ -150,7 +150,7 @@ end
 # @param f Function `f` for which `f(x,e)` which will be called on every element `e` with the current value of `x`, returning the new value of `x`.
 # @param x Initial value x1, to be updated by successive calls of `f(x,e)`.
 def list.fold.right(f, x, l)
-  list.ind(l, x, fun (e, l, r) -> f(e, r))
+  list.ind(l, x, fun (e, _, r) -> f(e, r))
 end
 
 # Filter a list according to a predicate. The order in which elements are
@@ -177,20 +177,20 @@ end
 # Concatenate two lists.
 # @category List
 def list.append(l, m)
-  list.ind(l, m, fun (x, l, r) -> list.cons(x, r))
+  list.ind(l, m, fun (x, _, r) -> list.cons(x, r))
 end
 
 # Add a new last element to the list.
 # @category List
 # @flag hidden
 def list.snoc(y, l)
-  list.ind(l, list.cons(y, []), fun (x, l, r) -> list.cons(x, r))
+  list.ind(l, list.cons(y, []), fun (x, _, r) -> list.cons(x, r))
 end
 
 # Revert list order.
 # @category List
 def list.rev(l)
-  list.ind(l, [], fun (x, l, r) -> list.snoc(x, r))
+  list.ind(l, [], fun (x, _, r) -> list.snoc(x, r))
 end
 
 # Associate a value to a key in an association list. This functions raises
@@ -292,7 +292,7 @@ end
 # @param p Predicate.
 # @param l List.
 def list.index(p, l)
-  list.ind(l, 0, fun (x, l, r) -> if p(x) then 0 else r+1 end)
+  list.ind(l, 0, fun (x, _, r) -> if p(x) then 0 else r+1 end)
 end
 
 # list.assoc.mem(key,l) returns true if l contains a pair (key,value).

--- a/libs/metadata.liq
+++ b/libs/metadata.liq
@@ -118,7 +118,7 @@ end
 # such information.
 # @category System
 # @param file File from which the cover should be obtained
-def file.cover(~id=null(), fname)
+def file.cover(fname)
   metadata.cover(file.metadata(fname))
 end
 
@@ -126,5 +126,5 @@ end
 # with coverart when logging metadata.
 # @category Source / Track Processing
 def metadata.cover.remove(m)
-  list.assoc.filter(fun (k, v) -> k != "metadata_block_picture" and k != "apic", m)
+  list.assoc.filter(fun (k, _) -> k != "metadata_block_picture" and k != "apic", m)
 end

--- a/libs/native.liq
+++ b/libs/native.liq
@@ -49,7 +49,7 @@ def native.sequence(~id=null(), sources)
     end
   end
   infallible = not source.fallible(list.last(default=fail, sources))
-  s = source.dynamic(infallible=infallible, track_sensitive=true, s)
+  s = source.dynamic(id=id, infallible=infallible, track_sensitive=true, s)
 
   first = ref(true)
   def ot(_)
@@ -80,6 +80,9 @@ let native.request = request
 
 # @docof request.dynamic.list
 def native.request.dynamic(%argsof(request.dynamic.list), f)
+  ignore(available)
+  ignore(timeout)
+
   # Prepared requests
   queue = ref([])
 

--- a/libs/playlist.liq
+++ b/libs/playlist.liq
@@ -51,8 +51,6 @@ let stdlib_native = native
 #   enter into a consuming loop and stop playing anything.
 # @param ~prefetch How many requests should be queued in advance.
 # @param ~loop Loop on the playlist.
-# @param ~mime_type Default MIME type for the playlist. Empty string means \
-#  automatic detection.
 # @param ~mode Play the files in the playlist either in the order ("normal" mode), \
 #  or shuffle the playlist each time it is loaded, and play it in this order for a \
 #  whole round ("randomize" mode), or pick a random file in the playlist each time \
@@ -62,7 +60,7 @@ let stdlib_native = native
 # @param ~timeout Timeout (in sec.) for a single download.
 # @param playlist Playlist.
 # @method reload Reload the playlist with given list of songs.
-def playlist.list(~id=null(), ~check_next=null(), ~prefetch=1, ~loop=true, ~mime_type=null(),
+def playlist.list(~id=null(), ~check_next=null(), ~prefetch=1, ~loop=true,
                   ~mode="normal", ~native=false, ~on_done={()}, ~timeout=20., playlist)
   id = string.id.default(default="playlist.list", id)
   mode =
@@ -218,10 +216,8 @@ def playlist.reloadable(
   files := load_playlist()
 
   s = playlist.list(
-    id=id, check_next=check_next, prefetch=prefetch,
-    loop=loop, mime_type=mime_type, mode=mode,
-    native=native, on_done=on_done, timeout=timeout,
-    !files)
+    id=id, check_next=check_next, prefetch=prefetch, loop=loop, mode=mode,
+    native=native, on_done=on_done, timeout=timeout, !files)
 
   source.set_name(s, "playlist.reloadable")
 

--- a/libs/protocols.liq
+++ b/libs/protocols.liq
@@ -17,7 +17,7 @@ let settings.protocol.replaygain.path = settings.make(
 
 # @flag hidden
 def exec_replaygain(~extract_replaygain="#{configure.bindir}/extract-replaygain",
-                       ~delay,file)
+                     ~delay=_,file)
   log = log.info(label="extract.replaygain")
   p = process.run("#{extract_replaygain} #{string.quote(file)}")
   stdout = string.replace(pattern='\\n', fun (_) -> "", p.stdout)

--- a/libs/protocols.liq
+++ b/libs/protocols.liq
@@ -32,7 +32,7 @@ end
 
 # Register the replaygain protocol.
 # @flag hidden
-def replaygain_protocol(~rlog,~maxtime,arg)
+def replaygain_protocol(~rlog=_,~maxtime,arg)
  delay = maxtime - time()
  # The extraction program
  extract_replaygain = settings.protocol.replaygain.path()
@@ -66,7 +66,7 @@ let settings.protocol.process.inherit_env = settings.make(
 # [("input",<input file>),("output",<output file>),("colon",":")]
 # See say: protocol for an example.
 # @flag hidden
-def process_protocol(~rlog,~maxtime,arg)
+def process_protocol(~rlog=_,~maxtime,arg)
   log.info("Processing #{arg}")
 
   x = string.split(separator=":",arg)
@@ -261,7 +261,7 @@ add_protocol("youtube-dl", youtube_dl_protocol,
 # Register the youtube-pl protocol.
 # Syntax: youtube-pl:<ID>
 # @flag hidden
-def youtube_pl_protocol(~rlog,~maxtime,arg)
+def youtube_pl_protocol(~rlog=_,~maxtime=_,arg)
   tmp = file.temp("youtube-pl","")
   file.write(data="youtube-pl:#{arg}",tmp)
   [tmp]
@@ -272,7 +272,7 @@ add_protocol("youtube-pl", youtube_pl_protocol,
 
 # Register tmp
 # @flag hidden
-def tmp_protocol(~rlog,~maxtime,arg) =
+def tmp_protocol(~rlog=_, ~maxtime=_, arg) =
   [arg]
 end
 add_protocol("tmp",tmp_protocol,
@@ -489,7 +489,7 @@ add_protocol("ffmpeg",ffmpeg_protocol,
 # Register stereo protocol which converts a file to stereo (currently decodes as
 # wav).
 # @flag hidden
-def stereo_protocol(~rlog, ~maxtime, arg)
+def stereo_protocol(~rlog=_, ~maxtime=_, arg)
   file = file.temp("liq-stereo", ".wav")
   r = request.create(arg)
   if not request.resolve(r) then
@@ -513,7 +513,7 @@ let settings.protocol.text2wave.path = settings.make(
 
 # Register the text2wave: protocol using text2wav
 # @flag hidden
-def text2wave_protocol(~rlog,~maxtime,arg) =
+def text2wave_protocol(~rlog=_, ~maxtime=_, arg) =
   binary = settings.protocol.text2wave.path()
   [process_uri(extname="wav", "echo #{string.quote(arg)} | #{binary} -scale 1.9 > $(output)")]
 end
@@ -530,7 +530,7 @@ let settings.protocol.gtts.path = settings.make(
 
 # Register the gtts: protocol using gtts
 # @flag hidden
-def gtts_protocol(~rlog,~maxtime,arg) =
+def gtts_protocol(~rlog=_, ~maxtime=_, arg) =
   binary = settings.protocol.gtts.path()
   [process_uri(extname="mp3", "#{binary} -o $(output) #{string.quote(arg)}")]
 end
@@ -540,7 +540,7 @@ add_protocol(static=true,"gtts",gtts_protocol,
 
 # Register the legacy say: protocol
 # @flag hidden
-def say_protocol(~rlog,~maxtime,arg) =
+def say_protocol(~rlog=_, ~maxtime=_, arg) =
   ["stereo:gtts:#{arg}", "stereo:text2wave:#{arg}"]
 end
 add_protocol(static=true,"say",say_protocol,
@@ -615,7 +615,7 @@ end
 
 # Register the s3:// protocol 
 # @flag hidden
-def s3_protocol(~rlog,~maxtime,arg) =
+def s3_protocol(~rlog=_, ~maxtime=_, arg) =
   extname = file.extension(leading_dot=false,dir_sep="/",arg)
   [process_uri(extname=extname,"#{aws_base()} s3 cp s3:#{arg} $(output)")]
 end
@@ -625,7 +625,7 @@ add_protocol("s3",s3_protocol,doc="Fetch files from s3 using the AWS CLI",
 # Register the polly: protocol using AWS Polly
 # speech synthesis services. Syntax: polly:<text>
 # @flag hidden
-def polly_protocol(~rlog,~maxtime,text) =
+def polly_protocol(~rlog=_, ~maxtime=_, text) =
   aws = aws_base()
 
   format = settings.protocol.aws.polly.format()
@@ -654,7 +654,7 @@ add_protocol(static=true,"polly",polly_protocol,
 
 # Protocol to synthesize audio.
 # @flag hidden
-def synth_protocol(~rlog,~maxtime,text) =
+def synth_protocol(~rlog=_, ~maxtime=_, text) =
   log.debug(label="synth", "Synthesizing request: #{text}")
   args = string.split(separator=",", text)
   args = list.map(string.split(separator="="), args)
@@ -699,7 +699,7 @@ syntax="synth:shape=sine,frequency=440.,duration=10.")
 
 # File protocol
 # @flag hidden
-def file_protocol(~rlog,~maxtime,arg) =
+def file_protocol(~rlog=_, ~maxtime=_, arg) =
   path = list.nth(default="", string.split(separator=":",arg), 1)
   segments = string.split(separator="/",path)
 

--- a/libs/resolvers.liq
+++ b/libs/resolvers.liq
@@ -21,6 +21,7 @@ end
 
 # @flag hidden
 def youtube_playlist_parser(~pwd="",url) =
+  ignore(pwd)
   binary = null.get(settings.protocol.youtube_dl.path())
 
   def parse_line(line) =

--- a/libs/server.liq
+++ b/libs/server.liq
@@ -84,7 +84,7 @@ end
 # @param ~port Port of the server.
 # @param ~uri URI of the server.
 def server.harbor(~port=8000, ~uri="/telnet")
-  def webpage(~protocol, ~data, ~headers, uri)
+  def webpage(~protocol=_, ~data=_, ~headers=_, _)
     data="
 <html>
   <head>
@@ -146,7 +146,7 @@ def server.harbor(~port=8000, ~uri="/telnet")
 
   harbor.http.register(port=port, method="GET", uri, webpage)
 
-  def setter(~protocol, ~data, ~headers, uri)
+  def setter(~protocol=_, ~data, ~headers=_, _)
     log.info("Executing command: #{data}")
     answer = server.execute(data)
     answer = string.concat(separator="\n", answer) ^ "\n"

--- a/libs/shoutcast.liq
+++ b/libs/shoutcast.liq
@@ -1,4 +1,3 @@
-
 %ifdef output.icecast
 # Output to shoutcast.
 # @category Source / Output

--- a/libs/sound.liq
+++ b/libs/sound.liq
@@ -22,7 +22,7 @@
 # @method target_gain Current target amplification coefficient (in linear scale).
 # @method rms Current rms (in linear scale).
 def replaces normalize(~id=null(), ~target=getter(-13.), ~up=getter(10.), ~down=getter(.1), ~gain_min=-12., ~gain_max=12., ~lookahead=getter(0.), ~window=getter(.5), ~threshold=getter(-40.), ~track_sensitive=true, ~debug=null(), s)
-  s = rms.smooth(duration=window, s)
+  s = rms.smooth(id=id, duration=window, s)
   v = ref(1.)
   frame = frame.duration()
   gain_min = lin_of_dB(gain_min)
@@ -52,7 +52,7 @@ def replaces normalize(~id=null(), ~target=getter(-13.), ~up=getter(10.), ~down=
     end
   s = source.on_frame(s, update)
   if track_sensitive then source.on_track(s, fun (_) -> v := 1.) end
-  amplify({!v}, delay_line(lookahead, s)).{ rms = rms, gain = fun() -> !v, target_gain = target_gain }
+  amplify(id=id, {!v}, delay_line(lookahead, s)).{ rms = rms, gain = fun() -> !v, target_gain = target_gain }
 end
 
 
@@ -69,8 +69,8 @@ end
 # @param ~high Higher frequency of the bandpass filter.
 # @param ~q Q factor.
 def filter.iir.eq.low_high(~id=null(), ~low, ~high, ~q=1., s)
-  s = if not (getter.is_constant(high) and getter.get(high) == infinity) then filter.iir.eq.low(frequency=high, q=q, s) else s end
-  s = if not (getter.is_constant(low) and getter.get(low) == 0.) then filter.iir.eq.high(frequency=low, q=q, s) else s end
+  s = if not (getter.is_constant(high) and getter.get(high) == infinity) then filter.iir.eq.low(id=id, frequency=high, q=q, s) else s end
+  s = if not (getter.is_constant(low) and getter.get(low) == 0.) then filter.iir.eq.high(id=id, frequency=low, q=q, s) else s end
   s
 end
 
@@ -178,7 +178,7 @@ end
 # @param ~frequency Frequency under which sound should be lowered.
 # @param s The input source.
 def mic_filter(~frequency=200., s)
-  filter(freq=200.,q=1.,mode="high",s)
+  filter(freq=frequency, q=1., mode="high", s)
 end
 
 # Mix between dry and wet sources. Useful for testing effects. Typically:

--- a/libs/utils.liq
+++ b/libs/utils.liq
@@ -70,7 +70,7 @@ def playlog(~duration=infinity, ~persistency=null(), ~hash=fun(m)->m["filename"]
   def prune()
     if duration != infinity then
       t = time()
-      l := list.assoc.filter(fun(f, tf) -> t - tf <= duration, !l)
+      l := list.assoc.filter(fun(_, tf) -> t - tf <= duration, !l)
     end
   end
   # Add a new entry

--- a/libs/video.liq
+++ b/libs/video.liq
@@ -281,6 +281,6 @@ def replaces video.add_text(~id=null(),~color=0xffffff,~cycle=true,~font="",
                    ~metadata="",~size=18,~speed=70,~x=getter(10),~y=getter(10),
                    d,s) =
   video.add_text.best(id=id,cycle=cycle,font=font,
-     metadata=metadata,size=size,
+     metadata=metadata,size=size,color=color,
      speed=speed,x=x,y=y,d,s)
 end

--- a/libs/visualization.liq
+++ b/libs/visualization.liq
@@ -17,8 +17,8 @@ def vumeter(~rms_min=-25., ~rms_max=-5., ~window=0.5, ~scroll=false, s)
     n = int_of_float(x * float_of_int(bar_width))
     bar = ref("")
     if not scroll then bar := "\r" end
-    for i = 0 to n-1 do bar := !bar ^ "=" end
-    for i = 0 to bar_width-n-1 do bar := !bar ^ "." end
+    for _ = 0 to n-1 do bar := !bar ^ "=" end
+    for _ = 0 to bar_width-n-1 do bar := !bar ^ "." end
     bar := !bar ^ " " ^ string_of(v)
     if scroll then bar := !bar ^ "\n" end
     print(newline=false, !bar)

--- a/src/lang/lang.ml
+++ b/src/lang/lang.ml
@@ -140,8 +140,8 @@ let reference x = mk (Ref x)
 let val_fun p f = mk (FFI (p, [], f))
 
 let val_cst_fun p c =
-  let p' = List.map (fun (l, d) -> (l, l, d)) p in
-  let f t tm = mk (Fun (p', [], [], { Term.t; Term.term = tm })) in
+  let p = List.map (fun (l, d) -> (l, "_", d)) p in
+  let f t tm = mk (Fun (p, [], [], { Term.t; Term.term = tm })) in
   let mkg t = T.make (T.Ground t) in
   (* Convert the value into a term if possible, to enable introspection, mostly
      for printing. *)
@@ -151,7 +151,7 @@ let val_cst_fun p c =
     | Ground (Bool i) -> f (mkg T.Bool) (Term.Ground (Term.Ground.Bool i))
     | Ground (Float i) -> f (mkg T.Float) (Term.Ground (Term.Ground.Float i))
     | Ground (String i) -> f (mkg T.String) (Term.Ground (Term.Ground.String i))
-    | _ -> mk (FFI (p', [], fun _ -> c))
+    | _ -> mk (FFI (p, [], fun _ -> c))
 
 let metadata m =
   list (Hashtbl.fold (fun k v l -> product (string k) (string v) :: l) m [])

--- a/src/lang/lang_parser.mly
+++ b/src/lang/lang_parser.mly
@@ -169,7 +169,8 @@ expr:
   | FUN LPAR arglist RPAR YIELDS expr{ mk_fun ~pos:$loc $3 $6 }
   | LCUR exprss RCUR                 { mk_fun ~pos:$loc [] $2 }
   | WHILE expr DO exprs END          { mk ~pos:$loc (App (mk ~pos:$loc($1) (Var "while"), ["", mk_fun ~pos:$loc($2) [] $2; "", mk_fun ~pos:$loc($4) [] $4])) }
-  | FOR VAR GETS expr DO exprs END   { mk ~pos:$loc (App (mk ~pos:$loc($1) (Var "for"), ["", $4; "", mk_fun ~pos:$loc($6) ["", $2, T.fresh_evar ~level:(-1) ~pos:(Some $loc($2)), None] $6])) }
+  | FOR bindvar GETS expr DO exprs END
+                                     { mk ~pos:$loc (App (mk ~pos:$loc($1) (Var "for"), ["", $4; "", mk_fun ~pos:$loc($6) ["", $2, T.fresh_evar ~level:(-1) ~pos:(Some $loc($2)), None] $6])) }
   | expr TO expr                     { mk ~pos:$loc (App (mk ~pos:$loc($2) (Invoke (mk ~pos:$loc($2) (Var "iterator"), "int")), ["", $1; "", $3])) }
   | expr COALESCE expr               { let null = mk ~pos:$loc($1) (Var "null") in
                                        let op =  mk ~pos:$loc($1) (Invoke (null, "default")) in

--- a/src/lang/lang_parser_helper.ml
+++ b/src/lang/lang_parser_helper.ml
@@ -144,7 +144,9 @@ let args_of, app_of =
     let t = T.make ~pos:(Some pos) t.T.descr in
     Lang_values.{ t; term }
   in
-  (gen_args_of get_args, gen_args_of get_app)
+  let args_of = gen_args_of get_args in
+  let app_of = gen_args_of get_app in
+  (args_of, app_of)
 
 (** Create a new value with an unknown type. *)
 let mk ~pos e =


### PR DESCRIPTION
We now report arguments which are not used in functions (unless named `_`).

This fixes #1249 : the problem was that `err` argument was not used, but
reported at the wrong position.