### PR TITLE
Switch to Re for regular expressions

### DIFF
--- a/liquidsoap.opam
+++ b/liquidsoap.opam
@@ -25,7 +25,7 @@ depends: [
   "ocamlfind" {build}
   "conf-pkg-config" {build}
   "conf-which" {build}
-  "pcre"
+  "re"
   "sedlex" {>= "2.2"}
 ]
 depopts: [

--- a/src/io/ffmpeg_io.ml
+++ b/src/io/ffmpeg_io.ml
@@ -212,13 +212,18 @@ class http_input ~autostart ~self_sync ~poll_delay ~debug ~clock_safe
           Avutil.Options.get_string ~search_children:true
             ~name:"icy_metadata_headers" (Av.input_obj input)
         in
-        let icy_headers = Pcre.split ~rex:(Pcre.regexp "[\r]?\n") icy_headers in
+        let icy_headers =
+          Re.Pcre.split ~rex:(Re.Pcre.regexp "[\r]?\n") icy_headers
+        in
         List.fold_left
           (fun ret header ->
             if header <> "" then (
               try
-                let res = Pcre.exec ~pat:"([^:]*):\\s*(.*)" header in
-                (Pcre.get_substring res 1, Pcre.get_substring res 2) :: ret
+                let res =
+                  Re.Pcre.exec ~rex:(Re.Pcre.regexp "([^:]*):\\s*(.*)") header
+                in
+                (Re.Pcre.get_substring res 1, Re.Pcre.get_substring res 2)
+                :: ret
               with Not_found -> ret)
             else ret)
           [] icy_headers

--- a/src/io/srt_io.ml
+++ b/src/io/srt_io.ml
@@ -439,7 +439,12 @@ let conf_enforced_encryption =
 let log = Log.make ["srt"]
 
 let log_handler { Srt.Log.message } =
-  let message = Pcre.substitute ~pat:"[ \r\n]+$" ~subst:(fun _ -> "") message in
+  let message =
+    Re.Pcre.substitute
+      ~rex:(Re.Pcre.regexp "[ \r\n]+$")
+      ~subst:(fun _ -> "")
+      message
+  in
   log#f conf_level#get "%s" message
 
 (** Common polling task for all srt input/output.

--- a/src/lang/builtins_files.ml
+++ b/src/lang/builtins_files.ml
@@ -321,17 +321,23 @@ let () =
       in
       let pattern =
         pattern
-        |> Option.map (fun s -> Pcre.replace ~pat:"\\." ~templ:"\\." s)
-        |> Option.map (fun s -> Pcre.replace ~pat:"\\*" ~templ:".*" s)
+        |> Option.map (fun s ->
+               Re.Pcre.substitute ~rex:(Re.Pcre.regexp "\\.")
+                 ~subst:(fun _ -> "\\.")
+                 s)
+        |> Option.map (fun s ->
+               Re.Pcre.substitute ~rex:(Re.Pcre.regexp "\\*")
+                 ~subst:(fun _ -> ".*")
+                 s)
         |> Option.map (fun s -> "^" ^ s ^ "$")
       in
       let pattern = Option.value ~default:"" pattern in
-      let rex = Pcre.regexp pattern in
+      let rex = Re.Pcre.regexp pattern in
       let dir = Lang.to_string (List.assoc "" p) in
       let dir = Utils.home_unrelate dir in
       let readdir dir =
         Array.to_list (Sys.readdir dir)
-        |> List.filter (fun s -> Pcre.pmatch ~rex s)
+        |> List.filter (fun s -> Re.Pcre.pmatch ~rex s)
       in
       let files =
         if not recursive then readdir dir

--- a/src/lang/builtins_server.ml
+++ b/src/lang/builtins_server.ml
@@ -64,7 +64,7 @@ let () =
       in
       let f = Lang.assoc "" 2 p in
       let f x = Lang.to_string (Lang.apply f [("", Lang.string x)]) in
-      let ns = Pcre.split ~pat:"\\." namespace in
+      let ns = Re.Pcre.split ~rex:(Re.Pcre.regexp "\\.") namespace in
       Server.add ~ns ~usage ~descr command f;
       Lang.unit)
 

--- a/src/lang/builtins_string.ml
+++ b/src/lang/builtins_string.ml
@@ -326,7 +326,7 @@ let () =
       in
       Lang.string
         (if space_sensitive then (
-         let l = Pcre.split ~pat:" " string in
+         let l = Re.Pcre.split ~rex:(Re.Pcre.regexp " ") string in
          let l = List.map f l in
          String.concat " " l)
         else f string))

--- a/src/lang/lang_builtins.ml
+++ b/src/lang/lang_builtins.ml
@@ -349,7 +349,8 @@ let () =
     let a = Lang.to_string (Lang.assoc "" 2 p) in
     let s = match a with "" -> c | _ -> c ^ " " ^ a in
     let r = try Server.exec s with Not_found -> "Command not found!" in
-    Lang.list (List.map Lang.string (Pcre.split ~pat:"\r?\n" r))
+    Lang.list
+      (List.map Lang.string (Re.Pcre.split ~rex:(Re.Pcre.regexp "\r?\n") r))
   in
   Lang.add_builtin "server.execute" ~category ~descr params return_t execute
 

--- a/src/lang/lexer.ml
+++ b/src/lang/lexer.ml
@@ -50,20 +50,22 @@ end
 
 let parse_time t =
   let g sub n =
-    let s = Pcre.get_substring sub n in
+    let s = Re.Pcre.get_substring sub n in
     if s = "" then None
     else Some (int_of_string (String.sub s 0 (String.length s - 1)))
   in
   try
-    let pat = "^((?:\\d+w)?)((?:\\d+h)?)((?:\\d+m)?)((?:\\d+s)?)$" in
-    let sub = Pcre.exec ~pat t in
+    let rex =
+      Re.Pcre.regexp "^((?:\\d+w)?)((?:\\d+h)?)((?:\\d+m)?)((?:\\d+s)?)$"
+    in
+    let sub = Re.Pcre.exec ~rex t in
     let g = g sub in
     List.map g [1; 2; 3; 4]
   with Not_found ->
-    let pat = "^((?:\\d+w)?)(\\d+h)(\\d+)$" in
-    let sub = Pcre.exec ~pat t in
+    let rex = Re.Pcre.regexp "^((?:\\d+w)?)(\\d+h)(\\d+)$" in
+    let sub = Re.Pcre.exec ~rex t in
     let g = g sub in
-    [g 1; g 2; Some (int_of_string (Pcre.get_substring sub 3)); None]
+    [g 1; g 2; Some (int_of_string (Re.Pcre.get_substring sub 3)); None]
 
 let skipped = [%sedlex.regexp? Sub (white_space, '\n') | '\r' | '\t']
 let decimal_digit = [%sedlex.regexp? '0' .. '9']
@@ -129,7 +131,7 @@ let rec token lexbuf =
     | skipped -> token lexbuf
     | Plus ('#', Star (Compl '\n'), '\n') ->
         let doc = Sedlexing.Utf8.lexeme lexbuf in
-        let doc = Pcre.split ~pat:"\n" doc in
+        let doc = Re.Pcre.split ~rex:(Re.Pcre.regexp "\n") doc in
         PP_COMMENT doc
     | '\n' -> PP_ENDL
     | "%ifdef", Plus ' ', var, Star ("" | '.', var) ->

--- a/src/main.ml
+++ b/src/main.ml
@@ -172,7 +172,7 @@ let format_doc s =
   let prefix = "\t  " in
   let indent = 8 + 2 in
   let max_width = 80 in
-  let s = Pcre.split ~pat:" " s in
+  let s = Re.Pcre.split ~rex:(Re.Pcre.regexp " ") s in
   let s =
     let rec join line width = function
       | [] -> [line]

--- a/src/operators/chord.ml
+++ b/src/operators/chord.ml
@@ -69,11 +69,13 @@ class chord ~kind metadata_name (source : source) =
               (fun c ->
                 try
                   let sub =
-                    Pcre.exec ~pat:"^([A-G-](?:b|#)?)(|M|m|M7|m7|dim)$" c
+                    Re.Pcre.exec
+                      ~rex:(Re.Pcre.regexp "^([A-G-](?:b|#)?)(|M|m|M7|m7|dim)$")
+                      c
                   in
-                  let n = Pcre.get_substring sub 1 in
+                  let n = Re.Pcre.get_substring sub 1 in
                   let n = note_of_string n in
-                  let m = Pcre.get_substring sub 2 in
+                  let m = Re.Pcre.get_substring sub 2 in
                   ans := (t, n, m) :: !ans
                 with Not_found ->
                   self#log#important "Could not parse chord '%s'." c)

--- a/src/operators/frei0r_op.ml
+++ b/src/operators/frei0r_op.ml
@@ -39,7 +39,7 @@ let frei0r_enable =
 let plugin_dirs =
   try
     let path = Unix.getenv "LIQ_FREI0R_PATH" in
-    Pcre.split ~pat:":" path
+    Re.Pcre.split ~rex:(Re.Pcre.regexp ":") path
   with Not_found -> Frei0r.default_paths
 
 class frei0r_filter ~kind ~name bgra instance params (source : source) =
@@ -297,7 +297,9 @@ let register_plugin fname =
   let explanation =
     let e = info.Frei0r.explanation in
     let e = String.capitalize_ascii e in
-    let e = Pcre.substitute ~pat:"@" ~subst:(fun _ -> "(at)") e in
+    let e =
+      Re.Pcre.substitute ~rex:(Re.Pcre.regexp "@") ~subst:(fun _ -> "(at)") e
+    in
     if e = "" then e
     else if e.[String.length e - 1] = '.' then
       String.sub e 0 (String.length e - 1)
@@ -305,7 +307,9 @@ let register_plugin fname =
   in
   let author =
     let a = info.Frei0r.author in
-    let a = Pcre.substitute ~pat:"@" ~subst:(fun _ -> "(at)") a in
+    let a =
+      Re.Pcre.substitute ~rex:(Re.Pcre.regexp "@") ~subst:(fun _ -> "(at)") a
+    in
     a
   in
   let descr = Printf.sprintf "%s (by %s)." explanation author in

--- a/src/operators/ladspa_op.ml
+++ b/src/operators/ladspa_op.ml
@@ -311,7 +311,9 @@ let register_descr plugin_name descr_n d inputs outputs =
     @ if ni = 0 then [] else [("", Lang.source_t input_t, None, None)]
   in
   let maker = Descriptor.maker d in
-  let maker = Pcre.substitute ~pat:"@" ~subst:(fun _ -> "(at)") maker in
+  let maker =
+    Re.Pcre.substitute ~rex:(Re.Pcre.regexp "@") ~subst:(fun _ -> "(at)") maker
+  in
   let descr = Printf.sprintf "%s by %s." (Descriptor.name d) maker in
   let output_kind =
     if mono then input_kind else Frame.{ input_kind with audio = audio_n no }

--- a/src/outputs/harbor_output.ml
+++ b/src/outputs/harbor_output.ml
@@ -597,11 +597,11 @@ module Make (T : T) = struct
         let enc = data.factory self#id in
         encoder <- Some (enc Meta_format.empty_metadata);
         let handler ~protocol ~data:_ ~headers ~socket uri =
-          let rex = Pcre.regexp "^(.+)\\?(.+)$" in
+          let rex = Re.Pcre.regexp "^(.+)\\?(.+)$" in
           let _, args =
             try
-              let sub = Pcre.exec ~rex uri in
-              (Pcre.get_substring sub 1, Pcre.get_substring sub 2)
+              let sub = Re.Pcre.exec ~rex uri in
+              (Re.Pcre.get_substring sub 1, Re.Pcre.get_substring sub 2)
             with Not_found -> (uri, "")
           in
           let args = Http.args_split args in

--- a/src/outputs/pipe_output.ml
+++ b/src/outputs/pipe_output.ml
@@ -292,7 +292,9 @@ class virtual file_output_base p =
       let filename = Utils.strftime filename in
       let filename = Utils.home_unrelate filename in
       (* Avoid / in metas for filename.. *)
-      let subst m = Pcre.substitute ~pat:"/" ~subst:(fun _ -> "-") m in
+      let subst m =
+        Re.Pcre.substitute ~rex:(Re.Pcre.regexp "/") ~subst:(fun _ -> "-") m
+      in
       self#interpolate ~subst filename
 
     method private on_close = on_close

--- a/src/request.ml
+++ b/src/request.ml
@@ -38,9 +38,11 @@ let log = Log.make ["request"]
 
 let remove_file_proto s =
   (* First remove file:// 🤮 *)
-  let s = Pcre.substitute ~pat:"^file://" ~subst:(fun _ -> "") s in
+  let s =
+    Re.Pcre.substitute ~rex:(Re.Pcre.regexp "^file://") ~subst:(fun _ -> "") s
+  in
   (* Then remove file: 😇 *)
-  Pcre.substitute ~pat:"^file:" ~subst:(fun _ -> "") s
+  Re.Pcre.substitute ~rex:(Re.Pcre.regexp "^file:") ~subst:(fun _ -> "") s
 
 let home_unrelate s = Utils.home_unrelate (remove_file_proto s)
 

--- a/src/shebang.ml
+++ b/src/shebang.ml
@@ -63,7 +63,7 @@ let argv =
           [| Sys.argv.(1) |],
           Array.sub Sys.argv 2 (Array.length Sys.argv - 2) )
       else
-        ( Array.of_list (Pcre.split ~pat:"\\s+" Sys.argv.(1)),
+        ( Array.of_list (Re.Pcre.split ~rex:(Re.Pcre.regexp "\\s+") Sys.argv.(1)),
           [| Sys.argv.(2) |],
           Array.sub Sys.argv 3 (Array.length Sys.argv - 3) )
     in

--- a/src/source.ml
+++ b/src/source.ml
@@ -387,7 +387,11 @@ class virtual operator ?(name = "src") ?audio_in ?video_in ?midi_in out_kind
     method id = id
 
     method set_id ?(definitive = true) s =
-      let s = Pcre.substitute ~pat:"[ \t\n]" ~subst:(fun _ -> "_") s in
+      let s =
+        Re.Pcre.substitute ~rex:(Re.Pcre.regexp "[ \t\n]")
+          ~subst:(fun _ -> "_")
+          s
+      in
       if not definitive_id then (
         id <- s;
         definitive_id <- definitive);

--- a/src/sources/harbor_input.ml
+++ b/src/sources/harbor_input.ml
@@ -191,8 +191,8 @@ module Make (Harbor : T) = struct
       method register_decoder mime =
         let mime =
           try
-            let sub = Pcre.exec ~pat:"^([^;]+);.*$" mime in
-            Pcre.get_substring sub 1
+            let sub = Re.Pcre.exec ~rex:(Re.Pcre.regexp "^([^;]+);.*$") mime in
+            Re.Pcre.get_substring sub 1
           with Not_found -> mime
         in
         Generator.set_mode generator `Undefined;

--- a/src/stream/ffmpeg_raw_content.ml
+++ b/src/stream/ffmpeg_raw_content.ml
@@ -214,12 +214,12 @@ module VideoSpecs = struct
       | "pixel_aspect" ->
           let pixel_aspect =
             try
-              let rex = Pcre.regexp "(\\d+)/(\\d+)" in
-              let sub = Pcre.exec ~rex value in
+              let rex = Re.Pcre.regexp "(\\d+)/(\\d+)" in
+              let sub = Re.Pcre.exec ~rex value in
               Some
                 {
-                  Avutil.num = int_of_string (Pcre.get_substring sub 1);
-                  den = int_of_string (Pcre.get_substring sub 2);
+                  Avutil.num = int_of_string (Re.Pcre.get_substring sub 1);
+                  den = int_of_string (Re.Pcre.get_substring sub 2);
                 }
             with _ -> None
           in

--- a/src/synth/dssi_op.ml
+++ b/src/synth/dssi_op.ml
@@ -35,13 +35,13 @@ let dssi_enable =
 let dssi_load =
   try
     let venv = Unix.getenv "LIQ_DSSI_LOAD" in
-    Pcre.split ~pat:":" venv
+    Re.Pcre.split ~rex:(Re.Pcre.regexp ":") venv
   with Not_found -> []
 
 let plugin_dirs =
   try
     let path = Unix.getenv "LIQ_DSSI_PATH" in
-    Pcre.split ~pat:":" path
+    Re.Pcre.split ~rex:(Re.Pcre.regexp ":") path
   with Not_found -> ["/usr/lib/dssi"; "/usr/local/lib/dssi"]
 
 (* Number of channels to synthesize when in all mode *)

--- a/src/tools/http.ml
+++ b/src/tools/http.ml
@@ -173,7 +173,8 @@ module Make (Transport : Transport_t) = struct
       Bytes.unsafe_to_string s
 
   let url_encode ?(plus = true) s =
-    Pcre.substitute ~pat:"[^A-Za-z0-9_.!*-]"
+    Re.Pcre.substitute
+      ~rex:(Re.Pcre.regexp "[^A-Za-z0-9_.!*-]")
       ~subst:(fun x ->
         if plus && x = " " then "+"
         else (
@@ -189,9 +190,9 @@ module Make (Transport : Transport_t) = struct
       | _ -> raise UrlDecoding
 
   let url_decode ?(plus = true) s =
-    Pcre.substitute
-      ~pat:
-        "\\+|%..|%.|%"
+    Re.Pcre.substitute
+      ~rex:
+        (Re.Pcre.regexp "\\+|%..|%.|%")
         (* TODO why do we match %. and % and seem to exclude them below ? *)
       ~subst:(fun s ->
         if s = "+" then if plus then " " else "+"
@@ -206,7 +207,7 @@ module Make (Transport : Transport_t) = struct
   let args_split s =
     let args = Hashtbl.create 2 in
     let fill_arg arg =
-      match Pcre.split ~pat:"=" arg with
+      match Re.Pcre.split ~rex:(Re.Pcre.regexp "=") arg with
         | e :: l ->
             (* There should be only arg=value *)
             List.iter
@@ -214,7 +215,7 @@ module Make (Transport : Transport_t) = struct
               l
         | [] -> ()
     in
-    List.iter fill_arg (Pcre.split ~pat:"&" s);
+    List.iter fill_arg (Re.Pcre.split ~rex:(Re.Pcre.regexp "&") s);
     args
 
   let connect = Transport.connect
@@ -227,32 +228,33 @@ module Make (Transport : Transport_t) = struct
 
   let parse_url url =
     let basic_rex =
-      Pcre.regexp "^([Hh][Tt][Tt][Pp][sS]?)://([^/:]+)(:[0-9]+)?(/.*)?$"
+      Re.Pcre.regexp "^([Hh][Tt][Tt][Pp][sS]?)://([^/:]+)(:[0-9]+)?(/.*)?$"
     in
     let sub =
-      try Pcre.exec ~rex:basic_rex url
+      try Re.Pcre.exec ~rex:basic_rex url
       with Not_found -> (* raise Invalid_url *)
                         failwith "Invalid URL."
     in
-    let protocol = Pcre.get_substring sub 1 in
-    let host = Pcre.get_substring sub 2 in
+    let protocol = Re.Pcre.get_substring sub 1 in
+    let host = Re.Pcre.get_substring sub 2 in
     let port =
       try
-        let port = Pcre.get_substring sub 3 in
+        let port = Re.Pcre.get_substring sub 3 in
         let port = String.sub port 1 (String.length port - 1) in
         let port = int_of_string port in
         Some port
       with Not_found -> None
     in
-    let path = try Pcre.get_substring sub 4 with Not_found -> "/" in
+    let path = try Re.Pcre.get_substring sub 4 with Not_found -> "/" in
     { protocol; host; port; path }
 
-  let is_url path = Pcre.pmatch ~pat:"^[Hh][Tt][Tt][Pp][sS]?://.+" path
+  let is_url path =
+    Re.Pcre.pmatch ~rex:(Re.Pcre.regexp "^[Hh][Tt][Tt][Pp][sS]?://.+") path
 
   let dirname url =
-    let rex = Pcre.regexp "^([Hh][Tt][Tt][Pp][sS]?://.+/)[^/]*$" in
-    let s = Pcre.exec ~rex url in
-    Pcre.get_substring s 1
+    let rex = Re.Pcre.regexp "^([Hh][Tt][Tt][Pp][sS]?://.+/)[^/]*$" in
+    let s = Re.Pcre.exec ~rex url in
+    Re.Pcre.get_substring s 1
 
   let read_with_timeout ?(log = fun _ -> ()) ~timeout socket buflen =
     Transport.wait_for ~log (`Read socket) timeout;
@@ -324,8 +326,8 @@ module Make (Transport : Transport_t) = struct
   (* Read chunked transfer. *)
   let read_chunked ~timeout socket =
     let read = read_crlf ~count:1 ~timeout socket in
-    let len = List.hd (Pcre.split ~pat:"[\r]?\n" read) in
-    let len = List.hd (Pcre.split ~pat:";" len) in
+    let len = List.hd (Re.Pcre.split ~rex:(Re.Pcre.regexp "[\r]?\n") read) in
+    let len = List.hd (Re.Pcre.split ~rex:(Re.Pcre.regexp ";") len) in
     let len = int_of_string ("0x" ^ len) in
     let s = really_read socket ~timeout len in
     ignore (read_crlf ~count:1 ~timeout socket);
@@ -338,23 +340,23 @@ module Make (Transport : Transport_t) = struct
       Transport.write socket (Bytes.of_string request) 0 len < len
     then raise Socket;
     let header = read_crlf ~log ~timeout socket in
-    let header = Pcre.split ~pat:"[\r]?\n" header in
+    let header = Re.Pcre.split ~rex:(Re.Pcre.regexp "[\r]?\n") header in
     let response, header =
       match header with e :: tl -> (e, tl) | [] -> raise Response
     in
     let response_http_version, response_status, response_msg =
-      let pat = "^((?:HTTP/[0-9.]+)|ICY) ([0-9]+) (.*)$" in
+      let rex = Re.Pcre.regexp "^((?:HTTP/[0-9.]+)|ICY) ([0-9]+) (.*)$" in
       try
-        let ( !! ) = Pcre.get_substring (Pcre.exec ~pat response) in
+        let ( !! ) = Re.Pcre.get_substring (Re.Pcre.exec ~rex response) in
         (!!1, int_of_string !!2, !!3)
       with Not_found -> raise Response
     in
     let fields =
-      let pat = "([^:]*):\\s*(.*)" in
+      let rex = Re.Pcre.regexp "([^:]*):\\s*(.*)" in
       List.fold_left
         (fun fields line ->
           try
-            let ( !! ) = Pcre.get_substring (Pcre.exec ~pat line) in
+            let ( !! ) = Re.Pcre.get_substring (Re.Pcre.exec ~rex line) in
             (String.lowercase_ascii !!1, !!2) :: fields
           with Not_found -> fields)
         [] header

--- a/src/tools/liqcurl.ml
+++ b/src/tools/liqcurl.ml
@@ -186,7 +186,7 @@ let rec http_request ?headers ?http_version ~follow_redirect ~timeout ~url
             ~request ~on_body_data ()
       | _ ->
           let response_headers =
-            Pcre.split ~rex:(Pcre.regexp "[\r]?\n")
+            Re.Pcre.split ~rex:(Re.Pcre.regexp "[\r]?\n")
               (Buffer.contents response_headers)
           in
           let protocol_version, status_code, status_message =
@@ -197,9 +197,13 @@ let rec http_request ?headers ?http_version ~follow_redirect ~timeout ~url
               (fun ret header ->
                 if header <> "" then (
                   try
-                    let res = Pcre.exec ~pat:"([^:]*):\\s*(.*)" header in
-                    ( String.lowercase_ascii (Pcre.get_substring res 1),
-                      Pcre.get_substring res 2 )
+                    let res =
+                      Re.Pcre.exec
+                        ~rex:(Re.Pcre.regexp "([^:]*):\\s*(.*)")
+                        header
+                    in
+                    ( String.lowercase_ascii (Re.Pcre.get_substring res 1),
+                      Re.Pcre.get_substring res 2 )
                     :: ret
                   with Not_found -> ret)
                 else ret)

--- a/src/tools/sandbox.ml
+++ b/src/tools/sandbox.ml
@@ -41,7 +41,7 @@ let conf_setenv =
 let get_setenv () =
   List.fold_left
     (fun cur s ->
-      match Pcre.split ~pat:"=" s with
+      match Re.Pcre.split ~rex:(Re.Pcre.regexp "=") s with
         | [] -> cur
         | lbl :: l -> (lbl, String.concat "=" l) :: cur)
     [] conf_setenv#get

--- a/src/tools/server.ml
+++ b/src/tools/server.ml
@@ -239,7 +239,11 @@ let () =
   add "help" ~usage:"help [<command>]"
     ~descr:"Get information on available commands." (fun args ->
       try
-        let args = Pcre.substitute ~pat:"\\s*" ~subst:(fun _ -> "") args in
+        let args =
+          Re.Pcre.substitute ~rex:(Re.Pcre.regexp "\\s*")
+            ~subst:(fun _ -> "")
+            args
+        in
         let _, us, d = Tutils.mutexify lock (Hashtbl.find commands) args in
         Printf.sprintf "Usage: %s\r\n  %s" us d
       with Not_found ->

--- a/src/tools/tutils.ml
+++ b/src/tools/tutils.ml
@@ -204,7 +204,7 @@ let create ~queue f x s =
                     Printexc.raise_with_backtrace e bt
             with e ->
               let raw_bt = Printexc.get_raw_backtrace () in
-              let l = Pcre.split ~pat:"\n" bt in
+              let l = Re.Pcre.split ~rex:(Re.Pcre.regexp "\n") bt in
               List.iter (log#info "%s") l;
               mutexify lock
                 (fun () ->


### PR DESCRIPTION
The library seems to be well maintainer, under the `ocaml` banner and has no external dependencies. Since `Pcre` is hard dependency for u, it would make sense to use a native library.