### PR TITLE
Runtime eval!

### DIFF
--- a/libs/error.liq
+++ b/libs/error.liq
@@ -1,7 +1,7 @@
 let error.not_found = error.register("not_found")
 let error.assertion = error.register("assertion")
 let error.invalid = error.register("invalid")
-let error.eval = errpr.register("eval")
+let error.eval = error.register("eval")
 
 # Ensure that a condition is satisfied (raise `error.assertion` exception
 # otherwise).

--- a/libs/error.liq
+++ b/libs/error.liq
@@ -1,8 +1,7 @@
 let error.not_found = error.register("not_found")
-
 let error.assertion = error.register("assertion")
-
 let error.invalid = error.register("invalid")
+let error.eval = errpr.register("eval")
 
 # Ensure that a condition is satisfied (raise `error.assertion` exception
 # otherwise).

--- a/scripts/liquidsoap-mode.el
+++ b/scripts/liquidsoap-mode.el
@@ -5,7 +5,7 @@
  '(
    ("#.*" . 'font-lock-comment-face)
    ("^\\(%ifdef .*\\|%ifndef .*\\|%ifencoder .*\\|%ifnencoder .*\\|%ifversion .*\\|%else .*\\|%endif\\|%include\\|%define\\)" . 'font-lock-preprocessor-face)
-   ("\\<\\(fun\\|def\\|rec\\|replaces\\|begin\\|end\\|if\\|then\\|else\\|elsif\\|let\\|try\\|catch\\|while\\|for\\|in\\|to\\|do\\|open\\)\\>\\|->\\|;" . font-lock-keyword-face)
+   ("\\<\\(fun\\|def\\|rec\\|replaces\\|eval\\|begin\\|end\\|if\\|then\\|else\\|elsif\\|let\\|try\\|catch\\|while\\|for\\|in\\|to\\|do\\|open\\)\\>\\|->\\|;" . font-lock-keyword-face)
    ("\\<\\(and\\|or\\|not\\|mod\\|??\\)\\>\\|:=" . font-lock-builtin-face)
    ("\\<\\(true\\|false\\)\\>" . font-lock-constant-face)
    ("\\<def[ \t]+\\([^ (]*\\)" 1 'font-lock-function-name-face)

--- a/scripts/liquidsoap.xml
+++ b/scripts/liquidsoap.xml
@@ -16,6 +16,7 @@
   <highlighting>
     <list name="Keywords">
       <item>def</item>
+      <item>eval</item>
       <item>replaces</item>
       <item>rec</item>
       <item>let</item>

--- a/src/lang/lexer.ml
+++ b/src/lang/lexer.ml
@@ -184,14 +184,16 @@ let rec token lexbuf =
     | "%argsof" -> ARGS_OF
     | '#', Star (Compl '\n'), eof -> EOF
     | eof -> EOF
-    | "def" -> PP_DEF
-    | "replaces" -> REPLACES
+    | "def", Plus skipped, "rec" -> PP_DEF `Recursive
+    | "def", Plus skipped, "replaces" -> PP_DEF `Replaces
+    | "def" -> PP_DEF `None
     | "try" -> TRY
     | "catch" -> CATCH
     | "do" -> DO
-    | "let" -> LET
+    | "let", Plus skipped, "replaces" -> LET `Replaces
+    | "let", Plus skipped, "eval" -> LET `Eval
+    | "let" -> LET `None
     | "fun" -> FUN
-    | "rec" -> REC
     | '=' -> GETS
     | "end" -> END
     | "begin" -> BEGIN

--- a/src/lang/parser_helper.ml
+++ b/src/lang/parser_helper.ml
@@ -25,6 +25,14 @@
 open Term
 open Ground
 
+type let_decoration = [ `None | `Recursive | `Replaces | `Eval ]
+
+let string_of_let_decoration = function
+  | `None -> ""
+  | `Recursive -> "rec"
+  | `Replaces -> "replaces"
+  | `Eval -> "eval"
+
 let gen_args_of ~only ~except ~pos get_args name =
   match Environment.get_builtin name with
     | Some ((_, t), Value.{ value = Fun (args, _, _, _) })
@@ -168,15 +176,50 @@ let mk_fun ~pos args body =
   let fv = Term.free_vars ~bound body in
   mk ~pos (Fun (fv, args, body))
 
-let mk_let ~pos (doc, replace, pat, def) body =
-  mk ~pos (Let { doc; replace; pat; gen = []; def; body })
-
 let mk_rec_fun ~pos pat args body =
-  let name = match pat with PVar [name] -> name | _ -> assert false in
+  let name =
+    match pat with
+      | PVar l when l <> [] -> List.hd (List.rev l)
+      | _ -> assert false
+  in
   let bound = List.map (fun (_, x, _, _) -> x) args in
   let bound = name :: bound in
   let fv = Term.free_vars ~bound body in
   mk ~pos (RFun (name, fv, args, body))
+
+let mk_eval ~pos (doc, pat, def, body) =
+  let ty = Type.var () in
+  let tty = Value.RuntimeType.to_term ty in
+  let eval = mk ~pos (Var "_eval_") in
+  let def = mk ~pos (App (eval, [("type", tty); ("", def)])) in
+  let def = mk ~pos (Cast (def, ty)) in
+  mk ~pos (Let { doc; replace = false; pat; gen = []; def; body })
+
+let mk_let ~pos (doc, decoration, pat, arglist, def) body =
+  match (arglist, decoration) with
+    | Some arglist, `None | Some arglist, `Replaces ->
+        let replace = decoration = `Replaces in
+        let def = mk_fun ~pos arglist def in
+        mk ~pos (Let { doc; replace; pat; gen = []; def; body })
+    | Some arglist, `Recursive ->
+        let def = mk_rec_fun ~pos pat arglist def in
+        mk ~pos (Let { doc; replace = false; pat; gen = []; def; body })
+    | None, `None | None, `Replaces ->
+        let replace = decoration = `Replaces in
+        mk ~pos (Let { doc; replace; pat; gen = []; def; body })
+    | None, `Eval -> mk_eval ~pos (doc, pat, def, body)
+    | Some _, v ->
+        raise
+          (Parse_error
+             ( pos,
+               string_of_let_decoration v
+               ^ " does not apply to function assignments" ))
+    | None, v ->
+        raise
+          (Parse_error
+             ( pos,
+               string_of_let_decoration v
+               ^ " only applies to function assignments" ))
 
 let mk_encoder ~pos e p = mk ~pos (Encoder (e, p))
 

--- a/src/lang/parser_helper.ml
+++ b/src/lang/parser_helper.ml
@@ -188,7 +188,7 @@ let mk_rec_fun ~pos pat args body =
   mk ~pos (RFun (name, fv, args, body))
 
 let mk_eval ~pos (doc, pat, def, body) =
-  let ty = Type.var ~level:(-1) () in
+  let ty = Type.var ~level:(-1) ~pos () in
   let tty = Value.RuntimeType.to_term ty in
   let eval = mk ~pos (Var "_eval_") in
   let def = mk ~pos (App (eval, [("type", tty); ("", def)])) in

--- a/src/lang/parser_helper.ml
+++ b/src/lang/parser_helper.ml
@@ -188,7 +188,7 @@ let mk_rec_fun ~pos pat args body =
   mk ~pos (RFun (name, fv, args, body))
 
 let mk_eval ~pos (doc, pat, def, body) =
-  let ty = Type.var () in
+  let ty = Type.var ~level:(-1) () in
   let tty = Value.RuntimeType.to_term ty in
   let eval = mk ~pos (Var "_eval_") in
   let def = mk ~pos (App (eval, [("type", tty); ("", def)])) in

--- a/src/lang/preprocessor.ml
+++ b/src/lang/preprocessor.ml
@@ -221,7 +221,7 @@ type doc_type = [ `Full | `Argsof of string list ]
 (* Glue the documenting comments to the corresponding PP_DEF (read pre-DEF) *
    and strip out other comments. *)
 let parse_comments tokenizer =
-  let documented_def (doc, doc_startp) (startp, endp) =
+  let documented_def decoration (doc, doc_startp) (startp, endp) =
     let startp =
       match doc_startp with Some startp -> startp | None -> startp
     in
@@ -373,7 +373,7 @@ let parse_comments tokenizer =
         | `Category c -> doc#add_subsection "_category" (Doc.trivial c)
         | `Flag c -> doc#add_subsection "_flag" (Doc.trivial c))
       special;
-    (Parser.DEF (doc, params, methods), (startp, endp))
+    (Parser.DEF ((doc, params, methods), decoration), (startp, endp))
   in
   let comment = ref ([], None) in
   let rec token () =
@@ -381,10 +381,10 @@ let parse_comments tokenizer =
       | Parser.PP_COMMENT c, (startp, _) ->
           comment := (c, Some startp);
           token ()
-      | Parser.PP_DEF, pos ->
+      | Parser.PP_DEF decoration, pos ->
           let c = !comment in
           comment := ([], None);
-          documented_def c pos
+          documented_def decoration c pos
       | x ->
           comment := ([], None);
           x

--- a/src/lang/runtime.mli
+++ b/src/lang/runtime.mli
@@ -46,4 +46,4 @@ val from_string : ?parse_only:bool -> lib:bool -> string -> unit
 val interactive : unit -> unit
 
 (** Evaluate a string *)
-val eval : string -> Value.t option
+val eval : ty:Type.t -> string -> Value.t

--- a/src/lang/runtime.mli
+++ b/src/lang/runtime.mli
@@ -45,5 +45,5 @@ val from_string : ?parse_only:bool -> lib:bool -> string -> unit
 (** Interactive loop: read from command line, eval, print and loop. *)
 val interactive : unit -> unit
 
-(** Evaluate a string *)
+(** Evaluate a string. The result is checked to have the given type. *)
 val eval : ty:Type.t -> string -> Value.t

--- a/src/lang/value.ml
+++ b/src/lang/value.ml
@@ -231,3 +231,12 @@ module MkAbstract (Def : AbstractDef) = struct
   module Term = Term.MkAbstract (Def)
   include MkAbstractFromTerm (Term)
 end
+
+module RuntimeType = MkAbstract (struct
+  type content = Type.t
+
+  let name = "type"
+  let descr _ = "type"
+  let to_json ~compact:_ ~json5:_ _ = "\"<type>\""
+  let compare = Stdlib.compare
+end)

--- a/tests/language/eval.liq
+++ b/tests/language/eval.liq
@@ -49,6 +49,22 @@ def f() =
   t("16", { "bla" == (true ? "bla" : "foo") })
   t("17", { "foo" == (false ? "bla" : "foo") })
 
+  # Generic eval
+  let eval x = "{foo = 123, gni = \"aabbcc\"}"
+  t("18", { x.foo == 123 })
+  t("19", { x.gni == "aabbcc"})
+
+  # Eval with sources!
+  let eval x = "output.dummy(id='bla', blank())"
+  t("20", { x.id() == "bla"})
+
+  # Eval with patterns
+  let eval {foo, gni = [x, y]} = "{foo = 123, gni = [1,2]}"
+  t("21", { foo == 123 })
+  t("22", { gni == [1, 2]})
+  t("23", { x == 1})
+  t("24", { y == 2})
+
   if !fail then test.fail() else test.pass() end
 end
 


### PR DESCRIPTION
This PR adds runtime, type-safe `eval` let patterns!

The implementation uses a runtime type variable that is used to type-check the parsed term at runtime to make sure that it matches the expected type.

This could be used to write runtime hot loader script. See below for details.

### Examples
```ruby
let eval x = "{foo = 123, gni = \"aabbcc\"}"

let eval x = "output.dummy(id='bla', blank())"

# Eval with patterns
let eval {foo, gni = [x, y]} = "{foo = 123, gni = [1,2]}"
```

### Runtime hot loader

The idea for a runtime hot loader would be to pass a string containing a code that:
* Initializes a new stream
* Returns a callback to shutdown the stream

This could be used to implement a long-needed feature from users, live reload. 

Here's a quick prototype:
```ruby
loaded_streams = ref([])

def start_stream(x) =
  let eval (stream_name, shutdown_callback) = x
  loaded_streams := (stream_name, shutdown_callback)::!loaded_streams
end

def stop_stream(name)
  if list.assoc.mem(name, !loaded_streams) then
    shutdown_callback = list.assoc(name, !loaded_streams)
    shutdown_callback()
    loaded_streams := list.assoc.remove(name, !loaded_streams)
  end
end
```

Then you would call the `start_stream` function with, for instance: `"s = output.ao(sine()); {source.shutdown(s)}"`.  This could be connected to a telnet function or a HTTP callback for instance.

### Implementation details

The implementation also refactors the `let` decorators to remove them from the list of keywords and make them a parameter of the `LET` token. This should allow for more flexibility for future decorators (I have some in store!)