### PR TITLE
Strict boolean operations.

### DIFF
--- a/src/lang/builtins_bool.ml
+++ b/src/lang/builtins_bool.ml
@@ -71,16 +71,24 @@ let () =
 
 let () =
   add_builtin "and" ~cat:Bool ~descr:"Return the conjunction of its arguments"
-    [("", Lang.bool_t, None, None); ("", Lang.bool_t, None, None)] Lang.bool_t
+    [
+      ("", Lang.getter_t Lang.bool_t, None, None);
+      ("", Lang.getter_t Lang.bool_t, None, None);
+    ]
+    Lang.bool_t
     (fun p ->
-      match List.map (fun (_, x) -> Lang.to_bool x) p with
-        | [a; b] -> Lang.bool (a && b)
+      match List.map (fun (_, x) -> Lang.to_bool_getter x) p with
+        | [a; b] -> Lang.bool (if a () then b () else false)
         | _ -> assert false);
   add_builtin "or" ~cat:Bool ~descr:"Return the disjunction of its arguments"
-    [("", Lang.bool_t, None, None); ("", Lang.bool_t, None, None)] Lang.bool_t
+    [
+      ("", Lang.getter_t Lang.bool_t, None, None);
+      ("", Lang.getter_t Lang.bool_t, None, None);
+    ]
+    Lang.bool_t
     (fun p ->
-      match List.map (fun (_, x) -> Lang.to_bool x) p with
-        | [a; b] -> Lang.bool (a || b)
+      match List.map (fun (_, x) -> Lang.to_bool_getter x) p with
+        | [a; b] -> Lang.bool (if a () then true else b ())
         | _ -> assert false)
 
 let () =

--- a/src/lang/lang_lexer.ml
+++ b/src/lang/lang_lexer.ml
@@ -249,7 +249,7 @@ let rec token lexbuf =
     | "do" -> DO
     | "not" -> NOT
     | "open" -> OPEN
-    | "and" | "or" -> BIN0 (Sedlexing.Utf8.lexeme lexbuf)
+    | "and" | "or" -> BINB (Sedlexing.Utf8.lexeme lexbuf)
     | "!=" | "==" | "<" | "<=" | ">" | ">=" ->
         BIN1 (Sedlexing.Utf8.lexeme lexbuf)
     | "+" | "%" | "^" | "+." | "-." -> BIN2 (Sedlexing.Utf8.lexeme lexbuf)

--- a/src/lang/lang_parser.mly
+++ b/src/lang/lang_parser.mly
@@ -51,7 +51,7 @@ open Lang_parser_helper
 %token LBRA RBRA LCUR RCUR
 %token FUN YIELDS
 %token DOTDOTDOT
-%token <string> BIN0
+%token <string> BINB
 %token <string> BIN1
 %token <string> BIN2
 %token <string> BIN3
@@ -74,7 +74,7 @@ open Lang_parser_helper
 %right SET             /* expr := (expr + expr), expr := (expr := expr) */
 %nonassoc TO
 %nonassoc QUESTION    /* x ? y : z */
-%left BIN0             /* ((x+(y*z))==3) or ((not a)==b) */
+%left BINB             /* ((x+(y*z))==3) or ((not a)==b) */
 %left BIN1
 %nonassoc NOT
 %left BIN2 MINUS
@@ -202,7 +202,9 @@ expr:
                                        let op = mk ~pos:$loc($1) (Var "if") in
                                        mk ~pos:$loc (App (op, ["", cond; "then", then_b; "else", else_b])) }
 
-  | expr BIN0 expr                 { mk ~pos:$loc (App (mk ~pos:$loc($2) (Var $2), ["",$1;"",$3])) }
+  | expr BINB expr                 { let left = mk_fun ~pos:$loc($1) [] $1 in
+                                     let right= mk_fun ~pos:$loc($3) [] $3 in
+                                     mk ~pos:$loc (App (mk ~pos:$loc($2) (Var $2), ["",left;"",right])) }
   | expr BIN1 expr                 { mk ~pos:$loc (App (mk ~pos:$loc($2) (Var $2), ["",$1;"",$3])) }
   | expr BIN2 expr                 { mk ~pos:$loc (App (mk ~pos:$loc($2) (Var $2), ["",$1;"",$3])) }
   | expr BIN3 expr                 { mk ~pos:$loc (App (mk ~pos:$loc($2) (Var $2), ["",$1;"",$3])) }

--- a/tests/language/bool.liq
+++ b/tests/language/bool.liq
@@ -2,7 +2,20 @@
 
 %include "test.liq"
 
+def t(x, y)
+  if x != y then
+    print("Failure: got #{x} instead of #{y}")
+    test.fail()
+  end
+end
+
 def f() =
+  # Test strictness and evaluation order
+  l = ref(false)
+  r = ref(false)
+  if begin l := true; true end or begin r := true; true end then () end
+  t(!l and (not !r), true)
+
   ignore(true == false ? 5 : 6)
   test.pass()
 end


### PR DESCRIPTION
Conjunction and disjunction are evaluated with first argument first, and
second argument is only evaluated if needed. Fixes #1644.