### PR TITLE
Add usual cons notation for lists.

### DIFF
--- a/libs/audio.liq
+++ b/libs/audio.liq
@@ -264,8 +264,8 @@ def replaces dtmf(~duration=0.1, ~delay=0.05, dtmf)
         (0., 0.)
       end
     s = add([sine(row, duration=duration), sine(col, duration=duration)])
-    l := list.add(blank(duration=delay), !l)
-    l := list.add(s, !l)
+    l := blank(duration=delay) :: !l
+    l := s :: !l
   end
   l = list.rev(!l)
   sequence(l)

--- a/libs/http.liq
+++ b/libs/http.liq
@@ -21,7 +21,7 @@ def http.response(~protocol="HTTP/1.1",
                  ("Connection", "close")])
   headers =
     if content_type != "" then
-      list.add(("Content-Type", content_type), headers)
+      ("Content-Type", content_type)::headers
     else
       headers
     end
@@ -71,7 +71,7 @@ def http.response.stream(
                  ("Connection", "close")])
   headers =
     if content_type != "" then
-      list.add(("Content-Type", content_type), headers)
+      ("Content-Type", content_type)::headers
     else
       headers
     end

--- a/libs/interactive.liq
+++ b/libs/interactive.liq
@@ -144,7 +144,7 @@ let stdlib_osc = osc
 # @param ~type Type of the variable.
 def interactive.create(~name, ~description="", ~osc="", ~type)
   if list.assoc.mem(name, !variables) then error.raise(interactive.error, "variable already registered") end
-  variables := list.add((name, { type=type, description=description }), !variables)
+  variables := (name, { type=type, description=description }) :: !variables
   variables := list.sort(fun(n, n') -> if fst(n) < fst(n') then -1 else 1 end, !variables)
 %ifdef osc
   if osc != "" then
@@ -413,7 +413,7 @@ end
 def replaces interactive.float(~min=0.-infinity, ~max=infinity, ~step=0.1, ~description="", ~unit="", ~osc="", name, v)
   interactive.create(name=name, description=description, osc=osc, type="float")
   r = ref(v)
-  variables_float := list.add((name, {ref=r, unit=unit, min=min, max=max, step=step }), !variables_float)
+  variables_float := (name, {ref=r, unit=unit, min=min, max=max, step=step })::!variables_float
   ref.getter(r).{set = interactive.float.set(name), remove = {interactive.float.remove(name)}}
 end
 
@@ -426,7 +426,7 @@ end
 def replaces interactive.int(~description="", ~osc="", name, v)
   interactive.create(name=name, description=description, osc=osc, type="int")
   r = ref(v)
-  variables_int := list.add((name, {ref=r }), !variables_int)
+  variables_int := (name, {ref=r })::!variables_int
   ref.getter(r).{set = interactive.int.set(name), remove = {interactive.int.remove(name)}}
 end
 
@@ -439,7 +439,7 @@ end
 def replaces interactive.bool(~description="", ~osc="", name, v)
   interactive.create(name=name, description=description, osc=osc, type="bool")
   r = ref(v)
-  variables_bool := list.add((name, { ref=r }), !variables_bool)
+  variables_bool := (name, { ref=r })::!variables_bool
   ref.getter(r).{set = interactive.bool.set(name), remove = {interactive.bool.remove(name)}}
 end
 
@@ -452,7 +452,7 @@ end
 def replaces interactive.string(~description="", ~osc="", name, v)
   interactive.create(name=name, description=description, osc=osc, type="string")
   r = ref(v)
-  variables_string := list.add((name, { ref=r }), !variables_string)
+  variables_string := (name, { ref=r }) :: !variables_string
   ref.getter(r).{set = interactive.string.set(name), remove = {interactive.string.remove(name)}}
 end
 

--- a/libs/interactive.liq
+++ b/libs/interactive.liq
@@ -413,7 +413,7 @@ end
 def replaces interactive.float(~min=0.-infinity, ~max=infinity, ~step=0.1, ~description="", ~unit="", ~osc="", name, v)
   interactive.create(name=name, description=description, osc=osc, type="float")
   r = ref(v)
-  variables_float := (name, {ref=r, unit=unit, min=min, max=max, step=step })::!variables_float
+  variables_float := (name, {ref=r, unit=unit, min=min, max=max, step=step }) :: !variables_float
   ref.getter(r).{set = interactive.float.set(name), remove = {interactive.float.remove(name)}}
 end
 
@@ -426,7 +426,7 @@ end
 def replaces interactive.int(~description="", ~osc="", name, v)
   interactive.create(name=name, description=description, osc=osc, type="int")
   r = ref(v)
-  variables_int := (name, {ref=r })::!variables_int
+  variables_int := (name, {ref=r }) :: !variables_int
   ref.getter(r).{set = interactive.int.set(name), remove = {interactive.int.remove(name)}}
 end
 
@@ -439,7 +439,7 @@ end
 def replaces interactive.bool(~description="", ~osc="", name, v)
   interactive.create(name=name, description=description, osc=osc, type="bool")
   r = ref(v)
-  variables_bool := (name, { ref=r })::!variables_bool
+  variables_bool := (name, { ref=r }) :: !variables_bool
   ref.getter(r).{set = interactive.bool.set(name), remove = {interactive.bool.remove(name)}}
 end
 

--- a/libs/list.liq
+++ b/libs/list.liq
@@ -32,7 +32,7 @@ end
 def list.init(n, f)
   def rec aux(i)
     if i == n then [] else
-      list.add(f(i), aux(i+1))
+      f(i)::aux(i+1)
     end
   end
   if n < 0 then [] else aux(0) end
@@ -332,14 +332,14 @@ def list.insert(index, new_element, l) =
   end
 
   if index == 0 then
-    list.add(new_element, l)
+    new_element::l
   else
     def f(cur, el) =
       let (pos, l) = cur
       l = if pos+1 == index then
-          list.add(new_element, list.add(el, l))
+          new_element::el::l
         else
-          list.add(el, l)
+          el::l
         end
       (pos+1, l)
     end
@@ -363,7 +363,7 @@ end
 def list.prefix(n, l)
   def rec aux(n, l)
     if n <= 0 or list.is_empty(l) then [] else
-      list.add(list.hd(l), aux(n-1, list.tl(l)))
+      list.hd(l)::aux(n-1, list.tl(l))
     end
   end
   aux(n, l)

--- a/libs/protocols.liq
+++ b/libs/protocols.liq
@@ -333,7 +333,7 @@ def ffmpeg_protocol(~rlog,~maxtime,arg) =
       if list.length(m) >= 2 then
         key = list.hd(default="",m)
         value = string.concat(separator="=",list.tl(m))
-        list.add((key,value),cur)
+        (key,value)::cur
       else
         cur
       end

--- a/libs/request.liq
+++ b/libs/request.liq
@@ -81,7 +81,7 @@ def request.player(~simultaneous=true)
 
     def play(r)
       collect()
-      l := list.add(request.once(r), !l)
+      l := request.once(r)::!l
     end
 
     source.dynamic({add(normalize=false, !l)}).{play=play, length={collect(); list.length(!l)}}

--- a/libs/shoutcast.liq
+++ b/libs/shoutcast.liq
@@ -22,7 +22,7 @@ def output.shoutcast(
   def map(m) =
     dj = dj()
     if dj != "" then
-      list.add(("dj",dj),m)
+      ("dj",dj)::m
     else
       m
     end

--- a/libs/switches.liq
+++ b/libs/switches.liq
@@ -105,7 +105,7 @@ def rotate(~id=null(), ~override="liq_transition_length", ~replay_metadata=true,
              transition_length=transition_length, transitions=transitions,
              list.mapi(add_condition, sources))
 
-  fallback(id=id, track_sensitive=true, list.add(s, sources))
+  fallback(id=id, track_sensitive=true, s::sources)
 end
 
 # At the beginning of every track, select a random ready child.
@@ -131,7 +131,7 @@ def replaces random(~id=null(), ~override="liq_transition_length", ~replay_metad
       let (current_weight, indexes) =
         if source.is_ready(s) then
           weight = weight()
-          indexes = list.add((current_weight, current_weight+weight, index), indexes)
+          indexes = (current_weight, current_weight+weight, index) :: indexes
           (current_weight + weight, indexes)
         else
           (current_weight, indexes)
@@ -182,5 +182,5 @@ def replaces random(~id=null(), ~override="liq_transition_length", ~replay_metad
              transition_length=transition_length, transitions=transitions,
              list.mapi(add_condition, sources))
 
-  fallback(id=id, track_sensitive=true, list.add(s, sources))
+  fallback(id=id, track_sensitive=true, s::sources)
 end

--- a/libs/utils.liq
+++ b/libs/utils.liq
@@ -77,7 +77,7 @@ def playlog(~duration=infinity, ~persistency=null(), ~hash=fun(m)->m["filename"]
   def add(m)
     prune()
     f = hash(m)
-    l := list.add((f, time()), !l)
+    l := (f, time()) :: !l
     save()
   end
   # Last time this entry was played

--- a/src/lang/builtins_list.ml
+++ b/src/lang/builtins_list.ml
@@ -108,16 +108,19 @@ let () =
 
 let () =
   let a = Lang.univ_t () in
-  Lang.add_builtin "list.add" ~category:`List
-    ~descr:"Add an element at the top of a list."
-    [("", a, None, None); ("", Lang.list_t a, None, None)]
-    (Lang.list_t a)
-    (fun p ->
-      let x, l =
-        match p with [("", x); ("", l)] -> (x, l) | _ -> assert false
-      in
-      let l = Lang.to_list l in
-      Lang.list (x :: l))
+  List.iter
+    (fun name ->
+      Lang.add_builtin name ~category:`List
+        ~descr:"Add an element at the top of a list."
+        [("", a, None, None); ("", Lang.list_t a, None, None)]
+        (Lang.list_t a)
+        (fun p ->
+          let x, l =
+            match p with [("", x); ("", l)] -> (x, l) | _ -> assert false
+          in
+          let l = Lang.to_list l in
+          Lang.list (x :: l)))
+    ["list.add"; "_::_"]
 
 let () =
   let t = Lang.list_t (Lang.univ_t ()) in

--- a/src/lang/lexer.ml
+++ b/src/lang/lexer.ml
@@ -213,6 +213,7 @@ let rec token lexbuf =
     | '{' -> LCUR
     | '}' -> RCUR
     | ',' -> COMMA
+    | "::" -> COLONCOLON
     | ':' -> COLON
     | ';' -> SEQ
     | ";;" -> SEQSEQ

--- a/src/lang/parser.mly
+++ b/src/lang/parser.mly
@@ -48,7 +48,7 @@ open Parser_helper
 %token IF THEN ELSE ELSIF
 %token SLASH
 %token OPEN
-%token LPAR RPAR COMMA SEQ SEQSEQ COLON DOT
+%token LPAR RPAR COMMA SEQ SEQSEQ COLON COLONCOLON DOT
 %token LBRA RBRA LCUR RCUR
 %token FUN YIELDS
 %token DOTDOTDOT
@@ -80,6 +80,7 @@ open Parser_helper
 %nonassoc NOT
 %left BIN2 MINUS
 %left BIN3 TIMES
+%right COLONCOLON
 %nonassoc GET          (* (!x)+2 *)
 %left DOT
 %nonassoc COLON
@@ -151,6 +152,7 @@ expr:
   | expr DOT VAR                     { mk ~pos:$loc (Invoke ($1, $3)) }
   | expr DOT VARLPAR app_list RPAR   { mk ~pos:$loc (App (mk ~pos:($startpos($1),$endpos($3)) (Invoke ($1, $3)), $4)) }
   | VARLPAR app_list RPAR            { mk ~pos:$loc (App (mk ~pos:$loc($1) (Var $1), $2)) }
+  | expr COLONCOLON expr             { mk ~pos:$loc (App (mk ~pos:$loc($2) (Var "_::_"), ["", $1; "", $3])) }
   | VARLBRA expr RBRA                { mk ~pos:$loc (App (mk ~pos:$loc (Var "_[_]"), ["", mk ~pos:$loc($1) (Var $1); "", $2])) }
   | expr DOT VARLBRA expr RBRA       { mk ~pos:$loc (App (mk ~pos:$loc (Var "_[_]"), ["", mk ~pos:($startpos($1),$endpos($3)) (Invoke ($1, $3)); "", $4])) }
   | BEGIN exprs END                  { $2 }

--- a/tests/language/list.liq
+++ b/tests/language/list.liq
@@ -12,6 +12,7 @@ def t(x, y)
 end
   
 def f() =
+  t(1::2::[3,4], [1,2,3,4])
   t(list.hd(default=0,[]), 0)
   t(list.hd([5,6]), 5)
   t(try list.hd([]) catch _ do 9 end, 9)


### PR DESCRIPTION
This allows for
```
1::2::[3,4]
```
I think we use lists enough now to justify introducing this notation.