### PR TITLE
Add optional `start` option to unknown clocks

### DIFF
--- a/src/clock.ml
+++ b/src/clock.ml
@@ -135,10 +135,13 @@ let sync_descr = function
   | `CPU -> "CPU sync"
   | `None -> "no sync"
 
-class clock ?(start = true) ?(sync = `Auto) id =
+class clock ?start ?(sync = `Auto) id =
   object (self)
     initializer Clocks.add clocks (self :> Source.clock)
     method id = id
+    val mutable start = start
+    method start = start
+    method set_start b = start <- Some b
     method sync_mode : Source.sync = sync
     val log = Log.make ["clock"; id]
 
@@ -398,7 +401,7 @@ class clock ?(start = true) ?(sync = `Auto) id =
           log#info "Stopping %d sources..." (List.length leaving);
           List.iter (fun (s : active_source) -> leave s) leaving);
         if
-          start
+          Option.value ~default:true start
           && List.exists (function `Active, _ -> true | _ -> false) outputs
         then
           do_running (fun () ->

--- a/src/clock.mli
+++ b/src/clock.mli
@@ -159,8 +159,10 @@ type clock_variable = Source.clock_variable
 val to_string : clock_variable -> string
 
 val create_unknown :
+  ?start:bool ->
   sources:Source.active_source list ->
   sub_clocks:clock_variable list ->
+  unit ->
   clock_variable
 
 val create_known : clock -> clock_variable

--- a/src/source.mli
+++ b/src/source.mli
@@ -281,6 +281,8 @@ class type clock =
     method id : string
 
     method sync_mode : sync
+    method start : bool option
+    method set_start : bool -> unit
 
     (** Attach an active source to the clock. *)
     method attach : active_source -> unit
@@ -308,8 +310,10 @@ module Clock_variables : sig
   val to_string : clock_variable -> string
 
   val create_unknown :
+    ?start:bool ->
     sources:active_source list ->
     sub_clocks:clock_variable list ->
+    unit ->
     clock_variable
 
   val create_known : clock -> clock_variable

--- a/src/sources/bjack_in.ml
+++ b/src/sources/bjack_in.ml
@@ -36,7 +36,7 @@ class jack_in ~kind ~clock_safe ~on_start ~on_stop ~fallible ~autostart
     inherit
       Start_stop.active_source
         ~name:"input.jack" ~content_kind:kind ~clock_safe ~on_start ~on_stop
-          ~fallible ~autostart () as active_source
+          ~get_clock:bjack_clock ~fallible ~autostart () as active_source
 
     inherit [Bytes.t] IoRing.input ~nb_blocks as ioring
 

--- a/src/test/source_test.ml
+++ b/src/test/source_test.ml
@@ -3,9 +3,9 @@ open Source.Clock_variables
 (* Reference: https://github.com/savonet/liquidsoap/pull/1272 *)
 
 let () =
-  let c1 = create_unknown ~sources:[] ~sub_clocks:[] in
-  let c2 = create_unknown ~sources:[] ~sub_clocks:[c1] in
-  let c3 = create_unknown ~sources:[] ~sub_clocks:[c1] in
+  let c1 = create_unknown ~sources:[] ~sub_clocks:[] () in
+  let c2 = create_unknown ~sources:[] ~sub_clocks:[c1] () in
+  let c3 = create_unknown ~sources:[] ~sub_clocks:[c1] () in
   (* Make sure unification of a variable with itself
      works as expected. *)
   unify c2 c2;

--- a/src/tools/child_support.ml
+++ b/src/tools/child_support.ml
@@ -53,14 +53,18 @@ class virtual base ~check_self_sync children_val =
 
     method private set_clock =
       child_clock <-
-        Some
-          (Clock.create_known
-             (new Clock.clock ~start:false (Printf.sprintf "%s.child" self#id)));
+        Some (Clock.create_unknown ~start:false ~sources:[] ~sub_clocks:[] ());
 
       Clock.unify self#clock
-        (Clock.create_unknown ~sources:[] ~sub_clocks:[self#child_clock]);
+        (Clock.create_unknown ~sources:[] ~sub_clocks:[self#child_clock] ());
 
       List.iter (fun c -> Clock.unify self#child_clock c#clock) children;
+
+      if not (Source.Clock_variables.is_known self#child_clock) then (
+        let c =
+          new Clock.clock ~start:false (Printf.sprintf "%s.child" self#id)
+        in
+        Clock.unify (Clock.create_known c) self#child_clock);
 
       Gc.finalise (finalise_child_clock self#child_clock) self
 


### PR DESCRIPTION
_Unknown clocks_ are variables used during clock unification to hold that a source does not yet have a clock assigned to it. Opposite to that is a _known clock_, which is an instantiated clock.

In `Child_support`, we create a situation wherein a parent clock animates its child clock depending on its own activity. In the original implementation, we decided to attach a known source to the children, created with a `start=false` option to prevent it from starting its own streaming loop.

However, this creates situations where the children cannot be sources that already have another known clock assigned to them, for instance `input.jack` while, in fact, all we care about is that _which ever clock gets assigned to the children, it should not start its own streaming loop_.

Therefore, in the PR, we change the implementation to pass around a `start` option to unknown clocks and use it during unification to force the `start` parameter on known clocks.

Although this is a pretty significant change, I would like to consider it for inclusion to `2.0.1`.