### PR TITLE
Handle nullable then.

### DIFF
--- a/libs/ffmpeg.liq
+++ b/libs/ffmpeg.liq
@@ -50,7 +50,7 @@ def video.add_text.ffmpeg(~color=0xffffff, ~font="", ~size=18, ~x=10, ~y=10, tex
     if font == "" then
       null()
     else
-      null(font)
+      font
     end
   def mkfilter(graph)
     s = ffmpeg.filter.video.input(graph, s)

--- a/libs/file.liq
+++ b/libs/file.liq
@@ -35,7 +35,7 @@ def file.iterator(fname)
   f = file.read(fname)
   fun () -> begin
     s = f()
-    (s=="")?null():null(s)
+    (s=="")?null():s
   end
 end
 

--- a/libs/playlist.liq
+++ b/libs/playlist.liq
@@ -343,7 +343,7 @@ def replaces playlist(
         watched_uri := uri
         watcher :=
            if file.exists(uri) then
-             null(file.watch(uri, s.reload))
+             file.watch(uri, s.reload)
            else
              null()
            end

--- a/libs/protocols.liq
+++ b/libs/protocols.liq
@@ -162,7 +162,7 @@ def http_protocol(proto,~rlog,~maxtime,arg) =
 
   mime =
     if 200 <= code and code < 300 then
-      null(headers["content-type"])
+      headers["content-type"]
     else
       log(level=3,"Failed to fetch mime-type for #{uri}.")
       log(level=4,"Request response: #{ret}")

--- a/src/lang/lang_parser.mly
+++ b/src/lang/lang_parser.mly
@@ -195,12 +195,12 @@ expr:
                                        let then_b = mk_fun ~pos:($startpos($3),$endpos($4)) [] $4 in
                                        let else_b = $5 in
                                        let op = mk ~pos:$loc($1) (Var "if") in
-                                       mk ~pos:$loc (App (op, ["", cond; "else", else_b; "then", then_b])) }
+                                       mk ~pos:$loc (App (op, ["", cond; "then", then_b; "else", else_b])) }
   | expr QUESTION expr COLON expr    { let cond = $1 in
                                        let then_b = mk_fun ~pos:$loc($3) [] $3 in
                                        let else_b = mk_fun ~pos:$loc($5) [] $5 in
                                        let op = mk ~pos:$loc($1) (Var "if") in
-                                       mk ~pos:$loc (App (op, ["", cond; "else", else_b; "then", then_b])) } 
+                                       mk ~pos:$loc (App (op, ["", cond; "then", then_b; "else", else_b])) }
 
   | expr BIN0 expr                 { mk ~pos:$loc (App (mk ~pos:$loc($2) (Var $2), ["",$1;"",$3])) }
   | expr BIN1 expr                 { mk ~pos:$loc (App (mk ~pos:$loc($2) (Var $2), ["",$1;"",$3])) }
@@ -388,7 +388,7 @@ if_elsif:
                                       let then_b = mk_fun ~pos:($startpos($3), $endpos($4)) [] $4 in
                                       let else_b = $5 in
                                       let op = mk ~pos:$loc($1) (Var "if") in
-                                      mk_fun ~pos:$loc [] (mk ~pos:$loc (App (op,["",cond; "else",else_b; "then",then_b]))) }
+                                      mk_fun ~pos:$loc [] (mk ~pos:$loc (App (op,["",cond; "then",then_b; "else",else_b]))) }
   | ELSE exprs                      { mk_fun ~pos:($startpos($1),$endpos($2)) [] $2 }
   |                                 { mk_fun ~pos:$loc [] (mk ~pos:$loc unit) }
 

--- a/src/lang/lang_values.ml
+++ b/src/lang/lang_values.ml
@@ -831,11 +831,11 @@ let rec check ?(print_toplevel = false) ~throw ~level ~(env : T.env) e =
        the then branch is nullable but the else branch is not, see #1816. *)
     | App
         ( ({ term = Var "if" } as e_if),
-          [("", e_cond); ("else", e_else); ("then", e_then)] ) ->
+          [("", e_cond); ("then", e_then); ("else", e_else)] ) ->
         check ~throw ~level ~env e_if;
         check ~throw ~level ~env e_cond;
-        check ~throw ~level ~env e_else;
         check ~throw ~level ~env e_then;
+        check ~throw ~level ~env e_else;
         let a = T.fresh_evar ~level ~pos in
         e_cond.t <: T.make (T.Ground T.Bool);
         e_else.t <: T.make (T.Arrow ([], a));

--- a/src/lang/lang_values.ml
+++ b/src/lang/lang_values.ml
@@ -827,6 +827,27 @@ let rec check ?(print_toplevel = false) ~throw ~level ~(env : T.env) e =
         if not (can_ignore a.t) then throw (Ignored a);
         check ~print_toplevel ~throw ~level ~env b;
         e.t >: b.t
+    (* Special case for if branchings in order to backtrack in the case where
+       the then branch is nullable but the else branch is not, see #1816. *)
+    | App
+        ( ({ term = Var "if" } as e_if),
+          [("", e_cond); ("else", e_else); ("then", e_then)] ) ->
+        check ~throw ~level ~env e_if;
+        check ~throw ~level ~env e_cond;
+        check ~throw ~level ~env e_else;
+        check ~throw ~level ~env e_then;
+        let a = T.fresh_evar ~level ~pos in
+        e_cond.t <: T.make (T.Ground T.Bool);
+        e_else.t <: T.make (T.Arrow ([], a));
+        if
+          try
+            e_then.t <: T.make (T.Arrow ([], a));
+            true
+          with _ -> false
+        then e.t >: a
+        else (
+          e_then.t <: T.make (T.Arrow ([], T.make (T.Nullable a)));
+          e.t >: T.make (T.Nullable a))
     | App (a, l) -> (
         check ~throw ~level ~env a;
         List.iter (fun (_, b) -> check ~throw ~env ~level b) l;

--- a/tests/language/null.liq
+++ b/tests/language/null.liq
@@ -32,6 +32,14 @@ def f() =
     end
   end
 
+  def f()
+    if true then null() else 1 end
+  end
+
+  def f()
+    if true then 1 else null() end
+  end
+
   test.pass()
 end
 


### PR DESCRIPTION
Add a special case in the typechecker in order to handle conditionals
where the then branch is nullable and the else branch is not. This is a
hack but a proper fix would involve deferring unification to a
constraint solver, which we are not prepared for (yet). Fixes #1816.