### PR TITLE
Revert "Do not force channels too early."

### DIFF
--- a/src/lang_encoders/lang_wav.ml
+++ b/src/lang_encoders/lang_wav.ml
@@ -31,9 +31,7 @@ let make params =
       Wav_format.samplesize = 16;
       header = true;
       duration = None;
-      (* We use a hardcoded value in order not to force the evaluation of the
-                       number of channels too early, see #933. *)
-      channels = 2;
+      channels = Lazy.force Frame.audio_channels;
       samplerate = Frame.audio_rate;
     }
   in


### PR DESCRIPTION
We revert commit b1989cab0dcd94525151102518c80091d9385567, which should not be needed since we now delay encoders creation.