### PR TITLE
Decode ffmpeg frame metadata

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,4 +1,4 @@
-version=0.18.0
+version=0.19.0
 profile = conventional
 break-separators = after
 space-around-lists = false

--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,4 +1,4 @@
-version=0.19.0
+version=0.18.0
 profile = conventional
 break-separators = after
 space-around-lists = false

--- a/src/encoder/ffmpeg_internal_encoder.ml
+++ b/src/encoder/ffmpeg_internal_encoder.ml
@@ -63,7 +63,7 @@ let write_audio_frame ~time_base ~sample_rate ~channel_layout ~sample_format
       nb_samples :=
         Int64.add !nb_samples
           (Int64.of_int (Avutil.Audio.frame_nb_samples frame));
-      Avutil.frame_set_pts frame (Some frame_pts)
+      Avutil.Frame.set_pts frame (Some frame_pts)
   in
 
   let add_final_frame_pts = add_frame_pts () in
@@ -369,7 +369,7 @@ let mk_video ~ffmpeg ~options output =
                 ~dst:stream_time_base pts)
             (Ffmpeg_utils.best_pts frame)
         in
-        Avutil.frame_set_pts frame frame_pts;
+        Avutil.Frame.set_pts frame frame_pts;
         Av.write_frame stream frame;
         if Av.was_keyframe stream then was_keyframe := true)
   in
@@ -393,7 +393,7 @@ let mk_video ~ffmpeg ~options output =
         let f = Video.get vbuf i in
         let vdata = Ffmpeg_utils.pack_image f in
         let frame = InternalScaler.convert scaler vdata in
-        Avutil.frame_set_pts frame (Some !nb_frames);
+        Avutil.Frame.set_pts frame (Some !nb_frames);
         nb_frames := Int64.succ !nb_frames;
         cb ~stream_idx ~time_base frame
       done
@@ -420,7 +420,7 @@ let mk_video ~ffmpeg ~options output =
                   in
                   fun frame ->
                     let scaled = RawScaler.convert scaler frame in
-                    Avutil.frame_set_pts scaled (Ffmpeg_utils.best_pts frame);
+                    Avutil.Frame.set_pts scaled (Ffmpeg_utils.best_pts frame);
                     scaled)
                 else fun f -> f
               in

--- a/src/io/ffmpeg_filter_io.ml
+++ b/src/io/ffmpeg_filter_io.ml
@@ -67,7 +67,7 @@ class audio_output ~name ~kind source_val =
               ((Lazy.force convert_frame_pts) (Frame.pts memo))
               (Int64.of_int pos)
           in
-          Avutil.frame_set_pts frame (Some pts);
+          Avutil.Frame.set_pts frame (Some pts);
           input frame)
         frames
   end
@@ -106,7 +106,7 @@ class video_output ~kind ~name source_val =
               ((Lazy.force convert_frame_pts) (Frame.pts memo))
               (Int64.of_int pos)
           in
-          Avutil.frame_set_pts frame (Some pts);
+          Avutil.Frame.set_pts frame (Some pts);
           input frame)
         frames
   end
@@ -156,6 +156,11 @@ class audio_input ~bufferize kind =
       let rec f () =
         try
           let ffmpeg_frame = output.Avfilter.handler () in
+          let metadata = Avutil.Frame.metadata ffmpeg_frame in
+          if metadata <> [] then (
+            let m = Hashtbl.create (List.length metadata) in
+            List.iter (fun (k, v) -> Hashtbl.add m k v) metadata;
+            Generator.add_metadata generator m);
           let frame =
             {
               Ffmpeg_raw_content.time_base = ffmpeg_frame_time_base;
@@ -249,6 +254,11 @@ class video_input ~bufferize ~fps kind =
       let rec f () =
         try
           let ffmpeg_frame = output.Avfilter.handler () in
+          let metadata = Avutil.Frame.metadata ffmpeg_frame in
+          if metadata <> [] then (
+            let m = Hashtbl.create (List.length metadata) in
+            List.iter (fun (k, v) -> Hashtbl.add m k v) metadata;
+            Generator.add_metadata generator m);
           let frame =
             {
               Ffmpeg_raw_content.time_base = ffmpeg_frame_time_base;

--- a/src/lang/builtins_ffmpeg_encoder.ml
+++ b/src/lang/builtins_ffmpeg_encoder.ml
@@ -339,7 +339,7 @@ let encode_video_frame ~kind_t ~mode ~opts ?codec ~format generator =
         let f = Video.get vbuf i in
         let vdata = Ffmpeg_utils.pack_image f in
         let frame = InternalScaler.convert (Option.get !scaler) vdata in
-        Avutil.frame_set_pts frame (Some !nb_frames);
+        Avutil.Frame.set_pts frame (Some !nb_frames);
         nb_frames := Int64.succ !nb_frames;
         encode_ffmpeg_frame frame
       done

--- a/src/stream/frame.mli
+++ b/src/stream/frame.mli
@@ -26,6 +26,8 @@
 
 type 'a fields = { audio : 'a; video : 'a; midi : 'a }
 
+val map_fields : ('a -> 'b) -> 'a fields -> 'b fields
+
 (** High-level description of the content. *)
 type kind =
   [ `Any

--- a/src/tools/ffmpeg_utils.ml
+++ b/src/tools/ffmpeg_utils.ml
@@ -87,9 +87,9 @@ let () =
 *)
 
 let best_pts frame =
-  match Avutil.frame_pts frame with
+  match Avutil.Frame.pts frame with
     | Some pts -> Some pts
-    | None -> Avutil.frame_best_effort_timestamp frame
+    | None -> Avutil.Frame.best_effort_timestamp frame
 
 module Fps = struct
   type filter = {
@@ -170,7 +170,7 @@ module Fps = struct
     match converter with
       | `Pass_through _ -> cb frame
       | `Filter { input; output } ->
-          Avutil.frame_set_pts frame (best_pts frame);
+          Avutil.Frame.set_pts frame (best_pts frame);
           input frame;
           let rec flush () =
             try

--- a/tests/streams/ffmpeg_rms.liq
+++ b/tests/streams/ffmpeg_rms.liq
@@ -1,0 +1,34 @@
+#!../../src/liquidsoap ../../libs/stdlib.liq ../../libs/deprecations.liq
+
+%include "test.liq"
+
+settings.log.level.set(4)
+
+def astats(s) =
+  def mkfilter(graph) =
+    s = ffmpeg.filter.audio.input(graph, s)
+    s = ffmpeg.filter.astats(graph, s, metadata=true, reset=3)
+    ffmpeg.filter.audio.output(graph, s)
+  end
+
+  ffmpeg.filter.create(mkfilter)
+end
+
+s = noise()
+
+s = ffmpeg.raw.encode.audio(%ffmpeg(%audio.raw), s)
+
+s = astats(s)
+
+s = ffmpeg.raw.decode.audio(s)
+
+def test(m) =
+  if list.mem_assoc("lavfi.astats.Overall.RMS_peak", m) then
+    test.pass()
+  end
+end
+
+s.on_metadata(test)
+
+output.dummy(fallible=true, s)
+


### PR DESCRIPTION
FFmpeg frames carry metadata that can be useful in particular via plugins. Typical use is to get RMS info.

In this PR, we add support for decoding ffmpeg frame metadata and pushing them through liquidsoap's metadadata layer. 

The converse, pushing liquidsoap's metadata as FFmpeg frame metadata is not obvious at first. These metadata seem to be rather internal and not meant for external use and apply to only one sub-stream while ours are global. Most likely, liquidsoap metadata should be pushed through the regular metadata workflow, which sends them to the muxer as top-level metadata.

Here's a test script:
```
settings.log.level.set(4)

s = input.http("https://supersoul.live:8020/SRRS64kbps")

s = ffmpeg.raw.encode.audio(%ffmpeg(%audio.raw), s)

def astats(s) =
  def mkfilter(graph) =
    s = ffmpeg.filter.audio.input(graph, s)
    s = ffmpeg.filter.astats(graph, s, metadata=true, reset=3)
    ffmpeg.filter.audio.output(graph, s)
  end

  ffmpeg.filter.create(mkfilter)
end

s = astats(s)

s = ffmpeg.raw.decode.audio(s)

s.on_metadata(print)

output.ao(fallible=true, s)
```