### PR TITLE
Turn encoder errors into runtime errors.

### DIFF
--- a/src/lang/runtime.ml
+++ b/src/lang/runtime.ml
@@ -119,7 +119,7 @@ let throw print_error = function
       error_header 7 (Type.print_pos_opt v.Value.pos);
       Format.printf "Invalid value:@ %s@]@." msg;
       raise Error
-  | Lang_encoder.Error (pos, s) ->
+  | Lang_encoder.Encoder_error (pos, s) ->
       error_header 8 (Type.print_pos_opt pos);
       Format.printf "%s@]@." (String.capitalize_ascii s);
       raise Error

--- a/src/lang_encoders/lang_fdkaac.ml
+++ b/src/lang_encoders/lang_fdkaac.ml
@@ -50,7 +50,7 @@ let make params =
            Printf.sprintf "invalid samplerate value. Possible values: %s"
              (String.concat ", " (List.map string_of_int valid_samplerates))
          in
-         raise (Lang_encoder.Error (pos, err)));
+         raise (Lang_encoder.error ~pos err));
        i)
   in
   let defaults =
@@ -78,7 +78,7 @@ let make params =
             let aot =
               try Fdkaac_format.aot_of_string s
               with Not_found ->
-                raise (Lang_encoder.Error (pos, "invalid aot value"))
+                raise (Lang_encoder.error ~pos "invalid aot value")
             in
             { f with Fdkaac_format.aot }
         | "vbr", `Value { value = Ground (Int i); pos } ->
@@ -87,7 +87,7 @@ let make params =
                 Printf.sprintf "invalid vbr mode. Possible values: %s"
                   (String.concat ", " (List.map string_of_int valid_vbr))
               in
-              raise (Lang_encoder.Error (pos, err)));
+              raise (Lang_encoder.error ~pos err));
             { f with Fdkaac_format.bitrate_mode = `Variable i }
         | "bandwidth", `Value { value = Ground (Int i); _ } ->
             { f with Fdkaac_format.bandwidth = `Fixed i }
@@ -109,7 +109,7 @@ let make params =
             let transmux =
               try Fdkaac_format.transmux_of_string s
               with Not_found ->
-                raise (Lang_encoder.Error (pos, "invalid transmux value"))
+                raise (Lang_encoder.error ~pos "invalid transmux value")
             in
             { f with Fdkaac_format.transmux }
         | "", `Value { value = Ground (String s); _ }

--- a/src/lang_encoders/lang_ffmpeg.ml
+++ b/src/lang_encoders/lang_ffmpeg.ml
@@ -124,21 +124,21 @@ let ffmpeg_gen params =
       | Ground (Int i) -> i
       | Ground (String s) -> int_of_string s
       | Ground (Float f) -> int_of_float f
-      | _ -> raise (Lang_encoder.Error (t.pos, "integer expected"))
+      | _ -> raise (Lang_encoder.error ~pos:t.pos "integer expected")
   in
   let to_string t =
     match t.value with
       | Ground (Int i) -> Printf.sprintf "%i" i
       | Ground (String s) -> s
       | Ground (Float f) -> Printf.sprintf "%f" f
-      | _ -> raise (Lang_encoder.Error (t.pos, "string expected"))
+      | _ -> raise (Lang_encoder.error ~pos:t.pos "string expected")
   in
   let to_float t =
     match t.value with
       | Ground (Int i) -> float i
       | Ground (String s) -> float_of_string s
       | Ground (Float f) -> f
-      | _ -> raise (Lang_encoder.Error (t.pos, "float expected"))
+      | _ -> raise (Lang_encoder.error ~pos:t.pos "float expected")
   in
   let rec parse_args ~format ~mode f = function
     | [] -> f
@@ -244,7 +244,7 @@ let ffmpeg_gen params =
           | `Audio -> Hashtbl.add f.Ffmpeg_format.audio_opts k (`Float fl)
           | `Video -> Hashtbl.add f.Ffmpeg_format.video_opts k (`Float fl));
         parse_args ~format ~mode f l
-    | (_, t) :: _ -> raise (Lang_encoder.Error (t.pos, "unexpected option"))
+    | (_, t) :: _ -> raise (Lang_encoder.error ~pos:t.pos "unexpected option")
   in
   List.fold_left
     (fun f -> function

--- a/src/lang_encoders/lang_flac.ml
+++ b/src/lang_encoders/lang_flac.ml
@@ -46,11 +46,11 @@ let flac_gen params =
           { f with Flac_format.samplerate = Lazy.from_val i }
       | "compression", `Value { value = Ground (Int i); pos } ->
           if i < 0 || i > 8 then
-            raise (Lang_encoder.Error (pos, "invalid compression value"));
+            raise (Lang_encoder.error ~pos "invalid compression value");
           { f with Flac_format.compression = i }
       | "bits_per_sample", `Value { value = Ground (Int i); pos } ->
           if not (List.mem i accepted_bits_per_sample) then
-            raise (Lang_encoder.Error (pos, "invalid bits_per_sample value"));
+            raise (Lang_encoder.error ~pos "invalid bits_per_sample value");
           { f with Flac_format.bits_per_sample = i }
       | "bytes_per_page", `Value { value = Ground (Int i); _ } ->
           { f with Flac_format.fill = Some i }

--- a/src/lang_encoders/lang_gstreamer.ml
+++ b/src/lang_encoders/lang_gstreamer.ml
@@ -80,10 +80,8 @@ let make ?pos params =
     && gstreamer.Gstreamer_format.channels = 0
   then
     raise
-      (Lang_encoder.Error
-         ( pos,
-           "must have at least one audio channel when passing an audio pipeline"
-         ));
+      (Lang_encoder.error ~pos
+         "must have at least one audio channel when passing an audio pipeline");
   if
     gstreamer.Gstreamer_format.pipeline = None
     && gstreamer.Gstreamer_format.video <> None
@@ -91,8 +89,8 @@ let make ?pos params =
     && gstreamer.Gstreamer_format.muxer = None
   then
     raise
-      (Lang_encoder.Error
-         (pos, "must have a muxer when passing an audio and a video pipeline"));
+      (Lang_encoder.error ~pos
+         "must have a muxer when passing an audio and a video pipeline");
   Encoder.GStreamer gstreamer
 
 let () = Lang_encoder.register "gstreamer" kind_of_encoder (make ?pos:None)

--- a/src/lang_encoders/lang_mp3.ml
+++ b/src/lang_encoders/lang_mp3.ml
@@ -37,7 +37,7 @@ let check_samplerate ~pos i =
        [8000; 11025; 12000; 16000; 22050; 24000; 32000; 44100; 48000]
      in
      if not (List.mem i allowed) then
-       raise (Lang_encoder.Error (pos, "invalid samplerate value"));
+       raise (Lang_encoder.error ~pos "invalid samplerate value");
      i)
 
 let mp3_base_defaults () =
@@ -63,14 +63,14 @@ let mp3_base f = function
           | "default" -> Mp3_format.Default
           | "joint_stereo" -> Mp3_format.Joint_stereo
           | "stereo" -> Mp3_format.Stereo
-          | _ -> raise (Lang_encoder.Error (pos, "invalid stereo mode"))
+          | _ -> raise (Lang_encoder.error ~pos "invalid stereo mode")
       in
       { f with Mp3_format.stereo_mode = mode }
   | "internal_quality", `Value { value = Ground (Int q); pos } ->
       if q < 0 || q > 9 then
         raise
-          (Lang_encoder.Error
-             (pos, "internal quality must be a value between 0 and 9"));
+          (Lang_encoder.error ~pos
+             "internal quality must be a value between 0 and 9");
       { f with Mp3_format.internal_quality = q }
   | "msg_interval", `Value { value = Ground (Float i); _ } ->
       { f with Mp3_format.msg_interval = i }
@@ -82,8 +82,8 @@ let mp3_base f = function
       match !Mp3_format.id3v2_export with
         | None ->
             raise
-              (Lang_encoder.Error
-                 (pos, "no id3v2 support available for the mp3 encoder"))
+              (Lang_encoder.error ~pos
+                 "no id3v2 support available for the mp3 encoder")
         | Some g -> { f with Mp3_format.id3v2 = Some g })
   | "id3v2", `Value { value = Ground (Bool false); _ } ->
       { f with Mp3_format.id3v2 = None }
@@ -113,7 +113,7 @@ let make_cbr params =
       (fun f -> function
         | "bitrate", `Value { value = Ground (Int i); pos } ->
             if not (List.mem i allowed_bitrates) then
-              raise (Lang_encoder.Error (pos, "invalid bitrate value"));
+              raise (Lang_encoder.error ~pos "invalid bitrate value");
             set_bitrate f i
         | x -> mp3_base f x)
       defaults params
@@ -205,21 +205,21 @@ let make_abr_vbr ~default params =
       (fun f -> function
         | "quality", `Value { value = Ground (Int q); pos } when is_vbr f ->
             if q < 0 || q > 9 then
-              raise (Lang_encoder.Error (pos, "quality should be in [0..9]"));
+              raise (Lang_encoder.error ~pos "quality should be in [0..9]");
             set_quality f (Some q)
         | "hard_min", `Value { value = Ground (Bool b); _ } ->
             set_hard_min f (Some b)
         | "bitrate", `Value { value = Ground (Int i); pos } ->
             if not (List.mem i allowed_bitrates) then
-              raise (Lang_encoder.Error (pos, "invalid bitrate value"));
+              raise (Lang_encoder.error ~pos "invalid bitrate value");
             set_mean_bitrate f (Some i)
         | "min_bitrate", `Value { value = Ground (Int i); pos } ->
             if not (List.mem i allowed_bitrates) then
-              raise (Lang_encoder.Error (pos, "invalid bitrate value"));
+              raise (Lang_encoder.error ~pos "invalid bitrate value");
             set_min_bitrate f (Some i)
         | "max_bitrate", `Value { value = Ground (Int i); pos } ->
             if not (List.mem i allowed_bitrates) then
-              raise (Lang_encoder.Error (pos, "invalid bitrate value"));
+              raise (Lang_encoder.error ~pos "invalid bitrate value");
             set_max_bitrate f (Some i)
         | x -> mp3_base f x)
       default params

--- a/src/lang_encoders/lang_opus.ml
+++ b/src/lang_encoders/lang_opus.ml
@@ -56,7 +56,7 @@ let make params =
             (* Doc say this should be from 0 to 10. *)
             if c < 0 || c > 10 then
               raise
-                (Lang_encoder.Error (pos, "Opus complexity should be in 0..10"));
+                (Lang_encoder.error ~pos "Opus complexity should be in 0..10");
             { f with Opus_format.complexity = Some c }
         | "max_bandwidth", `Value { value = Ground (String "narrow_band"); _ }
           ->
@@ -75,26 +75,23 @@ let make params =
             let frame_sizes = [2.5; 5.; 10.; 20.; 40.; 60.] in
             if not (List.mem size frame_sizes) then
               raise
-                (Lang_encoder.Error
-                   ( pos,
-                     "Opus frame size should be one of 2.5, 5., 10., 20., 40. \
-                      or 60." ));
+                (Lang_encoder.error ~pos
+                   "Opus frame size should be one of 2.5, 5., 10., 20., 40. or \
+                    60.");
             { f with Opus_format.frame_size = size }
         | "samplerate", `Value { value = Ground (Int i); pos } ->
             let samplerates = [8000; 12000; 16000; 24000; 48000] in
             if not (List.mem i samplerates) then
               raise
-                (Lang_encoder.Error
-                   ( pos,
-                     "Opus samplerate should be one of 8000, 12000, 16000, \
-                      24000 or 48000" ));
+                (Lang_encoder.error ~pos
+                   "Opus samplerate should be one of 8000, 12000, 16000, 24000 \
+                    or 48000");
             { f with Opus_format.samplerate = i }
         | "bitrate", `Value { value = Ground (Int i); pos } ->
             let i = i * 1000 in
             (* Doc say this should be from 500 to 512000. *)
             if i < 500 || i > 512000 then
-              raise
-                (Lang_encoder.Error (pos, "Opus bitrate should be in 5..512"));
+              raise (Lang_encoder.error ~pos "Opus bitrate should be in 5..512");
             { f with Opus_format.bitrate = `Bitrate i }
         | "bitrate", `Value { value = Ground (String "auto"); _ } ->
             { f with Opus_format.bitrate = `Auto }
@@ -103,8 +100,8 @@ let make params =
         | "channels", `Value { value = Ground (Int i); pos } ->
             if i < 1 || i > 2 then
               raise
-                (Lang_encoder.Error
-                   (pos, "only mono and stereo streams are supported for now"));
+                (Lang_encoder.error ~pos
+                   "only mono and stereo streams are supported for now");
             { f with Opus_format.channels = i }
         | "vbr", `Value { value = Ground (String "none"); _ } ->
             { f with Opus_format.mode = Opus_format.CBR }

--- a/src/lang_encoders/lang_speex.ml
+++ b/src/lang_encoders/lang_speex.ml
@@ -53,8 +53,7 @@ let make params =
         | "quality", `Value { value = Ground (Int q); pos } ->
             (* Doc say this should be from 0 to 10. *)
             if q < 0 || q > 10 then
-              raise
-                (Lang_encoder.Error (pos, "Speex quality should be in 0..10"));
+              raise (Lang_encoder.error ~pos "Speex quality should be in 0..10");
             { f with Speex_format.bitrate_control = Speex_format.Quality q }
         | "vbr", `Value { value = Ground (Int q); _ } ->
             { f with Speex_format.bitrate_control = Speex_format.Vbr q }
@@ -73,7 +72,7 @@ let make params =
             (* Doc says this should be between 1 and 10. *)
             if i < 1 || i > 10 then
               raise
-                (Lang_encoder.Error (pos, "Speex complexity should be in 1..10"));
+                (Lang_encoder.error ~pos "Speex complexity should be in 1..10");
             { f with Speex_format.complexity = Some i }
         | "bytes_per_page", `Value { value = Ground (Int i); _ } ->
             { f with Speex_format.fill = Some i }

--- a/src/lang_encoders/lang_theora.ml
+++ b/src/lang_encoders/lang_theora.ml
@@ -52,8 +52,7 @@ let make params =
           (* According to the doc, this should be a value between
            * 0 and 63. *)
           if i < 0 || i > 63 then
-            raise
-              (Lang_encoder.Error (pos, "Theora quality should be in 0..63"));
+            raise (Lang_encoder.error ~pos "Theora quality should be in 0..63");
           { f with Theora_format.bitrate_control = Theora_format.Quality i }
       | "bitrate", `Value { value = Ground (Int i); _ } ->
           { f with Theora_format.bitrate_control = Theora_format.Bitrate i }
@@ -61,29 +60,29 @@ let make params =
           (* According to the doc: must be a multiple of 16, and less than 1048576. *)
           if i mod 16 <> 0 || i >= 1048576 then
             raise
-              (Lang_encoder.Error
-                 (pos, "invalid frame width value (should be a multiple of 16)"));
+              (Lang_encoder.error ~pos
+                 "invalid frame width value (should be a multiple of 16)");
           { f with Theora_format.width = lazy i; picture_width = lazy i }
       | "height", `Value { value = Ground (Int i); pos } ->
           (* According to the doc: must be a multiple of 16, and less than 1048576. *)
           if i mod 16 <> 0 || i >= 1048576 then
             raise
-              (Lang_encoder.Error
-                 (pos, "invalid frame height value (should be a multiple of 16)"));
+              (Lang_encoder.error ~pos
+                 "invalid frame height value (should be a multiple of 16)");
           { f with Theora_format.height = lazy i; picture_height = lazy i }
       | "picture_width", `Value { value = Ground (Int i); pos } ->
           (* According to the doc: must not be larger than width. *)
           if i > Lazy.force f.Theora_format.width then
             raise
-              (Lang_encoder.Error
-                 (pos, "picture width must not be larger than width"));
+              (Lang_encoder.error ~pos
+                 "picture width must not be larger than width");
           { f with Theora_format.picture_width = lazy i }
       | "picture_height", `Value { value = Ground (Int i); pos } ->
           (* According to the doc: must not be larger than height. *)
           if i > Lazy.force f.Theora_format.height then
             raise
-              (Lang_encoder.Error
-                 (pos, "picture height must not be larger than height"));
+              (Lang_encoder.error ~pos
+                 "picture height must not be larger than height");
           { f with Theora_format.picture_height = lazy i }
       | "picture_x", `Value { value = Ground (Int i); pos } ->
           (* According to the doc: must be no larger than width-picture_width
@@ -96,10 +95,9 @@ let make params =
                 255
           then
             raise
-              (Lang_encoder.Error
-                 ( pos,
-                   "picture x must not be larger than width - picture width or \
-                    255, whichever is smaller" ));
+              (Lang_encoder.error ~pos
+                 "picture x must not be larger than width - picture width or \
+                  255, whichever is smaller");
           { f with Theora_format.picture_x = i }
       | "picture_y", `Value { value = Ground (Int i); pos } ->
           (* According to the doc: must be no larger than width-picture_width
@@ -110,14 +108,12 @@ let make params =
               - Lazy.force f.Theora_format.picture_height
           then
             raise
-              (Lang_encoder.Error
-                 ( pos,
-                   "picture y must not be larger than height - picture height"
-                 ));
+              (Lang_encoder.error ~pos
+                 "picture y must not be larger than height - picture height");
           if Lazy.force f.Theora_format.picture_height - i > 255 then
             raise
-              (Lang_encoder.Error
-                 (pos, "picture height - picture y must not be larger than 255"));
+              (Lang_encoder.error ~pos
+                 "picture height - picture y must not be larger than 255");
           { f with Theora_format.picture_y = i }
       | "aspect_numerator", `Value { value = Ground (Int i); _ } ->
           { f with Theora_format.aspect_numerator = i }

--- a/src/lang_encoders/lang_vorbis.ml
+++ b/src/lang_encoders/lang_vorbis.ml
@@ -117,13 +117,11 @@ let make params =
             { f with Vorbis_format.samplerate = Lazy.from_val i }
         | "quality", `Value { value = Ground (Float q); pos } ->
             if q < -0.2 || q > 1. then
-              raise
-                (Lang_encoder.Error (pos, "quality should be in [(-0.2)..1]"));
+              raise (Lang_encoder.error ~pos "quality should be in [(-0.2)..1]");
             { f with Vorbis_format.mode = Vorbis_format.VBR q }
         | "quality", `Value { value = Ground (Int i); pos } ->
             if i <> 0 && i <> 1 then
-              raise
-                (Lang_encoder.Error (pos, "quality should be in [-(0.2)..1]"));
+              raise (Lang_encoder.error ~pos "quality should be in [-(0.2)..1]");
             let q = float i in
             { f with Vorbis_format.mode = Vorbis_format.VBR q }
         | "channels", `Value { value = Ground (Int i); _ } ->

--- a/src/lang_encoders/lang_wav.ml
+++ b/src/lang_encoders/lang_wav.ml
@@ -58,7 +58,7 @@ let make params =
             { f with Wav_format.samplerate = Lazy.from_val i }
         | "samplesize", `Value { value = Ground (Int i); pos } ->
             if i <> 8 && i <> 16 && i <> 24 && i <> 32 then
-              raise (Lang_encoder.Error (pos, "invalid sample size"));
+              raise (Lang_encoder.error ~pos "invalid sample size");
             { f with Wav_format.samplesize = i }
         | "header", `Value { value = Ground (Bool b); _ } ->
             { f with Wav_format.header = b }

--- a/tests/language/encoders.liq
+++ b/tests/language/encoders.liq
@@ -1,0 +1,17 @@
+#!../../src/liquidsoap ../../libs/stdlib.liq ../../libs/deprecations.liq
+
+%include "test.liq"
+
+def f() =
+  try
+    enc = %wav(samplesize=123456)
+  catch err do
+    if err.kind != "encoder" or err.message != "invalid sample size" then
+      test.fail()
+    end
+  end
+
+  test.pass()
+end
+
+test.check(f)


### PR DESCRIPTION
This PR turns encoder errors into runtime errors after streaming has started:
```
% ./src/liquidsoap 'print(%wav(samplesize=123456))'
At line 0, char 22-28:
Error 8: Invalid sample size
```

```ruby
def f() =
  try
    enc = %wav(samplesize=123456)
  catch err do
    if err.message != "invalid sample size" then
      test.fail()
    end
  end

  test.pass()
end

test.check(f)
```