### PR TITLE
Add socket API

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@ New:
   **Breaking change** values that cannot be represented as `JSON` will now raise
   `error.json` when converted to `JSON`. `infinite` and `nan` floats can be exported
   using the `json5` export format.
+- Added socket API (#2014)
 
 Changes:
 - `output.youtube.live` renamed `output.youtube.live.rtmp`, remove `bitrate` and

--- a/libs/error.liq
+++ b/libs/error.liq
@@ -2,6 +2,8 @@ let error.not_found = error.register("not_found")
 let error.assertion = error.register("assertion")
 let error.invalid = error.register("invalid")
 let error.eval = error.register("eval")
+let error.file = error.register("file")
+let error.socket = error.register("socket")
 
 # Ensure that a condition is satisfied (raise `error.assertion` exception
 # otherwise).

--- a/libs/file.liq
+++ b/libs/file.liq
@@ -2,7 +2,7 @@
 # done reading when function returns the empty string `""`.
 # @category File
 def file.read(fname) =
-  fd = file.open(read=true, write=false, fname)
+  fd = file.open(write=false, fname)
   is_done = ref(false)
   def read() =
     if !is_done then
@@ -28,7 +28,7 @@ let file.write = ()
 # @param ~perms Default file rights if created. Default: `0o644`.
 # @param path Path to write to
 def file.write.stream(~perms=0o644, ~append=false, path) =
-  fd = file.open(write=true, read=false, append=append, perms=perms, path)
+  fd = file.open(write=true, append=append, perms=perms, path)
   def write(s) =
     s = s ?? ""
     if s == "" then fd.close() else

--- a/libs/file.liq
+++ b/libs/file.liq
@@ -1,9 +1,62 @@
-# Error raised when a problem occurred when accessing files.
-# @category System
-let file.error = error.register("file")
+# Read the content of a file. Returns a function of type `()->string`. File is
+# done reading when function returns the empty string `""`.
+# @category File
+def file.read(fname) =
+  fd = file.fopen(read=true, write=false, fname)
+  is_done = ref(false)
+  def read() =
+    if !is_done then
+      ""
+    else
+      s = fd.read()
+      is_done := s == ""
+      if !is_done then
+        fd.close()
+      end
+      s
+    end
+  end
+  read
+end
 
+let file.write = ()
+
+# Stream data to a file. Returns a callback to write to the file. Execute
+# with `null` or `""` to signify the end of the writing operation.
+# @category File
+# @param ~append Append data if file exists.
+# @param ~perms Default file rights if created. Default: `0o644`.
+# @param path Path to write to
+def file.write.stream(~perms=0o644, ~append=false, path) =
+  fd = file.fopen(write=true, read=false, append=append, perms=perms, path)
+  def write(s) =
+    s = s ?? ""
+    if s == "" then fd.close() else
+      fd.write(s)
+    end
+  end
+  write
+end
+
+# Write data to a file.
+# @category File
+# @param ~data Data to write. If passing a callback `() -> string?`, the callback \
+#              must return `null` or `""` when it has finished sending all its data.
+# @param ~append Append data if file exists.
+# @param ~perms Default file rights if created. Default: `0o644`.
+# @param path Path to write to
+def replaces file.write(~data, ~perms=0o644, ~append=false, path) =
+  cb = file.write.stream(append=append, perms=perms, path)
+  def rec write() =
+    s = getter.get(data) ?? ""
+    cb(s)
+    if s != "" then write() end
+  end
+  write()
+end
+    
 # Read the whole contents of a file.
-# @category System
+# @category File
 def file.contents(fname) =
   fn = file.read(fname)
   def rec f(cur) =
@@ -18,19 +71,19 @@ def file.contents(fname) =
 end
 
 # Get the list of lines of a file.
-# @category System
+# @category File
 def file.lines(fname)
   r/\n/.split(file.contents(fname))
 end
 
 # Iterate over the lines of a file.
-# @category System
+# @category File
 def file.lines.iterator(fname)
   list.iterator(file.lines(fname))
 end
 
 # Iterate over the contents of a file.
-# @category System
+# @category File
 def file.iterator(fname)
   f = file.read(fname)
   fun () -> begin
@@ -40,13 +93,13 @@ def file.iterator(fname)
 end
 
 # Dummy implementation of file.mime
-# @category System
+# @category File
 def file.mime_default(_)
   ""
 end
 %ifdef file.mime
 # Alias of file.mime (because it is available)
-# @category System
+# @category File
 def file.mime_default(fname)
   file.mime(fname)
 end
@@ -55,7 +108,7 @@ end
 # Generic mime test. First try to use file.mime if it exist.  Otherwise try to
 # get the value using the file binary. Returns "" (empty string) if no value
 # can be found.
-# @category System
+# @category File
 # @param file The file to test
 def get_mime(fname) =
   def file_method(fname) =
@@ -76,7 +129,7 @@ def get_mime(fname) =
 end
 
 # Getter to the contents of a file.
-# @category System
+# @category File
 # @param fname Name of the file from which the contents should be taken.
 def file.getter(fname)
   contents = ref("")
@@ -89,7 +142,7 @@ def file.getter(fname)
 end
 
 # Float getter from a file.
-# @category System
+# @category File
 # @param fname Name of the file from which the contents should be taken.
 # @param ~default Default value when the file contains invalid data.
 def file.getter.float(~default=0., fname)

--- a/libs/file.liq
+++ b/libs/file.liq
@@ -2,7 +2,7 @@
 # done reading when function returns the empty string `""`.
 # @category File
 def file.read(fname) =
-  fd = file.fopen(read=true, write=false, fname)
+  fd = file.open(read=true, write=false, fname)
   is_done = ref(false)
   def read() =
     if !is_done then
@@ -28,7 +28,7 @@ let file.write = ()
 # @param ~perms Default file rights if created. Default: `0o644`.
 # @param path Path to write to
 def file.write.stream(~perms=0o644, ~append=false, path) =
-  fd = file.fopen(write=true, read=false, append=append, perms=perms, path)
+  fd = file.open(write=true, read=false, append=append, perms=perms, path)
   def write(s) =
     s = s ?? ""
     if s == "" then fd.close() else
@@ -50,7 +50,11 @@ def replaces file.write(~data, ~perms=0o644, ~append=false, path) =
   def rec write() =
     s = getter.get(data) ?? ""
     cb(s)
-    if s != "" then write() end
+    if getter.is_constant(data) then
+      cb("")
+    elsif s != "" then
+      write()
+    end
   end
   write()
 end

--- a/src/Makefile
+++ b/src/Makefile
@@ -210,7 +210,7 @@ synth = synth/keyboard.ml synth/synth_op.ml \
 	$(if $(W_SDL),synth/keyboard_sdl.ml)
 
 builtins = lang/lang_builtins.ml \
-           lang/builtins_ref.ml \
+           lang/builtins_ref.ml lang/builtins_socket.ml \
            lang/builtins_bool.ml lang/builtins_list.ml \
            lang/builtins_string.ml lang/builtins_regexp.ml lang/builtins_json.ml \
            lang/builtins_request.ml lang/builtins_error.ml \

--- a/src/lang/builtins_files.ml
+++ b/src/lang/builtins_files.ml
@@ -147,130 +147,68 @@ let () =
       Lang.bool (try Sys.is_directory f with Sys_error _ -> false))
 
 let () =
-  Lang.add_builtin "file.read" ~category:`File [("", Lang.string_t, None, None)]
-    (Lang.fun_t [] Lang.string_t)
-    ~descr:
-      "Read the content of a file. Returns a function of type `()->string`. \
-       File is done reading when function returns the empty string `\"\"`."
-    (fun p ->
-      let f = Lang.to_string (List.assoc "" p) in
-      let mk_fn fn = Lang.val_fun [] (fun _ -> Lang.string (fn ())) in
-      try
-        let ic = ref (Some (open_in_bin f)) in
-        let buflen = Utils.pagesize in
-        let buf = Bytes.create buflen in
-        let fn () =
-          match !ic with
-            | Some c ->
-                let n = input c buf 0 buflen in
-                if n = 0 then (
-                  close_in c;
-                  ic := None);
-                Bytes.sub_string buf 0 n
-            | None -> ""
-        in
-        mk_fn fn
-      with e ->
-        let message =
-          Printf.sprintf "The file %s could not be read: %s" f
-            (Printexc.to_string e)
-        in
-        Lang.error ~message "file")
-
-let () =
-  Lang.add_builtin "file.write" ~category:`File
+  Lang.add_builtin "file.fopen" ~category:`File
     [
-      ( "data",
-        Lang.getter_t (Lang.nullable_t Lang.string_t),
-        None,
-        Some
-          "Data to write. If passing a callback `() -> string?`, the callback \
-           must return `null` when it has finished sending all its data." );
+      ("read", Lang.bool_t, Some (Lang.bool true), Some "Open file for reading");
+      ( "write",
+        Lang.bool_t,
+        Some (Lang.bool true),
+        Some "Open filet for writing" );
+      ( "truncate",
+        Lang.bool_t,
+        Some (Lang.bool false),
+        Some "Truncate to 0 length if existing" );
       ( "append",
         Lang.bool_t,
         Some (Lang.bool false),
         Some "Append data if file exists." );
-      ( "perms",
-        Lang.int_t,
-        Some (Lang.int 0o644),
-        Some "Default file rights if created" );
-      ("", Lang.string_t, None, Some "Path to write to");
-    ]
-    Lang.unit_t ~descr:"Write data to a file."
-    (fun p ->
-      let data =
-        let data = List.assoc "data" p in
-        match (Lang.demeth data).Lang.value with
-          | Lang.Ground (Lang.Ground.String s) ->
-              let is_done = ref false in
-              fun () ->
-                if not !is_done then (
-                  is_done := true;
-                  Lang.string s)
-                else Lang.null
-          | _ -> Lang.to_getter data
-      in
-      let append = Lang.to_bool (List.assoc "append" p) in
-      let perms = Lang.to_int (List.assoc "perms" p) in
-      let f = Lang.to_string (List.assoc "" p) in
-      let flag = if append then Open_append else Open_trunc in
-      let flags = [flag; Open_wronly; Open_creat; Open_binary] in
-      try
-        let oc = open_out_gen flags perms f in
-        let rec f () =
-          match Lang.to_option (data ()) with
-            | None -> ()
-            | Some data ->
-                output_string oc (Lang.to_string data);
-                f ()
-        in
-        f ();
-        close_out oc;
-        Lang.unit
-      with e ->
-        let message =
-          Printf.sprintf "The file %s could not be written: %s" f
-            (Printexc.to_string e)
-        in
-        Lang.error ~message "file")
-
-let () =
-  Lang.add_builtin "file.write.stream" ~category:`File
-    [
-      ( "append",
+      ( "non_blocking",
         Lang.bool_t,
         Some (Lang.bool false),
-        Some "Append data if file exists." );
+        Some "Open in non-blocking mode." );
       ( "perms",
         Lang.int_t,
         Some (Lang.int 0o644),
-        Some "Default file rights if created" );
-      ("", Lang.string_t, None, Some "Path to write to");
+        Some "Default file rights if created. Default: `0o644`" );
+      ("", Lang.string_t, None, None);
     ]
-    (Lang.fun_t [(false, "", Lang.nullable_t Lang.string_t)] Lang.unit_t)
-    ~descr:
-      "Stream data to a file. Returns a callback to write to the file. Execute \
-       with `null` to signify the end of the writing operation."
+    Builtins_socket.SocketValue.t ~descr:"Open a file."
     (fun p ->
-      let append = Lang.to_bool (List.assoc "append" p) in
-      let perms = Lang.to_int (List.assoc "perms" p) in
-      let f = Lang.to_string (List.assoc "" p) in
-      let flag = if append then Open_append else Open_trunc in
-      let flags = [flag; Open_wronly; Open_creat; Open_binary] in
-      let oc =
-        try open_out_gen flags perms f
-        with e ->
-          let message =
-            Printf.sprintf "The file %s could not be opened: %s" f
-              (Printexc.to_string e)
-          in
-          Lang.error ~message "file"
+      let read = Lang.to_bool (List.assoc "read" p) in
+      let write = Lang.to_bool (List.assoc "write" p) in
+      let read_flag =
+        match (read, write) with
+          | true, false -> Unix.O_RDONLY
+          | false, true -> Unix.O_WRONLY
+          | true, true -> Unix.O_RDWR
+          | false, false ->
+              Runtime_error.error
+                ~message:
+                  "At least one of: `read` or `write` must be `true` when \
+                   opening a file!"
+                "file"
       in
-      Lang.val_fun [("", "", None)] (fun p ->
-          (match Lang.to_option (List.assoc "" p) with
-            | None -> close_out oc
-            | Some s -> output_string oc (Lang.to_string s));
-          Lang.unit))
+      let flags =
+        [
+          ("truncate", Unix.O_TRUNC);
+          ("append", Unix.O_APPEND);
+          ("non_blocking", Unix.O_NONBLOCK);
+        ]
+      in
+      let flags =
+        List.fold_left
+          (fun flags (name, flag) ->
+            if Lang.to_bool (List.assoc name p) then flag :: flags else flags)
+          [read_flag] flags
+      in
+      let file_perms = Lang.to_int (List.assoc "perms" p) in
+      let path = Utils.home_unrelate (Lang.to_string (List.assoc "" p)) in
+      try
+        Builtins_socket.SocketValue.to_value
+          (Unix.openfile path flags file_perms)
+      with exn ->
+        let bt = Printexc.get_raw_backtrace () in
+        Lang.raise_as_runtime ~bt ~kind:"file" exn)
 
 let () =
   Lang.add_builtin "file.watch" ~category:`File

--- a/src/lang/builtins_files.ml
+++ b/src/lang/builtins_files.ml
@@ -147,7 +147,7 @@ let () =
       Lang.bool (try Sys.is_directory f with Sys_error _ -> false))
 
 let () =
-  Lang.add_builtin "file.fopen" ~category:`File
+  Lang.add_builtin "file.open" ~category:`File
     [
       ("read", Lang.bool_t, Some (Lang.bool true), Some "Open file for reading");
       ( "write",
@@ -158,6 +158,10 @@ let () =
         Lang.bool_t,
         Some (Lang.bool false),
         Some "Truncate to 0 length if existing" );
+      ( "create",
+        Lang.bool_t,
+        Some (Lang.bool true),
+        Some "Create if nonexistent" );
       ( "append",
         Lang.bool_t,
         Some (Lang.bool false),
@@ -192,6 +196,7 @@ let () =
         [
           ("truncate", Unix.O_TRUNC);
           ("append", Unix.O_APPEND);
+          ("create", Unix.O_CREAT);
           ("non_blocking", Unix.O_NONBLOCK);
         ]
       in

--- a/src/lang/builtins_socket.ml
+++ b/src/lang/builtins_socket.ml
@@ -25,7 +25,17 @@ module SocketValue = struct
     type content = Unix.file_descr
 
     let name = "socket"
-    let to_json ~compact:_ ~json5:_ _ = "<socket>"
+
+    let to_json _ =
+      raise
+        Runtime_error.(
+          Runtime_error
+            {
+              kind = "json";
+              msg = "Socket cannot be represented as json";
+              pos = [];
+            })
+
     let descr _ = "<socket>"
     let compare = Stdlib.compare
   end)
@@ -50,9 +60,9 @@ module SocketValue = struct
         "Read data from a socket. Reading is done when the function returns an \
          empty srring `\"\"`.",
         fun fd ->
+          let buflen = Utils.pagesize in
+          let buf = Bytes.create buflen in
           Lang.val_fun [] (fun _ ->
-              let buflen = Utils.pagesize in
-              let buf = Bytes.create buflen in
               try
                 let ic = Unix.in_channel_of_descr fd in
                 let n = input ic buf 0 buflen in

--- a/src/lang/builtins_socket.ml
+++ b/src/lang/builtins_socket.ml
@@ -1,0 +1,84 @@
+(*****************************************************************************
+
+  Liquidsoap, a programmable audio stream generator.
+  Copyright 2003-2021 Savonet team
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details, fully stated in the COPYING
+  file at the root of the liquidsoap distribution.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA
+
+ *****************************************************************************)
+
+module SocketValue = struct
+  include Value.MkAbstract (struct
+    type content = Unix.file_descr
+
+    let name = "socket"
+    let to_json ~compact:_ ~json5:_ _ = "<socket>"
+    let descr _ = "<socket>"
+    let compare = Stdlib.compare
+  end)
+
+  let meths =
+    [
+      ( "write",
+        ([], Lang.fun_t [(false, "", Lang.string_t)] Lang.unit_t),
+        "Write data to a socket",
+        fun fd ->
+          Lang.val_fun [("", "", None)] (fun p ->
+              let data = Lang.to_string (List.assoc "" p) in
+              try
+                let oc = Unix.out_channel_of_descr fd in
+                output_string oc data;
+                Lang.unit
+              with exn ->
+                let bt = Printexc.get_raw_backtrace () in
+                Lang.raise_as_runtime ~bt ~kind:"socket" exn) );
+      ( "read",
+        ([], Lang.fun_t [] Lang.string_t),
+        "Read data from a socket. Reading is done when the function returns an \
+         empty srring `\"\"`.",
+        fun fd ->
+          Lang.val_fun [] (fun _ ->
+              let buflen = Utils.pagesize in
+              let buf = Bytes.create buflen in
+              try
+                let ic = Unix.in_channel_of_descr fd in
+                let n = input ic buf 0 buflen in
+                Lang.string (Bytes.sub_string buf 0 n)
+              with exn ->
+                let bt = Printexc.get_raw_backtrace () in
+                Lang.raise_as_runtime ~bt ~kind:"socket" exn) );
+      ( "close",
+        ([], Lang.fun_t [] Lang.unit_t),
+        "Close the socket.",
+        fun fd ->
+          Lang.val_fun [] (fun _ ->
+              try
+                Unix.close fd;
+                Lang.unit
+              with exn ->
+                let bt = Printexc.get_raw_backtrace () in
+                Lang.raise_as_runtime ~bt ~kind:"socket" exn) );
+    ]
+
+  let t =
+    Lang.method_t t (List.map (fun (lbl, t, descr, _) -> (lbl, t, descr)) meths)
+
+  let to_value err =
+    Lang.meth (to_value err)
+      (List.map (fun (lbl, _, _, m) -> (lbl, m err)) meths)
+
+  let of_value err = of_value (Lang.demeth err)
+end

--- a/src/lang/lexer.ml
+++ b/src/lang/lexer.ml
@@ -205,6 +205,16 @@ let rec token lexbuf =
         let e = Sedlexing.Utf8.lexeme lexbuf in
         let e = String.sub e 1 (String.length e - 1) in
         ENCODER e
+    | '.', Star skipped, var ->
+        let m = Sedlexing.Utf8.lexeme lexbuf in
+        let lexbuf = Sedlexing.Utf8.from_string m in
+        let rec f () =
+          match%sedlex lexbuf with
+            | '.', Star skipped -> f ()
+            | var -> DOTVAR (Sedlexing.Utf8.lexeme lexbuf)
+            | _ -> assert false
+        in
+        f ()
     | '.' -> DOT
     | "..." -> DOTDOTDOT
     | '[' -> LBRA

--- a/src/lang/parser.mly
+++ b/src/lang/parser.mly
@@ -50,6 +50,7 @@ open Parser_helper
 %token SLASH
 %token OPEN
 %token LPAR RPAR COMMA SEQ SEQSEQ COLON COLONCOLON DOT
+%token <string> DOTVAR
 %token LBRA RBRA LCUR RCUR
 %token FUN YIELDS
 %token DOTDOTDOT

--- a/tests/language/file.liq
+++ b/tests/language/file.liq
@@ -2,22 +2,13 @@
 
 %include "test.liq"
   
-success = ref(true)
-
-def t(x, y)
-  if x != y then
-    print("Failure: got #{x} instead of #{y}")
-    success := false
-  end
-end
-  
 def f() =
   try
     ignore(file.read("mqlskjdfdjnsi"))
-    success := false
-  catch e : [file.error] do () end
-  
-  if !success then test.pass() else test.fail() end
+    test.fail()
+  catch e : [error.file] do
+    test.pass()
+  end
 end
 
 test.check(f)


### PR DESCRIPTION
This PR adds a socket API and uses it to export file read/write operations to the scripting library.

At the moment, only files are covered but more could be added. Sockets are ground-type values with `read`/`write`/`close` methods.