### PR TITLE
Cleanup utf8 parsing after JSON changes.

### DIFF
--- a/src/tools/utils.ml
+++ b/src/tools/utils.ml
@@ -133,6 +133,7 @@ let escape ~special_char ~next ~escape_char f s =
   let len = String.length s in
   let rec f pos =
     let new_pos = next s (pos : int) in
+    if len < new_pos then failwith "String parsing failed!";
     let s = String.sub s pos (new_pos - pos) in
     if special_char s then out (escape_char s) else out s;
     if new_pos < len then f new_pos
@@ -145,7 +146,7 @@ let utf8_next s i =
     | '\192' .. '\223' -> i + 2
     | '\224' .. '\239' -> i + 3
     | '\240' .. '\247' -> i + 4
-    | _ -> i + 1
+    | _ -> failwith "invalid utf8"
 
 (* Return the utf8 char code of the first utf8 character in the given
    string. *)
@@ -207,9 +208,6 @@ let escape_char ~escape_fun = function
   | c -> escape_fun c
 
 let escape_utf8_char =
-  let utf8_char_code s =
-    try utf8_char_code s with _ -> Uchar.to_int Uchar.rep
-  in
   escape_char ~escape_fun:(fun s -> Printf.sprintf "\\u%04X" (utf8_char_code s))
 
 let escape_utf8_formatter =


### PR DESCRIPTION
With the recent JSON changes, utf8 escaping was changed to use `Uchar.rep` when a character wasn't representable as utf8, to accommodate some weird JSON input data.

However, internally, we should really be strict on utf8 escaping and only use degraded output when necessary so we can guarantee that escaped strings can be unescaped back to their original values. 

This is particularly relevant outside of JSON specs. JSON string specs only recognize utf8 escape characters so we do have to resort to `Uchar.rep` when a character cannot be represented as utf8. However, with many other specs, we can still use the ascii escaping representation.

Therefore, we _do_ want the default utf8 escaping to raise exceptions when it fails so it can be caught and we can fallback to ascii escaping/quoting when acceptable.

This PR reverts it to this behavior by implementing a dedicated escaping function specific to JSON rendering.