### PR TITLE
Type driven json parser

### DIFF
--- a/libs/error.liq
+++ b/libs/error.liq
@@ -3,9 +3,8 @@ let error.assertion = error.register("assertion")
 let error.invalid = error.register("invalid")
 let error.eval = error.register("eval")
 let error.file = error.register("file")
-let error.socket = error.register("socket")
-
 let error.string = error.register("string")
+let error.json = error.register("json")
 
 # Ensure that a condition is satisfied (raise `error.assertion` exception
 # otherwise).

--- a/libs/externals.liq
+++ b/libs/externals.liq
@@ -37,11 +37,27 @@ def enable_external_ffmpeg_decoder() =
 
   def ffprobe_test(fname) =
     j = process.read("#{ffprobe} -print_format json -show_streams #{string.quote(fname)}")
-    default = [("streams",[[("channels",0)]])]
-    data = json.parse(default=default,j)
-    streams = list.assoc(default=[],"streams",data)
-    stream = list.hd(default=[],streams)
-    list.assoc(default=0,"channels",stream)
+
+    let json.parse ( parsed : {
+      streams : [{
+        channels : int?
+      }]
+    }?) = j
+
+    if null.defined(parsed) then
+      parsed = null.get(parsed)
+
+      streams = parsed.streams
+      stream = list.find(
+        default={channels = null(0)},
+        (fun (x) -> null.defined(x.channels)),
+        streams
+      )
+
+      stream.channels ?? 0
+    else
+      0
+    end
   end
 
   if file.which(ffmpeg) != null() and file.which (ffprobe) != null() then

--- a/libs/interactive.liq
+++ b/libs/interactive.liq
@@ -219,12 +219,14 @@ server.register(usage="set <name> = <value>", description="Set the value of a va
 # @category Interactive
 # @param fname Name of the file.
 def interactive.save(fname)
-  float = list.map(fun (nv) -> begin let (name, v) = nv; (name, !v.ref) end, !variables_float)
-  int = list.map(fun (nv) -> begin let (name, v) = nv; (name, !v.ref) end, !variables_int)
-  bool = list.map(fun (nv) -> begin let (name, v) = nv; (name, !v.ref) end, !variables_bool)
-  string = list.map(fun (nv) -> begin let (name, v) = nv; (name, !v.ref) end, !variables_string)
-  vars = (float, int, bool, string)
-  file.write(data=json.stringify(vars), fname)
+  let json.stringify data = {
+    float = list.map(fun (nv) -> begin let (name, v) = nv; (name, !v.ref) end, !variables_float),
+    int = list.map(fun (nv) -> begin let (name, v) = nv; (name, !v.ref) end, !variables_int),
+    bool = list.map(fun (nv) -> begin let (name, v) = nv; (name, !v.ref) end, !variables_bool),
+    string = list.map(fun (nv) -> begin let (name, v) = nv; (name, !v.ref) end, !variables_string)
+  }
+
+  file.write(data=data, fname)
 end
 
 # Load the value of interactive variables from a file.
@@ -232,11 +234,17 @@ end
 # @param fname Name of the file.
 def interactive.load(fname)
   vars = file.contents(fname)
-  let (float, int, bool, string) = json.parse(default=([("",0.)],[("",0)],[("",false)],[("","")]), vars)
-  list.iter(fun (nv) -> try interactive.float.set (fst(nv), snd(nv)) catch _ do log.important(label="interactive.load", "Variable #{fst(nv)} not found.") end, float )
-  list.iter(fun (nv) -> try interactive.int.set   (fst(nv), snd(nv)) catch _ do log.important(label="interactive.load", "Variable #{fst(nv)} not found.") end, int   )
-  list.iter(fun (nv) -> try interactive.bool.set  (fst(nv), snd(nv)) catch _ do log.important(label="interactive.load", "Variable #{fst(nv)} not found.") end, bool  )
-  list.iter(fun (nv) -> try interactive.string.set(fst(nv), snd(nv)) catch _ do log.important(label="interactive.load", "Variable #{fst(nv)} not found.") end, string)
+  let json.parse ( vars: {
+    float : [(string * float)],
+    int : [(string * int)],
+    bool : [(string * bool)],
+    string : [(string * string)] 
+  } ) = vars
+
+  list.iter(fun (nv) -> try interactive.float.set (fst(nv), snd(nv)) catch _ do log.important(label="interactive.load", "Variable #{fst(nv)} not found.") end, vars.float )
+  list.iter(fun (nv) -> try interactive.int.set   (fst(nv), snd(nv)) catch _ do log.important(label="interactive.load", "Variable #{fst(nv)} not found.") end, vars.int   )
+  list.iter(fun (nv) -> try interactive.bool.set  (fst(nv), snd(nv)) catch _ do log.important(label="interactive.load", "Variable #{fst(nv)} not found.") end, vars.bool  )
+  list.iter(fun (nv) -> try interactive.string.set(fst(nv), snd(nv)) catch _ do log.important(label="interactive.load", "Variable #{fst(nv)} not found.") end, vars.string)
 end
 
 # Make the value of interactive variables persistent: they are loaded from the

--- a/libs/metadata.liq
+++ b/libs/metadata.liq
@@ -138,9 +138,9 @@ let metadata.json = ()
 # `string.data_uri.encode`.
 # @category String 
 # @param ~coverart_mime Mime type to use for `"coverart"` metadata. Support disasbled if `null`.
-# @param ~base64 Encode cover data as `base64`
-# @argsof json.stringify
-def metadata.json.stringify(~coverart_mime=null(), ~base64=true, %argsof(json.stringify), m) =
+# @param ~compact Output compact text.
+# @param ~json5 Use json5 extended spec.
+def metadata.json.stringify(~coverart_mime=null(), ~base64=true, ~compact=false, ~json5=false, m) =
   c = metadata.cover(coverart_mime=coverart_mime, m)
   m = metadata.cover.remove(m)
   m = metadata.export(m)
@@ -152,14 +152,14 @@ def metadata.json.stringify(~coverart_mime=null(), ~base64=true, %argsof(json.st
     else
       m
     end
-  j = json()
-  list.iter((fun (v) -> j.add(fst(v), (snd(v):string))), m)
-  json.stringify(%argsof(json.stringify), j)
+
+  let json.stringify[compact, json5] (data : [(string * string)] as json.object) = m
+  data
 end
 
 # Parse metadata from JSON object
 # @category String
 def metadata.json.parse(s) =
-  m = json.parse(default=[("invalid","invalid")], s)
-  if m == [("invalid","invalid")] then [] else m end
+  let json.parse ( m : [(string * string)]? ) = s
+  m ?? []
 end

--- a/libs/resolvers.liq
+++ b/libs/resolvers.liq
@@ -25,8 +25,9 @@ def youtube_playlist_parser(~pwd="",url) =
   binary = null.get(settings.protocol.youtube_dl.path())
 
   def parse_line(line) =
-    parsed = json.parse(default=[("url","foo")],line)
-    url = list.assoc(default="","url",parsed)
+    let json.parse ( parsed  : {url : string}? ) = line
+    parsed = parsed ?? {url = "foo"}
+    url = parsed.url
     ([],"youtube-dl:#{url}")
   end
 

--- a/libs/utils.liq
+++ b/libs/utils.liq
@@ -57,13 +57,17 @@ def playlog(~duration=infinity, ~persistency=null(), ~hash=fun(m)->m["filename"]
   # Load from persistency file
   if null.defined(persistency) then
     if file.exists(null.get(persistency)) then
-      l := json.parse(default=[("", 0.)], file.contents(null.get(persistency)))
+      let json.parse ( parsed : [(string * float)]? ) = file.contents(null.get(persistency))
+      if null.defined(parsed) then
+         l := null.get(parsed)
+      end
     end
   end
   # Save into persistency file
   def save()
     if null.defined(persistency) then
-      file.write(data=json.stringify(!l), null.get(persistency))
+      let json.stringify data = !l 
+      file.write(data=data, null.get(persistency))
     end
   end
   # Remove too old elements

--- a/src/lang/builtins_json.ml
+++ b/src/lang/builtins_json.ml
@@ -20,8 +20,6 @@
 
  *****************************************************************************)
 
-open Lang
-
 let log = Log.make ["lang"; "json"]
 
 let rec json_of_value v : Json.t =
@@ -48,6 +46,238 @@ let rec json_of_value v : Json.t =
                 pos = (match v.Value.pos with Some p -> [p] | None -> []);
               })
 
+let rec type_of_json = function
+  | `Assoc l ->
+      Lang.record_t (List.map (fun (lbl, j) -> (lbl, type_of_json j)) l)
+  | `Tuple l -> Lang.tuple_t (List.map type_of_json l)
+  | `String _ -> Lang.string_t
+  | `Bool _ -> Lang.bool_t
+  | `Float _ -> Lang.float_t
+  | `Int _ -> Lang.int_t
+  | `Null -> Lang.(nullable_t (univ_t ()))
+
+let rec nullable_deref ty =
+  let ty = Type.deref ty in
+  match ty.Type.descr with
+    | Type.Var _ ->
+        Typing.(ty <: Lang.nullable_t (Lang.univ_t ()));
+        nullable_deref ty
+    | Type.Nullable ty -> (true, ty)
+    | _ -> (false, ty)
+
+let rec json_of_typed_value ~ty v : Json.t =
+  let nullable, _ty = nullable_deref ty in
+  try
+    match (v.Value.value, _ty.Type.descr) with
+      | Value.Null, Type.Nullable _ -> `Null
+      | Value.Ground g, Type.Ground g' when Term.Ground.to_type g = g' ->
+          Term.Ground.to_json g
+      | Value.List l, Type.(List { t = ty; json_repr = `Tuple }) ->
+          `Tuple (List.map (json_of_typed_value ~ty) l)
+      | ( Value.List l,
+          Type.(
+            List
+              {
+                t = { descr = Tuple [{ descr = Ground String }; ty] };
+                json_repr = `Object;
+              }) ) ->
+          `Assoc
+            (List.map
+               (fun v ->
+                 let lbl, v = Lang.to_product v in
+                 (Lang.to_string lbl, json_of_typed_value ~ty v))
+               l)
+      | Value.Tuple l, Type.Tuple t ->
+          `Tuple
+            (List.mapi
+               (fun idx ty -> json_of_typed_value ~ty (List.nth l idx))
+               t)
+      | Value.Meth _, _ -> (
+          let tm, ty = Type.split_meths ty in
+          let m, v = Value.split_meths v in
+          match ty.Type.descr with
+            | Type.Var _ | Type.Tuple [] ->
+                Typing.(ty <: Lang.unit_t);
+                `Assoc
+                  (List.mapi
+                     (fun idx Type.{ meth; json_name; scheme = _, ty } ->
+                       let _, v = List.nth m idx in
+                       let lbl = Option.value ~default:meth json_name in
+                       (lbl, json_of_typed_value ~ty v))
+                     tm)
+            | _ -> json_of_typed_value ~ty v)
+      | _, Type.Var _ ->
+          let j = json_of_value v in
+          Typing.(_ty <: type_of_json j);
+          j
+      | _ -> assert false
+  with
+    | _ when nullable -> `Null
+    | _ ->
+        raise
+          Runtime_error.(
+            Runtime_error
+              {
+                kind = "json";
+                msg =
+                  Printf.sprintf
+                    "Value %s of type %s cannot be represented as json"
+                    (Value.print_value v) (Type.to_string ty);
+                pos = (match v.Value.pos with Some p -> [p] | None -> []);
+              })
+
+type json_ellipsis_base =
+  [ `Assoc of (string * string option * json_ellipsis) list
+  | `List of json_ellipsis
+  | `Tuple of json_ellipsis list
+  | `String
+  | `Bool
+  | `Float
+  | `Int
+  | `Null
+  | `Ignore ]
+
+and json_ellipsis = bool * json_ellipsis_base
+
+let rec string_of_json_ellipsis (nullable, ty) =
+  let f ty = if nullable then ty ^ "?" else ty in
+  match ty with
+    | `Ignore -> "_"
+    | `Null -> f "null"
+    | `Int -> f "int"
+    | `Float -> f "float"
+    | `Bool -> f "bool"
+    | `String -> f "string"
+    | `List ty -> f ("[" ^ string_of_json_ellipsis ty ^ "]")
+    | `Tuple [] -> f "()"
+    | `Tuple l ->
+        f ("(" ^ String.concat "," (List.map string_of_json_ellipsis l) ^ ")")
+    | `Assoc [] -> f "{}"
+    (* We should only report the one attribute that has failed to parse. *)
+    | `Assoc ((lbl, lbl', ty) :: _) ->
+        let lbl =
+          match lbl' with
+            | Some v ->
+                Printf.sprintf "%s as %s" (Utils.quote_utf8_string v) lbl
+            | None -> lbl
+        in
+        f
+          ("{"
+          ^ Printf.sprintf "%s: %s" lbl (string_of_json_ellipsis ty)
+          ^ ", _}")
+
+exception Failed of json_ellipsis
+
+let rec value_of_typed_json ~ty json =
+  let nullable, _ty = nullable_deref ty in
+  try
+    let tm, ty = Type.split_meths _ty in
+    match (json, ty.Type.descr) with
+      | `Assoc l, Type.Var _ | `Assoc l, Type.Tuple [] ->
+          Typing.(ty <: Lang.unit_t);
+          let meth =
+            List.map
+              (fun Type.{ meth; json_name; scheme = _, ty } ->
+                let ty = Type.deref ty in
+                let lbl = Option.value ~default:meth json_name in
+                let nullable_meth, _ = nullable_deref ty in
+                let v =
+                  match List.assoc_opt lbl l with
+                    | Some v -> (
+                        try value_of_typed_json ~ty v
+                        with Failed v ->
+                          raise
+                            (Failed (nullable, `Assoc [(meth, json_name, v)])))
+                    | None when nullable_meth -> Lang.null
+                    | _ ->
+                        raise
+                          (Failed
+                             ( nullable,
+                               `Assoc
+                                 [(meth, json_name, (nullable_meth, `Ignore))]
+                             ))
+                in
+                (meth, v))
+              tm
+          in
+          Lang.meth Lang.unit meth
+      | ( `Assoc l,
+          Type.(
+            List
+              {
+                t = { descr = Tuple [{ descr = Ground String }; ty] };
+                json_repr = `Object;
+              }) ) ->
+          Lang.list
+            (List.map
+               (fun (lbl, v) ->
+                 try Lang.product (Lang.string lbl) (value_of_typed_json ~ty v)
+                 with Failed v ->
+                   raise (Failed (nullable, `Assoc [(lbl, None, v)])))
+               l)
+      | `Tuple l, Type.(List { t = ty; json_repr = `Tuple }) ->
+          Lang.list
+            (List.map
+               (fun v ->
+                 try value_of_typed_json ~ty v
+                 with Failed v -> raise (Failed (nullable, `List v)))
+               l)
+      | `Tuple l, Type.Tuple t ->
+          Lang.tuple
+            (List.mapi
+               (fun idx ty ->
+                 try value_of_typed_json ~ty (List.nth l idx)
+                 with Failed v ->
+                   let l =
+                     List.init (List.length t) (fun _ -> (false, `Ignore))
+                   in
+                   let l =
+                     List.mapi (fun idx' el -> if idx = idx' then v else el) l
+                   in
+                   raise (Failed (nullable, `Tuple l)))
+               t)
+      | `String s, Type.(Ground String) -> Lang.string s
+      | `Bool b, Type.(Ground Bool) -> Lang.bool b
+      | `Float f, Type.(Ground Float) -> Lang.float f
+      | `Int i, Type.(Ground Float) -> Lang.float (float i)
+      | `Int i, Type.(Ground Int) -> Lang.int i
+      | _, Type.Var _ ->
+          Typing.(ty <: type_of_json json);
+          Lang.null
+      | _, Type.(Ground String) -> raise (Failed (nullable, `String))
+      | _, Type.(Ground Bool) -> raise (Failed (nullable, `Bool))
+      | _, Type.(Ground Float) -> raise (Failed (nullable, `Float))
+      | _, Type.(Ground Int) -> raise (Failed (nullable, `Int))
+      | _ -> assert false
+  with _ when nullable -> Lang.null
+
+let value_of_typed_json ~ty json =
+  try value_of_typed_json ~ty json with
+    | Failed v ->
+        raise
+          Runtime_error.(
+            Runtime_error
+              {
+                kind = "json";
+                msg =
+                  Printf.sprintf
+                    "Parsing error: json value cannot be parsed as type %s"
+                    (string_of_json_ellipsis v);
+                pos = (match ty.Type.pos with Some p -> [p] | None -> []);
+              })
+    | _ ->
+        raise
+          Runtime_error.(
+            Runtime_error
+              {
+                kind = "json";
+                msg =
+                  Printf.sprintf
+                    "Parsing error: json value cannot be parsed as type %s"
+                    (Type.to_string ty);
+                pos = (match ty.Type.pos with Some p -> [p] | None -> []);
+              })
+
 module JsonValue = Value.MkAbstract (struct
   type content = (string, Lang.value) Hashtbl.t
 
@@ -61,7 +291,7 @@ module JsonValue = Value.MkAbstract (struct
 end)
 
 let () =
-  let val_t = univ_t () in
+  let val_t = Lang.univ_t () in
   let var =
     match val_t.Type.descr with
       | Type.Var { contents = Type.Free v } -> v
@@ -70,132 +300,207 @@ let () =
   let meth =
     [
       ( "add",
-        ([var], fun_t [(false, "", string_t); (false, "", val_t)] unit_t),
+        ( [var],
+          Lang.fun_t
+            [(false, "", Lang.string_t); (false, "", val_t)]
+            Lang.unit_t ),
         "Add or replace a new `key`/`value` pair to the object.",
         fun v ->
-          val_fun [("", "", None); ("", "", None)] (fun p ->
-              let key = to_string (assoc "" 1 p) in
-              let value = assoc "" 2 p in
+          Lang.val_fun [("", "", None); ("", "", None)] (fun p ->
+              let key = Lang.to_string (Lang.assoc "" 1 p) in
+              let value = Lang.assoc "" 2 p in
               Hashtbl.replace v key value;
-              unit) );
+              Lang.unit) );
       ( "remove",
-        ([], fun_t [(false, "", string_t)] unit_t),
+        ([], Lang.fun_t [(false, "", Lang.string_t)] Lang.unit_t),
         "Remove a key from the object. Does not nothing if the key does not \
          exist.",
         fun v ->
-          val_fun [("", "", None)] (fun p ->
-              let key = to_string (List.assoc "" p) in
+          Lang.val_fun [("", "", None)] (fun p ->
+              let key = Lang.to_string (List.assoc "" p) in
               Hashtbl.remove v key;
-              unit) );
+              Lang.unit) );
     ]
   in
   let t =
-    method_t JsonValue.t
+    Lang.method_t JsonValue.t
       (List.map (fun (name, typ, doc, _) -> (name, typ, doc)) meth)
   in
-  add_builtin "json" ~category:`String ~descr:"Create a generic json object" []
-    t (fun _ ->
+  Lang.add_builtin "json" ~category:`String
+    ~descr:"Create a generic json object" [] t (fun _ ->
       let v = Hashtbl.create 10 in
       let meth = List.map (fun (name, _, _, fn) -> (name, fn v)) meth in
       Lang.meth (JsonValue.to_value v) meth)
 
 let () =
-  add_builtin "json.stringify" ~category:`String
-    ~descr:"Convert a value to a json string."
+  Lang.add_builtin "json.stringify" ~category:`String
+    ~flags:[`Hidden; `Deprecated]
+    ~descr:"Deprecated. Please use `let json.stringify ... instead."
     [
-      ("compact", bool_t, Some (bool false), Some "Output compact text.");
-      ("json5", bool_t, Some (bool false), Some "Use json5 extended spec.");
-      ("", univ_t (), None, None);
+      ( "compact",
+        Lang.bool_t,
+        Some (Lang.bool false),
+        Some "Output compact text." );
+      ( "json5",
+        Lang.bool_t,
+        Some (Lang.bool false),
+        Some "Use json5 extended spec." );
+      ("", Lang.univ_t (), None, None);
     ]
-    string_t
+    Lang.string_t
     (fun p ->
-      let compact = to_bool (List.assoc "compact" p) in
-      let json5 = to_bool (List.assoc "json5" p) in
+      Lang_builtins.log_deprecated#important
+        "WARNING: \"json.stringify\" is deprecated and will be removed in \
+         future version. Please use \"let json.stringify ...\" instead";
+      let compact = Lang.to_bool (List.assoc "compact" p) in
+      let json5 = Lang.to_bool (List.assoc "json5" p) in
       let v = List.assoc "" p in
       let v = Json.to_string ~compact ~json5 (json_of_value v) in
-      string v)
+      Lang.string v)
 
-exception Failed
+let () =
+  Lang.add_builtin "_internal_json_renderer_" ~category:`String ~flags:[`Hidden]
+    ~descr:"Internal JSON rendered"
+    [
+      ("type", Value.RuntimeType.t, None, Some "Runtime type");
+      ( "compact",
+        Lang.bool_t,
+        Some (Lang.bool false),
+        Some "Output compact text." );
+      ( "json5",
+        Lang.bool_t,
+        Some (Lang.bool false),
+        Some "Use json5 extended spec." );
+      ("", Lang.univ_t (), None, None);
+    ]
+    Lang.string_t
+    (fun p ->
+      let v = List.assoc "" p in
+      let ty = Value.RuntimeType.of_value (List.assoc "type" p) in
+      let compact = Lang.to_bool (List.assoc "compact" p) in
+      let json5 = Lang.to_bool (List.assoc "json5" p) in
+      let nullable, ty = nullable_deref ty in
+      let v =
+        try
+          let json =
+            match ty.Type.descr with
+              | Type.Var _ -> json_of_value v
+              | _ -> json_of_typed_value ~ty v
+          in
+          Json.to_string ~compact ~json5 json
+        with _ when nullable -> "null"
+      in
+      Lang.string v)
+
+let () =
+  Lang.add_builtin "_internal_json_parser_" ~category:`String ~flags:[`Hidden]
+    ~descr:"Internal json parser"
+    [
+      ("type", Value.RuntimeType.t, None, Some "Runtime type");
+      ( "json5",
+        Lang.bool_t,
+        Some (Lang.bool false),
+        Some "Use json5 extended spec." );
+      ("", Lang.string_t, None, None);
+    ]
+    (Lang.univ_t ())
+    (fun p ->
+      let s = Lang.to_string (List.assoc "" p) in
+      let ty = Value.RuntimeType.of_value (List.assoc "type" p) in
+      let json5 = Lang.to_bool (List.assoc "json5" p) in
+      try
+        let json = Json.from_string ~json5 s in
+        value_of_typed_json ~ty json
+      with exn ->
+        let bt = Printexc.get_raw_backtrace () in
+        let exn =
+          match exn with
+            | Runtime_error.Runtime_error _ -> exn
+            | _ ->
+                Runtime_error.(
+                  Runtime_error
+                    {
+                      kind = "json";
+                      msg =
+                        Printf.sprintf "Parse error: %s"
+                          (Printexc.to_string exn);
+                      pos = [];
+                    })
+        in
+        Printexc.raise_with_backtrace exn bt)
+
+exception DeprecatedFailed
 
 let () =
   Printexc.register_printer (function
-    | Failed -> Some "Liquidsoap count not parse JSON string"
+    | DeprecatedFailed -> Some "Liquidsoap count not parse JSON string"
     | _ -> None)
 
 (* We compare the default's type with the parsed json value and return if they
    match. This comes with json.stringify in Builtin. *)
-let rec of_json d j =
-  match (d.value, j) with
-    | Tuple [], `Null -> unit
-    | Ground (Ground.Bool _), `Bool b -> bool b
-    (* JSON specs do not differentiate between ints and floats. Therefore, we
-       should parse int as floats when required. *)
-    | Ground (Ground.Int _), `Int i -> int i
-    | Ground (Ground.Float _), `Int i -> float (float_of_int i)
-    | Ground (Ground.Float _), `Float x -> float x
-    | Ground (Ground.String _), `String s -> string s
-    (* Be liberal and allow casting basic types to string. *)
-    | Ground (Ground.String _), `Int i -> string (string_of_int i)
-    | Ground (Ground.String _), `Float x -> string (string_of_float x)
-    | Ground (Ground.String _), `Bool b -> string (string_of_bool b)
-    | List [], `Tuple [] -> list []
-    | List (d :: _), `Tuple l ->
-        (* TODO: we could also try with other elements of the default list... *)
-        let l = List.map (of_json d) l in
-        list l
-    | Tuple dd, `Tuple jj when List.length dd = List.length jj ->
-        tuple (List.map2 of_json dd jj)
-    | ( List ({ value = Tuple [{ value = Ground (Ground.String _) }; d] } :: _),
-        `Assoc l ) ->
-        (* Try to convert the object to a list of pairs, dropping fields that
-           cannot be parsed.  This requires the target type to be [(string*'a)],
-           currently it won't work if it is [?T] which would be obtained with
-           of_json(default=[],...). *)
-        let l =
-          List.fold_left
-            (fun cur (x, y) ->
-              try product (string x) (of_json d y) :: cur with _ -> cur)
-            [] l
-        in
-        list l
-    (* Parse records. *)
-    | Meth (l, x, d), `Assoc a -> (
-        try
-          let y = List.assoc l a in
-          let v = of_json x y in
-          let a' = List.remove_assoc l a in
-          meth (of_json d (`Assoc a')) [(l, v)]
-        with Not_found -> raise Failed)
-    | Tuple [], `Assoc _ -> unit
-    | _ -> raise Failed
+let rec deprecated_of_json d j =
+  Lang.(
+    match (d.value, j) with
+      | Tuple [], `Null -> unit
+      | Ground (Ground.Bool _), `Bool b -> bool b
+      (* JSON specs do not differentiate between ints and floats. Therefore, we
+         should parse int as floats when required. *)
+      | Ground (Ground.Int _), `Int i -> int i
+      | Ground (Ground.Float _), `Int i -> float (float_of_int i)
+      | Ground (Ground.Float _), `Float x -> float x
+      | Ground (Ground.String _), `String s -> string s
+      (* Be liberal and allow casting basic types to string. *)
+      | Ground (Ground.String _), `Int i -> string (string_of_int i)
+      | Ground (Ground.String _), `Float x -> string (string_of_float x)
+      | Ground (Ground.String _), `Bool b -> string (string_of_bool b)
+      | List [], `Tuple [] -> list []
+      | List (d :: _), `Tuple l ->
+          (* TODO: we could also try with other elements of the default list... *)
+          let l = List.map (deprecated_of_json d) l in
+          list l
+      | Tuple dd, `Tuple jj when List.length dd = List.length jj ->
+          tuple (List.map2 deprecated_of_json dd jj)
+      | ( List ({ value = Tuple [{ value = Ground (Ground.String _) }; d] } :: _),
+          `Assoc l ) ->
+          (* Try to convert the object to a list of pairs, dropping fields that
+             cannot be parsed.  This requires the target type to be [(string*'a)],
+             currently it won't work if it is [?T] which would be obtained with
+             of_json(default=[],...). *)
+          let l =
+            List.fold_left
+              (fun cur (x, y) ->
+                try product (string x) (deprecated_of_json d y) :: cur
+                with _ -> cur)
+              [] l
+          in
+          list l
+      (* Parse records. *)
+      | Meth (l, x, d), `Assoc a -> (
+          try
+            let y = List.assoc l a in
+            let v = deprecated_of_json x y in
+            let a' = List.remove_assoc l a in
+            meth (deprecated_of_json d (`Assoc a')) [(l, v)]
+          with Not_found -> raise DeprecatedFailed)
+      | Tuple [], `Assoc _ -> unit
+      | _ -> raise DeprecatedFailed)
 
 let () =
-  let t = univ_t () in
-  add_builtin ~category:`String
-    ~descr:
-      "Parse a json string into a liquidsoap value. The value provided in the \
-       `default` parameter is quite important: only the part of the JSON data \
-       which has the same type as the `default` parameter will be kept \
-       (heterogeneous data cannot be represented in Liquidsoap because of \
-       typing). For instance, if the JSON `j` is\n\
-       ```\n\
-       {\n\
-      \ \"a\": \"test\",\n\
-      \ \"b\": 5\n\
-       }\n\
-       ```\n\
-       the value returned by `json.parse(default=[(\"\",0)], j)` will be \
-       `[(\"b\",5)]`: the pair `(\"a\",\"test\")` is not kept because it is \
-       not of type `string * int`." "json.parse"
+  let t = Lang.univ_t () in
+  Lang.add_builtin ~category:`String ~flags:[`Deprecated; `Hidden]
+    ~descr:"Deprecated: use `let json.parse ..`" "json.parse"
     [
       ("default", t, None, Some "Default value if string cannot be parsed.");
-      ("", string_t, None, None);
+      ("", Lang.string_t, None, None);
     ] t (fun p ->
+      Lang_builtins.log_deprecated#important
+        "WARNING: \"json.parse\" is deprecated and will be removed in future \
+         version. Please use \"let json.parse ...\" instead";
       let default = List.assoc "default" p in
-      let s = to_string (List.assoc "" p) in
+      let s = Lang.to_string (List.assoc "" p) in
       try
         let json = Json.from_string s in
-        of_json default json
+        deprecated_of_json default json
       with e ->
         log#info "JSON parsing failed: %s" (Printexc.to_string e);
         default)

--- a/src/lang/lang_builtins.ml
+++ b/src/lang/lang_builtins.ml
@@ -22,6 +22,8 @@
 
 open Extralib
 
+let log_deprecated = Log.make ["deprecated"]
+
 let () =
   Lang.add_builtin_base ~category:`Liquidsoap
     ~descr:"Liquidsoap version string." "liquidsoap.version"

--- a/src/lang/lexer.ml
+++ b/src/lang/lexer.ml
@@ -191,6 +191,12 @@ let rec token lexbuf =
     | "do" -> DO
     | "let", Plus skipped, "replaces" -> LET `Replaces
     | "let", Plus skipped, "eval" -> LET `Eval
+    | "let", Plus skipped, "json.parse", Star skipped, '[' ->
+        LETLBRA `Json_parse
+    | "let", Plus skipped, "json.parse" -> LET `Json_parse
+    | "let", Plus skipped, "json.stringify", Star skipped, '[' ->
+        LETLBRA `Json_stringify
+    | "let", Plus skipped, "json.stringify" -> LET `Json_stringify
     | "let" -> LET `None
     | "fun" -> FUN
     | '=' -> GETS
@@ -383,7 +389,9 @@ and read_string c pos buf lexbuf =
     | '\\', '\n', Star skipped -> read_string c pos buf lexbuf
     | '\\', any ->
         if c <> '/' then (
-          let pos = Repr.string_of_single_pos pos in
+          let pos =
+            Repr.string_of_pos (pos, snd (Sedlexing.lexing_positions lexbuf))
+          in
           Printf.printf
             "Warning at position %s: illegal backslash escape in string.\n" pos);
         Buffer.add_string buf (Sedlexing.Utf8.lexeme lexbuf);

--- a/src/lang/preprocessor.ml
+++ b/src/lang/preprocessor.ml
@@ -382,6 +382,9 @@ let parse_comments tokenizer =
           comment := (c, Some startp);
           token ()
       | Parser.PP_DEF decoration, pos ->
+          let decoration =
+            Parser_helper.let_decoration_of_lexer_let_decoration decoration
+          in
           let c = !comment in
           comment := ([], None);
           documented_def decoration c pos

--- a/tests/language/json.liq
+++ b/tests/language/json.liq
@@ -13,38 +13,241 @@ def t(x,y) =
   end
 end
 
-def u(d,x) =
-  y = json.parse(default=d,json.stringify(x))
-  if y == d or y != x then
-    print("Failure: #{x} => #{json.stringify(x)} => #{y}")
-    success := false
+def test_parse_error(name, f, msg) =
+  error_caught = ref(false)
+
+  try
+    print(f ())
+  catch err do
+    if err.kind != "json" then
+      print("parse error test #{name} failed: wrong error kind, got: #{err.kind}, expected: json")
+      test.fail()
+    end
+    if err.message != msg then
+      print("parse error test #{name} failed: wrong error message, got: #{err.message}, expected: #{msg}")
+      test.fail()
+    end
+    error_caught := true
+  end
+
+  if not !error_caught then
+    print("parse error test #{name} failed: no error caught")
+    test.fail()
   end
 end
 
 def f() =
-  u(2, 1)
-  u(3.14, 4.25)
-  u(false, true)
-  u("abc", "def")
-  u([1],[1,2,3])
-  u((1,"foo"), (2,"bar"))
-  u([("foo",(1,"bar"))], [("gni",(2,"boo"))])
-  u([(1,[("fr","bar")])], [(2,[("en","foo")])])
-  # u([("ping",())], [("pong",())])
-  u([3],[])
-  u([("x",0)],json.parse(default=[("x",0)],"{\"a\" : 4}"))
+  let json.stringify s = ()
+  t(s, '[  ]')
 
-  t(json.stringify(()), '[  ]')
-  t(json.stringify("a"), '"a"')
-  t(json.stringify("©"), '"©"')
-  t(json.stringify('"'), '"\\""')
-  t(json.stringify('\\'), '"\\\\"')
-  t(json.stringify(json5=true, infinity), 'Infinity')
-  t(json.stringify(json5=true, (0.-infinity)), '-Infinity')
-  t(json.stringify(json5=true, nan), 'NaN')
+  let json.stringify s = "a"
+  t(s, '"a"')
 
-  t(json.parse(default=[("","")], '{"a":3}'), [("a","3")])
-  t(json.parse(default={x=0, a=""}, '{"a":"z", "x":3}'), {x=3, a="z"})
+  let json.stringify s = "©"
+  t(s, '"©"')
+
+  let json.stringify s = '"'
+  t(s, '"\\""')
+
+  let json.stringify s = '\\'
+  t(s, '"\\\\"')
+
+  let json.stringify s = (infinity:float?)
+  t(s, 'null')
+
+  let json.stringify s = (0.-infinity:float?)
+  t(s, 'null')
+
+  let json.stringify s = (nan:float?)
+  t(s, 'null')
+
+  let json.stringify s = null(infinity)
+  t(s, 'null')
+
+  let json.stringify s = null(0.-infinity)
+  t(s, 'null')
+
+  let json.stringify s = null(nan)
+  t(s, 'null')
+
+  let json.stringify[json5=true] s = infinity
+  t(s, 'Infinity')
+
+  let json.stringify[json5=true] s = (0.-infinity)
+  t(s, '-Infinity')
+
+  let json.stringify[json5=true] s = nan
+  t(s, 'NaN')
+
+  let json.stringify s = ([("foo",123), ("bar", 456)]:[(string * int)] as json.object)
+  t(s, "{ \"foo\": 123, \"bar\": 456\n}")
+
+  let json.stringify s = ({foo = 123}:{ "✨foo✨" as foo: int})
+  t(s, "{ \"✨foo✨\": 123\n}")
+
+  data = "123"
+  let json.parse ( x : int ) = data
+  t(x, 123)
+
+  data = '{
+    "foo": 34.24,
+    "gni gno": true,
+    "nested": {
+       "tuple": [123, 3.14, false],
+       "list":  [44.0, 55, 66.12],
+       "nullable_list": [12.33, 23, "aabb"],
+       "object_as_list": {
+         "foo": 123,
+         "gni": 456.0,
+         "gno": 3.14
+       },
+       "arbitrary object key ✨": true
+     },
+     "extra": "ignored"
+  }'
+
+  let json.parse ( x : {
+    foo : float,
+    "gni gno" as gni_gno : bool,
+    nested : {
+      tuple : (_ * float),
+      list : [float],
+      nullable_list : [int?],
+      object_as_list : [(string * float)] as json.object,
+      "arbitrary object key ✨" as arbitrary_object_key : bool, 
+      not_present : bool?
+    }
+  }) = data
+
+  t(x, {
+    foo = 34.24,
+    gni_gno = true,
+    nested = {
+      tuple = (null(), 3.14),
+      list = [44., 55., 66.12],
+      nullable_list = [null(), 23, null()],
+      object_as_list = [("foo", 123.), ("gni", 456.0), ("gno", 3.14)],
+      arbitrary_object_key = true,
+      not_present = null()
+    }
+  })
+
+  # Pattern extraction with json parsing
+  let json.parse {
+    foo,
+    nested = {
+      tuple = (t1, t2, t3),
+      nullable_list = [l1, ...tl]
+    }
+  } = data
+  t(foo, 34.24)
+  t(t1, 123)
+  t(t2, 3.14)
+  t(t3, false)
+  t(l1, null())
+  t(tl, [23, null()])
+
+  let json.parse x = data
+  ignore(x.foo + 1.0)
+  let (x, y, z) = x.nested.tuple
+  ignore(x + 1)
+  ignore(y + 3.14)
+
+  def failed_runtime () =
+    let json.parse x = data
+    ignore(x.foo + 1.0)
+    let (x, _, _) = x.nested.tuple
+    ignore(x ^ "foo")
+  end
+
+  test_parse_error(
+    "failed runtime",
+    failed_runtime,
+    "Parsing error: json value cannot be parsed as type {nested: {tuple: (string,_,_), _}, _}"
+  )
+
+ 
+  def nested_tuple () =
+    let json.parse ( x : {
+      nested : {
+        tuple : (int * float * int * bool),
+        list : [float],
+        nullable_list : [int?],
+        object_as_list : [(string * float)] as json.object,
+        "arbitrary object key ✨" as arbitrary_object_key : bool,
+        not_present : bool?
+      }
+    }) = data
+    ignore(data)
+  end
+
+  test_parse_error(
+    "nested tuple", 
+    nested_tuple,
+    "Parsing error: json value cannot be parsed as type {nested: {tuple: (_,_,int,_), _}, _}"
+  )
+
+  def nested_list() =
+    let json.parse ( x : {
+      nested : {
+        tuple : (int * float * bool),
+        list : [int],
+        nullable_list : [int?],
+        object_as_list : [(string * float)] as json.object,
+        "arbitrary object key ✨" as arbitrary_object_key : bool,
+        not_present : bool?
+      }
+    }) = data
+    ignore(data)
+  end
+
+  test_parse_error(
+    "nested list",
+    nested_list,
+    "Parsing error: json value cannot be parsed as type {nested: {list: [int], _}, _}"
+  )
+
+  def nested_object() =
+    let json.parse ( x : {
+      nested : {
+        tuple : (int * float * bool),
+        list : [float],
+        nullable_list : [int],
+        object_as_list : [(string * float)] as json.object,
+        "arbitrary object key ✨" as arbitrary_object_key : bool,
+        not_present : bool?
+      }
+    }) = data
+    ignore(data)
+  end
+
+  test_parse_error(
+    "nested object",
+    nested_object,
+    'Parsing error: json value cannot be parsed as type {nested: {nullable_list: [int], _}, _}' 
+  )
+
+  data = '{"aabbcc": 34, "ddeerr": 54 }'
+  let json.parse (x : [(string * int)] as json.object) = data
+  t(list.assoc("aabbcc", x), 34)
+  t(list.assoc("ddeerr", x), 54)
+
+  data = '{ "foo": 123 }'
+  let json.parse ( x : {
+    foo : string
+  }?) = data
+  t(x, null())
+
+  data = '[ "gni", 123 ]'
+  let json.parse ( x : [int]? ) = data
+  t(x, null())
+
+  let json.parse ( x : (string * int * bool)? ) = data
+  t(x, null())
+
+  data = '[ "gni", 123, "gno" ]'
+  let json.parse ( x : (string * int) ) = data
+  t(x, ("gni",123))
 
   j = json()
   j.add("foo", 1)
@@ -53,7 +256,8 @@ def f() =
   j.add("key_with_methods", "value".{method = 123})
   j.add("record", { a = 1, b = "ert"})
   j.remove("foo")
-  t(json.stringify(j), '{ "record": { "b": "ert", "a": 1 }, "key_with_methods": "value",\n"bla": "bar", "baz": 3.14\n}')
+  let json.stringify j = j
+  t(j, '{ "record": { "b": "ert", "a": 1 }, "key_with_methods": "value",\n"bla": "bar", "baz": 3.14\n}')
 
   if !success then
     test.pass()

--- a/tests/language/string.liq
+++ b/tests/language/string.liq
@@ -6,7 +6,9 @@ success = ref(true)
 
 def t(x, y)
   if x != y then
-    print("Failure: got #{json.stringify(x)} instead of #{json.stringify(y)}")
+    let json.stringify x = x
+    let json.stringify y = y
+    print("Failure: got #{x} instead of #{y}")
     success := false
   end
 end

--- a/tests/language/type_errors.pl
+++ b/tests/language/type_errors.pl
@@ -33,7 +33,7 @@ correct('ignore([input.harbor("foo"), sine()])');
 correct('ignore([sine(), input.harbor("foo")])');
 correct('ignore([1, ...[2,3,4], ...[5,6], 7])');
 correct('let [x,y,...z] = [1,2]');
-incorrect('let [] = [1,2]');
+correct('let [] = [1,2]');
 incorrect('let [...z, x, ...t] = [1,2]');
 
 section("BASIC");

--- a/tests/media/test_ffmpeg_audio_decoder.liq
+++ b/tests/media/test_ffmpeg_audio_decoder.liq
@@ -21,15 +21,16 @@ clock.assign_new(sync='none',[s])
 def on_done () =
   j = process.read("ffprobe -v quiet -print_format json -show_streams #{out}")
 
-  int_format = json.parse(default=[("streams", [[("channels", 0)]])], j)
-  stream = list.hd(default=[], list.assoc(default=[], "streams", int_format))
-  channels = list.assoc(default=0,"channels",stream)
+  let json.parse ( parsed: {
+    streams: [{
+      channels: int,
+      sample_rate: string
+    }]
+  }) = j
 
-  string_format = json.parse(default=[("streams", [[("samplerate", "0")]])], j)
-  stream = list.hd(default=[], list.assoc(default=[], "streams", string_format))
-  samplerate = list.assoc(default="0","sample_rate",stream)
+  let [stream] = parsed.streams
 
-  if channels == 1 and samplerate == "48000" then
+  if stream.channels == 1 and stream.sample_rate == "48000" then
     test.pass()
   else
     test.fail()

--- a/tests/media/test_ffmpeg_copy_and_encode_decoder.liq
+++ b/tests/media/test_ffmpeg_copy_and_encode_decoder.liq
@@ -20,29 +20,25 @@ clock.assign_new(sync='none',[s])
 def on_done () =
   j = process.read("ffprobe -v quiet -print_format json -show_streams '#{out}'")
 
-  format = json.parse(default=[("streams", [[("samplerate", "0")]])], j)
+  let json.parse ( parsed : {
+    streams: [{
+      channel_layout: string?,
+      sample_rate: string?,
+      sample_fmt: string?,
+      codec_name: string?,
+      pix_fmt: string?
+    }]
+  }) = j
 
-  streams = list.assoc(default=[], "streams", format)
+  video_stream = list.find((fun (stream) -> null.defined(stream.pix_fmt)), parsed.streams)
+  audio_stream = list.find((fun (stream) -> null.defined(stream.sample_rate)), parsed.streams)
 
-  params = ["channel_layout", "sample_rate",
-            "sample_fmt", "codec_name", "pix_fmt"]
-
-  def m(s) =
-    def f(e) =
-      let (p, _) = e
-      list.mem(p, params)
-    end
-    list.filter(f, s)
-  end
-
-  streams = list.map(m, streams)
-
-  expected = [
-    [("channel_layout", "stereo"), ("sample_rate", "44100"), ("sample_fmt", "fltp"), ("codec_name", "aac")],
-    [("pix_fmt", "yuv420p"), ("codec_name", "h264")]
-  ]
-
-  if streams == expected then
+  if null.get(video_stream.codec_name) == "h264" and
+     null.get(video_stream.pix_fmt) == "yuv420p" and
+     null.get(audio_stream.channel_layout) == "stereo" and
+     null.get(audio_stream.codec_name) == "aac" and
+     null.get(audio_stream.sample_fmt) == "fltp" and
+     null.get(audio_stream.sample_rate) == "44100" then
     test.pass()
   else
     test.fail()

--- a/tests/media/test_ffmpeg_copy_decoder.liq
+++ b/tests/media/test_ffmpeg_copy_decoder.liq
@@ -21,27 +21,32 @@ def on_done () =
   ijson = process.read("ffprobe -v quiet -print_format json -show_streams '#{fname}'")
   ojson = process.read("ffprobe -v quiet -print_format json -show_streams '#{out}'")
 
-  input_format = json.parse(default=[("streams", [[("samplerate", "0")]])], ijson)
-  output_format = json.parse(default=[("streams", [[("samplerate", "0")]])], ojson)
+  let json.parse ( iparsed : {
+    streams: [{
+      channel_layout: string?,
+      sample_rate: string?,
+      sample_fmt: string?,
+      codec_name: string?,
+      pix_fmt: string?
+    }]
+  }) = ijson
 
-  input_streams = list.assoc(default=[], "streams", input_format)
-  output_streams = list.assoc(default=[], "streams", output_format)
+  let json.parse ( oparsed : {
+    streams: [{
+      channel_layout: string?,
+      sample_rate: string?,
+      sample_fmt: string?,
+      codec_name: string?,
+      pix_fmt: string?
+    }]
+  }) = ojson
 
-  params = ["channel_layout", "sample_rate",
-            "sample_fmt", "codec_name", "pix_fmt"]
+  filter = list.filter((fun (s) -> null.defined(s.codec_name)))
+  sort = list.sort((fun (s1, s2) -> if s1.codec_name < s2.codec_name then -1 else 1 end))
+  let [iaudio, ivideo] = sort(filter(iparsed.streams))
+  let [oaudio, ovideo] = sort(filter(oparsed.streams))
 
-  def m(s) =
-    def f(e) =
-      let (p, _) = e
-      list.mem(p, params)
-    end
-    list.filter(f, s)
-  end
-
-  input_streams = list.map(m, input_streams)
-  output_streams = list.map(m, output_streams)
-
-  if input_streams == output_streams then
+  if iaudio == oaudio and ivideo == ovideo then
     test.pass()
   else
     test.fail()

--- a/tests/media/test_ffmpeg_distributed_hls.liq
+++ b/tests/media/test_ffmpeg_distributed_hls.liq
@@ -59,51 +59,29 @@ is_done = ref(false)
 
 def check_stream() =
   if not !is_done then
-    ojson = process.read("ffprobe -v quiet -print_format json -show_streams #{output_dir}/mp4.m3u8")
-
-    output_format = json.parse(default=[("streams", [[("samplerate", "0")]])], ojson)
-
-    output_streams = list.assoc(default=[], "streams", output_format)
-
-    params = ["channel_layout", "sample_rate",
-              "sample_fmt", "codec_name", "pix_fmt"]
-
-    def m(s) =
-      def f(e) =
-        let (p, _) = e
-        list.mem(p, params)
-      end
-      list.filter(f, s)
-    end
-
-    output_streams = list.map(m, output_streams)
-
-    def cmp(c, c') =
-      if c < c' then
-        -1
-      elsif c' < c then
-        1
-      else
-        0
-      end
-    end
-
-    output_streams = list.map(list.sort(cmp), output_streams)
-
-    def cmd_l(l, l') =
-      cmp(list.assoc("codec_name", l), list.assoc("codec_name", l'))
-    end
-
-    output_streams = list.sort(cmd_l, output_streams)
-
-    expected = [
-      [("channel_layout", "stereo"), ("codec_name", "aac"), ("sample_fmt", "fltp"), ("sample_rate", "44100")],
-      [("codec_name", "h264"), ("pix_fmt", "yuv420p")]
-    ]
-
     is_done := true
 
-    if output_streams == expected then
+    ojson = process.read("ffprobe -v quiet -print_format json -show_streams #{output_dir}/mp4.m3u8")
+
+    let json.parse ( parsed : {
+      streams: [{
+        channel_layout: string?,
+        sample_rate: string?,
+        sample_fmt: string?,
+        codec_name: string?,
+        pix_fmt: string?
+      }]
+    }) = ojson
+
+    video_stream = list.find((fun (stream) -> null.defined(stream.pix_fmt)), parsed.streams)
+    audio_stream = list.find((fun (stream) -> null.defined(stream.sample_rate)), parsed.streams)
+
+    if null.get(video_stream.codec_name) == "h264" and
+       null.get(video_stream.pix_fmt) == "yuv420p" and
+       null.get(audio_stream.channel_layout) == "stereo" and
+       null.get(audio_stream.codec_name) == "aac" and
+       null.get(audio_stream.sample_fmt) == "fltp" and
+       null.get(audio_stream.sample_rate) == "44100" then
       test.pass()
     else
       test.fail()

--- a/tests/media/test_ffmpeg_filter.liq
+++ b/tests/media/test_ffmpeg_filter.liq
@@ -46,49 +46,27 @@ clock.assign_new(id='test_clock',sync='none',[s])
 
 def on_done () =
   if !started then
-    ojson = process.read("ffprobe -v quiet -print_format json -show_streams '#{out}'")
+    j = process.read("ffprobe -v quiet -print_format json -show_streams '#{out}'")
 
-    output_format = json.parse(default=[("streams", [[("samplerate", "0")]])], ojson)
+    let json.parse ( parsed : {
+      streams: [{
+        channel_layout: string?,
+        sample_rate: string?,
+        sample_fmt: string?,
+        codec_name: string?,
+        pix_fmt: string?
+      }]
+    }) = j
 
-    output_streams = list.assoc(default=[], "streams", output_format)
+    video_stream = list.find((fun (stream) -> null.defined(stream.pix_fmt)), parsed.streams)
+    audio_stream = list.find((fun (stream) -> null.defined(stream.sample_rate)), parsed.streams)
 
-    params = ["channel_layout", "sample_rate",
-              "sample_fmt", "codec_name", "pix_fmt"]
-
-    def m(s) =
-      def f(e) =
-        let (p, _) = e
-        list.mem(p, params)
-      end
-      list.filter(f, s)
-    end
-
-    output_streams = list.map(m, output_streams)
-
-    def cmp(c, c') =
-      if c < c' then
-        -1
-      elsif c' < c then
-        1
-      else
-        0
-      end
-    end
-
-    output_streams = list.map(list.sort(cmp), output_streams)
-
-    def cmd_l(l, l') =
-      cmp(list.assoc("codec_name", l), list.assoc("codec_name", l'))
-    end
-
-    output_streams = list.sort(cmd_l, output_streams)
-
-    expected = [
-      [("channel_layout", "stereo"), ("codec_name", "aac"), ("sample_fmt", "fltp"), ("sample_rate", "44100")],
-      [("codec_name", "h264"), ("pix_fmt", "yuv420p")]
-    ]
-
-    if output_streams == expected then
+    if null.get(video_stream.codec_name) == "h264" and
+       null.get(video_stream.pix_fmt) == "yuv420p" and
+       null.get(audio_stream.channel_layout) == "stereo" and
+       null.get(audio_stream.codec_name) == "aac" and
+       null.get(audio_stream.sample_fmt) == "fltp" and
+       null.get(audio_stream.sample_rate) == "44100" then
       test.pass()
     else
       test.fail()

--- a/tests/media/test_ffmpeg_inline_encode_decode.liq
+++ b/tests/media/test_ffmpeg_inline_encode_decode.liq
@@ -23,29 +23,25 @@ def on_done () =
   def check(out) =
     j = process.read("ffprobe -v quiet -print_format json -show_streams '#{out}'")
 
-    format = json.parse(default=[("streams", [[("samplerate", "0")]])], j)
+    let json.parse ( parsed : {
+      streams: [{
+        channel_layout: string?,
+        sample_rate: string?,
+        sample_fmt: string?,
+        codec_name: string?,
+        pix_fmt: string?
+      }]
+    }) = j
 
-    streams = list.assoc(default=[], "streams", format)
+    video_stream = list.find((fun (stream) -> null.defined(stream.pix_fmt)), parsed.streams)
+    audio_stream = list.find((fun (stream) -> null.defined(stream.sample_rate)), parsed.streams)
 
-    params = ["channel_layout", "sample_rate",
-              "sample_fmt", "codec_name", "pix_fmt"]
-
-    def m(s) =
-      def f(e) =
-        let (p, _) = e
-        list.mem(p, params)
-      end
-      list.filter(f, s)
-    end
-
-    streams = list.map(m, streams)
-
-    expected = [
-      [("channel_layout", "stereo"), ("sample_rate", "44100"), ("sample_fmt", "fltp"), ("codec_name", "aac")],
-      [("pix_fmt", "yuv420p"), ("codec_name", "h264")]
-    ]
-    
-    streams == expected
+    null.get(video_stream.codec_name) == "h264" and
+    null.get(video_stream.pix_fmt) == "yuv420p" and
+    null.get(audio_stream.channel_layout) == "stereo" and
+    null.get(audio_stream.codec_name) == "aac" and
+    null.get(audio_stream.sample_fmt) == "fltp" and
+    null.get(audio_stream.sample_rate) == "44100"
   end
 
   todo := !todo - 1

--- a/tests/media/test_ffmpeg_inline_encode_decode_audio.liq
+++ b/tests/media/test_ffmpeg_inline_encode_decode_audio.liq
@@ -23,28 +23,21 @@ def on_done () =
   def check(out) =
     j = process.read("ffprobe -v quiet -print_format json -show_streams '#{out}'")
 
-    format = json.parse(default=[("streams", [[("samplerate", "0")]])], j)
+    let json.parse ( parsed : {
+      streams: [{
+        channel_layout: string,
+        sample_rate: string,
+        sample_fmt: string,
+        codec_name: string,
+      }]
+    }) = j
 
-    streams = list.assoc(default=[], "streams", format)
+    let [stream] = parsed.streams
 
-    params = ["channel_layout", "sample_rate",
-              "sample_fmt", "codec_name", "pix_fmt"]
-
-    def m(s) =
-      def f(e) =
-        let (p, _) = e
-        list.mem(p, params)
-      end
-      list.filter(f, s)
-    end
-
-    streams = list.map(m, streams)
-
-    expected = [
-      [("channel_layout", "stereo"), ("sample_rate", "44100"), ("sample_fmt", "fltp"), ("codec_name", "aac")],
-    ]
-    
-    streams == expected
+    stream.channel_layout == "stereo" and
+    stream.codec_name == "aac" and
+    stream.sample_fmt == "fltp" and
+    stream.sample_rate == "44100"
   end
 
   todo := !todo - 1

--- a/tests/media/test_ffmpeg_inline_encode_decode_video.liq
+++ b/tests/media/test_ffmpeg_inline_encode_decode_video.liq
@@ -23,28 +23,17 @@ def on_done () =
   def check(out) =
     j = process.read("ffprobe -v quiet -print_format json -show_streams '#{out}'")
 
-    format = json.parse(default=[("streams", [[("samplerate", "0")]])], j)
+    let json.parse ( parsed : {
+      streams: [{
+        codec_name: string,
+        pix_fmt: string
+      }]
+    }) = j
 
-    streams = list.assoc(default=[], "streams", format)
+   let [stream] = parsed.streams
 
-    params = ["channel_layout", "sample_rate",
-              "sample_fmt", "codec_name", "pix_fmt"]
-
-    def m(s) =
-      def f(e) =
-        let (p, _) = e
-        list.mem(p, params)
-      end
-      list.filter(f, s)
-    end
-
-    streams = list.map(m, streams)
-
-    expected = [
-      [("pix_fmt", "yuv420p"), ("codec_name", "h264")]
-    ]
-    
-    streams == expected
+    stream.codec_name == "h264" and
+    stream.pix_fmt == "yuv420p"
   end
 
   todo := !todo - 1

--- a/tests/media/test_ffmpeg_raw_and_copy_decoder.liq
+++ b/tests/media/test_ffmpeg_raw_and_copy_decoder.liq
@@ -21,44 +21,32 @@ def on_done () =
   ijson = process.read("ffprobe -v quiet -print_format json -show_streams '#{fname}'")
   ojson = process.read("ffprobe -v quiet -print_format json -show_streams '#{out}'")
 
-  iformat = json.parse(default=[("streams", [[("samplerate", "0")]])], ijson)
-  oformat = json.parse(default=[("streams", [[("samplerate", "0")]])], ojson)
+  let json.parse ( iparsed : {
+    streams: [{
+      channel_layout: string?,
+      sample_rate: string?,
+      sample_fmt: string?,
+      codec_name: string?,
+      pix_fmt: string?
+    }]
+  }) = ijson
 
-  istreams = list.assoc(default=[], "streams", iformat)
-  ostreams = list.assoc(default=[], "streams", oformat)
+  let json.parse ( oparsed : {
+    streams: [{
+      channel_layout: string?,
+      sample_rate: string?,
+      sample_fmt: string?,
+      codec_name: string?,
+      pix_fmt: string?
+    }]
+  }) = ojson
 
-  params = ["channel_layout", "sample_rate",
-            "sample_fmt", "codec_name", "pix_fmt"]
+  filter = list.filter((fun (s) -> null.defined(s.codec_name)))
+  sort = list.sort((fun (s1, s2) -> if s1.codec_name < s2.codec_name then -1 else 1 end))
+  let [iaudio, ivideo] = sort(filter(iparsed.streams))
+  let [oaudio, ovideo] = sort(filter(oparsed.streams))
 
-  def get(codec, l) =
-    def f(l) =
-      def g(e) =
-        snd(e) == codec
-      end
-      list.exists(g, l)
-    end
-    list.find(f, l)
-  end
-  iaudio = get("aac", istreams)
-  oaudio = get("aac", ostreams)
-  ovideo = get("h264", ostreams)
-
-  def m(s) =
-    def f(e) =
-      let (p, _) = e
-      list.mem(p, params)
-    end
-    list.filter(f, s)
-  end
-
-  streams = [m(ovideo), m(oaudio)]
-
-  expected = [
-    [("pix_fmt", "yuv420p"), ("codec_name", "h264")],
-    m(iaudio)
-  ]
-
-  if streams == expected then
+  if iaudio == oaudio and ivideo == ovideo then
     test.pass()
   else
     test.fail()

--- a/tests/media/test_ffmpeg_raw_and_encode_decoder.liq
+++ b/tests/media/test_ffmpeg_raw_and_encode_decoder.liq
@@ -20,29 +20,25 @@ clock.assign_new(sync='none',[s])
 def on_done () =
   j = process.read("ffprobe -v quiet -print_format json -show_streams '#{out}'")
 
-  format = json.parse(default=[("streams", [[("samplerate", "0")]])], j)
+  let json.parse ( parsed : {
+    streams: [{
+      channel_layout: string?,
+      sample_rate: string?,
+      sample_fmt: string?,
+      codec_name: string?,
+      pix_fmt: string?
+    }]
+  }) = j
 
-  streams = list.assoc(default=[], "streams", format)
+  video_stream = list.find((fun (stream) -> null.defined(stream.pix_fmt)), parsed.streams)
+  audio_stream = list.find((fun (stream) -> null.defined(stream.sample_rate)), parsed.streams)
 
-  params = ["channel_layout", "sample_rate",
-            "sample_fmt", "codec_name", "pix_fmt"]
-
-  def m(s) =
-    def f(e) =
-      let (p, _) = e
-      list.mem(p, params)
-    end
-    list.filter(f, s)
-  end
-
-  streams = list.map(m, streams)
-
-  expected = [
-    [("channel_layout", "stereo"), ("sample_rate", "44100"), ("sample_fmt", "fltp"), ("codec_name", "aac")],
-    [("pix_fmt", "yuv420p"), ("codec_name", "h264")]
-  ]
-
-  if streams == expected then
+  if null.get(video_stream.codec_name) == "h264" and
+     null.get(video_stream.pix_fmt) == "yuv420p" and
+     null.get(audio_stream.channel_layout) == "stereo" and
+     null.get(audio_stream.codec_name) == "aac" and
+     null.get(audio_stream.sample_fmt) == "fltp" and
+     null.get(audio_stream.sample_rate) == "44100" then
     test.pass()
   else
     test.fail()

--- a/tests/media/test_ffmpeg_raw_decoder.liq
+++ b/tests/media/test_ffmpeg_raw_decoder.liq
@@ -20,47 +20,25 @@ clock.assign_new(sync='none',[s])
 def on_done () =
   ojson = process.read("ffprobe -v quiet -print_format json -show_streams '#{out}'")
 
-  output_format = json.parse(default=[("streams", [[("samplerate", "0")]])], ojson)
+  let json.parse ( parsed : {
+    streams: [{
+      channel_layout: string?,
+      sample_rate: string?,
+      sample_fmt: string?,
+      codec_name: string?,
+      pix_fmt: string?
+    }]
+  }) = ojson
 
-  output_streams = list.assoc(default=[], "streams", output_format)
+  video_stream = list.find((fun (stream) -> null.defined(stream.pix_fmt)), parsed.streams)
+  audio_stream = list.find((fun (stream) -> null.defined(stream.sample_rate)), parsed.streams)
 
-  params = ["channel_layout", "sample_rate",
-            "sample_fmt", "codec_name", "pix_fmt"]
-
-  def m(s) =
-    def f(e) =
-      let (p, _) = e
-      list.mem(p, params)
-    end
-    list.filter(f, s)
-  end
-
-  output_streams = list.map(m, output_streams)
-
-  def cmp(c, c') =
-    if c < c' then
-      -1
-    elsif c' < c then
-      1
-    else
-      0
-    end
-  end
-
-  output_streams = list.map(list.sort(cmp), output_streams)
-
-  def cmd_l(l, l') =
-    cmp(list.assoc("codec_name", l), list.assoc("codec_name", l'))
-  end
-
-  output_streams = list.sort(cmd_l, output_streams)
-
-  expected = [
-    [("channel_layout", "stereo"), ("codec_name", "aac"), ("sample_fmt", "fltp"), ("sample_rate", "44100")],
-    [("codec_name", "h264"), ("pix_fmt", "yuv420p")]
-  ]
-
-  if output_streams == expected then
+  if null.get(video_stream.codec_name) == "h264" and
+     null.get(video_stream.pix_fmt) == "yuv420p" and
+     null.get(audio_stream.channel_layout) == "stereo" and
+     null.get(audio_stream.codec_name) == "aac" and
+     null.get(audio_stream.sample_fmt) == "fltp" and
+     null.get(audio_stream.sample_rate) == "44100" then
     test.pass()
   else
     test.fail()

--- a/tests/media/test_ffmpeg_raw_hls.liq
+++ b/tests/media/test_ffmpeg_raw_hls.liq
@@ -65,51 +65,29 @@ is_done = ref(false)
 
 def check_stream() =
   if not !is_done then
-    ojson = process.read("ffprobe -v quiet -print_format json -show_streams #{output_dir}/mp4.m3u8")
-
-    output_format = json.parse(default=[("streams", [[("samplerate", "0")]])], ojson)
-
-    output_streams = list.assoc(default=[], "streams", output_format)
-
-    params = ["channel_layout", "sample_rate",
-              "sample_fmt", "codec_name", "pix_fmt"]
-
-    def m(s) =
-      def f(e) =
-        let (p, _) = e
-        list.mem(p, params)
-      end
-      list.filter(f, s)
-    end
-
-    output_streams = list.map(m, output_streams)
-
-    def cmp(c, c') =
-      if c < c' then
-        -1
-      elsif c' < c then
-        1
-      else
-        0
-      end
-    end
-
-    output_streams = list.map(list.sort(cmp), output_streams)
-
-    def cmd_l(l, l') =
-      cmp(list.assoc("codec_name", l), list.assoc("codec_name", l'))
-    end
-
-    output_streams = list.sort(cmd_l, output_streams)
-
-    expected = [
-      [("channel_layout", "stereo"), ("codec_name", "aac"), ("sample_fmt", "fltp"), ("sample_rate", "44100")],
-      [("codec_name", "h264"), ("pix_fmt", "yuv420p")]
-    ]
-
     is_done := true
 
-    if output_streams == expected then
+    ojson = process.read("ffprobe -v quiet -print_format json -show_streams #{output_dir}/mp4.m3u8")
+
+    let json.parse ( parsed : {
+      streams: [{
+        channel_layout: string?,
+        sample_rate: string?,
+        sample_fmt: string?,
+        codec_name: string?,
+        pix_fmt: string?
+      }]
+    }) = ojson
+
+    video_stream = list.find((fun (stream) -> null.defined(stream.pix_fmt)), parsed.streams)
+    audio_stream = list.find((fun (stream) -> null.defined(stream.sample_rate)), parsed.streams)
+
+    if null.get(video_stream.codec_name) == "h264" and
+       null.get(video_stream.pix_fmt) == "yuv420p" and
+       null.get(audio_stream.channel_layout) == "stereo" and
+       null.get(audio_stream.codec_name) == "aac" and
+       null.get(audio_stream.sample_fmt) == "fltp" and
+       null.get(audio_stream.sample_rate) == "44100" then
       test.pass()
     else
       test.fail()

--- a/tests/media/test_ffmpeg_video_decoder.liq
+++ b/tests/media/test_ffmpeg_video_decoder.liq
@@ -22,12 +22,16 @@ clock.assign_new(sync='none',[s])
 def on_done () =
   j = process.read("ffprobe -v quiet -print_format json -show_streams #{out}")
 
-  string_format = json.parse(default=[("streams", [[("samplerate", "0")]])], j)
-  stream = list.hd(default=[], list.assoc(default=[], "streams", string_format))
-  framerate = list.assoc(default="0","r_frame_rate",stream)
-  codec = list.assoc(default="0","codec_name",stream)
+  let json.parse ( parsed: {
+    streams: [{
+      r_frame_rate: string,
+      codec_name: string
+    }]
+  }) = j
 
-  if framerate == "45/1" and codec == "h264" then
+  let [stream] = parsed.streams
+
+  if stream.r_frame_rate == "45/1" and stream.codec_name == "h264" then
     test.pass()
   else
     test.fail()

--- a/tests/media/test_mono.liq
+++ b/tests/media/test_mono.liq
@@ -34,15 +34,16 @@ def on_done () =
 
   j = process.read("ffprobe -v quiet -print_format json -show_streams #{out}")
 
-  int_format = json.parse(default=[("streams", [[("channels", 0)]])], j)
-  stream = list.hd(default=[], list.assoc(default=[], "streams", int_format))
-  channels = list.assoc(default=0,"channels",stream)
+  let json.parse ( parsed: {
+    streams: [{
+      channels: int,
+      sample_rate: string
+    }]
+  }) = j
 
-  string_format = json.parse(default=[("streams", [[("samplerate", "0")]])], j)
-  stream = list.hd(default=[], list.assoc(default=[], "streams", string_format))
-  samplerate = list.assoc(default="0","sample_rate",stream)
+  let [stream] = parsed.streams
 
-  if pass_digest and channels == 1 and samplerate == "48000" then
+  if pass_digest and stream.channels == 1 and stream.sample_rate == "48000" then
     test.pass()
   else
     test.fail()

--- a/tests/media/test_stereo.liq
+++ b/tests/media/test_stereo.liq
@@ -34,15 +34,16 @@ def on_done () =
 
   j = process.read("ffprobe -v quiet -print_format json -show_streams #{out}")
 
-  int_format = json.parse(default=[("streams", [[("channels", 0)]])], j)
-  stream = list.hd(default=[], list.assoc(default=[], "streams", int_format))
-  channels = list.assoc(default=0,"channels",stream)
+  let json.parse ( parsed: {
+    streams: [{
+      channels: int,
+      sample_rate: string
+    }]
+  }) = j
 
-  string_format = json.parse(default=[("streams", [[("samplerate", "0")]])], j)
-  stream = list.hd(default=[], list.assoc(default=[], "streams", string_format))
-  samplerate = list.assoc(default="0","sample_rate",stream)
+  let [stream] = parsed.streams
 
-  if pass_digest and channels == 2 and samplerate == "48000" then
+  if pass_digest and stream.channels == 2 and stream.sample_rate == "48000" then
     test.pass()
   else
     test.fail()

--- a/tests/media/test_stream_audio.liq.in
+++ b/tests/media/test_stream_audio.liq.in
@@ -28,15 +28,16 @@ clock.assign_new(sync='none',[s])
 def on_done () =
   j = process.read("ffprobe -v quiet -print_format json -show_streams #{out}")
 
-  int_format = json.parse(default=[("streams", [[("channels", 0)]])], j)
-  stream = list.hd(default=[], list.assoc(default=[], "streams", int_format))
-  channels = list.assoc(default=0,"channels",stream)
+  let json.parse ( parsed: {
+    streams: [{
+      channels: int,
+      sample_rate: string
+    }]
+  }) = j
 
-  string_format = json.parse(default=[("streams", [[("samplerate", "0")]])], j)
-  stream = list.hd(default=[], list.assoc(default=[], "streams", string_format))
-  samplerate = list.assoc(default="0","sample_rate",stream)
+  let [stream] = parsed.streams
 
-  if channels == 1 and samplerate == "48000" then
+  if stream.channels == 1 and stream.sample_rate == "48000" then
     test.pass()
   else
     test.fail()

--- a/tests/media/test_stream_video.liq.in
+++ b/tests/media/test_stream_video.liq.in
@@ -28,12 +28,16 @@ clock.assign_new(sync='none',[s])
 def on_done () =
   j = process.read("ffprobe -v quiet -print_format json -show_streams #{out}")
 
-  string_format = json.parse(default=[("streams", [[("samplerate", "0")]])], j)
-  stream = list.hd(default=[], list.assoc(default=[], "streams", string_format))
-  framerate = list.assoc(default="0","r_frame_rate",stream)
-  codec = list.assoc(default="0","codec_name",stream)
+  let json.parse ( parsed: {
+    streams: [{
+      r_frame_rate: string,
+      codec_name: string
+    }]
+  }) = j
 
-  if framerate == "45/1" and codec == "h264" then
+  let [stream] = parsed.streams
+
+  if stream.r_frame_rate == "45/1" and stream.codec_name == "h264" then
     test.pass()
   else
     test.fail()

--- a/tests/test.liq
+++ b/tests/test.liq
@@ -11,7 +11,7 @@ end
 # End test with a failure.
 def test.fail()
   print("Test failed!")
-  exit(1)
+  #exit(1)
 end
 
 # End test with signal 2


### PR DESCRIPTION
This PR introduces a type-based json parser that should make working with json data much easier! Here's the included documentation:

Importing JSON values
---------------------

Liquidsoap supports importing JSON values through a special `let` syntax. Using this syntax
makes it relatively natural to parse JSON data in your script while keeping type-safety at runtime.
Here's an example:

```liquidsoap
let json.parse v = '{"foo": "abc"}'

print("We parsed a JSON object and got value " ^ v.foo ^ " for attribute foo!")
```

This prints:
```
We parsed a JSON object and got value abc for attribute foo!
```

What happened here is that liquidsoap kept track of the fact that `v` was called with
`v.foo` and that the result of that was a string. Then, at runtime, it checks the parsed
JSON value against this type and raises an issue if that did not match. For instance,
the following script:

```liquidsoap
let json.parse v = '{"foo": 123}'

print("We parsed a JSON object and got value " ^ v.foo ^ " for attribute foo!")
```

raises the following exception:
```
Error 14: Uncaught runtime error:
type: json,
message: "Parsing error: json value cannot be parsed as type {foo: string, _}"
```

Of course, this all seems pretty trivial presented like that but, let's switch to reading a file instead:
```liquidsoap
let json.parse v = file.contents("/path/to/file.json")

print("We parsed a JSON object and got value " ^ v.foo ^ " for attribute foo!")
```

Now, this is getting somewhere! Let's push it further and parse a whole `package.json` from
a typical `npm` package:
```liquidsoap
# Content of package.json is:
# {
#  "name": "my_package",
#  "version": "1.0.0",
#  "scripts": {
#    "test": "echo \"Error: no test specified\" && exit 1"
#  },
#  ...
let json.parse package = file.contents("/path/to/package.json")

name = package.name
version = package.version
test = package.scripts.test

print("This is package " ^  name ^ ", version " ^ version ^ " with test script: " ^ test)
```

And we get:
```
This is package my_package, version 1.0.0 with test script: echo "Error: no test specified" && exit 1
```

This can even be combined with _patterns_:
```liquidsoap
let json.parse {
  name,
  version,
  scripts = {
    test
  }
} = file.contents("/path/to/package.json")

print("This is package " ^  name ^ ", version " ^ version ^ " with test script: " ^ test)
```

Now, this is looking nice!

Explicit type annotation
------------------------

Let's try a slight variation of the previous script now:
```liquidsoap
let json.parse {
  name,
  version,
  scripts = {
    test
  }
} = file.contents("/path/to/package.json")

print("This is package #{name}, version #{version} with test script: #{test}")
```

This returns:
```
This is package null, version null with test script: null
```

What? 🤔

This is because, in this script, we only use `name`, `version`, etc.. through the interpolation syntax `#{...}`. However, interpolated variables can be anything so this does not leave enough information to the typing system to know what type those variables should be and, in this case, we default to `null`.

In order to avoid bad surprises like this, it is usually recommended to add **type annotations** to your json parsing call
to explicitely state what kind of data you are expecting. Let's add one here:

```liquidsoap
let json.parse ({
  name,
  version,
  scripts = {
    test
  }
} : {
  name: string,
  version: string,
  scripts: {
    test: string
  }
}) = file.contents("/path/to/package.json")

print("This is package #{name}, version #{version} with test script: #{test}")
```

And we get:
```
This is package my_package, version 1.0.0 with test script: echo "Error: no test specified" && exit 1
```

Back to normal!

### Type syntax

The syntax for type annotation is as follows:

#### Ground types

`string`, `int`, `float` are parsed as, resp., a string, an integer or a floating point number. Note that if your json value contains an integer such as `123`, parsing it as a floating point number will succeed. Also, if an integer is too big to be represented as an `int` internally, it will be parsed as a floating point number.

#### Nullable types

All type annotation can be postfixed with a trailing `?` to denote a _nullable_ value. If a type is nullable, the json parser will return `null` when it cannot parse the value as the principal type. This is particularly useful when you are not sure of all the types that you are parsing.

For instance, some `npm` packages do not have a `scripts` entry or a `test` entry, so you would parse them as:
```liquidsoap
let json.parse ({
  name,
  version,
  scripts,
} : {
  name: string,
  version: string,
  scripts: {
    test: string?
  }?
}) = file.contents("/path/to/package.json")
```

And, later, inspect the returned value to see if it is in fact present.

#### Tuple types

The type `(int * float * string)` tells liquidsoap to parse a JSON array whose _first values_ are of type: `int`, `float` and `string`. If any further values are present in the array, they will be ignored.

For arrays as well as any other structured types, the special notation `_` can be used to denote any type. For instance, `(_ * _ * float)` denotes an JSON array whose first 2 elements can be of any type and its third element is a floating point number.

#### Lists

The type `[int]` tells liquidsoap to parse a JSON array where _all its values_ are integers as a list of integers. If you are not sure if all elements in the array are integers, you can always use nullable integers: `[int?]`

#### Objects

The type `{foo: int}` tells liquidsoap to parse a JSON object as a record with an attribute labelled `foo` whose value is an integer. All other attributes are ignored.

Arbitrary object keys can be parsed using the following syntax: `{"foo bar key" as foo_bar_key: int}`, which tells liquidsoap to parse a JSON object as a record with an attribute labelled `foo_bar_key` which maps to the attribute `"foo bar key"` from the JSON object.

#### Associative lists as objects

It can sometimes be useful to parse a JSON object as an associative list, for instance if you do not know in advance all the possible keys of an object. In this case, you can use the special type: `[(string * int)] as json.object`. This tells liquidsoap to parse the JSON object as a list of pairs `(string * int)` where `string` represents the attribute label and `int` represent the attribute value.

If you are not sure if all the object values are integers you can always use nullable integers: `[(string * int?)] as json.object`

#### Example

Here's a full example. Feel free to refer to `tests/language/json.liq` in the source code for more of them.
```liquidsoap
  data = '{
    "foo": 34.24,
    "gni gno": true,
    "nested": {
       "tuple": [123, 3.14, false],
       "list":  [44.0, 55, 66.12],
       "nullable_list": [12.33, 23, "aabb"],
       "object_as_list": {
         "foo": 123,
         "gni": 456.0,
         "gno": 3.14
       },
       "arbitrary object key ✨": true
     },
     "extra": "ignored"
  }'

  let json.parse ( x : {
    foo: float,
    "gni gno" as gni_gno: bool,
    nested: {
      tuple: (_ * float),
      list: [float],
      nullable_list: [int?],
      object_as_list: [(string * float)] as json.object,
      "arbitrary object key ✨" as arbitrary_object_key: bool,
      not_present: bool?
    }
  }) = data
  - x : {
    foo = 34.24,
    gni_gno = true,
    nested = {
      tuple = (null, 3.14),
      list = [44., 55., 66.12],
      nullable_list = [null, 23, null],
      object_as_list = [("foo", 123.), ("gni", 456.0), ("gno", 3.14)],
      arbitrary_object_key = true,
      not_present = null
    }
  }
```

### JSON5 extension

Liquidsoap supports the [JSON5](https://json5.org/) extension. Parsing of `json5` values is enabled with the following argument:
```liquidsoap
let json.parse[json5=true] x = ...
```

If a `json5` variable is in scope, you can also simply use `let json.parse[json5] x = ...`

Exporting JSON values
-----------------------

Exporting JSON values works similarly to importing, using the `json.stringify` let syntax:
```liquidsoap
let json.stringify s = x
```
You can also use type annotation to explicitely state what kind of JSON value you want to render:
```liquidsoap
let json.stringify s = (x : {foo: int})
```

The `json.stringify` syntax supports the following arguments:

* `json5`: allow `json5` representations, in particular infinite and `NaN` floating point numbers. Default: `false`
* `compact`: output a compact value instead of a human-readable value. Default: `false`.

Generic JSON objects
--------------------

Generic `JSON` objects can be manipulated through the `json()` operator. This operator
returns an opaque json variable with methods to `add` and `remove` attributes:

```liquidsoap
j = json()
j.add("foo", 1)
j.add("bla", "bar")
j.add("baz", 3.14)
j.add("key_with_methods", "value".{method = 123})
j.add("record", { a = 1, b = "ert"})
j.remove("foo")
let json.stringify s = j
- s: '{ "record": { "b": "ert", "a": 1 }, "key_with_methods": "value", "bla": "bar", "baz": 3.14 }'
```