### PR TITLE
Runtime modules!

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -208,7 +208,7 @@ synth = synth/keyboard.ml synth/synth_op.ml \
 	$(if $(W_SDL),synth/keyboard_sdl.ml)
 
 builtins = lang/lang_builtins.ml \
-           lang/builtins_ref.ml \
+           lang/builtins_ref.ml lang/builtins_importer.ml \
            lang/builtins_bool.ml lang/builtins_list.ml \
            lang/builtins_string.ml lang/builtins_regexp.ml lang/builtins_json.ml \
            lang/builtins_request.ml lang/builtins_error.ml \

--- a/src/lang/builtins_importer.ml
+++ b/src/lang/builtins_importer.ml
@@ -22,6 +22,11 @@
 
 module TypeValue = Lang.MkAbstractValue (Parser_helper.TypeTerm)
 
+let throw exn =
+  let bt = Printexc.get_raw_backtrace () in
+  Lang.raise_as_runtime ~bt ~kind:"import" exn
+
+(* Default module exports. *)
 let () = Environment.add_builtin ["_exports_"] (([], Lang.unit_t), Lang.unit)
 
 let () =
@@ -44,6 +49,6 @@ let () =
           (fun () -> Runtime.mk_expr ~fname ~pwd Parser.export lexbuf)
       in
       let expr = Term.make (Term.Cast (expr, ty)) in
-      Typechecking.check ~throw:raise ~ignored:true expr;
+      Typechecking.check ~throw ~ignored:true expr;
       let exports = Evaluation.eval expr in
       exports)

--- a/src/lang/builtins_importer.ml
+++ b/src/lang/builtins_importer.ml
@@ -27,7 +27,9 @@ let raise exn =
   Lang.raise_as_runtime ~bt ~kind:"import" exn
 
 (* Default module exports. *)
-let () = Environment.add_builtin ["_exports_"] (([], Lang.unit_t), Lang.unit)
+let () =
+  Environment.add_builtin ~register:false ["_exports_"]
+    (([], Lang.unit_t), Lang.unit)
 
 let () =
   let t = Lang.univ_t () in

--- a/src/lang/lexer.ml
+++ b/src/lang/lexer.ml
@@ -240,6 +240,8 @@ let rec token lexbuf =
     | '_' -> UNDERSCORE
     | "true" -> BOOL true
     | "false" -> BOOL false
+    | "import" -> IMPORT
+    | "export" -> EXPORT
     | int_literal -> INT (int_of_string (Sedlexing.Utf8.lexeme lexbuf))
     | Star decimal_digit, '.', Star decimal_digit ->
         let matched = Sedlexing.Utf8.lexeme lexbuf in

--- a/src/lang/lexer.ml
+++ b/src/lang/lexer.ml
@@ -240,8 +240,6 @@ let rec token lexbuf =
     | '_' -> UNDERSCORE
     | "true" -> BOOL true
     | "false" -> BOOL false
-    | "import" -> IMPORT
-    | "export" -> EXPORT
     | int_literal -> INT (int_of_string (Sedlexing.Utf8.lexeme lexbuf))
     | Star decimal_digit, '.', Star decimal_digit ->
         let matched = Sedlexing.Utf8.lexeme lexbuf in

--- a/src/lang/parser.mly
+++ b/src/lang/parser.mly
@@ -70,6 +70,7 @@ open Parser_helper
 %token <string list> PP_COMMENT
 %token WHILE FOR TO
 %token LET_IMPORT LET_EXPORT
+%token <string> EXPORT_VAR_GETS
 
 %nonassoc YIELDS       (* fun x -> (x+x) *)
 %nonassoc COALESCE     (* (x ?? y) == z *)
@@ -367,7 +368,8 @@ import_record_elems:
   | VAR COMMA import_record_elems { $1::$3 }
 
 export_binding:
-  | LET_EXPORT VAR GETS expr { $2, $4 }
+  | EXPORT_VAR_GETS expr     { false, $1, $2 }
+  | LET_EXPORT VAR GETS expr { true, $2, $4 }
 
 list_binding:
   | LET LBRA list_bind RBRA GETS expr { $3,$6 }

--- a/src/lang/parser.mly
+++ b/src/lang/parser.mly
@@ -69,7 +69,7 @@ open Parser_helper
 %token <string> PP_INCLUDE
 %token <string list> PP_COMMENT
 %token WHILE FOR TO
-%token IMPORT EXPORT
+%token LET_IMPORT LET_EXPORT
 
 %nonassoc YIELDS       (* fun x -> (x+x) *)
 %nonassoc COALESCE     (* (x ?? y) == z *)
@@ -356,10 +356,18 @@ binding:
     }
 
 import_binding:
-  | LET IMPORT VAR GETS expr { $3, $5 }
+  | LET_IMPORT import_record GETS expr  { `Record $2, $4 }
+  | LET_IMPORT VAR GETS expr            { `Var $2, $4 }
+
+import_record:
+  | LCUR import_record_elems RCUR { $2 }
+
+import_record_elems:
+  | VAR                           { [$1] }
+  | VAR COMMA import_record_elems { $1::$3 }
 
 export_binding:
-  | LET EXPORT VAR GETS expr { $3, $5 }
+  | LET_EXPORT VAR GETS expr { $2, $4 }
 
 list_binding:
   | LET LBRA list_bind RBRA GETS expr { $3,$6 }

--- a/src/lang/parser_helper.ml
+++ b/src/lang/parser_helper.ml
@@ -385,19 +385,21 @@ let mk_import_let ~pos (bindings, from) body =
                  cur)
              body names)
 
-let mk_export_let ~pos (var, def) body =
+let mk_export_let ~pos (expose, var, def) body =
   let exports = mk ~pos (Var "_exports_") in
   let body =
-    mk ~pos
-      (Let
-         {
-           doc = (Doc.none (), [], []);
-           replace = false;
-           pat = PVar [var];
-           gen = [];
-           def = mk ~pos (Invoke (exports, var));
-           body;
-         })
+    if expose then
+      mk ~pos
+        (Let
+           {
+             doc = (Doc.none (), [], []);
+             replace = false;
+             pat = PVar [var];
+             gen = [];
+             def = mk ~pos (Invoke (exports, var));
+             body;
+           })
+    else body
   in
   mk ~pos
     (Let

--- a/tests/language/import.liq
+++ b/tests/language/import.liq
@@ -7,7 +7,7 @@ module = file.temp("tmp","module")
 data = '
 let export foo = 123
 
-let export gni = { foo = "bla" }
+export gni = { foo = "bla" }
 '
 
 file.write(data=data, module)

--- a/tests/language/import.liq
+++ b/tests/language/import.liq
@@ -12,12 +12,19 @@ let export gni = { foo = "bla" }
 
 file.write(data=data, module)
 
-on_shutdown(fun() -> file.unlink(module))
+on_shutdown(fun() -> file.remove(module))
 
 def f() =
   let import x = module
-   ignore(x.foo + 1)
-   ignore(string.length(x.gni.foo))
+  ignore(x.foo + 1)
+  ignore(string.length(x.gni.foo))
+
+  try
+    let import x = module
+    ignore(string.length(x.foo))
+  catch err do
+    print(err)
+  end
 
   let import x = module
 

--- a/tests/language/modules.liq
+++ b/tests/language/modules.liq
@@ -1,0 +1,33 @@
+#!../../src/liquidsoap ../../libs/stdlib.liq ../../libs/deprecations.liq
+
+%include "test.liq"
+
+module = file.temp("tmp","module")
+
+data = '
+let export foo = 123
+
+let export gni = { foo = "bla" }
+'
+
+file.write(data=data, module)
+
+on_shutdown(fun() -> file.unlink(module))
+
+def f() =
+  let import x = module
+   ignore(x.foo + 1)
+   ignore(string.length(x.gni.foo))
+
+  let import x = module
+
+  ignore(x.foo + 1)
+
+  let import {foo, gni} = module
+  ignore(foo + 1)
+  ignore(string.length(gni.foo))
+
+  test.pass()
+end
+
+test.check(f)


### PR DESCRIPTION
This is fun!
```shell
% cat /tmp/module.liq
# foo is exported and defined locally
let export foo = 123

print(foo)

# gni is exported but not defined locally
export gni = { bla = 123.455 }
```

```ruby
# let import x = "/tmp/module.liq";;
x : {foo : int, gni : {bla : float}} = {foo = 123, gni = {bla = 123.455}}

# let import {foo, gni} = "/tmp/module.liq";;
gni : {bla : float} = {bla = 123.455}
foo : int = 123
```