### PR TITLE
Cleanup past metadata

### DIFF
--- a/src/operators/cross.ml
+++ b/src/operators/cross.ml
@@ -192,10 +192,7 @@ class cross ~kind val_source ~cross_length ~override_duration ~rms_width
               self#log#info "Buffering end of track...";
               status <- `Before;
               Frame.set_breaks buf_frame [Frame.position frame];
-              Frame.set_all_metadata buf_frame
-                (match Frame.get_past_metadata frame with
-                  | Some x -> [(-1, x)]
-                  | None -> []);
+              Frame.set_all_metadata buf_frame [];
               self#buffering cross_length;
               if status <> `Limit then
                 self#log#info "More buffering will be needed.";

--- a/src/operators/insert_metadata.ml
+++ b/src/operators/insert_metadata.ml
@@ -129,8 +129,13 @@ class replay ~kind meta src =
     method private get_frame ab =
       let start = Frame.position ab in
       src#get ab;
+      let stop = Frame.position ab in
       if first then (
-        if Frame.get_metadata ab start = None then
-          Frame.set_metadata ab start meta;
+        if
+          List.filter
+            (fun (pos, _) -> start <= pos && pos <= stop)
+            (Frame.get_all_metadata ab)
+          = []
+        then Frame.set_metadata ab start meta;
         first <- false)
   end

--- a/src/operators/switch.ml
+++ b/src/operators/switch.ml
@@ -251,7 +251,10 @@ class virtual switch ~kind ~name ~override_meta ~transition_length
                         | None -> fun (p, m) -> Some (p, m)
                         | Some (curp, curm) ->
                             fun (p, m) ->
-                              Some (if p >= curp then (p, m) else (curp, curm)))
+                              Some
+                                (if p >= curp && p <= Frame.position ab then
+                                 (p, m)
+                                else (curp, curm)))
                       (match c.cur_meta with
                         | None -> None
                         | Some m -> Some (-1, m))

--- a/src/stream/frame.ml
+++ b/src/stream/frame.ml
@@ -163,12 +163,7 @@ let advance b =
   Frame_content.clear b.content.midi;
   b.pts <- Int64.succ b.pts;
   b.breaks <- [];
-  let max a (p, m) =
-    match a with Some (pa, _) when pa > p -> a | _ -> Some (p, m)
-  in
-  let rec last a = function [] -> a | b :: l -> last (max a b) l in
-  b.metadata <-
-    (match last None b.metadata with None -> [] | Some (_, e) -> [(-1, e)])
+  b.metadata <- []
 
 (** Presentation time stuff. *)
 
@@ -196,9 +191,6 @@ let get_all_metadata b =
 
 let get_all_raw_metadata b = b.metadata
 let set_all_metadata b l = b.metadata <- l
-
-let get_past_metadata b =
-  try Some (List.assoc (-1) b.metadata) with Not_found -> None
 
 let fill_content src src_pos dst dst_pos len =
   let fill src dst = fill src src_pos dst dst_pos len in

--- a/src/stream/frame.mli
+++ b/src/stream/frame.mli
@@ -173,9 +173,6 @@ val get_all_raw_metadata : t -> (int * metadata) list
 (** Set all metadata. *)
 val set_all_metadata : t -> (int * metadata) list -> unit
 
-(** Retrieve "past metadata" which are stored at offset [-1] (cf. [advance]). *)
-val get_past_metadata : t -> metadata option
-
 (** {2 Content operations} *)
 
 exception No_chunk


### PR DESCRIPTION
This is another long-standing liquidsoap legacy: how we handle replaying past metadata in liquidsoap.

Initially, we used to store a "past" metadata at position `-1` when cleaning up a frame after a streaming cycle. This does not seem to be used anymore though I found some vestiges of it in `cross.ml`.

More recently, it seems that we did switch to an explicit last metadata variable, which should work as expected. However, this PR also pushes a couple of sanity check, in particular making sure the metadata is not replayed if there is any metadata in the first frame, not just at the starting position.

We should test that to confirm that it does not break anything and merge it.