### PR TITLE
Nicer implementation of type variables

### DIFF
--- a/src/lang/builtins_json.ml
+++ b/src/lang/builtins_json.ml
@@ -133,7 +133,9 @@ let () = to_json_ref := to_json
 let () =
   let val_t = univ_t () in
   let var =
-    match val_t.Type.descr with Type.EVar v -> v | _ -> assert false
+    match val_t.Type.descr with
+      | Type.Var { contents = Type.Free v } -> v
+      | _ -> assert false
   in
   let meth =
     [

--- a/src/lang/environment.ml
+++ b/src/lang/environment.ml
@@ -62,7 +62,7 @@ let add_builtin ?(override = false) ?(register = true) ?doc name ((g, t), v) =
               (* Updated type for x.l1...li, obtained by changing the type of
                  the field li+1. *)
               let t =
-                Type.make ~pos:t.Type.pos (Type.Meth (l, (lvg, lvt), "", vt))
+                Type.make ?pos:t.Type.pos (Type.Meth (l, (lvg, lvt), "", vt))
               in
               (* Update value for x.l1...li. *)
               let value = Value.Meth (l, lv, v) in

--- a/src/lang/lang.ml
+++ b/src/lang/lang.ml
@@ -65,7 +65,7 @@ let of_list_t t =
 let nullable_t t = Type.make (Type.Nullable t)
 let ref_t t = Term.ref_t t
 let metadata_t = list_t (product_t string_t string_t)
-let univ_t ?(constraints = []) () = Type.fresh ~level:0 ~constraints ~pos:None
+let univ_t ?(constraints = []) () = Type.var ~constraints ()
 let getter_t a = Type.make (Type.Getter a)
 let frame_kind_t ~audio ~video ~midi = Term.frame_kind_t audio video midi
 let of_frame_kind_t t = Term.of_frame_kind_t t

--- a/src/lang/lang_encoder.ml
+++ b/src/lang/lang_encoder.ml
@@ -85,10 +85,10 @@ let kind_of_encoder ((e, p) : Term.encoder) = (find_encoder e).kind_of_encoder p
 
 let type_of_encoder ~pos e =
   let kind = kind_of_encoder e in
-  let audio = kind_t ~pos kind.Frame.audio in
-  let video = kind_t ~pos kind.Frame.video in
-  let midi = kind_t ~pos kind.Frame.midi in
-  format_t ~pos (frame_kind_t ~pos audio video midi)
+  let audio = kind_t ?pos kind.Frame.audio in
+  let video = kind_t ?pos kind.Frame.video in
+  let midi = kind_t ?pos kind.Frame.midi in
+  format_t ?pos (frame_kind_t ?pos audio video midi)
 
 let make_encoder ~pos t ((e, p) : Value.encoder) =
   try

--- a/src/lang/lang_encoder.ml
+++ b/src/lang/lang_encoder.ml
@@ -96,5 +96,4 @@ let make_encoder ~pos t ((e, p) : Value.encoder) =
     let (_ : Encoder.factory) = Encoder.get_factory e in
     e
   with Not_found ->
-    raise
-      (error ~pos (Printf.sprintf "unsupported format: %s" (Term.print_term t)))
+    raise (error ~pos (Printf.sprintf "unsupported format: %s" (Term.print t)))

--- a/src/lang/lang_encoder.ml
+++ b/src/lang/lang_encoder.ml
@@ -83,12 +83,12 @@ let channels_of_params ?(default = 2) p =
     result than [Encoder.kind_of_format] once evaluated... *)
 let kind_of_encoder ((e, p) : Term.encoder) = (find_encoder e).kind_of_encoder p
 
-let type_of_encoder ~pos ~level e =
+let type_of_encoder ~pos e =
   let kind = kind_of_encoder e in
-  let audio = kind_t ~pos ~level kind.Frame.audio in
-  let video = kind_t ~pos ~level kind.Frame.video in
-  let midi = kind_t ~pos ~level kind.Frame.midi in
-  format_t ~pos ~level (frame_kind_t ~pos ~level audio video midi)
+  let audio = kind_t ~pos kind.Frame.audio in
+  let video = kind_t ~pos kind.Frame.video in
+  let midi = kind_t ~pos kind.Frame.midi in
+  format_t ~pos (frame_kind_t ~pos audio video midi)
 
 let make_encoder ~pos t ((e, p) : Value.encoder) =
   try

--- a/src/lang/parser.mly
+++ b/src/lang/parser.mly
@@ -158,7 +158,7 @@ expr:
   | LCUR exprss RCUR                 { mk_fun ~pos:$loc [] $2 }
   | WHILE expr DO exprs END          { mk ~pos:$loc (App (mk ~pos:$loc($1) (Var "while"), ["", mk_fun ~pos:$loc($2) [] $2; "", mk_fun ~pos:$loc($4) [] $4])) }
   | FOR bindvar GETS expr DO exprs END
-                                     { mk ~pos:$loc (App (mk ~pos:$loc($1) (Var "for"), ["", $4; "", mk_fun ~pos:$loc($6) ["", $2, Type.fresh_evar ~level:(-1) ~pos:(Some $loc($2)), None] $6])) }
+                                     { mk ~pos:$loc (App (mk ~pos:$loc($1) (Var "for"), ["", $4; "", mk_fun ~pos:$loc($6) ["", $2, Type.var ~pos:(Some $loc($2)) (), None] $6])) }
   | expr TO expr                     { mk ~pos:$loc (App (mk ~pos:$loc($2) (Invoke (mk ~pos:$loc($2) (Var "iterator"), "int")), ["", $1; "", $3])) }
   | expr COALESCE expr               { let null = mk ~pos:$loc($1) (Var "null") in
                                        let op =  mk ~pos:$loc($1) (Invoke (null, "default")) in
@@ -166,14 +166,14 @@ expr:
                                        mk ~pos:$loc (App (op, ["",$1;"",handler])) }
   | TRY exprs CATCH bindvar IN varlist DO exprs END
                                      { let fn = mk_fun ~pos:$loc($2) [] $2 in
-                                       let err_arg = ["", $4, Type.fresh_evar ~level:(-1) ~pos:(Some $loc($4)), None] in
+                                       let err_arg = ["", $4, Type.var ~pos:(Some $loc($4)) (), None] in
                                        let errors = mk_list ~pos:$loc $6 in
                                        let handler =  mk_fun ~pos:$loc($8) err_arg $8 in
                                        let error_module = mk ~pos:$loc($1) (Var "error") in
                                        let op = mk ~pos:$loc($1) (Invoke (error_module, "catch")) in
                                        mk ~pos:$loc (App (op, ["errors", errors; "", fn; "", handler])) }
   | TRY exprs CATCH bindvar DO exprs END { let fn = mk_fun ~pos:$loc($2) [] $2 in
-                                       let err_arg = ["", $4, Type.fresh_evar ~level:(-1) ~pos:(Some $loc($4)), None] in
+                                       let err_arg = ["", $4, Type.var ~pos:(Some $loc($4)) (), None] in
                                        let handler = mk_fun ~pos:$loc($6) err_arg $6 in
                                        let errors = mk ~pos:$loc Null in
                                        let error_module = mk ~pos:$loc($1) (Var "error") in
@@ -355,10 +355,10 @@ arglist:
   | arg                   { $1 }
   | arg COMMA arglist     { $1@$3 }
 arg:
-  | TILD var opt { [$2, $2, Type.fresh_evar ~level:(-1) ~pos:(Some $loc($2)), $3] }
+  | TILD var opt { [$2, $2, Type.var ~pos:(Some $loc($2)) (), $3] }
   | TILD LPAR var COLON ty RPAR opt { [$3, $3, $5, $7 ] }
-  | TILD var GETS UNDERSCORE opt { [$2, "_", Type.fresh_evar ~level:(-1) ~pos:(Some $loc($2)), $5] }
-  | bindvar opt  { ["", $1, Type.fresh_evar ~level:(-1) ~pos:(Some $loc($1)), $2] }
+  | TILD var GETS UNDERSCORE opt { [$2, "_", Type.var ~pos:(Some $loc($2)) (), $5] }
+  | bindvar opt  { ["", $1, Type.var ~pos:(Some $loc($1)) (), $2] }
   | LPAR bindvar COLON ty RPAR opt { ["", $2, $4, $6] }
   | ARGS_OF LPAR var RPAR { args_of ~only:[] ~except:[] ~pos:$loc $3 }
   | ARGS_OF LPAR subfield RPAR

--- a/src/lang/parser.mly
+++ b/src/lang/parser.mly
@@ -158,7 +158,7 @@ expr:
   | LCUR exprss RCUR                 { mk_fun ~pos:$loc [] $2 }
   | WHILE expr DO exprs END          { mk ~pos:$loc (App (mk ~pos:$loc($1) (Var "while"), ["", mk_fun ~pos:$loc($2) [] $2; "", mk_fun ~pos:$loc($4) [] $4])) }
   | FOR bindvar GETS expr DO exprs END
-                                     { mk ~pos:$loc (App (mk ~pos:$loc($1) (Var "for"), ["", $4; "", mk_fun ~pos:$loc($6) ["", $2, Type.var ~pos:(Some $loc($2)) (), None] $6])) }
+                                     { mk ~pos:$loc (App (mk ~pos:$loc($1) (Var "for"), ["", $4; "", mk_fun ~pos:$loc($6) ["", $2, Type.var ~pos:$loc($2) (), None] $6])) }
   | expr TO expr                     { mk ~pos:$loc (App (mk ~pos:$loc($2) (Invoke (mk ~pos:$loc($2) (Var "iterator"), "int")), ["", $1; "", $3])) }
   | expr COALESCE expr               { let null = mk ~pos:$loc($1) (Var "null") in
                                        let op =  mk ~pos:$loc($1) (Invoke (null, "default")) in
@@ -166,14 +166,14 @@ expr:
                                        mk ~pos:$loc (App (op, ["",$1;"",handler])) }
   | TRY exprs CATCH bindvar IN varlist DO exprs END
                                      { let fn = mk_fun ~pos:$loc($2) [] $2 in
-                                       let err_arg = ["", $4, Type.var ~pos:(Some $loc($4)) (), None] in
+                                       let err_arg = ["", $4, Type.var ~pos:$loc($4) (), None] in
                                        let errors = mk_list ~pos:$loc $6 in
                                        let handler =  mk_fun ~pos:$loc($8) err_arg $8 in
                                        let error_module = mk ~pos:$loc($1) (Var "error") in
                                        let op = mk ~pos:$loc($1) (Invoke (error_module, "catch")) in
                                        mk ~pos:$loc (App (op, ["errors", errors; "", fn; "", handler])) }
   | TRY exprs CATCH bindvar DO exprs END { let fn = mk_fun ~pos:$loc($2) [] $2 in
-                                       let err_arg = ["", $4, Type.var ~pos:(Some $loc($4)) (), None] in
+                                       let err_arg = ["", $4, Type.var ~pos:$loc($4) (), None] in
                                        let handler = mk_fun ~pos:$loc($6) err_arg $6 in
                                        let errors = mk ~pos:$loc Null in
                                        let error_module = mk ~pos:$loc($1) (Var "error") in
@@ -355,10 +355,10 @@ arglist:
   | arg                   { $1 }
   | arg COMMA arglist     { $1@$3 }
 arg:
-  | TILD var opt { [$2, $2, Type.var ~pos:(Some $loc($2)) (), $3] }
+  | TILD var opt { [$2, $2, Type.var ~pos:$loc($2) (), $3] }
   | TILD LPAR var COLON ty RPAR opt { [$3, $3, $5, $7 ] }
-  | TILD var GETS UNDERSCORE opt { [$2, "_", Type.var ~pos:(Some $loc($2)) (), $5] }
-  | bindvar opt  { ["", $1, Type.var ~pos:(Some $loc($1)) (), $2] }
+  | TILD var GETS UNDERSCORE opt { [$2, "_", Type.var ~pos:$loc($2) (), $5] }
+  | bindvar opt  { ["", $1, Type.var ~pos:$loc($1) (), $2] }
   | LPAR bindvar COLON ty RPAR opt { ["", $2, $4, $6] }
   | ARGS_OF LPAR var RPAR { args_of ~only:[] ~except:[] ~pos:$loc $3 }
   | ARGS_OF LPAR subfield RPAR

--- a/src/lang/parser_helper.ml
+++ b/src/lang/parser_helper.ml
@@ -92,9 +92,7 @@ let args_of, app_of =
   and get_app ~pos _ args =
     List.map
       (fun (n, _, _) ->
-        ( n,
-          Term.{ t = Type.fresh_evar ~level:(-1) ~pos:(Some pos); term = Var n }
-        ))
+        (n, Term.{ t = Type.var ~pos:(Some pos) (); term = Var n }))
       args
   and term_of_value ~pos t ({ Value.value } as v) =
     let get_list_type () =
@@ -270,15 +268,14 @@ let mk_time_pred ~pos (a, b, c) =
   mk ~pos (App (mk ~pos (Var "time_in_mod"), args))
 
 let mk_kind ~pos (kind, params) =
-  if kind = "any" then Type.fresh_evar ~level:(-1) ~pos:(Some pos)
+  if kind = "any" then Type.var ~pos:(Some pos) ()
   else (
     try
       let k = Frame_content.kind_of_string kind in
       match params with
         | [] -> Term.kind_t (`Kind k)
-        | [("", "any")] -> Type.fresh_evar ~level:(-1) ~pos:None
-        | [("", "internal")] ->
-            Type.fresh ~constraints:[Type.InternalMedia] ~level:(-1) ~pos:None
+        | [("", "any")] -> Type.var ()
+        | [("", "internal")] -> Type.var ~constraints:[Type.InternalMedia] ()
         | param :: params ->
             let mk_format (label, value) =
               Frame_content.parse_param k label value
@@ -321,7 +318,7 @@ let mk_source_ty ~pos name args =
 
 let mk_ty ~pos name =
   match name with
-    | "_" -> Type.fresh_evar ~level:(-1) ~pos:None
+    | "_" -> Type.var ()
     | "unit" -> Type.make Type.unit
     | "bool" -> Type.make (Type.Ground Type.Bool)
     | "int" -> Type.make (Type.Ground Type.Int)

--- a/src/lang/parser_helper.ml
+++ b/src/lang/parser_helper.ml
@@ -86,13 +86,12 @@ let args_of, app_of =
     in
     List.map
       (fun (n, n', v) ->
-        let t = Type.make ~pos:(Some pos) (get_arg_type t n).Type.descr in
+        let t = Type.make ~pos (get_arg_type t n).Type.descr in
         (n, n', t, Option.map (term_of_value ~pos t) v))
       args
   and get_app ~pos _ args =
     List.map
-      (fun (n, _, _) ->
-        (n, Term.{ t = Type.var ~pos:(Some pos) (); term = Var n }))
+      (fun (n, _, _) -> (n, Term.{ t = Type.var ~pos (); term = Var n }))
       args
   and term_of_value ~pos t ({ Value.value } as v) =
     let get_list_type () =
@@ -126,7 +125,7 @@ let args_of, app_of =
             Term.Meth (name, term_of_value ~pos t v, term_of_value ~pos t v')
         | Value.Fun (args, [], [], body) ->
             let body =
-              Term.{ body with t = Type.make ~pos:(Some pos) body.t.Type.descr }
+              Term.{ body with t = Type.make ~pos body.t.Type.descr }
             in
             Term.Fun (Term.free_vars body, get_args ~pos t args, body)
         | _ ->
@@ -136,7 +135,7 @@ let args_of, app_of =
                    Printf.sprintf "Term %s cannot be represented as a term"
                      (Value.print_value v) ))
     in
-    let t = Type.make ~pos:(Some pos) t.Type.descr in
+    let t = Type.make ~pos t.Type.descr in
     Term.{ t; term }
   in
   let args_of = gen_args_of get_args in
@@ -268,7 +267,7 @@ let mk_time_pred ~pos (a, b, c) =
   mk ~pos (App (mk ~pos (Var "time_in_mod"), args))
 
 let mk_kind ~pos (kind, params) =
-  if kind = "any" then Type.var ~pos:(Some pos) ()
+  if kind = "any" then Type.var ~pos ()
   else (
     try
       let k = Frame_content.kind_of_string kind in

--- a/src/lang/term.ml
+++ b/src/lang/term.ml
@@ -411,7 +411,7 @@ let rec print_term v =
 
 (** Create a new value. *)
 let make ?pos ?t e =
-  let t = match t with Some t -> t | None -> Type.var ~pos () in
+  let t = match t with Some t -> t | None -> Type.var ?pos () in
   if Lazy.force debug then
     Printf.eprintf "%s (%s): assigned type var %s\n"
       (Type.print_pos_opt t.Type.pos)

--- a/src/lang/term.ml
+++ b/src/lang/term.ml
@@ -364,6 +364,10 @@ let unit = Tuple []
 let is_ground x =
   match x.term with Ground _ -> true (* | Ref x -> is_ground x *) | _ -> false
 
+let rec string_of_pat = function
+  | PVar l -> String.concat "." l
+  | PTuple l -> "(" ^ String.concat ", " (List.map string_of_pat l) ^ ")"
+
 (** Print terms, (almost) assuming they are in normal form. *)
 let rec print_term v =
   match v.term with
@@ -399,11 +403,11 @@ let rec print_term v =
             tl
         in
         print_term hd ^ "(" ^ String.concat "," tl ^ ")"
-    | Let _ | Seq _ -> assert false
-
-let rec string_of_pat = function
-  | PVar l -> String.concat "." l
-  | PTuple l -> "(" ^ String.concat ", " (List.map string_of_pat l) ^ ")"
+    (* | Let _ | Seq _ -> assert false *)
+    | Let l ->
+        Printf.sprintf "let %s = %s in %s" (string_of_pat l.pat)
+          (print_term l.def) (print_term l.body)
+    | Seq (e, e') -> print_term e ^ "; " ^ print_term e'
 
 (** Create a new value. *)
 let make ?pos ?t e =

--- a/src/lang/type.ml
+++ b/src/lang/type.ml
@@ -302,7 +302,7 @@ let repr ?(filter_out = fun _ -> false) ?(generalized = []) t : repr =
           Hashtbl.add evars var.name name;
           name
       in
-      `EVar (Printf.sprintf "?%s%s" constr_symbols s, c))
+      `EVar (Printf.sprintf "'%s%s" constr_symbols s, c))
   in
   let rec repr g t =
     if filter_out t then `Ellipsis

--- a/src/lang/type.ml
+++ b/src/lang/type.ml
@@ -174,7 +174,7 @@ type repr =
 and var_repr = string * constraints
 
 let var_eq v v' = v.name = v'.name
-let make ?(pos = None) d = { pos; descr = d }
+let make ?pos d = { pos; descr = d }
 
 (** Dereferencing gives you the meaning of a term, going through links created
     by instantiations. One should (almost) never work on a non-dereferenced
@@ -630,9 +630,8 @@ let var =
       !c
   in
   let f ?(constraints = []) ?(level = max_int) ?pos () =
-    let pos = match pos with Some pos -> pos | None -> None in
     let name = name () in
-    make ~pos (Var (ref (Free { name; level; constraints })))
+    make ?pos (Var (ref (Free { name; level; constraints })))
   in
   f
 

--- a/src/lang/type.ml
+++ b/src/lang/type.ml
@@ -131,9 +131,9 @@ type variance = Covariant | Contravariant | Invariant
   * This is useful in order to know what can or cannot be generalized:
   * you need to compare the level of an abstraction and those of a ref or
   * source. *)
-type t = { pos : pos option; mutable level : int; mutable descr : descr }
+type t = { pos : pos option; descr : descr }
 
-and constructed = { name : string; params : (variance * t) list }
+and constructed = { constructor : string; params : (variance * t) list }
 
 and descr =
   | Constr of constructed
@@ -144,10 +144,11 @@ and descr =
   | Nullable of t
   | Meth of string * scheme * string * t (* label, type, documentation, type to decorate *)
   | Arrow of (bool * string * t) list * t
-  | EVar of var (* type variable *)
-  | Link of variance * t
+  | Var of invar ref
 
-and var = int * constraints
+and invar = Free of var | Link of variance * t
+
+and var = { name : int; mutable level : int; mutable constraints : constraints }
 
 and scheme = var list * t
 
@@ -159,24 +160,27 @@ type repr =
   | `List of repr
   | `Tuple of repr list
   | `Nullable of repr
-  | `Meth of string * ((string * constraints) list * repr) * repr
+  | `Meth of string * (var_repr list * repr) * repr
   | `Arrow of (bool * string * repr) list * repr
   | `Getter of repr
-  | `EVar of string * constraints (* existential variable *)
-  | `UVar of string * constraints (* universal variable *)
+  | `EVar of var_repr (* existential variable *)
+  | `UVar of var_repr (* universal variable *)
   | `Ellipsis (* omitted sub-term *)
   | `Range_Ellipsis (* omitted sub-terms (in a list, e.g. list of args) *)
   | `Debug of
     string * repr * string
     (* add annotations before / after, mostly used for debugging *) ]
 
-let make ?(pos = None) ?(level = -1) d = { pos; level; descr = d }
-let dummy = make ~pos:None (EVar (-1, []))
+and var_repr = string * constraints
+
+let var_eq v v' = v.name = v'.name
+let make ?(pos = None) d = { pos; descr = d }
 
 (** Dereferencing gives you the meaning of a term, going through links created
     by instantiations. One should (almost) never work on a non-dereferenced
     type. *)
-let rec deref t = match t.descr with Link (_, x) -> deref x | _ -> t
+let rec deref t =
+  match t.descr with Var { contents = Link (_, t) } -> deref t | _ -> t
 
 (** Remove methods. This function also removes links. *)
 let rec demeth t =
@@ -196,17 +200,17 @@ let rec invoke t l =
     | _ -> raise Not_found
 
 (** Add a method. *)
-let meth ?pos ?level l v ?(doc = "") t = make ?pos ?level (Meth (l, v, doc, t))
+let meth ?pos l v ?(doc = "") t = make ?pos (Meth (l, v, doc, t))
 
 (** Add methods. *)
-let rec meths ?pos ?level l v t =
+let rec meths ?pos l v t =
   match l with
     | [] -> assert false
-    | [l] -> meth ?pos ?level l v t
+    | [l] -> meth ?pos l v t
     | l :: ll ->
         let g, tl = invoke t l in
-        let v = meths ?pos ?level ll v tl in
-        meth ?pos ?level l (g, v) t
+        let v = meths ?pos ll v tl in
+        meth ?pos l (g, v) t
 
 (** Split the methods from the type. *)
 let split_meths t =
@@ -257,17 +261,16 @@ let repr ?(filter_out = fun _ -> false) ?(generalized = []) t : repr =
   let split_constr c =
     List.fold_left (fun (s, constraints) c -> (s, c :: constraints)) ("", []) c
   in
-  let uvar g level (i, c) =
-    let constr_symbols, c = split_constr c in
+  let uvar g var =
+    let constr_symbols, c = split_constr var.constraints in
     let rec index n = function
       | v :: tl ->
-          if fst v = i then Printf.sprintf "'%s%s" constr_symbols (name n)
+          if var_eq v var then Printf.sprintf "'%s%s" constr_symbols (name n)
           else index (n + 1) tl
       | [] -> assert false
     in
     let v = index 1 (List.rev g) in
     (* let v = Printf.sprintf "'%d" i in *)
-    let v = if !debug_levels then Printf.sprintf "%s[%d]" v level else v in
     `UVar (v, c)
   in
   let counter =
@@ -277,18 +280,22 @@ let repr ?(filter_out = fun _ -> false) ?(generalized = []) t : repr =
       !c
   in
   let evars = Hashtbl.create 10 in
-  let evar level i c =
-    let constr_symbols, c = split_constr c in
+  let evar var =
+    let constr_symbols, c = split_constr var.constraints in
     if !debug then (
-      let v = Printf.sprintf "?%s%s" constr_symbols (evar_global_name i) in
-      let v = if !debug_levels then Printf.sprintf "%s[%d]" v level else v in
+      let v =
+        Printf.sprintf "?%s%s" constr_symbols (evar_global_name var.name)
+      in
+      let v =
+        if !debug_levels then Printf.sprintf "%s[%d]" v var.level else v
+      in
       `EVar (v, c))
     else (
       let s =
-        try Hashtbl.find evars i
+        try Hashtbl.find evars var.name
         with Not_found ->
           let name = String.uppercase_ascii (name (counter ())) in
-          Hashtbl.add evars i name;
+          Hashtbl.add evars var.name name;
           name
       in
       `EVar (Printf.sprintf "?%s%s" constr_symbols s, c))
@@ -305,21 +312,21 @@ let repr ?(filter_out = fun _ -> false) ?(generalized = []) t : repr =
         | Meth (l, (g', u), _, v) ->
             let gen =
               List.map
-                (fun ic -> match uvar (g' @ g) t.level ic with `UVar ic -> ic)
+                (fun v -> match uvar (g' @ g) v with `UVar v -> v)
                 (List.sort_uniq compare g')
             in
             `Meth (l, (gen, repr (g' @ g) u), repr g v)
-        | Constr { name; params } ->
-            `Constr (name, List.map (fun (l, t) -> (l, repr g t)) params)
+        | Constr { constructor; params } ->
+            `Constr (constructor, List.map (fun (l, t) -> (l, repr g t)) params)
         | Arrow (args, t) ->
             `Arrow
               ( List.map (fun (opt, lbl, t) -> (opt, lbl, repr g t)) args,
                 repr g t )
-        | EVar (i, c) ->
-            if List.exists (fun (j, _) -> j = i) g then uvar g t.level (i, c)
-            else evar t.level i c
-        | Link (Covariant, t) when !debug -> `Debug ("[>", repr g t, "]")
-        | Link (_, t) -> repr g t)
+        | Var { contents = Free var } ->
+            if List.exists (var_eq var) g then uvar g var else evar var
+        | Var { contents = Link (Covariant, t) } when !debug ->
+            `Debug ("[>", repr g t, "]")
+        | Var { contents = Link (_, t) } -> repr g t)
   in
   repr generalized t
 
@@ -565,11 +572,11 @@ let print_repr f t =
 
 let pp_type f t = print_repr f (repr t)
 
-let pp_type_generalized generalized f t =
+let pp_scheme f (generalized, t) =
   if !debug then
     List.iter
       (fun v ->
-        print_repr f (repr ~generalized (make (EVar v)));
+        print_repr f (repr ~generalized (make (Var (ref (Free v)))));
         Format.fprintf f ".")
       generalized;
   print_repr f (repr ~generalized t)
@@ -611,21 +618,19 @@ let print_type_error error_header ((flipped, ta, tb, a, b) : explanation) =
                   (print_pos ~prefix:"" p))
           print_repr b (inferred_pos tb)
 
-let fresh =
-  let fresh_id =
-    let c = ref 0 in
+let var =
+  let name =
+    let c = ref (-1) in
     fun () ->
       incr c;
       !c
   in
-  let f ~constraints ~level ~pos =
-    { pos; level; descr = EVar (fresh_id (), constraints) }
+  let f ?(constraints = []) ?(level = max_int) ?pos () =
+    let pos = match pos with Some pos -> pos | None -> None in
+    let name = name () in
+    make ~pos (Var (ref (Free { name; level; constraints })))
   in
   f
-
-(** Simplified version of existential variable generation, without
-    constraints. This is used when parsing to annotate the AST. *)
-let fresh_evar = fresh ~constraints:[]
 
 (** Find all the free variables satisfying a predicate. *)
 let filter_vars f t =
@@ -641,8 +646,9 @@ let filter_vars f t =
           aux l u
       | Constr c -> List.fold_left (fun l (_, t) -> aux l t) l c.params
       | Arrow (p, t) -> aux (List.fold_left (fun l (_, _, t) -> aux l t) l p) t
-      | EVar (i, constraints) -> if f t then (i, constraints) :: l else l
-      | Link _ -> assert false
+      | Var { contents = Free var } ->
+          if f var && not (List.exists (var_eq var) l) then var :: l else l
+      | Var { contents = Link _ } -> assert false
   in
   aux [] t
 
@@ -657,7 +663,9 @@ let rec invokes t = function
 let doc_of_type ~generalized t =
   let margin = Format.pp_get_margin Format.str_formatter () in
   Format.pp_set_margin Format.str_formatter 58;
-  Format.fprintf Format.str_formatter "%a@?" (pp_type_generalized generalized) t;
+  Format.fprintf Format.str_formatter "%a@?"
+    (fun f t -> pp_scheme f (generalized, t))
+    t;
   Format.pp_set_margin Format.str_formatter margin;
   Doc.trivial (Format.flush_str_formatter ())
 

--- a/src/lang/type.ml
+++ b/src/lang/type.ml
@@ -284,10 +284,14 @@ let repr ?(filter_out = fun _ -> false) ?(generalized = []) t : repr =
     let constr_symbols, c = split_constr var.constraints in
     if !debug then (
       let v =
-        Printf.sprintf "?%s%s" constr_symbols (evar_global_name var.name)
+        Printf.sprintf "'%s%s" constr_symbols (evar_global_name var.name)
       in
       let v =
-        if !debug_levels then Printf.sprintf "%s[%d]" v var.level else v
+        if !debug_levels then (
+          let level = var.level in
+          let level = if level = max_int then "∞" else string_of_int level in
+          Printf.sprintf "%s[%s]" v level)
+        else v
       in
       `EVar (v, c))
     else (

--- a/src/lang/type.mli
+++ b/src/lang/type.mli
@@ -89,11 +89,12 @@ val make : ?pos:pos option -> descr -> t
     matching on types. *)
 val deref : t -> t
 
-(** Compare two variables for equality. This comparison should always be used to
-    compare variables (as opposed to =). *)
 val var : ?constraints:constraints -> ?level:int -> ?pos:pos option -> unit -> t
 
+(** Compare two variables for equality. This comparison should always be used to
+    compare variables (as opposed to =). *)
 val var_eq : var -> var -> bool
+
 val filter_vars : (var -> bool) -> t -> var list
 
 (** Add a method to a type. *)

--- a/src/lang/type.mli
+++ b/src/lang/type.mli
@@ -83,12 +83,15 @@ and var = { name : int; mutable level : int; mutable constraints : constraints }
 and scheme = var list * t
 
 val unit : descr
+
+(** Create a type from its value. *)
 val make : ?pos:pos -> descr -> t
 
 (** Remove links in a type: this function should always be called before
     matching on types. *)
 val deref : t -> t
 
+(** Create a fresh variable. *)
 val var : ?constraints:constraints -> ?level:int -> ?pos:pos -> unit -> t
 
 (** Compare two variables for equality. This comparison should always be used to

--- a/src/lang/type.mli
+++ b/src/lang/type.mli
@@ -83,13 +83,13 @@ and var = { name : int; mutable level : int; mutable constraints : constraints }
 and scheme = var list * t
 
 val unit : descr
-val make : ?pos:pos option -> descr -> t
+val make : ?pos:pos -> descr -> t
 
 (** Remove links in a type: this function should always be called before
     matching on types. *)
 val deref : t -> t
 
-val var : ?constraints:constraints -> ?level:int -> ?pos:pos option -> unit -> t
+val var : ?constraints:constraints -> ?level:int -> ?pos:pos -> unit -> t
 
 (** Compare two variables for equality. This comparison should always be used to
     compare variables (as opposed to =). *)
@@ -99,10 +99,10 @@ val var_eq : var -> var -> bool
 val filter_vars : (var -> bool) -> t -> var list
 
 (** Add a method to a type. *)
-val meth : ?pos:pos option -> string -> scheme -> ?doc:string -> t -> t
+val meth : ?pos:pos -> string -> scheme -> ?doc:string -> t -> t
 
 (** Add a submethod to a type. *)
-val meths : ?pos:pos option -> string list -> scheme -> t -> t
+val meths : ?pos:pos -> string list -> scheme -> t -> t
 
 (** Remove all methods in a type. *)
 val demeth : t -> t
@@ -131,10 +131,10 @@ type repr =
   | `Meth of string * ((string * constraints) list * repr) * repr
   | `Arrow of (bool * string * repr) list * repr
   | `Getter of repr
-  | `EVar of string * constraints (** existential variable *)
-  | `UVar of string * constraints (** universal variable *)
-  | `Ellipsis (** omitted sub-term *)
-  | `Range_Ellipsis (** omitted sub-terms (in a list, e.g. list of args) *)
+  | `EVar of string * constraints  (** existential variable *)
+  | `UVar of string * constraints  (** universal variable *)
+  | `Ellipsis  (** omitted sub-term *)
+  | `Range_Ellipsis  (** omitted sub-terms (in a list, e.g. list of args) *)
   | `Debug of string * repr * string ]
 
 (** Representation of a type. *)

--- a/src/lang/type.mli
+++ b/src/lang/type.mli
@@ -95,6 +95,7 @@ val var : ?constraints:constraints -> ?level:int -> ?pos:pos option -> unit -> t
     compare variables (as opposed to =). *)
 val var_eq : var -> var -> bool
 
+(** Find all variables satisfying a predicate. *)
 val filter_vars : (var -> bool) -> t -> var list
 
 (** Add a method to a type. *)
@@ -106,6 +107,7 @@ val meths : ?pos:pos option -> string list -> scheme -> t -> t
 (** Remove all methods in a type. *)
 val demeth : t -> t
 
+(** Split a type between methods and the main type. *)
 val split_meths : t -> (string * (scheme * string)) list * t
 
 (** Put the methods of the first type around the second type. *)
@@ -119,6 +121,7 @@ val invokes : t -> string list -> scheme
 
 (** {1 Representation of types} *)
 
+(** Representation of a type. *)
 type repr =
   [ `Constr of string * (variance * repr) list
   | `Ground of ground
@@ -128,13 +131,16 @@ type repr =
   | `Meth of string * ((string * constraints) list * repr) * repr
   | `Arrow of (bool * string * repr) list * repr
   | `Getter of repr
-  | `EVar of string * constraints (* existential variable *)
-  | `UVar of string * constraints (* universal variable *)
-  | `Ellipsis (* omitted sub-term *)
-  | `Range_Ellipsis (* omitted sub-terms (in a list, e.g. list of args) *)
+  | `EVar of string * constraints  (** existential variable *)
+  | `UVar of string * constraints  (** universal variable *)
+  | `Ellipsis  (** omitted sub-term *)
+  | `Range_Ellipsis  (** omitted sub-terms (in a list, e.g. list of args) *)
   | `Debug of string * repr * string ]
 
+(** Representation of a type. *)
 val repr : ?filter_out:(t -> bool) -> ?generalized:var list -> t -> repr
+
+(** Print the representation of a type. *)
 val print_repr : Format.formatter -> repr -> unit
 
 (** {1 Typing errors} *)

--- a/src/lang/type.mli
+++ b/src/lang/type.mli
@@ -131,14 +131,16 @@ type repr =
   | `List of repr
   | `Tuple of repr list
   | `Nullable of repr
-  | `Meth of string * ((string * constraints) list * repr) * repr
+  | `Meth of string * (var_repr list * repr) * repr
   | `Arrow of (bool * string * repr) list * repr
   | `Getter of repr
-  | `EVar of string * constraints  (** existential variable *)
-  | `UVar of string * constraints  (** universal variable *)
+  | `EVar of var_repr  (** existential variable *)
+  | `UVar of var_repr  (** universal variable *)
   | `Ellipsis  (** omitted sub-term *)
   | `Range_Ellipsis  (** omitted sub-terms (in a list, e.g. list of args) *)
   | `Debug of string * repr * string ]
+
+and var_repr = string * constraints
 
 (** Representation of a type. *)
 val repr : ?filter_out:(t -> bool) -> ?generalized:var list -> t -> repr

--- a/src/lang/type.mli
+++ b/src/lang/type.mli
@@ -131,10 +131,10 @@ type repr =
   | `Meth of string * ((string * constraints) list * repr) * repr
   | `Arrow of (bool * string * repr) list * repr
   | `Getter of repr
-  | `EVar of string * constraints  (** existential variable *)
-  | `UVar of string * constraints  (** universal variable *)
-  | `Ellipsis  (** omitted sub-term *)
-  | `Range_Ellipsis  (** omitted sub-terms (in a list, e.g. list of args) *)
+  | `EVar of string * constraints (** existential variable *)
+  | `UVar of string * constraints (** universal variable *)
+  | `Ellipsis (** omitted sub-term *)
+  | `Range_Ellipsis (** omitted sub-terms (in a list, e.g. list of args) *)
   | `Debug of string * repr * string ]
 
 (** Representation of a type. *)

--- a/src/lang/typechecking.ml
+++ b/src/lang/typechecking.ml
@@ -23,7 +23,7 @@
 open Term
 open Typing
 
-let debug = ref true
+let debug = ref false
 
 (** {1 Type checking / inference} *)
 
@@ -246,8 +246,9 @@ let rec check ?(print_toplevel = false) ~throw ~level ~(env : Typing.env) e =
                       if replace then Type.remeth (snd (List.assoc x env)) a
                       else a
                     in
-                    Printf.printf "\nLET %s : %s\n%!" x
-                      (Type.print_scheme (generalized, a));
+                    if !debug then
+                      Printf.printf "\nLET %s : %s\n%!" x
+                        (Type.print_scheme (generalized, a));
                     (x, (generalized, a))
                 | l :: ll -> (
                     try

--- a/src/lang/typechecking.ml
+++ b/src/lang/typechecking.ml
@@ -91,8 +91,10 @@ let rec check ?(print_toplevel = false) ~throw ~level ~(env : Typing.env) e =
       List.fold_left
         (fun (p, env) -> function
           | lbl, var, kind, None ->
+              update_level ~level kind;
               ((false, lbl, kind) :: p, (var, ([], kind)) :: env)
           | lbl, var, kind, Some v ->
+              update_level ~level kind;
               base_check v;
               v.t <: kind;
               ((true, lbl, kind) :: p, (var, ([], kind)) :: env))
@@ -244,7 +246,8 @@ let rec check ?(print_toplevel = false) ~throw ~level ~(env : Typing.env) e =
                       if replace then Type.remeth (snd (List.assoc x env)) a
                       else a
                     in
-                    (* Printf.printf "env: %s : %s\n\n%!" x (Type.print_scheme (generalized,a)); *)
+                    Printf.printf "\nLET %s : %s\n%!" x
+                      (Type.print_scheme (generalized, a));
                     (x, (generalized, a))
                 | l :: ll -> (
                     try

--- a/src/lang/typechecking.ml
+++ b/src/lang/typechecking.ml
@@ -72,11 +72,11 @@ let rec type_of_pat ~level ~pos = function
 (* Type-check an expression. *)
 let rec check ?(print_toplevel = false) ~throw ~level ~(env : Typing.env) e =
   let check = check ~throw in
-  if !debug then Printf.printf "\n# %s : ?\n\n%!" (Term.print_term e);
+  if !debug then Printf.printf "\n# %s : ?\n\n%!" (Term.print e);
   let check ?print_toplevel ~level ~env e =
     check ?print_toplevel ~level ~env e;
     if !debug then
-      Printf.printf "\n# %s : %s\n\n%!" (Term.print_term e) (Type.print e.t)
+      Printf.printf "\n# %s : %s\n\n%!" (Term.print e) (Type.print e.t)
   in
   (* The toplevel position of the (un-dereferenced) type is the actual parsing
      position of the value. When we synthesize a type against which the type of
@@ -120,7 +120,7 @@ let rec check ?(print_toplevel = false) ~throw ~level ~(env : Typing.env) e =
           with Not_found ->
             let bt = Printexc.get_raw_backtrace () in
             Printexc.raise_with_backtrace
-              (Unsupported_format (pos, print_term e))
+              (Unsupported_format (pos, Term.print e))
               bt
         in
         e.t >: t

--- a/src/lang/typing.ml
+++ b/src/lang/typing.ml
@@ -203,7 +203,7 @@ let satisfies_constraint b = function
                     raise (Unsatisfied_constraint (Dtools, b'))
               | Var ({ contents = Free _ } as v) ->
                   (* TODO: we should check the constraints and the lower bound *)
-                  v := Link (Invariant, make ~pos:b.pos (Ground String))
+                  v := Link (Invariant, make ?pos:b.pos (Ground String))
               | _ -> raise (Unsatisfied_constraint (Dtools, b')))
         | Var { contents = Free v } ->
             if not (List.mem Dtools v.constraints) then
@@ -278,7 +278,7 @@ let rec sup ~pos a b =
     match (deref a).descr with
       | Meth (l', t, _, _) when l = l' -> Some t
       | Meth (_, _, _, a) -> meth_type l a
-      | Var { contents = Free _ } -> Some ([], var ~pos ())
+      | Var { contents = Free _ } -> Some ([], var ?pos ())
       | _ -> None
   in
   match ((deref a).descr, (deref b).descr) with

--- a/src/lang/typing.ml
+++ b/src/lang/typing.ml
@@ -253,6 +253,14 @@ let bind ?(variance = Invariant) a b =
   let variance = if a.constraints <> [] then Invariant else variance in
   v := Link (variance, b)
 
+(** Lower all type variables to given level. *)
+let update_level ~level a =
+  let x = Type.var ~level () in
+  let x =
+    match x.descr with Var { contents = Free x } -> x | _ -> assert false
+  in
+  occur_check x a
+
 (** {1 Subtype checking/inference} *)
 
 exception Incompatible

--- a/src/lang/typing.ml
+++ b/src/lang/typing.ml
@@ -24,9 +24,9 @@
 
 open Type
 
-(* let () = Type.debug := true *)
-
-let debug_subtyping = ref false
+let () = Type.debug := true
+let () = Type.debug_levels := true
+let debug_subtyping = ref true
 
 type env = (string * scheme) list
 
@@ -243,7 +243,7 @@ let bind ?(variance = Invariant) a b =
       | Var ({ contents = Free a } as v) -> (v, a)
       | _ -> assert false
   in
-  (* if !debug then Printf.eprintf "%s := %s\n%!" (print a0) (print b); *)
+  if !debug then Printf.printf "\n%s := %s\n%!" (print a0) (print b);
   let b = deref b in
   occur_check a b;
   satisfies_constraints b a.constraints;
@@ -354,7 +354,7 @@ exception Error of (repr * repr)
   * In case of error, generate an explanation. *)
 let rec ( <: ) a b =
   if !debug || !debug_subtyping then
-    Printf.eprintf "\n%s <: %s\n%!" (print a) (print b);
+    Printf.printf "\n%s <: %s\n%!" (print a) (print b);
   match (a.descr, b.descr) with
     | Var { contents = Free v }, Var { contents = Free v' } when var_eq v v' ->
         ()

--- a/src/lang/typing.ml
+++ b/src/lang/typing.ml
@@ -24,9 +24,9 @@
 
 open Type
 
-let () = Type.debug := true
-let () = Type.debug_levels := true
-let debug_subtyping = ref true
+let () = Type.debug := false
+let () = Type.debug_levels := false
+let debug_subtyping = ref false
 
 type env = (string * scheme) list
 

--- a/src/lang/typing.ml
+++ b/src/lang/typing.ml
@@ -202,7 +202,7 @@ let satisfies_constraint b = function
                   if g <> String then
                     raise (Unsatisfied_constraint (Dtools, b'))
               | Var ({ contents = Free _ } as v) ->
-                  (* TODO: we should check the constraints and the lower bound *)
+                  (* TODO: we should check the constraints *)
                   v := Link (Invariant, make ?pos:b.pos (Ground String))
               | _ -> raise (Unsatisfied_constraint (Dtools, b')))
         | Var { contents = Free v } ->

--- a/src/lang/typing.ml
+++ b/src/lang/typing.ml
@@ -61,7 +61,9 @@ let rec hide_meth l a =
   * This is performed after type inference on the left-hand side
   * of a let-in, with [level] being the level of that let-in.
   * Uses the simple method of ML, to be associated with a value restriction. *)
-let generalizable ~level t = filter_vars (fun t -> t.level >= level) t
+let generalizable ~level t = filter_vars (fun v -> v.level > level) t
+
+let generalize ~level t : scheme = (generalizable ~level t, t)
 
 (** Substitutions. *)
 module Subst = struct
@@ -69,13 +71,13 @@ module Subst = struct
     type t = var
 
     (* We can compare variables with their indices. *)
-    let compare (x : var) (y : var) = compare (fst x) (fst y)
+    let compare (v : var) (v' : var) = compare v.name v'.name
   end)
 
   type subst = t M.t
   type t = subst
 
-  let of_seq seq : t = M.of_seq seq
+  let of_list l : t = M.of_seq (List.to_seq l)
 
   (** Retrieve the value of a variable. *)
   let value (s : t) (i : var) = M.find i s
@@ -91,29 +93,31 @@ end
   * preserved. *)
 let copy_with (subst : Subst.t) t =
   let rec aux t =
-    let cp x = { t with descr = x } in
-    match t.descr with
-      | EVar v -> ( try Subst.value subst v with Not_found -> t)
-      | Constr c ->
-          let params = List.map (fun (v, t) -> (v, aux t)) c.params in
-          cp (Constr { c with params })
-      | Ground _ -> cp t.descr
-      | Getter t -> cp (Getter (aux t))
-      | List t -> cp (List (aux t))
-      | Nullable t -> cp (Nullable (aux t))
-      | Tuple l -> cp (Tuple (List.map aux l))
-      | Meth (l, (g, t), d, u) ->
-          (* We assume that we don't substitute generalized variables. *)
-          if !debug then
-            assert (Subst.M.for_all (fun v _ -> not (List.mem v g)) subst);
-          cp (Meth (l, (g, aux t), d, aux u))
-      | Arrow (p, t) ->
-          cp (Arrow (List.map (fun (o, l, t) -> (o, l, aux t)) p, aux t))
-      | Link (v, t) ->
-          (* Keep links to preserve rich position information,
-           * and to make it possible to check if the application left
-           * the type unchanged. *)
-          cp (Link (v, aux t))
+    let descr =
+      match t.descr with
+        | Var { contents = Free v } as var -> (
+            try (Subst.value subst v).descr with Not_found -> var)
+        | Constr c ->
+            let params = List.map (fun (v, t) -> (v, aux t)) c.params in
+            Constr { c with params }
+        | Ground _ as g -> g
+        | Getter t -> Getter (aux t)
+        | List t -> List (aux t)
+        | Nullable t -> Nullable (aux t)
+        | Tuple l -> Tuple (List.map aux l)
+        | Meth (l, (g, t), d, u) ->
+            (* We assume that we don't substitute generalized variables. *)
+            if !debug then
+              assert (Subst.M.for_all (fun v _ -> not (List.mem v g)) subst);
+            Meth (l, (g, aux t), d, aux u)
+        | Arrow (p, t) ->
+            Arrow (List.map (fun (o, l, t) -> (o, l, aux t)) p, aux t)
+        | Var { contents = Link (_, t) } ->
+            (* TOOD: we remove the link here, it would be too difficult to preserve
+               sharing. We could at least keep it when no variable is changed. *)
+            (aux t).descr
+    in
+    { t with descr }
   in
   if Subst.is_identity subst then t else aux t
 
@@ -125,25 +129,25 @@ let copy_with (subst : Subst.t) t =
   * irrelevant. *)
 let instantiate ~level ~generalized =
   let subst =
-    Seq.map
-      (fun ic -> (ic, fresh ~level ~constraints:(snd ic) ~pos:None))
-      (List.to_seq generalized)
+    List.map
+      (fun v -> (v, var ~level ~constraints:v.constraints ()))
+      generalized
   in
-  let subst = Subst.of_seq subst in
+  let subst = Subst.of_list subst in
   fun t -> copy_with subst t
 
 (** {1 Assignation} *)
 
 (** These two exceptions can be raised when attempting to assign a variable. *)
-exception Occur_check of t * t
+exception Occur_check of var * t
 
 exception Unsatisfied_constraint of constr * t
 
 (** Check that [a] (a dereferenced type variable) does not occur in [b],
-  * and prepare the instantiation [a<-b] by adjusting the levels. *)
-let rec occur_check a b =
+    and prepare the instantiation [a<-b] by adjusting the levels. *)
+let rec occur_check (a : var) b =
+  let b0 = b in
   let b = deref b in
-  if a == b then raise (Occur_check (a, b));
   match b.descr with
     | Constr c -> List.iter (fun (_, x) -> occur_check a x) c.params
     | Tuple l -> List.iter (occur_check a) l
@@ -157,112 +161,97 @@ let rec occur_check a b =
     | Arrow (p, t) ->
         List.iter (fun (_, _, t) -> occur_check a t) p;
         occur_check a t
-    | EVar _ ->
-        (* In normal type inference level -1 should never arise.
-         * Unfortunately we can't check it strictly because this code
-         * is also used to process type annotations, which make use
-         * of unknown levels. Also note that >=0 levels can arise
-         * when processing type annotations, because of builtins. *)
-        if b.level = -1 then b.level <- a.level
-        else if a.level <> -1 then b.level <- min b.level a.level
     | Ground _ -> ()
-    | Link _ -> assert false
+    | Var { contents = Free b } ->
+        if a.name = b.name then raise (Occur_check (a, b0));
+        b.level <- min a.level b.level
+    | Var { contents = Link _ } -> assert false
 
-(* Perform [a := b] where [a] is an EVar, check that [type(a)<:type(b)]. *)
-let rec bind ?(variance = Invariant) a0 b =
+(** Ensure that a type satisfies a given constraint, i.e. morally that b <: c. *)
+let satisfies_constraint b = function
+  | Ord ->
+      let rec check b =
+        let m, b = split_meths b in
+        match b.descr with
+          | Ground _ -> ()
+          | Var { contents = Free v } ->
+              if not (List.mem Ord v.constraints) then
+                v.constraints <- Ord :: v.constraints
+          | Tuple [] ->
+              (* For records, we want to ensure that all fields are ordered. *)
+              List.iter
+                (fun (_, ((v, a), _)) ->
+                  if v <> [] then raise (Unsatisfied_constraint (Ord, a));
+                  check a)
+                m
+          | Tuple l -> List.iter (fun b -> check b) l
+          | List b -> check b
+          | Nullable b -> check b
+          | _ -> raise (Unsatisfied_constraint (Ord, b))
+      in
+      check b
+  | Dtools -> (
+      match b.descr with
+        | Ground g ->
+            if not (List.mem g [Bool; Int; Float; String]) then
+              raise (Unsatisfied_constraint (Dtools, b))
+        | Tuple [] -> ()
+        | List b' -> (
+            match (deref b').descr with
+              | Ground g ->
+                  if g <> String then
+                    raise (Unsatisfied_constraint (Dtools, b'))
+              | Var ({ contents = Free _ } as v) ->
+                  (* TODO: we should check the constraints and the lower bound *)
+                  v := Link (Invariant, make ~pos:b.pos (Ground String))
+              | _ -> raise (Unsatisfied_constraint (Dtools, b')))
+        | Var { contents = Free v } ->
+            if not (List.mem Dtools v.constraints) then
+              v.constraints <- Dtools :: v.constraints
+        | _ -> raise (Unsatisfied_constraint (Dtools, b)))
+  | InternalMedia -> (
+      let is_internal name =
+        try
+          let kind = Frame_content.kind_of_string name in
+          Frame_content.is_internal kind
+        with Frame_content.Invalid -> false
+      in
+      match b.descr with
+        | Constr { constructor } when is_internal constructor -> ()
+        | Ground (Format f) when Frame_content.(is_internal (kind f)) -> ()
+        | Var { contents = Free v } ->
+            if not (List.mem InternalMedia v.constraints) then
+              v.constraints <- InternalMedia :: v.constraints
+        | _ -> raise (Unsatisfied_constraint (InternalMedia, b)))
+  | Num -> (
+      match (demeth b).descr with
+        | Ground g ->
+            if g <> Int && g <> Float then
+              raise (Unsatisfied_constraint (Num, b))
+        | Var { contents = Free v } ->
+            if not (List.mem Num v.constraints) then
+              v.constraints <- Num :: v.constraints
+        | _ -> raise (Unsatisfied_constraint (Num, b)))
+
+let satisfies_constraints b c = List.iter (satisfies_constraint b) c
+
+(** Make a variable link to given type *)
+let bind ?(variance = Invariant) a b =
+  let a0 = a in
+  let v, a =
+    match a.descr with
+      | Var ({ contents = Free a } as v) -> (v, a)
+      | _ -> assert false
+  in
   (* if !debug then Printf.eprintf "%s := %s\n%!" (print a0) (print b); *)
-  let a = deref a0 in
   let b = deref b in
-  if b == a then ()
-  else (
-    occur_check a b;
-    let constraints =
-      match a.descr with
-        | EVar (_, constraints) ->
-            List.iter
-              (function
-                | Ord ->
-                    let rec check b =
-                      let m, b = split_meths b in
-                      match b.descr with
-                        | Ground _ -> ()
-                        | EVar (j, c) ->
-                            if List.mem Ord c then ()
-                            else b.descr <- EVar (j, Ord :: c)
-                        | Tuple [] ->
-                            (* For records, we want to ensure that all fields are ordered. *)
-                            List.iter
-                              (fun (_, ((v, a), _)) ->
-                                if v <> [] then
-                                  raise (Unsatisfied_constraint (Ord, a));
-                                check a)
-                              m
-                        | Tuple l -> List.iter (fun b -> check b) l
-                        | List b -> check b
-                        | Nullable b -> check b
-                        | _ -> raise (Unsatisfied_constraint (Ord, b))
-                    in
-                    check b
-                | Dtools -> (
-                    match b.descr with
-                      | Ground g ->
-                          if not (List.mem g [Bool; Int; Float; String]) then
-                            raise (Unsatisfied_constraint (Dtools, b))
-                      | Tuple [] -> ()
-                      | List b' -> (
-                          match (deref b').descr with
-                            | Ground g ->
-                                if g <> String then
-                                  raise (Unsatisfied_constraint (Dtools, b'))
-                            | EVar (_, _) -> bind b' (make (Ground String))
-                            | _ -> raise (Unsatisfied_constraint (Dtools, b')))
-                      | EVar (j, c) ->
-                          if not (List.mem Dtools c) then
-                            b.descr <- EVar (j, Dtools :: c)
-                      | _ -> raise (Unsatisfied_constraint (Dtools, b)))
-                | InternalMedia -> (
-                    let is_internal name =
-                      try
-                        let kind = Frame_content.kind_of_string name in
-                        Frame_content.is_internal kind
-                      with Frame_content.Invalid -> false
-                    in
-                    match b.descr with
-                      | Constr { name } when is_internal name -> ()
-                      | Ground (Format f)
-                        when Frame_content.(is_internal (kind f)) ->
-                          ()
-                      | EVar (j, c) ->
-                          if List.mem InternalMedia c then ()
-                          else b.descr <- EVar (j, InternalMedia :: c)
-                      | _ -> raise (Unsatisfied_constraint (InternalMedia, b)))
-                | Num -> (
-                    match (demeth b).descr with
-                      | Ground g ->
-                          if g <> Int && g <> Float then
-                            raise (Unsatisfied_constraint (Num, b))
-                      | EVar (j, c) ->
-                          if List.mem Num c then ()
-                          else b.descr <- EVar (j, Num :: c)
-                      | _ -> raise (Unsatisfied_constraint (Num, b))))
-              constraints;
-            constraints
-        | _ -> assert false
-      (* only EVars are bindable *)
-    in
-
-    (* We do not want to check the constraints when we increase the types (for
-       now). *)
-    let variance = if constraints <> [] then Invariant else variance in
-
-    (* This is a shaky hack...
-     * When a value is passed to a FFI, its type is bound to a type without
-     * any location.
-     * If it doesn't break sharing, we set the parsing position of
-     * that variable occurrence to the position of the inferred type. *)
-    if b.pos = None && match b.descr with EVar _ -> false | _ -> true then
-      a.descr <- Link (variance, { a0 with descr = b.descr })
-    else a.descr <- Link (variance, b))
+  occur_check a b;
+  satisfies_constraints b a.constraints;
+  let b = if b.pos = None then { b with pos = a0.pos } else b in
+  (* We do not want to check the constraints when we increase the types (for
+     now). *)
+  let variance = if a.constraints <> [] then Invariant else variance in
+  v := Link (variance, b)
 
 (** {1 Subtype checking/inference} *)
 
@@ -273,7 +262,7 @@ exception Incompatible
     function so that it should always be followed by a subtyping. *)
 let rec sup ~pos a b =
   let sup = sup ~pos in
-  let mk descr = { level = -1; pos; descr } in
+  let mk descr = { pos; descr } in
   let scheme_sup t t' =
     match (t, t') with ([], t), ([], t') -> ([], sup t t') | _ -> t'
   in
@@ -281,12 +270,12 @@ let rec sup ~pos a b =
     match (deref a).descr with
       | Meth (l', t, _, _) when l = l' -> Some t
       | Meth (_, _, _, a) -> meth_type l a
-      | EVar _ -> Some ([], fresh_evar ~level:(-1) ~pos)
+      | Var { contents = Free _ } -> Some ([], var ~pos ())
       | _ -> None
   in
   match ((deref a).descr, (deref b).descr) with
-    | EVar _, _ -> b
-    | _, EVar _ -> a
+    | Var { contents = Free _ }, _ -> b
+    | _, Var { contents = Free _ } -> a
     | Nullable a, Nullable b -> mk (Nullable (sup a b))
     | Nullable a, _ -> mk (Nullable (sup a b))
     | _, Nullable b -> mk (Nullable (sup a b))
@@ -313,7 +302,8 @@ let rec sup ~pos a b =
           (* TODO: I guess that we should hide other methods named l *)
           | Some t' -> mk (Meth (l, scheme_sup t' t, d, sup a b))
           | None -> sup a b)
-    | Constr { name = c; params = a }, Constr { name = d; params = b } ->
+    | ( Constr { constructor = c; params = a },
+        Constr { constructor = d; params = b } ) ->
         if c <> d || List.length a <> List.length b then raise Incompatible;
         let params =
           List.map2
@@ -322,7 +312,7 @@ let rec sup ~pos a b =
               (v, sup a b))
             a b
         in
-        mk (Constr { name = c; params })
+        mk (Constr { constructor = c; params })
     | Getter a, Getter b -> mk (Getter (sup a b))
     | Getter a, Arrow ([], b) -> mk (Getter (sup a b))
     | Getter a, _ -> mk (Getter (sup a b))
@@ -366,7 +356,9 @@ let rec ( <: ) a b =
   if !debug || !debug_subtyping then
     Printf.eprintf "\n%s <: %s\n%!" (print a) (print b);
   match (a.descr, b.descr) with
-    | _, Link (Covariant, b') ->
+    | Var { contents = Free v }, Var { contents = Free v' } when var_eq v v' ->
+        ()
+    | _, Var ({ contents = Link (Covariant, b') } as var) ->
         (* When the variable is covariant, we take the opportunity here to correct
            bad choices. For instance, if we took int, but then have a 'a?, we
            change our mind and use int? instead. *)
@@ -376,14 +368,14 @@ let rec ( <: ) a b =
            failwith
              (Printf.sprintf "sup did to increase: %s !< %s" (Type.print b')
                 (Type.print b'')));
-        if b'' != b' then b.descr <- Link (Covariant, b'');
+        if b'' != b' then var := Link (Covariant, b'');
         a <: b''
-    | Link (Covariant, a'), _ ->
-        a.descr <- Link (Invariant, a');
+    | Var ({ contents = Link (Covariant, a') } as var), _ ->
+        var := Link (Invariant, a');
         a <: b
-    | _, Link (_, b) -> a <: b
-    | Link (_, a), _ -> a <: b
-    | Constr c1, Constr c2 when c1.name = c2.name ->
+    | _, Var { contents = Link (_, b) } -> a <: b
+    | Var { contents = Link (_, a) }, _ -> a <: b
+    | Constr c1, Constr c2 when c1.constructor = c2.constructor ->
         let rec aux pre p1 p2 =
           match (p1, p2) with
             | (v1, h1) :: t1, (v2, h2) :: t2 ->
@@ -401,8 +393,8 @@ let rec ( <: ) a b =
                     let post = List.map (fun (v, _) -> (v, `Ellipsis)) t1 in
                     Printexc.raise_with_backtrace
                       (Error
-                         ( `Constr (c1.name, pre @ [(v1, a)] @ post),
-                           `Constr (c1.name, pre @ [(v2, b)] @ post) ))
+                         ( `Constr (c1.constructor, pre @ [(v1, a)] @ post),
+                           `Constr (c1.constructor, pre @ [(v2, b)] @ post) ))
                       bt
                 end;
                 aux ((v1, `Ellipsis) :: pre) t1 t2
@@ -495,16 +487,17 @@ let rec ( <: ) a b =
     | Arrow ([], t1), Getter t2 -> (
         try t1 <: t2
         with Error (a, b) -> raise (Error (`Arrow ([], a), `Getter b)))
-    | EVar _, _ -> (
+    | Var { contents = Free _ }, _ -> (
         try bind a b
         with Occur_check _ | Unsatisfied_constraint _ ->
           (* Can't do more concise than a full representation, as the problem
              isn't local. *)
           raise (Error (repr a, repr b)))
-    | _, EVar (_, c)
+    | _, Var { contents = Free v }
     (* Force dropping the methods when we have constraints (see #1496) unless
        we are comparing records (see #1930). *)
-      when (not (has_meth a)) || c = [] || (demeth a).descr = unit -> (
+      when (not (has_meth a)) || v.constraints = [] || (demeth a).descr = unit
+      -> (
         try bind ~variance:Covariant b a
         with Occur_check _ | Unsatisfied_constraint _ ->
           raise (Error (repr a, repr b)))
@@ -546,14 +539,8 @@ let rec ( <: ) a b =
         with Not_found -> (
           let a' = demeth a in
           match a'.descr with
-            | EVar _ ->
-                a'
-                <: make
-                     (Meth
-                        ( l,
-                          (g2, t2),
-                          "",
-                          fresh ~level:(-1) ~constraints:[] ~pos:None ));
+            | Var { contents = Free _ } ->
+                a' <: make (Meth (l, (g2, t2), "", var ()));
                 a <: b
             | _ -> raise (Error (repr a, `Meth (l, ([], `Ellipsis), `Ellipsis))))
         )
@@ -566,7 +553,7 @@ let rec ( <: ) a b =
         let filter () =
           let already = ref false in
           function
-          | { descr = Link _; _ } -> false
+          | { descr = Var { contents = Link _ }; _ } -> false
           | _ ->
               let x = !already in
               already := true;

--- a/src/lang/typing.mli
+++ b/src/lang/typing.mli
@@ -33,6 +33,9 @@ val instantiate : level:int -> generalized:var list -> t -> t
 (** Find all generalizable variables. *)
 val generalize : level:int -> t -> scheme
 
+(** Lower all type variables to given level. *)
+val update_level : level:int -> t -> unit
+
 (** Subtyping. *)
 val ( <: ) : t -> t -> unit
 

--- a/src/lang/typing.mli
+++ b/src/lang/typing.mli
@@ -31,7 +31,7 @@ type env = (string * scheme) list
 val instantiate : level:int -> generalized:var list -> t -> t
 
 (** Find all generalizable variables. *)
-val generalizable : level:int -> t -> var list
+val generalize : level:int -> t -> scheme
 
 (** Subtyping. *)
 val ( <: ) : t -> t -> unit

--- a/src/lang/value.ml
+++ b/src/lang/value.ml
@@ -92,7 +92,7 @@ let rec print_value v =
           match e.value with Tuple [] -> "" | _ -> print_value e ^ "."
         in
         e ^ "{" ^ m ^ "}"
-    | Fun ([], _, _, x) when Term.is_ground x -> "{" ^ Term.print_term x ^ "}"
+    | Fun ([], _, _, x) when Term.is_ground x -> "{" ^ Term.print x ^ "}"
     | Fun (l, _, _, x) when Term.is_ground x ->
         let f (label, _, value) =
           match (label, value) with
@@ -102,8 +102,7 @@ let rec print_value v =
             | label, None -> Printf.sprintf "~%s=_" label
         in
         let args = List.map f l in
-        Printf.sprintf "fun (%s) -> %s" (String.concat "," args)
-          (Term.print_term x)
+        Printf.sprintf "fun (%s) -> %s" (String.concat "," args) (Term.print x)
     | Fun _ | FFI _ -> "<fun>"
 
 (** Find a method in a value. *)

--- a/src/test/meth.ml
+++ b/src/test/meth.ml
@@ -38,7 +38,7 @@ let () =
   (* Make sure unifying variables sees top-level methods:
      We do: t = ('a).{ f : int } <: t' = int.{ ff : int, f : float }
      and make sure that this fails. *)
-  let t = Type.fresh_evar ~level:(-1) ~pos:None in
+  let t = Type.var () in
   let t = Type.meth "f" ([], Type.make (Type.Ground Type.Int)) t in
   let t' = Type.make (Type.Ground Type.Int) in
   let t' = Type.meth "f" ([], Type.make (Type.Ground Type.Float)) t' in

--- a/src/test/types.ml
+++ b/src/test/types.ml
@@ -1,66 +1,42 @@
+open Type
+
 let should_work t t' r =
-  let t = Type.make t in
-  let t' = Type.make t' in
-  let r = Type.make r in
-  Printf.printf "Finding min for %s and %s\n%!" (Type.print t) (Type.print t');
+  let t = make t in
+  let t' = make t' in
+  let r = make r in
+  Printf.printf "Finding min for %s and %s\n%!" (print t) (print t');
   let m = Typing.sup ~pos:None t t' in
-  Printf.printf "Got: %s, expect %s\n%!" (Type.print m) (Type.print r);
+  Printf.printf "Got: %s, expect %s\n%!" (print m) (print r);
   Typing.(m <: r);
   Typing.(t <: m);
   Typing.(t' <: m)
 
 let should_fail t t' =
   try
-    ignore (Typing.sup ~pos:None (Type.make t) (Type.make t'));
+    ignore (Typing.sup ~pos:None (make t) (make t'));
     assert false
   with _ -> ()
 
 let () =
-  should_work
-    (Type.EVar (1, []))
-    (Type.Ground Type.Bool) (Type.Ground Type.Bool);
-  should_work (Type.Ground Type.Bool)
-    (Type.EVar (1, []))
-    (Type.Ground Type.Bool);
+  should_work (var ()).descr (Ground Bool) (Ground Bool);
+  should_work (Ground Bool) (var ()).descr (Ground Bool);
 
-  should_fail (Type.Ground Type.Bool) (Type.Ground Type.Int);
-  should_fail
-    (Type.List (Type.make (Type.Ground Type.Bool)))
-    (Type.List (Type.make (Type.Ground Type.Int)));
+  should_fail (Ground Bool) (Ground Int);
+  should_fail (List (make (Ground Bool))) (List (make (Ground Int)));
 
-  let m =
-    Type.Meth
-      ( "aa",
-        ([], Type.make (Type.Ground Type.Int)),
-        "",
-        Type.make (Type.Ground Type.Bool) )
-  in
+  let m = Meth ("aa", ([], make (Ground Int)), "", make (Ground Bool)) in
 
-  should_work m (Type.Ground Type.Bool) (Type.Ground Type.Bool);
+  should_work m (Ground Bool) (Ground Bool);
 
-  let n =
-    Type.Meth ("b", ([], Type.make (Type.Ground Type.Bool)), "", Type.make m)
-  in
+  let n = Meth ("b", ([], make (Ground Bool)), "", make m) in
 
   should_work m n m;
 
-  let n =
-    Type.Meth
-      ( "aa",
-        ([], Type.make (Type.Ground Type.Int)),
-        "",
-        Type.make (Type.Ground Type.Int) )
-  in
+  let n = Meth ("aa", ([], make (Ground Int)), "", make (Ground Int)) in
 
   should_fail m n;
 
-  let n =
-    Type.Meth
-      ( "aa",
-        ([], Type.make (Type.Ground Type.Bool)),
-        "",
-        Type.make (Type.Ground Type.Bool) )
-  in
+  let n = Meth ("aa", ([], make (Ground Bool)), "", make (Ground Bool)) in
 
   should_fail m n;
 

--- a/tests/language/.gitignore
+++ b/tests/language/.gitignore
@@ -1,0 +1,1 @@
+interactive.json

--- a/tests/streams/radio2.liq
+++ b/tests/streams/radio2.liq
@@ -1,4 +1,4 @@
-#!../../src/liquidsoap -i ../../libs/stdlib.liq ../../libs/deprecations.liq
+#!../../src/liquidsoap -i ../../libs/stdlib.liq
 
 # Basic radio test
 


### PR DESCRIPTION
This cleans up the current implementation of type variables while keeping the same functionalities :
- we have a clean definition of the type `var` of variables
- levels are attached to existential variables only (this is the only place where they are used)
- the level computation is fixed (it was not handled correctly)
- substitution is done in a reference attached to a variable instead of having to preserve sharing in the surrounding `descr`
- we now use `max_int` instead of `-1` as default level, which behaves correctly wrt `min`
- many various small improvements