### PR TITLE
Allow "any" as maximal kind

### DIFF
--- a/src/lang/typing.ml
+++ b/src/lang/typing.ml
@@ -320,8 +320,11 @@ let rec sup ~pos a b =
             (fun (v, a) (v', b) ->
               if v <> v' then raise Incompatible;
               let a =
-                if c = "stream_kind" then
-                  if a = b then b else mk (Constr { name = "any"; params = [] })
+                if c = "stream_kind" then (
+                  match ((deref a).descr, (deref b).descr) with
+                    | Constr { name = a }, Constr { name = b } when a <> b ->
+                        mk (Constr { name = "any"; params = [] })
+                    | _ -> sup a b)
                 else sup a b
               in
               (v, a))

--- a/src/lang/typing.ml
+++ b/src/lang/typing.ml
@@ -319,7 +319,12 @@ let rec sup ~pos a b =
           List.map2
             (fun (v, a) (v', b) ->
               if v <> v' then raise Incompatible;
-              (v, sup a b))
+              let a =
+                if c = "stream_kind" then
+                  if a = b then b else mk (Constr { name = "any"; params = [] })
+                else sup a b
+              in
+              (v, a))
             a b
         in
         mk (Constr { name = c; params })
@@ -387,9 +392,16 @@ let rec ( <: ) a b =
         let rec aux pre p1 p2 =
           match (p1, p2) with
             | (v, h1) :: t1, (_, h2) :: t2 ->
+                let is_any t =
+                  match (deref t).descr with
+                    | Constr { name = "any" } -> true
+                    | _ -> false
+                in
                 begin
-                  try (* TODO use variance info *)
-                      h1 <: h2
+                  try
+                    (* TODO use variance info *)
+                    if c1.name = "stream_kind" && is_any h2 then ()
+                    else h1 <: h2
                   with Error (a, b) ->
                     let bt = Printexc.get_raw_backtrace () in
                     let post = List.map (fun (v, _) -> (v, `Ellipsis)) t1 in

--- a/tests/language/encoders.liq
+++ b/tests/language/encoders.liq
@@ -3,6 +3,7 @@
 %include "test.liq"
 
 def f() =
+  # Test errors for encoder parameters
   try
     enc = %wav(samplesize=123456)
   catch err do
@@ -10,6 +11,14 @@ def f() =
       test.fail()
     end
   end
+
+  # Test encoded or not streams, see #1915.
+  encoder =
+    if true then
+      (%ffmpeg(format="fdkaac", %audio.copy))
+    else
+      (%ffmpeg(format="mp3", %audio(codec = "libmp3lame", samplerate=44100,b="320k")))
+    end
 
   test.pass()
 end


### PR DESCRIPTION
This should allow using incompatible encoders as in the situation proposed in #1915.