### PR TITLE
Add support for abstract generic json object.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,11 +6,11 @@ New:
 - Add support for errors with `error.*` and `try ... catch` (#1242).
 - Add support for optional values with `null.*` (#1242).
 - Add support for `x ? y : z` syntax (#1266).
+- Added support for list spread and deconstruction syntax (#1269).
 - Add support for generic JSON objects, map `(string, 'a)` lists to regular lists,
   add support for json5 floats (`NaN`, `Infinity`), return `null` for those otherwise,
-  rename `json_of` into `json.stringify` and `json.parse` into `json.parse` with 
+  rename `json_of` into `json.stringify` and `of_json` into `json.parse` with
   deprecation (#1824)
-- Added support for list spread and deconstruction syntax (#1269).
 - Added support for video encoding and decoding using `ffmpeg` (#1038).
 - Added support for hardware-accelerated video encoding using `ffmpeg` (#1380)
 - Added support for ffmpeg filters (#1038).
@@ -630,7 +630,7 @@ New:
   SecureTransport.
 - Add optional "dj" and "next" metadata for Shoutcast v2, wrap "dj" value in a
   callback in output.shoutcast (#370, #388)
-- Allow partial parsing of JSON objects in json.parse.
+- Allow partial parsing of JSON objects in of_json.
 - Generalize list.assoc to allow default values. Legacy code must be updated:
   list.assoc(k,l) -> list.assoc(default="",k,l)
 - Generalize list.hd to allow default values. Legacy code must be updated:
@@ -952,7 +952,7 @@ Enhancements:
 
 1.0.0 beta3 (05-08-2011)
 ========================
-- Feature: Added json.parse to parse json data. Depends
+- Feature: Added of_json to parse json data. Depends
   on json-wheel.
 - Feature: Added file.exists and is_directory.
 - Feature: Added timeout options for:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,10 @@ New:
 - Add support for errors with `error.*` and `try ... catch` (#1242).
 - Add support for optional values with `null.*` (#1242).
 - Add support for `x ? y : z` syntax (#1266).
+- Add support for generic JSON objects, map `(string, 'a)` lists to regular lists,
+  add support for json5 floats (`NaN`, `Infinity`), return `null` for those otherwise,
+  rename `json_of` into `json.stringify` and `json.parse` into `json.parse` with 
+  deprecation (#1824)
 - Added support for list spread and deconstruction syntax (#1269).
 - Added support for video encoding and decoding using `ffmpeg` (#1038).
 - Added support for hardware-accelerated video encoding using `ffmpeg` (#1380)
@@ -626,7 +630,7 @@ New:
   SecureTransport.
 - Add optional "dj" and "next" metadata for Shoutcast v2, wrap "dj" value in a
   callback in output.shoutcast (#370, #388)
-- Allow partial parsing of JSON objects in of_json.
+- Allow partial parsing of JSON objects in json.parse.
 - Generalize list.assoc to allow default values. Legacy code must be updated:
   list.assoc(k,l) -> list.assoc(default="",k,l)
 - Generalize list.hd to allow default values. Legacy code must be updated:
@@ -948,7 +952,7 @@ Enhancements:
 
 1.0.0 beta3 (05-08-2011)
 ========================
-- Feature: Added of_json to parse json data. Depends
+- Feature: Added json.parse to parse json data. Depends
   on json-wheel.
 - Feature: Added file.exists and is_directory.
 - Feature: Added timeout options for:

--- a/doc/content/build.md
+++ b/doc/content/build.md
@@ -97,7 +97,7 @@ Libraries not developed by Savonet are:
 | tsdl                |  >= 0.2.0                 | Display videos                                |
 | tsdl-image          |            | Load images                                   |
 | tsdl-tff            |              | Render fonts                                  |
-| yojson              |                | Parsing JSON data (json.parse function)          |
+| yojson              |                | Parsing JSON data (of_json function)          |
 
 ### Runtime optional dependencies:
 

--- a/doc/content/build.md
+++ b/doc/content/build.md
@@ -97,7 +97,7 @@ Libraries not developed by Savonet are:
 | tsdl                |  >= 0.2.0                 | Display videos                                |
 | tsdl-image          |            | Load images                                   |
 | tsdl-tff            |              | Render fonts                                  |
-| yojson              |                | Parsing JSON data (of_json function)          |
+| yojson              |                | Parsing JSON data (json.parse function)          |
 
 ### Runtime optional dependencies:
 

--- a/doc/content/build.md.in
+++ b/doc/content/build.md.in
@@ -97,7 +97,7 @@ Libraries not developed by Savonet are:
 | tsdl                | @tsdl_version_descr@                 | Display videos                                |
 | tsdl-image          | @tsdl_image_version_descr@           | Load images                                   |
 | tsdl-tff            | @tsdl_ttf_version_descr@             | Render fonts                                  |
-| yojson              | @yojson_version_descr@               | Parsing JSON data (json.parse function)          |
+| yojson              | @yojson_version_descr@               | Parsing JSON data (of_json function)          |
 
 ### Runtime optional dependencies:
 

--- a/doc/content/build.md.in
+++ b/doc/content/build.md.in
@@ -97,7 +97,7 @@ Libraries not developed by Savonet are:
 | tsdl                | @tsdl_version_descr@                 | Display videos                                |
 | tsdl-image          | @tsdl_image_version_descr@           | Load images                                   |
 | tsdl-tff            | @tsdl_ttf_version_descr@             | Render fonts                                  |
-| yojson              | @yojson_version_descr@               | Parsing JSON data (of_json function)          |
+| yojson              | @yojson_version_descr@               | Parsing JSON data (json.parse function)          |
 
 ### Runtime optional dependencies:
 

--- a/doc/content/harbor_http.md
+++ b/doc/content/harbor_http.md
@@ -148,7 +148,7 @@ Get metadata
 ------------
 You can use harbor to register HTTP services to 
 fecth/set the metadata of a source. For instance, 
-using the [JSON export function](json.html) `json_of`:
+using the [JSON export function](json.html) `json.stringify`:
 
 ```liquidsoap
 meta = ref([])
@@ -179,7 +179,7 @@ def get_meta(~protocol,~data,~headers,uri) =
     protocol=protocol,
     code=200,
     headers=[("Content-Type","application/json; charset=utf-8")],
-    data=json_of(m)
+    data=json.stringify(m)
   )
 end
 

--- a/doc/content/json.md
+++ b/doc/content/json.md
@@ -28,7 +28,7 @@ The specific cases to keep in mind are:
 
 * Tuples are exported as lists, including `()`, which is an empty tuple.
 * Records (unit value with decorated methods) are exported as JSON objects.
-* Values with decorated with methods are exported without their methods. 
+* Values decorated with methods are exported without their methods. 
 
 Output format is pretty printed by default. A compact output can
 be obtained by using the optional argument: `compact=true`.

--- a/doc/content/json.md
+++ b/doc/content/json.md
@@ -52,7 +52,7 @@ j.add("key_with_methods", "value".{method = 123})
 j.add("record", { a = 1, b = "ert"})
 j.remove("foo")
 json.stringify(j)
-- '{ "record": { "b": "ert", "a": 1 }, "key_with_methods": "value",\n"bla": "bar", "baz": 3.14\n}'
+- '{ "record": { "b": "ert", "a": 1 }, "key_with_methods": "value", "bla": "bar", "baz": 3.14 }'
 ```
 
 Importing values using JSON

--- a/doc/content/json.md
+++ b/doc/content/json.md
@@ -1,18 +1,21 @@
 Exporting values using JSON
 ---------------------------
 
-Liquidsoap can export any language value in JSON using `json_of`.
+Liquidsoap can export any language value in JSON using `json.stringify`.
 
 The format is the following :
 
-* `() : unit` -> `null`
+* `() : unit` -> `[ ]`
 * `true: bool` -> `true`
 * `"abc" : string` -> `"abc"`
 * `23 : int` -> `23`
 * `2.0 : float` -> `2.0`
+* `infinity : float` -> default: `null`, json5-enabled: `Infinity`
+* `nan : float` -> default: `null`, json5-enabled: `NaN`
 * `[2,3,4] : [int]` -> `[2,3,4]`
-* `[("f",1),("b",4)] : [(string*int)]` -> `{ "f": 1, "b": 4 }`
 * `("foo",123) : string*int` -> `[ "foo", 123 ]`
+* `3.14.{a = "foo", b = 24}` -> `3.14`
+* `{a = "foo", b = 24}` -> `{"a": "foo", "b": 24}`
 * `s : source` -> `"<source>"`
 * `r : ref(int)` -> `{ "reference":4 }`
 * `%mp3 : format(...)` -> ```
@@ -21,19 +24,42 @@ The format is the following :
 * `r : request(...)` -> `"<request>"`
 * `f : (...)->_` -> `"<fun>"`
 
-The two particular cases are:
+The specific cases to keep in mind are:
 
-* Products are exported as lists.
-* Lists of type `[(string*'a)]` are exported as objects of the form `{"key": value}`.
+* Tuples are exported as lists, including `()`, which is an empty tuple.
+* Records (unit value with decorated methods) are exported as JSON objects.
+* Values with decorated with methods are exported without their methods. 
 
 Output format is pretty printed by default. A compact output can
 be obtained by using the optional argument: `compact=true`.
+
+By default, the output follows the most common `JSON` standard. However, support
+for `json5` format can be enabled by passing the optional argument `json5=true`.
+In particular, this allows `nan` and `infinity` to be exported to `NaN` and `Infinity`.
+
+Generic JSON objects
+--------------------
+
+Generic `JSON` objects can be manipulated through the `json()` operator. This operator 
+returns an opaque json variable with methods to `add` and `remove` attributes:
+
+```liquidsoap
+j = json()
+j.add("foo", 1)
+j.add("bla", "bar")
+j.add("baz", 3.14)
+j.add("key_with_methods", "value".{method = 123})
+j.add("record", { a = 1, b = "ert"})
+j.remove("foo")
+json.stringify(j)
+- '{ "record": { "b": "ert", "a": 1 }, "key_with_methods": "value",\n"bla": "bar", "baz": 3.14\n}'
+```
 
 Importing values using JSON
 ---------------------------
 
 If compiled with `yojson` support, Liquidsoap can also
-parse JSON data into values. using `of_json`.
+parse JSON data into values. using `json.parse`.
 
 The format is a subset of the format of exported values with the notable
 difference that only ground types (`int`, `floats`, `string`, ...)
@@ -53,7 +79,7 @@ The JSON standards specify that a proper JSON payload can only be an array or an
 object. However, simple integers, floats, strings and null values are
 also accepted by Liquidsoap.
 
-The function `of_json` has the following type:
+The function `json.parse` has the following type:
 
 ```
   (default:'a,string)->'a
@@ -71,11 +97,11 @@ Suppose that we want to receive a list of metadata, encoded as an object:
  "artist": "bar" }
 ```
 
-Then, you would use of_json with default value `[("error","fail")]` and do:
+Then, you would use json.parse with default value `[("error","fail")]` and do:
 
 ```liquidsoap
 # Parse metadata from json
-m = of_json(default= [("error","fail")], json_string)
+m = json.parse(default= [("error","fail")], json_string)
 ```
 
 The type of the default value constrains the parser. For instance, in the 
@@ -84,7 +110,7 @@ function will return the values passed as default.
 
 You can use the default value in two different ways:
 
-* To detect that the received json string was invalid/could not be parsed to the expected type. In the example above, if `of_json` return a metadata value of `[("error","fail")]` (the default) then you can detect in your code that parsing has failed.
+* To detect that the received json string was invalid/could not be parsed to the expected type. In the example above, if `json.parse` return a metadata value of `[("error","fail")]` (the default) then you can detect in your code that parsing has failed.
 * As a default value for the rest of the script, if you do not want to care about parsing errors.. This can be useful for instance for JSON-RPC notifications, which should not send any response to the client anyway.
 
 If your JSON object is of mixed type, like this one:
@@ -99,12 +125,12 @@ You can parse it in multiple steps. For instance:
 ```liquidsoap
 # First parse key,value list:
 hint = [("key","value")]
-data = of_json(default=hint,payload)
+data = json.parse(default=hint,payload)
 print(data["uri"]) # "https://..."
 
 # Then key -> (key,value) list
 hint = [("list",[("key","value")])]
-data = of_json(default=hint,payload)
+data = json.parse(default=hint,payload)
 m    = list.assoc(default=[],"metadata",data)
 print(m["title"]) # "foo"
 ```

--- a/doc/content/migrating.md
+++ b/doc/content/migrating.md
@@ -124,6 +124,13 @@ in advance.
 Should you need more advanced queueing strategy, `request.dynamic.list` and `request.dynamic` now export functions to retrieve 
 and set their own queue of requests.
 
+### JSON import/export
+
+`json_of` has been renamed `json.stringify` and `of_json` has been renamed `json.parse`.
+
+JSON export has been enhanced with a new generic json object export. Associative lists of type `(string, 'a)` are now
+exported as lists. See our [JSON documentation page](json.html) for more details.
+
 ### Deprecated operators
 
 Some operators have been deprecated. For most of them, we provide a backward-compatible support 

--- a/libs/deprecations.liq
+++ b/libs/deprecations.liq
@@ -463,3 +463,17 @@ def add_playlist_parser(%argsof(playlist.parse.register), s) =
   deprecated("add_playlist_parser", "playlist.parse.register")
   playlist.parse.register(%argsof(playlist.parse.register), s)
 end
+
+# Deprecated: use 'json.stringify` instead
+# @flag deprecated
+def json_of(%argsof(json.stringify), v) =
+  deprecated("json_of", "json.stringify")
+  json.stringify(%argsof(json.stringify), v)
+end
+
+# Deprecated: use 'json.stringify` instead
+# @flag deprecated
+def of_json(%argsof(json.parse), v) =
+  deprecated("of_json", "json.parse")
+  json.parse(%argsof(json.parse), v)
+end

--- a/libs/externals.liq
+++ b/libs/externals.liq
@@ -36,9 +36,9 @@ def enable_external_ffmpeg_decoder() =
   mime_types = settings.decoder.mime_types.ffmpeg()
 
   def ffprobe_test(fname) =
-    json = process.read("#{ffprobe} -print_format json -show_streams #{string.quote(fname)}")
+    j = process.read("#{ffprobe} -print_format json -show_streams #{string.quote(fname)}")
     default = [("streams",[[("channels",0)]])]
-    data = of_json(default=default,json)
+    data = json.parse(default=default,j)
     streams = list.assoc(default=[],"streams",data)
     stream = list.hd(default=[],streams)
     list.assoc(default=0,"channels",stream)

--- a/libs/interactive.liq
+++ b/libs/interactive.liq
@@ -183,7 +183,7 @@ def interactive.save(fname)
   bool = list.map(fun (nv) -> begin let (name, v) = nv; (name, !v.ref) end, !variables_bool)
   string = list.map(fun (nv) -> begin let (name, v) = nv; (name, !v.ref) end, !variables_string)
   vars = (float, int, bool, string)
-  file.write(data=json_of(vars), fname)
+  file.write(data=json.stringify(vars), fname)
 end
 
 # Load the value of interactive variables from a file.
@@ -191,7 +191,7 @@ end
 # @param fname Name of the file.
 def interactive.load(fname)
   vars = file.contents(fname)
-  let (float, int, bool, string) = of_json(default=([("",0.)],[("",0)],[("",false)],[("","")]), vars)
+  let (float, int, bool, string) = json.parse(default=([("",0.)],[("",0)],[("",false)],[("","")]), vars)
   list.iter(fun (nv) -> try interactive.float.set (fst(nv), snd(nv)) catch _ do log.important(label="interactive.load", "Variable #{fst(nv)} not found.") end, float )
   list.iter(fun (nv) -> try interactive.int.set   (fst(nv), snd(nv)) catch _ do log.important(label="interactive.load", "Variable #{fst(nv)} not found.") end, int   )
   list.iter(fun (nv) -> try interactive.bool.set  (fst(nv), snd(nv)) catch _ do log.important(label="interactive.load", "Variable #{fst(nv)} not found.") end, bool  )

--- a/libs/math.liq
+++ b/libs/math.liq
@@ -21,3 +21,13 @@ end
 def lin_of_dB(x)
   pow(10., x / 20.)
 end
+
+# A special floating-point value denoting the result of an undefined operation
+# such as 0.0 /. 0.0. Stands for 'not a number'. Any floating-point operation
+# with nan as argument returns nan as result. As for floating-point comparisons, 
+# `==`, `<`, `<=`, `>` and `>=` return `false` and `!=` returns `true` if one or
+# both of their arguments is `nan`.
+# @category Math
+def nan
+  sqrt(-1.)
+end

--- a/libs/math.liq
+++ b/libs/math.liq
@@ -21,13 +21,3 @@ end
 def lin_of_dB(x)
   pow(10., x / 20.)
 end
-
-# A special floating-point value denoting the result of an undefined operation
-# such as 0.0 /. 0.0. Stands for 'not a number'. Any floating-point operation
-# with nan as argument returns nan as result. As for floating-point comparisons, 
-# `==`, `<`, `<=`, `>` and `>=` return `false` and `!=` returns `true` if one or
-# both of their arguments is `nan`.
-# @category Math
-def nan
-  sqrt(-1.)
-end

--- a/libs/resolvers.liq
+++ b/libs/resolvers.liq
@@ -25,7 +25,7 @@ def youtube_playlist_parser(~pwd="",url) =
   binary = null.get(settings.protocol.youtube_dl.path())
 
   def parse_line(line) =
-    parsed = of_json(default=[("url","foo")],line)
+    parsed = json.parse(default=[("url","foo")],line)
     url = list.assoc(default="","url",parsed)
     ([],"youtube-dl:#{url}")
   end

--- a/libs/utils.liq
+++ b/libs/utils.liq
@@ -57,13 +57,13 @@ def playlog(~duration=infinity, ~persistency=null(), ~hash=fun(m)->m["filename"]
   # Load from persistency file
   if null.defined(persistency) then
     if file.exists(null.get(persistency)) then
-      l := of_json(default=[("", 0.)], file.contents(null.get(persistency)))
+      l := json.parse(default=[("", 0.)], file.contents(null.get(persistency)))
     end
   end
   # Save into persistency file
   def save()
     if null.defined(persistency) then
-      file.write(data=json_of(!l), null.get(persistency))
+      file.write(data=json.stringify(!l), null.get(persistency))
     end
   end
   # Remove too old elements

--- a/src/lang/builtins_error.ml
+++ b/src/lang/builtins_error.ml
@@ -33,7 +33,7 @@ module ErrorDef = struct
     Printf.sprintf "error(kind=%S,message=%s)" kind
       (match msg with Some msg -> Printf.sprintf "%S" msg | None -> "none")
 
-  let to_json ~compact:_ v = Printf.sprintf "%S" (descr v)
+  let to_json ~compact:_ ~json5:_ v = Printf.sprintf "%S" (descr v)
   let compare = Stdlib.compare
 end
 

--- a/src/lang/builtins_error.ml
+++ b/src/lang/builtins_error.ml
@@ -33,6 +33,7 @@ module ErrorDef = struct
     Printf.sprintf "error(kind=%S,message=%s)" kind
       (match msg with Some msg -> Printf.sprintf "%S" msg | None -> "none")
 
+  let to_json ~compact:_ v = Printf.sprintf "%S" (descr v)
   let compare = Stdlib.compare
 end
 

--- a/src/lang/builtins_ffmpeg_filters.ml
+++ b/src/lang/builtins_ffmpeg_filters.ml
@@ -53,6 +53,7 @@ module Graph = Lang.MkAbstract (struct
 
   let name = "ffmpeg.filter.graph"
   let descr _ = name
+  let to_json ~compact:_ v = Printf.sprintf "%S" (descr v)
   let compare = Stdlib.compare
 end)
 
@@ -64,6 +65,7 @@ module Audio = Lang.MkAbstract (struct
 
   let name = "ffmpeg.filter.audio"
   let descr _ = name
+  let to_json ~compact:_ v = Printf.sprintf "%S" (descr v)
   let compare = Stdlib.compare
 end)
 
@@ -75,6 +77,7 @@ module Video = Lang.MkAbstract (struct
 
   let name = "ffmpeg.filter.video"
   let descr _ = name
+  let to_json ~compact:_ v = Printf.sprintf "%S" (descr v)
   let compare = Stdlib.compare
 end)
 

--- a/src/lang/builtins_ffmpeg_filters.ml
+++ b/src/lang/builtins_ffmpeg_filters.ml
@@ -53,7 +53,7 @@ module Graph = Lang.MkAbstract (struct
 
   let name = "ffmpeg.filter.graph"
   let descr _ = name
-  let to_json ~compact:_ v = Printf.sprintf "%S" (descr v)
+  let to_json ~compact:_ ~json5:_ v = Printf.sprintf "%S" (descr v)
   let compare = Stdlib.compare
 end)
 
@@ -65,7 +65,7 @@ module Audio = Lang.MkAbstract (struct
 
   let name = "ffmpeg.filter.audio"
   let descr _ = name
-  let to_json ~compact:_ v = Printf.sprintf "%S" (descr v)
+  let to_json ~compact:_ ~json5:_ v = Printf.sprintf "%S" (descr v)
   let compare = Stdlib.compare
 end)
 
@@ -77,7 +77,7 @@ module Video = Lang.MkAbstract (struct
 
   let name = "ffmpeg.filter.video"
   let descr _ = name
-  let to_json ~compact:_ v = Printf.sprintf "%S" (descr v)
+  let to_json ~compact:_ ~json5:_ v = Printf.sprintf "%S" (descr v)
   let compare = Stdlib.compare
 end)
 

--- a/src/lang/builtins_json.ml
+++ b/src/lang/builtins_json.ml
@@ -31,11 +31,8 @@ module JSON = Lang.MkAbstract (struct
   let descr _ = "json"
 
   let to_json ~compact v =
-    if Hashtbl.length v > 0 then
-      !to_json_ref ~compact
-        (Lang.list
-           (Hashtbl.fold (fun k v l -> Lang.tuple [Lang.string k; v] :: l) v []))
-    else "{}"
+    !to_json_ref ~compact
+      (Lang.record (Hashtbl.fold (fun k v l -> (k, v) :: l) v []))
 
   let compare = Stdlib.compare
 end)

--- a/src/lang/builtins_math.ml
+++ b/src/lang/builtins_math.ml
@@ -152,6 +152,19 @@ let () =
     Lang.float_t
 
 let () =
+  Lang.add_builtin_base ~category:(string_of_category Math)
+    ~descr:
+      "A special floating-point value denoting the result of an undefined \
+       operation such as 0.0 /. 0.0. Stands for 'not a number'. Any \
+       floating-point operation with nan as argument returns nan as result. As \
+       for floating-point comparisons, `==`, `<`, `<=`, `>` and `>=` return \
+       `false` and `!=` returns `true` if one or both of their arguments is \
+       `nan`."
+    "nan"
+    Lang.(Ground (Ground.Float nan))
+    Lang.float_t
+
+let () =
   add_builtin "lsl" ~cat:Math ~descr:"Logical shift left."
     [
       ("", Lang.int_t, None, Some "Number to shift.");

--- a/src/lang/lang.ml
+++ b/src/lang/lang.ml
@@ -689,7 +689,7 @@ module type AbstractDef = sig
   type content
 
   val name : string
-  val to_json : compact:bool -> content -> string
+  val to_json : compact:bool -> json5:bool -> content -> string
   val descr : content -> string
   val compare : content -> content -> int
 end
@@ -711,7 +711,8 @@ module MkAbstract (Def : AbstractDef) = struct
           Some
             {
               G.descr = (fun () -> Def.descr v);
-              to_json = (fun ~compact () -> Def.to_json ~compact v);
+              to_json =
+                (fun ~compact ~json5 () -> Def.to_json ~compact ~json5 v);
               compare;
               typ = Type;
             }

--- a/src/lang/lang.mli
+++ b/src/lang/lang.mli
@@ -41,7 +41,7 @@ module Ground : sig
 
   type content = Lang_values.Ground.content = {
     descr : unit -> string;
-    to_json : compact:bool -> unit -> string;
+    to_json : compact:bool -> json5:bool -> unit -> string;
     compare : t -> int;
     typ : Lang_types.ground;
   }
@@ -341,7 +341,7 @@ module type AbstractDef = sig
   type content
 
   val name : string
-  val to_json : compact:bool -> content -> string
+  val to_json : compact:bool -> json5:bool -> content -> string
   val descr : content -> string
   val compare : content -> content -> int
 end

--- a/src/lang/lang.mli
+++ b/src/lang/lang.mli
@@ -41,6 +41,7 @@ module Ground : sig
 
   type content = Lang_values.Ground.content = {
     descr : unit -> string;
+    to_json : compact:bool -> unit -> string;
     compare : t -> int;
     typ : Lang_types.ground;
   }
@@ -333,12 +334,14 @@ module type Abstract = sig
   val t : t
   val to_value : content -> value
   val of_value : value -> content
+  val is_value : value -> bool
 end
 
 module type AbstractDef = sig
   type content
 
   val name : string
+  val to_json : compact:bool -> content -> string
   val descr : content -> string
   val compare : content -> content -> int
 end

--- a/tests/language/json.liq
+++ b/tests/language/json.liq
@@ -14,9 +14,9 @@ def t(x,y) =
 end
 
 def u(d,x) =
-  y = of_json(default=d,json_of(x))
+  y = json.parse(default=d,json.stringify(x))
   if y == d or y != x then
-    print("Failure: #{x} => #{json_of(x)} => #{y}")
+    print("Failure: #{x} => #{json.stringify(x)} => #{y}")
     success := false
   end
 end
@@ -32,21 +32,22 @@ def f() =
   u([(1,[("fr","bar")])], [(2,[("en","foo")])])
   # u([("ping",())], [("pong",())])
   u([3],[])
-  u([("x",0)],of_json(default=[("x",0)],"{\"a\" : 4}"))
+  u([("x",0)],json.parse(default=[("x",0)],"{\"a\" : 4}"))
 
-  t(json_of("a"), '"a"')
-  t(json_of("©"), '"©"')
-  t(json_of('"'), '"\\""')
-  t(json_of('\\'), '"\\\\"')
-  t(json_of(infinity), 'null')
-  t(json_of((0.-infinity)), 'null')
-  t(json_of(nan), 'null')
-  t(json_of(json5=true, infinity), 'Infinity')
-  t(json_of(json5=true, (0.-infinity)), '-Infinity')
-  t(json_of(json5=true, nan), 'NaN')
+  t(json.stringify(()), 'null')
+  t(json.stringify("a"), '"a"')
+  t(json.stringify("©"), '"©"')
+  t(json.stringify('"'), '"\\""')
+  t(json.stringify('\\'), '"\\\\"')
+  t(json.stringify(infinity), 'null')
+  t(json.stringify((0.-infinity)), 'null')
+  t(json.stringify(nan), 'null')
+  t(json.stringify(json5=true, infinity), 'Infinity')
+  t(json.stringify(json5=true, (0.-infinity)), '-Infinity')
+  t(json.stringify(json5=true, nan), 'NaN')
 
-  t(of_json(default=[("","")], '{"a":3}'), [("a","3")])
-  t(of_json(default={x=0, a=""}, '{"a":"z", "x":3}'), {x=3, a="z"})
+  t(json.parse(default=[("","")], '{"a":3}'), [("a","3")])
+  t(json.parse(default={x=0, a=""}, '{"a":"z", "x":3}'), {x=3, a="z"})
 
   j = json()
   j.add("foo", 1)
@@ -55,7 +56,7 @@ def f() =
   j.add("key_with_methods", "value".{method = 123})
   j.add("record", { a = 1, b = "ert"})
   j.remove("foo")
-  t(json_of(j), '{ "record": { "b": "ert", "a": 1 }, "key_with_methods": "value",\n"bla": "bar", "baz": 3.14\n}')
+  t(json.stringify(j), '{ "record": { "b": "ert", "a": 1 }, "key_with_methods": "value",\n"bla": "bar", "baz": 3.14\n}')
 
   if !success then
     test.pass()

--- a/tests/language/json.liq
+++ b/tests/language/json.liq
@@ -38,9 +38,24 @@ def f() =
   t(json_of("©"), '"©"')
   t(json_of('"'), '"\\""')
   t(json_of('\\'), '"\\\\"')
+  t(json_of(infinity), 'null')
+  t(json_of((0.-infinity)), 'null')
+  t(json_of(nan), 'null')
+  t(json_of(json5=true, infinity), 'Infinity')
+  t(json_of(json5=true, (0.-infinity)), '-Infinity')
+  t(json_of(json5=true, nan), 'NaN')
 
   t(of_json(default=[("","")], '{"a":3}'), [("a","3")])
   t(of_json(default={x=0, a=""}, '{"a":"z", "x":3}'), {x=3, a="z"})
+
+  j = json()
+  j.add("foo", 1)
+  j.add("bla", "bar")
+  j.add("baz", 3.14)
+  j.add("key_with_methods", "value".{method = 123})
+  j.add("record", { a = 1, b = "ert"})
+  j.remove("foo")
+  t(json_of(j), '{ "record": { "b": "ert", "a": 1 }, "key_with_methods": "value",\n"bla": "bar", "baz": 3.14\n}')
 
   if !success then
     test.pass()

--- a/tests/media/test_ffmpeg_audio_decoder.liq
+++ b/tests/media/test_ffmpeg_audio_decoder.liq
@@ -21,11 +21,11 @@ clock.assign_new(sync='none',[s])
 def on_done () =
   json = process.read("ffprobe -v quiet -print_format json -show_streams #{out}")
 
-  int_format = of_json(default=[("streams", [[("channels", 0)]])], json)
+  int_format = json.parse(default=[("streams", [[("channels", 0)]])], json)
   stream = list.hd(default=[], list.assoc(default=[], "streams", int_format))
   channels = list.assoc(default=0,"channels",stream)
 
-  string_format = of_json(default=[("streams", [[("samplerate", "0")]])], json)
+  string_format = json.parse(default=[("streams", [[("samplerate", "0")]])], json)
   stream = list.hd(default=[], list.assoc(default=[], "streams", string_format))
   samplerate = list.assoc(default="0","sample_rate",stream)
 

--- a/tests/media/test_ffmpeg_copy_and_encode_decoder.liq
+++ b/tests/media/test_ffmpeg_copy_and_encode_decoder.liq
@@ -20,7 +20,7 @@ clock.assign_new(sync='none',[s])
 def on_done () =
   json = process.read("ffprobe -v quiet -print_format json -show_streams '#{out}'")
 
-  format = of_json(default=[("streams", [[("samplerate", "0")]])], json)
+  format = json.parse(default=[("streams", [[("samplerate", "0")]])], json)
 
   streams = list.assoc(default=[], "streams", format)
 

--- a/tests/media/test_ffmpeg_copy_decoder.liq
+++ b/tests/media/test_ffmpeg_copy_decoder.liq
@@ -21,8 +21,8 @@ def on_done () =
   ijson = process.read("ffprobe -v quiet -print_format json -show_streams '#{fname}'")
   ojson = process.read("ffprobe -v quiet -print_format json -show_streams '#{out}'")
 
-  input_format = of_json(default=[("streams", [[("samplerate", "0")]])], ijson)
-  output_format = of_json(default=[("streams", [[("samplerate", "0")]])], ojson)
+  input_format = json.parse(default=[("streams", [[("samplerate", "0")]])], ijson)
+  output_format = json.parse(default=[("streams", [[("samplerate", "0")]])], ojson)
 
   input_streams = list.assoc(default=[], "streams", input_format)
   output_streams = list.assoc(default=[], "streams", output_format)

--- a/tests/media/test_ffmpeg_distributed_hls.liq
+++ b/tests/media/test_ffmpeg_distributed_hls.liq
@@ -61,7 +61,7 @@ def check_stream() =
   if not !is_done then
     ojson = process.read("ffprobe -v quiet -print_format json -show_streams #{output_dir}/mp4.m3u8")
 
-    output_format = of_json(default=[("streams", [[("samplerate", "0")]])], ojson)
+    output_format = json.parse(default=[("streams", [[("samplerate", "0")]])], ojson)
 
     output_streams = list.assoc(default=[], "streams", output_format)
 

--- a/tests/media/test_ffmpeg_filter.liq
+++ b/tests/media/test_ffmpeg_filter.liq
@@ -48,7 +48,7 @@ def on_done () =
   if !started then
     ojson = process.read("ffprobe -v quiet -print_format json -show_streams '#{out}'")
 
-    output_format = of_json(default=[("streams", [[("samplerate", "0")]])], ojson)
+    output_format = json.parse(default=[("streams", [[("samplerate", "0")]])], ojson)
 
     output_streams = list.assoc(default=[], "streams", output_format)
 

--- a/tests/media/test_ffmpeg_inline_encode_decode.liq
+++ b/tests/media/test_ffmpeg_inline_encode_decode.liq
@@ -23,7 +23,7 @@ def on_done () =
   def check(out) =
     json = process.read("ffprobe -v quiet -print_format json -show_streams '#{out}'")
 
-    format = of_json(default=[("streams", [[("samplerate", "0")]])], json)
+    format = json.parse(default=[("streams", [[("samplerate", "0")]])], json)
 
     streams = list.assoc(default=[], "streams", format)
 

--- a/tests/media/test_ffmpeg_inline_encode_decode_audio.liq
+++ b/tests/media/test_ffmpeg_inline_encode_decode_audio.liq
@@ -23,7 +23,7 @@ def on_done () =
   def check(out) =
     json = process.read("ffprobe -v quiet -print_format json -show_streams '#{out}'")
 
-    format = of_json(default=[("streams", [[("samplerate", "0")]])], json)
+    format = json.parse(default=[("streams", [[("samplerate", "0")]])], json)
 
     streams = list.assoc(default=[], "streams", format)
 

--- a/tests/media/test_ffmpeg_inline_encode_decode_video.liq
+++ b/tests/media/test_ffmpeg_inline_encode_decode_video.liq
@@ -23,7 +23,7 @@ def on_done () =
   def check(out) =
     json = process.read("ffprobe -v quiet -print_format json -show_streams '#{out}'")
 
-    format = of_json(default=[("streams", [[("samplerate", "0")]])], json)
+    format = json.parse(default=[("streams", [[("samplerate", "0")]])], json)
 
     streams = list.assoc(default=[], "streams", format)
 

--- a/tests/media/test_ffmpeg_raw_and_copy_decoder.liq
+++ b/tests/media/test_ffmpeg_raw_and_copy_decoder.liq
@@ -21,8 +21,8 @@ def on_done () =
   ijson = process.read("ffprobe -v quiet -print_format json -show_streams '#{fname}'")
   ojson = process.read("ffprobe -v quiet -print_format json -show_streams '#{out}'")
 
-  iformat = of_json(default=[("streams", [[("samplerate", "0")]])], ijson)
-  oformat = of_json(default=[("streams", [[("samplerate", "0")]])], ojson)
+  iformat = json.parse(default=[("streams", [[("samplerate", "0")]])], ijson)
+  oformat = json.parse(default=[("streams", [[("samplerate", "0")]])], ojson)
 
   istreams = list.assoc(default=[], "streams", iformat)
   ostreams = list.assoc(default=[], "streams", oformat)

--- a/tests/media/test_ffmpeg_raw_and_encode_decoder.liq
+++ b/tests/media/test_ffmpeg_raw_and_encode_decoder.liq
@@ -20,7 +20,7 @@ clock.assign_new(sync='none',[s])
 def on_done () =
   json = process.read("ffprobe -v quiet -print_format json -show_streams '#{out}'")
 
-  format = of_json(default=[("streams", [[("samplerate", "0")]])], json)
+  format = json.parse(default=[("streams", [[("samplerate", "0")]])], json)
 
   streams = list.assoc(default=[], "streams", format)
 

--- a/tests/media/test_ffmpeg_raw_decoder.liq
+++ b/tests/media/test_ffmpeg_raw_decoder.liq
@@ -20,7 +20,7 @@ clock.assign_new(sync='none',[s])
 def on_done () =
   ojson = process.read("ffprobe -v quiet -print_format json -show_streams '#{out}'")
 
-  output_format = of_json(default=[("streams", [[("samplerate", "0")]])], ojson)
+  output_format = json.parse(default=[("streams", [[("samplerate", "0")]])], ojson)
 
   output_streams = list.assoc(default=[], "streams", output_format)
 

--- a/tests/media/test_ffmpeg_raw_hls.liq
+++ b/tests/media/test_ffmpeg_raw_hls.liq
@@ -67,7 +67,7 @@ def check_stream() =
   if not !is_done then
     ojson = process.read("ffprobe -v quiet -print_format json -show_streams #{output_dir}/mp4.m3u8")
 
-    output_format = of_json(default=[("streams", [[("samplerate", "0")]])], ojson)
+    output_format = json.parse(default=[("streams", [[("samplerate", "0")]])], ojson)
 
     output_streams = list.assoc(default=[], "streams", output_format)
 

--- a/tests/media/test_ffmpeg_video_decoder.liq
+++ b/tests/media/test_ffmpeg_video_decoder.liq
@@ -22,7 +22,7 @@ clock.assign_new(sync='none',[s])
 def on_done () =
   json = process.read("ffprobe -v quiet -print_format json -show_streams #{out}")
 
-  string_format = of_json(default=[("streams", [[("samplerate", "0")]])], json)
+  string_format = json.parse(default=[("streams", [[("samplerate", "0")]])], json)
   stream = list.hd(default=[], list.assoc(default=[], "streams", string_format))
   framerate = list.assoc(default="0","r_frame_rate",stream)
   codec = list.assoc(default="0","codec_name",stream)

--- a/tests/media/test_mono.liq
+++ b/tests/media/test_mono.liq
@@ -34,11 +34,11 @@ def on_done () =
 
   json = process.read("ffprobe -v quiet -print_format json -show_streams #{out}")
 
-  int_format = of_json(default=[("streams", [[("channels", 0)]])], json)
+  int_format = json.parse(default=[("streams", [[("channels", 0)]])], json)
   stream = list.hd(default=[], list.assoc(default=[], "streams", int_format))
   channels = list.assoc(default=0,"channels",stream)
 
-  string_format = of_json(default=[("streams", [[("samplerate", "0")]])], json)
+  string_format = json.parse(default=[("streams", [[("samplerate", "0")]])], json)
   stream = list.hd(default=[], list.assoc(default=[], "streams", string_format))
   samplerate = list.assoc(default="0","sample_rate",stream)
 

--- a/tests/media/test_stereo.liq
+++ b/tests/media/test_stereo.liq
@@ -34,11 +34,11 @@ def on_done () =
 
   json = process.read("ffprobe -v quiet -print_format json -show_streams #{out}")
 
-  int_format = of_json(default=[("streams", [[("channels", 0)]])], json)
+  int_format = json.parse(default=[("streams", [[("channels", 0)]])], json)
   stream = list.hd(default=[], list.assoc(default=[], "streams", int_format))
   channels = list.assoc(default=0,"channels",stream)
 
-  string_format = of_json(default=[("streams", [[("samplerate", "0")]])], json)
+  string_format = json.parse(default=[("streams", [[("samplerate", "0")]])], json)
   stream = list.hd(default=[], list.assoc(default=[], "streams", string_format))
   samplerate = list.assoc(default="0","sample_rate",stream)
 

--- a/tests/media/test_stream_audio.liq.in
+++ b/tests/media/test_stream_audio.liq.in
@@ -28,11 +28,11 @@ clock.assign_new(sync='none',[s])
 def on_done () =
   json = process.read("ffprobe -v quiet -print_format json -show_streams #{out}")
 
-  int_format = of_json(default=[("streams", [[("channels", 0)]])], json)
+  int_format = json.parse(default=[("streams", [[("channels", 0)]])], json)
   stream = list.hd(default=[], list.assoc(default=[], "streams", int_format))
   channels = list.assoc(default=0,"channels",stream)
 
-  string_format = of_json(default=[("streams", [[("samplerate", "0")]])], json)
+  string_format = json.parse(default=[("streams", [[("samplerate", "0")]])], json)
   stream = list.hd(default=[], list.assoc(default=[], "streams", string_format))
   samplerate = list.assoc(default="0","sample_rate",stream)
 

--- a/tests/media/test_stream_video.liq.in
+++ b/tests/media/test_stream_video.liq.in
@@ -28,7 +28,7 @@ clock.assign_new(sync='none',[s])
 def on_done () =
   json = process.read("ffprobe -v quiet -print_format json -show_streams #{out}")
 
-  string_format = of_json(default=[("streams", [[("samplerate", "0")]])], json)
+  string_format = json.parse(default=[("streams", [[("samplerate", "0")]])], json)
   stream = list.hd(default=[], list.assoc(default=[], "streams", string_format))
   framerate = list.assoc(default="0","r_frame_rate",stream)
   codec = list.assoc(default="0","codec_name",stream)


### PR DESCRIPTION
This PR implements a couple of well-needed JSON improvements:
* Add optional support for `json5` style `NaN` and `Infinity` floats, revert float output to be compliant in the old case
* Add support for generic json object manipulation
* Cleanup json export to export `(string, 'a)` lists as lists
* Allow values decorated with methods to be exported as values, except for `()` (records) which as kepts exported as objects
* Renamed, with deprecations, `json_of` into `json.stringify` and `of_json` into `json.parse`

Test script for generic JSON object:
```
# j = json();;
# j.add("foo", 1);;
# j.add("bla", "baz");;
# j.add("gni", 3.14);;
# j.remove("foo");;
# json.stringify(j);;
- : string = "{ \"gni\": 3.14, \"bla\": \"baz\" }"
```

TODO:
* ~~Rename `json_of` `json.stringify` and `of_json`, `json.parse` (with deprecations)~~
* ~~Fix #1823~~
* ~~Document~~ 
* ~~Test~~

