### PR TITLE
Fix record comparison.

### DIFF
--- a/src/lang/builtins_bool.ml
+++ b/src/lang/builtins_bool.ml
@@ -28,38 +28,7 @@ let () =
       [("", t, None, None); ("", t, None, None)] Lang.bool_t (fun p ->
         let a = Lang.assoc "" 1 p in
         let b = Lang.assoc "" 2 p in
-        let a' = Lang.demeth a in
-        let b' = Lang.demeth b in
-        (* For records, we also compare fields. *)
-        let ans =
-          if a'.Lang.value = Lang.Tuple [] && b'.Lang.value = Lang.Tuple [] then (
-            let r a =
-              let m, _ = Term.Value.split_meths a in
-              m
-            in
-            let a = r a in
-            let b = r b in
-            (* Keep only common fields: with subtyping it might happen that some fields are ignored. *)
-            let a =
-              List.filter
-                (fun (l, _) -> List.exists (fun (l', _) -> l = l') b)
-                a
-            in
-            let b =
-              List.filter
-                (fun (l, _) -> List.exists (fun (l', _) -> l = l') a)
-                b
-            in
-            (* TODO: the order is not the expected one on records (for < we want
-               one field to be < and the other to be <=). *)
-            List.for_all
-              (fun (l, v) ->
-                let v' = List.assoc l b in
-                op (Lang.compare_values v v'))
-              a)
-          else op (Lang.compare_values a' b')
-        in
-        Lang.bool ans)
+        Lang.bool (op (Lang.compare_values a b)))
   in
   register_op "==" (fun c -> c = 0);
   register_op "!=" (fun c -> c <> 0);

--- a/src/lang/lang.ml
+++ b/src/lang/lang.ml
@@ -161,7 +161,7 @@ let compare_values a b =
     | Ground a, Ground b -> Ground.compare a b
     | Tuple l, Tuple m ->
         List.fold_left2
-          (fun cmp a b -> if cmp <> 0 then cmp else aux (a.value, b.value))
+          (fun cmp a b -> if cmp <> 0 then cmp else compare_values (a, b))
           0 l m
     | List l1, List l2 ->
         let rec cmp = function
@@ -169,7 +169,7 @@ let compare_values a b =
           | [], _ -> -1
           | _, [] -> 1
           | h1 :: l1, h2 :: l2 ->
-              let c = aux (h1.value, h2.value) in
+              let c = compare_values (h1, h2) in
               if c = 0 then cmp (l1, l2) else c
         in
         cmp (l1, l2)
@@ -177,8 +177,32 @@ let compare_values a b =
     | Null, _ -> -1
     | _, Null -> 1
     | _ -> assert false
+  and compare_values (a, b) =
+    let a' = demeth a in
+    let b' = demeth b in
+    (* For records, we compare the list ["label", field; ..] of common fields. *)
+    if a'.value = Tuple [] && b'.value = Tuple [] then (
+      let r a =
+        let m, _ = Term.Value.split_meths a in
+        m
+      in
+      let a = r a in
+      let b = r b in
+      (* Keep only common fields: with subtyping it might happen that some fields are ignored. *)
+      let a =
+        List.filter (fun (l, _) -> List.exists (fun (l', _) -> l = l') b) a
+      in
+      let b =
+        List.filter (fun (l, _) -> List.exists (fun (l', _) -> l = l') a) b
+      in
+      let a = List.sort (fun x x' -> Stdlib.compare (fst x) (fst x')) a in
+      let b = List.sort (fun x x' -> Stdlib.compare (fst x) (fst x')) b in
+      let a = Tuple (List.map (fun (lbl, v) -> product (string lbl) v) a) in
+      let b = Tuple (List.map (fun (lbl, v) -> product (string lbl) v) b) in
+      aux (a, b))
+    else aux (a'.value, b'.value)
   in
-  aux (a.value, b.value)
+  compare_values (a, b)
 
 (** Helpers for defining protocols. *)
 

--- a/tests/language/record.liq
+++ b/tests/language/record.liq
@@ -77,6 +77,8 @@ def f() =
   t({a = 5} == {a = 6}, false)
   t({a = 5, b = 3} == {a = 6}, false)
   t({a = 5} == {a = 6, b = 4}, false)
+  t([{a = 5}] == [{a = 5}], true)
+  t(({a = 5}) == ({a = 5}), true)
 
   if !success then test.pass() else test.fail() end
 end


### PR DESCRIPTION
I believe that this fixes #1916 by lifting the record subcase to the common comparison function.

Also, I didn't want to have too much to think about how to define the order so I delegated to comparing the tuple `(("label", method), ...)` as a value. Please advise if that's a good idea.

Bonus: Every heard the joke about a polytechnicien, a pot on a stove with water in it, a nail on the wall, and a pack of matches? 🙂