### PR TITLE
Split out repr and rename print to to_string.

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -250,7 +250,8 @@ liquidsoap_sources= \
 	$(if $(W_ALSA), alsa_settings.ml)
 
 liquidsoap_sources += \
-	lang/type.ml lang/typing.ml lang/profiler.ml lang/term.ml lang/value.ml \
+	lang/type.ml lang/repr.ml lang/typing.ml \
+	lang/profiler.ml lang/term.ml lang/value.ml \
 	lang/lang_encoder.ml $(lang_encoders) \
 	lang/environment.ml lang/typechecking.ml \
 	lang/evaluation.ml lang/error.ml lang/documentation.ml \

--- a/src/lang/error.ml
+++ b/src/lang/error.ml
@@ -30,14 +30,14 @@ exception Kind_conflict of (Type.pos option * string * string)
 let () =
   Printexc.register_printer (function
     | Clock_conflict (pos, a, b) ->
-        let pos = Type.string_of_pos_opt pos in
+        let pos = Repr.string_of_pos_opt pos in
         Some
           (Printf.sprintf
              "Clock_conflict: At position: %s, a source cannot belong to two \
               clocks (%s, %s)"
              pos a b)
     | Clock_loop (pos, a, b) ->
-        let pos = Type.string_of_pos_opt pos in
+        let pos = Repr.string_of_pos_opt pos in
         Some
           (Printf.sprintf
              "Clock_loop: At position: %s, cannot unify two nested clocks \

--- a/src/lang/error.ml
+++ b/src/lang/error.ml
@@ -30,14 +30,14 @@ exception Kind_conflict of (Type.pos option * string * string)
 let () =
   Printexc.register_printer (function
     | Clock_conflict (pos, a, b) ->
-        let pos = Type.print_pos_opt pos in
+        let pos = Type.string_of_pos_opt pos in
         Some
           (Printf.sprintf
              "Clock_conflict: At position: %s, a source cannot belong to two \
               clocks (%s, %s)"
              pos a b)
     | Clock_loop (pos, a, b) ->
-        let pos = Type.print_pos_opt pos in
+        let pos = Type.string_of_pos_opt pos in
         Some
           (Printf.sprintf
              "Clock_loop: At position: %s, cannot unify two nested clocks \

--- a/src/lang/evaluation.ml
+++ b/src/lang/evaluation.ml
@@ -415,7 +415,7 @@ let toplevel_add (doc, params, methods) pat ~t v =
     (fun (s, _) ->
       Printf.eprintf "WARNING: Unused @param %S for %s %s\n" s
         (string_of_pat pat)
-        (Type.string_of_pos_opt v.Value.pos))
+        (Repr.string_of_pos_opt v.Value.pos))
     params;
   (let meths, t =
      let meths, t = Type.split_meths t in

--- a/src/lang/lang.ml
+++ b/src/lang/lang.ml
@@ -178,7 +178,7 @@ type proto = (string * t * value option * string option) list
 let doc_of_prototype_item ~generalized t d doc =
   let doc = match doc with None -> "(no doc)" | Some d -> d in
   let item = new Doc.item doc in
-  item#add_subsection "type" (Type.doc_of_type ~generalized t);
+  item#add_subsection "type" (Repr.doc_of_type ~generalized t);
   item#add_subsection "default"
     (match d with
       | None -> Doc.trivial "None"
@@ -196,12 +196,12 @@ let to_plugin_doc category flags main_doc proto return_t =
   let generalized = Type.filter_vars (fun _ -> true) t in
   item#add_subsection "_category"
     (Doc.trivial (Documentation.string_of_category category));
-  item#add_subsection "_type" (Type.doc_of_type ~generalized t);
+  item#add_subsection "_type" (Repr.doc_of_type ~generalized t);
   List.iter
     (fun f ->
       item#add_subsection "_flag" (Doc.trivial (Documentation.string_of_flag f)))
     flags;
-  if meths <> [] then item#add_subsection "_methods" (Type.doc_of_meths meths);
+  if meths <> [] then item#add_subsection "_methods" (Repr.doc_of_meths meths);
   List.iter
     (fun (l, t, d, doc) ->
       item#add_subsection
@@ -246,7 +246,7 @@ let add_builtin_base ~category ~descr ?(flags = []) name value t =
   let generalized = Type.filter_vars (fun _ -> true) t in
   doc#add_subsection "_category"
     (Doc.trivial (Documentation.string_of_category category));
-  doc#add_subsection "_type" (Type.doc_of_type ~generalized t);
+  doc#add_subsection "_type" (Repr.doc_of_type ~generalized t);
   List.iter
     (fun f ->
       doc#add_subsection "_flag" (Doc.trivial (Documentation.string_of_flag f)))

--- a/src/lang/lang_encoder.ml
+++ b/src/lang/lang_encoder.ml
@@ -96,4 +96,5 @@ let make_encoder ~pos t ((e, p) : Value.encoder) =
     let (_ : Encoder.factory) = Encoder.get_factory e in
     e
   with Not_found ->
-    raise (error ~pos (Printf.sprintf "unsupported format: %s" (Term.print t)))
+    raise
+      (error ~pos (Printf.sprintf "unsupported format: %s" (Term.to_string t)))

--- a/src/lang/lexer.ml
+++ b/src/lang/lexer.ml
@@ -383,7 +383,7 @@ and read_string c pos buf lexbuf =
     | '\\', '\n', Star skipped -> read_string c pos buf lexbuf
     | '\\', any ->
         if c <> '/' then (
-          let pos = Type.string_of_single_pos pos in
+          let pos = Repr.string_of_single_pos pos in
           Printf.printf
             "Warning at position %s: illegal backslash escape in string.\n" pos);
         Buffer.add_string buf (Sedlexing.Utf8.lexeme lexbuf);

--- a/src/lang/lexer.ml
+++ b/src/lang/lexer.ml
@@ -383,7 +383,7 @@ and read_string c pos buf lexbuf =
     | '\\', '\n', Star skipped -> read_string c pos buf lexbuf
     | '\\', any ->
         if c <> '/' then (
-          let pos = Type.print_single_pos pos in
+          let pos = Type.string_of_single_pos pos in
           Printf.printf
             "Warning at position %s: illegal backslash escape in string.\n" pos);
         Buffer.add_string buf (Sedlexing.Utf8.lexeme lexbuf);

--- a/src/lang/parser_helper.ml
+++ b/src/lang/parser_helper.ml
@@ -90,7 +90,7 @@ let args_of, app_of =
                    Printf.sprintf
                      "Cannot get argument type of %s, this is not a function, \
                       it has type: %s."
-                     name (Type.print t) ))
+                     name (Type.to_string t) ))
     in
     List.map
       (fun (n, n', v) ->

--- a/src/lang/repr.ml
+++ b/src/lang/repr.ml
@@ -27,6 +27,11 @@ let show_record_schemes = ref true
 
 open Type
 
+let string_of_single_pos = Runtime_error.print_single_pos
+let string_of_pos = Runtime_error.print_pos
+let string_of_pos_opt = Runtime_error.print_pos_opt
+let string_of_pos_list = Runtime_error.print_pos_list
+
 type t =
   [ `Constr of string * (variance * t) list
   | `Ground of ground

--- a/src/lang/repr.ml
+++ b/src/lang/repr.ml
@@ -1,0 +1,465 @@
+(*****************************************************************************
+
+  Liquidsoap, a programmable audio stream generator.
+  Copyright 2003-2021 Savonet team
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details, fully stated in the COPYING
+  file at the root of the liquidsoap distribution.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA
+
+ *****************************************************************************)
+
+(** User-friendly representation of types. *)
+
+(** Show generalized variables in records. *)
+let show_record_schemes = ref true
+
+open Type
+
+type t =
+  [ `Constr of string * (variance * t) list
+  | `Ground of ground
+  | `List of t
+  | `Tuple of t list
+  | `Nullable of t
+  | `Meth of string * (var list * t) * t
+  | `Arrow of (bool * string * t) list * t
+  | `Getter of t
+  | `EVar of var (* existential variable *)
+  | `UVar of var (* universal variable *)
+  | `Ellipsis (* omitted sub-term *)
+  | `Range_Ellipsis (* omitted sub-terms (in a list, e.g. list of args) *)
+  | `Debug of
+    string * t * string
+    (* add annotations before / after, mostly used for debugging *) ]
+
+and var = string * constraints
+
+(** Given a strictly positive integer, generate a name in [a-z]+:
+    a, b, ... z, aa, ab, ... az, ba, ... *)
+let name =
+  let base = 26 in
+  let c i = char_of_int (int_of_char 'a' + i - 1) in
+  let add i suffix = Printf.sprintf "%c%s" (c i) suffix in
+  let rec n suffix i =
+    if i <= base then add i suffix
+    else (
+      let head = i mod base in
+      let head = if head = 0 then base else head in
+      n (add head suffix) ((i - head) / base))
+  in
+  n ""
+
+(** Generate a globally unique name for evars (used for debugging only). *)
+let evar_global_name =
+  let evars = Hashtbl.create 10 in
+  let n = ref (-1) in
+  fun i ->
+    try Hashtbl.find evars i
+    with Not_found ->
+      incr n;
+      let name = String.uppercase_ascii (name !n) in
+      Hashtbl.add evars i name;
+      name
+
+(** Compute the structure that a term represents, given the list of universally
+    quantified variables. Also takes care of computing the printing name of
+    variables, including constraint symbols, which are removed from constraint
+    lists. It supports a mechanism for filtering out parts of the type, which are
+    then translated as `Ellipsis. *)
+let make ?(filter_out = fun _ -> false) ?(generalized = []) t : t =
+  let split_constr c =
+    List.fold_left (fun (s, constraints) c -> (s, c :: constraints)) ("", []) c
+  in
+  let uvar g var =
+    let constr_symbols, c = split_constr var.constraints in
+    let rec index n = function
+      | v :: tl ->
+          if var_eq v var then Printf.sprintf "'%s%s" constr_symbols (name n)
+          else index (n + 1) tl
+      | [] -> assert false
+    in
+    let v = index 1 (List.rev g) in
+    (* let v = Printf.sprintf "'%d" i in *)
+    `UVar (v, c)
+  in
+  let counter =
+    let c = ref 0 in
+    fun () ->
+      incr c;
+      !c
+  in
+  let evars = Hashtbl.create 10 in
+  let evar var =
+    let constr_symbols, c = split_constr var.constraints in
+    if !debug then (
+      let v =
+        Printf.sprintf "'%s%s" constr_symbols (evar_global_name var.name)
+      in
+      let v =
+        if !debug_levels then (
+          let level = var.level in
+          let level = if level = max_int then "∞" else string_of_int level in
+          Printf.sprintf "%s[%s]" v level)
+        else v
+      in
+      `EVar (v, c))
+    else (
+      let s =
+        try Hashtbl.find evars var.name
+        with Not_found ->
+          let name = String.uppercase_ascii (name (counter ())) in
+          Hashtbl.add evars var.name name;
+          name
+      in
+      `EVar (Printf.sprintf "'%s%s" constr_symbols s, c))
+  in
+  let rec repr g t =
+    if filter_out t then `Ellipsis
+    else (
+      match t.descr with
+        | Ground g -> `Ground g
+        | Getter t -> `Getter (repr g t)
+        | List { t } -> `List (repr g t)
+        | Tuple l -> `Tuple (List.map (repr g) l)
+        | Nullable t -> `Nullable (repr g t)
+        | Meth ({ meth = l; scheme = g', u }, v) ->
+            let gen =
+              List.map
+                (fun v -> match uvar (g' @ g) v with `UVar v -> v)
+                (List.sort_uniq compare g')
+            in
+            `Meth (l, (gen, repr (g' @ g) u), repr g v)
+        | Constr { constructor; params } ->
+            `Constr (constructor, List.map (fun (l, t) -> (l, repr g t)) params)
+        | Arrow (args, t) ->
+            `Arrow
+              ( List.map (fun (opt, lbl, t) -> (opt, lbl, repr g t)) args,
+                repr g t )
+        | Var { contents = Free var } ->
+            if List.exists (var_eq var) g then uvar g var else evar var
+        | Var { contents = Link (Covariant, t) } when !debug ->
+            `Debug ("[>", repr g t, "]")
+        | Var { contents = Link (_, t) } -> repr g t)
+  in
+  repr generalized t
+
+(** Sets of type descriptions. *)
+module DS = Set.Make (struct
+  type t = string * constraints
+
+  let compare = compare
+end)
+
+(** Print a type representation. Unless in debug mode, variable identifiers are
+    not shown, and variable names are generated. Names are only meaningful over
+    one printing, as they are re-used. *)
+let print f t =
+  (* Display the type and return the list of variables that occur in it.
+   * The [par] params tells whether (..)->.. should be surrounded by
+   * parenthesis or not. *)
+  let rec print ~par vars : t -> DS.t = function
+    | `Constr ("stream_kind", params) -> (
+        (* Let's assume that stream_kind occurs only inside a source
+         * or format type -- this should be pretty much true with the
+         * current API -- and simplify the printing by labeling its
+         * parameters and omitting the stream_kind(...) to avoid
+         * source(stream_kind(pcm(stereo),none,none)). *)
+        match params with
+          | [(_, a); (_, v); (_, m)] ->
+              let first, has_ellipsis, vars =
+                List.fold_left
+                  (fun (first, has_ellipsis, vars) (lbl, t) ->
+                    if t = `Ellipsis then (false, true, vars)
+                    else (
+                      if not first then Format.fprintf f ",@ ";
+                      Format.fprintf f "%s=" lbl;
+                      let vars = print ~par:false vars t in
+                      (false, has_ellipsis, vars)))
+                  (true, false, vars)
+                  [("audio", a); ("video", v); ("midi", m)]
+              in
+              if not has_ellipsis then vars
+              else (
+                if not first then Format.fprintf f ",@,";
+                print ~par:false vars `Range_Ellipsis)
+          | _ -> assert false)
+    | `Constr ("none", _) ->
+        Format.fprintf f "none";
+        vars
+    | `Constr (_, [(_, `Ground (Format format))]) ->
+        Format.fprintf f "%s" (Frame_content.string_of_format format);
+        vars
+    | `Constr (name, params) ->
+        Format.open_box (1 + String.length name);
+        Format.fprintf f "%s(" name;
+        let vars = print_list vars params in
+        Format.fprintf f ")";
+        Format.close_box ();
+        vars
+    | `Ground g ->
+        Format.fprintf f "%s" (string_of_ground g);
+        vars
+    | `Tuple [] ->
+        Format.fprintf f "unit";
+        vars
+    | `Tuple l ->
+        if par then Format.fprintf f "@[<1>(" else Format.fprintf f "@[<0>";
+        let rec aux vars = function
+          | [a] -> print ~par:true vars a
+          | a :: l ->
+              let vars = print ~par:true vars a in
+              Format.fprintf f " *@ ";
+              aux vars l
+          | [] -> assert false
+        in
+        let vars = aux vars l in
+        if par then Format.fprintf f ")@]" else Format.fprintf f "@]";
+        vars
+    | `Nullable t ->
+        let vars = print ~par:true vars t in
+        Format.fprintf f "?";
+        vars
+    | `Meth (l, (_, a), b) as t ->
+        if not !debug then (
+          (* Find all methods. *)
+          let rec aux = function
+            | `Meth (l, t, u) ->
+                let m, u = aux u in
+                ((l, t) :: m, u)
+            | u -> ([], u)
+          in
+          let m, t = aux t in
+          (* Filter out duplicates. *)
+          let rec aux = function
+            | (l, t) :: m ->
+                (l, t) :: aux (List.filter (fun (l', _) -> l <> l') m)
+            | [] -> []
+          in
+          let m = aux m in
+          (* Put latest addition last. *)
+          let m = List.rev m in
+          (* First print the main value. *)
+          let vars =
+            if t = `Tuple [] then (
+              Format.fprintf f "@,@[<hv 2>{@,";
+              vars)
+            else (
+              let vars = print ~par:true vars t in
+              Format.fprintf f "@,@[<hv 2>.{@,";
+              vars)
+          in
+          let vars =
+            if m = [] then vars
+            else (
+              let rec gen = function
+                | (x, _) :: g -> x ^ "." ^ gen g
+                | [] -> ""
+              in
+              let gen g =
+                if !show_record_schemes then gen (List.sort compare g) else ""
+              in
+              let rec aux vars = function
+                | [(l, (g, t))] ->
+                    Format.fprintf f "%s : %s" l (gen g);
+                    print ~par:true vars t
+                | (l, (g, t)) :: m ->
+                    Format.fprintf f "%s : %s" l (gen g);
+                    let vars = print ~par:false vars t in
+                    Format.fprintf f ",@ ";
+                    aux vars m
+                | [] -> assert false
+              in
+              aux vars m)
+          in
+          Format.fprintf f "@]@,}";
+          vars)
+        else (
+          let vars = print ~par:true vars b in
+          Format.fprintf f ".{%s = " l;
+          let vars = print ~par:false vars a in
+          Format.fprintf f "}";
+          vars)
+    | `List t ->
+        Format.fprintf f "@[<1>[";
+        let vars = print ~par:false vars t in
+        Format.fprintf f "]@]";
+        vars
+    | `Getter t ->
+        Format.fprintf f "{";
+        let vars = print ~par:false vars t in
+        Format.fprintf f "}";
+        vars
+    | `EVar (a, [InternalMedia]) ->
+        Format.fprintf f "?internal(%s)" a;
+        vars
+    | `UVar (a, [InternalMedia]) ->
+        Format.fprintf f "internal(%s)" a;
+        vars
+    | `EVar (name, c) | `UVar (name, c) ->
+        Format.fprintf f "%s" name;
+        if c <> [] then DS.add (name, c) vars else vars
+    | `Arrow (p, t) ->
+        if par then Format.fprintf f "@[<hov 1>("
+        else Format.fprintf f "@[<hov 0>";
+        Format.fprintf f "@[<1>(";
+        let _, vars =
+          List.fold_left
+            (fun (first, vars) (opt, lbl, kind) ->
+              if not first then Format.fprintf f ",@ ";
+              if opt then Format.fprintf f "?";
+              if lbl <> "" then Format.fprintf f "%s : " lbl;
+              let vars = print ~par:true vars kind in
+              (false, vars))
+            (true, vars) p
+        in
+        Format.fprintf f ")@] ->@ ";
+        let vars = print ~par:false vars t in
+        if par then Format.fprintf f ")@]" else Format.fprintf f "@]";
+        vars
+    | `Ellipsis ->
+        Format.fprintf f "_";
+        vars
+    | `Range_Ellipsis ->
+        Format.fprintf f "...";
+        vars
+    | `Debug (a, b, c) ->
+        Format.fprintf f "%s" a;
+        let vars = print ~par:false vars b in
+        Format.fprintf f "%s" c;
+        vars
+  and print_list ?(first = true) ?(acc = []) vars = function
+    | [] -> vars
+    | (_, x) :: l ->
+        if not first then Format.fprintf f ",";
+        let vars = print ~par:false vars x in
+        print_list ~first:false ~acc:(x :: acc) vars l
+  in
+  Format.fprintf f "@[";
+  begin
+    match t with
+    (* We're only printing a variable: ignore its [repr]esentation. *)
+    | `EVar (_, c) when c <> [] ->
+        Format.fprintf f "something that is %s"
+          (String.concat " and " (List.map string_of_constr c))
+    | `UVar (_, c) when c <> [] ->
+        Format.fprintf f "anything that is %s"
+          (String.concat " and " (List.map string_of_constr c))
+    (* Print the full thing, then display constraints *)
+    | _ ->
+        let constraints = print ~par:false DS.empty t in
+        let constraints = DS.elements constraints in
+        if constraints <> [] then (
+          let constraints =
+            List.map
+              (fun (name, c) ->
+                (name, String.concat " and " (List.map string_of_constr c)))
+              constraints
+          in
+          let constraints =
+            List.stable_sort (fun (_, a) (_, b) -> compare a b) constraints
+          in
+          let group : ('a * 'b) list -> ('a list * 'b) list = function
+            | [] -> []
+            | (i, c) :: l ->
+                let rec group prev acc = function
+                  | [] -> [(List.rev acc, prev)]
+                  | (i, c) :: l ->
+                      if prev = c then group c (i :: acc) l
+                      else (List.rev acc, prev) :: group c [i] l
+                in
+                group c [i] l
+          in
+          let constraints = group constraints in
+          let constraints =
+            List.map
+              (fun (ids, c) -> String.concat ", " ids ^ " is " ^ c)
+              constraints
+          in
+          Format.fprintf f "@ @[<2>where@ ";
+          Format.fprintf f "%s" (List.hd constraints);
+          List.iter (fun s -> Format.fprintf f ",@ %s" s) (List.tl constraints);
+          Format.fprintf f "@]")
+  end;
+  Format.fprintf f "@]"
+
+let print_type f t = print f (make t)
+
+let print_scheme f (generalized, t) =
+  if !debug then
+    List.iter
+      (fun v ->
+        print f (make ~generalized (Type.make (Var (ref (Free v)))));
+        Format.fprintf f ".")
+      generalized;
+  print f (make ~generalized t)
+
+let string_of_type ?generalized t : string =
+  print Format.str_formatter (make ?generalized t);
+  Format.fprintf Format.str_formatter "@?";
+  Format.flush_str_formatter ()
+
+let () = Type.to_string_fun := string_of_type
+let string_of_scheme (g, t) = string_of_type ~generalized:g t
+
+type explanation = bool * Type.t * Type.t * t * t
+
+exception Type_error of explanation
+
+let print_type_error error_header ((flipped, ta, tb, a, b) : explanation) =
+  error_header (string_of_pos_opt ta.pos);
+  match b with
+    | `Meth (l, ([], `Ellipsis), `Ellipsis) when not flipped ->
+        Format.printf "this value has no method %s@." l
+    | _ ->
+        let inferred_pos a =
+          let dpos = (deref a).pos in
+          if a.pos = dpos then ""
+          else (
+            match dpos with
+              | None -> ""
+              | Some p -> " (inferred at " ^ string_of_pos ~prefix:"" p ^ ")")
+        in
+        let ta, tb, a, b = if flipped then (tb, ta, b, a) else (ta, tb, a, b) in
+        Format.printf "this value has type@.@[<2>  %a@]%s@ " print a
+          (inferred_pos ta);
+        Format.printf "but it should be a %stype of%s@.@[<2>  %a@]%s@]@."
+          (if flipped then "super" else "sub")
+          (match tb.pos with
+            | None -> ""
+            | Some p ->
+                Printf.sprintf " the type of the value at %s"
+                  (string_of_pos ~prefix:"" p))
+          print b (inferred_pos tb)
+
+(** {1 Documentation} *)
+
+let doc_of_type ~generalized t =
+  let margin = Format.pp_get_margin Format.str_formatter () in
+  Format.pp_set_margin Format.str_formatter 58;
+  Format.fprintf Format.str_formatter "%a@?"
+    (fun f t -> print_scheme f (generalized, t))
+    t;
+  Format.pp_set_margin Format.str_formatter margin;
+  Doc.trivial (Format.flush_str_formatter ())
+
+let doc_of_meths m =
+  let items = new Doc.item "" in
+  List.iter
+    (fun { meth = m; scheme = generalized, t; doc } ->
+      let i = new Doc.item ~sort:false doc in
+      i#add_subsection "type" (doc_of_type ~generalized t);
+      items#add_subsection m i)
+    m;
+  items

--- a/src/lang/runtime.ml
+++ b/src/lang/runtime.ml
@@ -59,7 +59,7 @@ let throw print_error = function
   (* Warnings *)
   | Term.Ignored tm when Term.is_fun (Type.deref tm.Term.t) ->
       flush_all ();
-      warning_header 1 (Type.string_of_pos_opt tm.Term.t.Type.pos);
+      warning_header 1 (Repr.string_of_pos_opt tm.Term.t.Type.pos);
       Format.printf
         "This function application is partial,@ being of type %s.@ Maybe some \
          arguments are missing.@]@."
@@ -67,19 +67,19 @@ let throw print_error = function
       if !strict then raise Error
   | Term.Ignored tm when Term.is_source (Type.deref tm.Term.t) ->
       flush_all ();
-      warning_header 2 (Type.string_of_pos_opt tm.Term.t.Type.pos);
+      warning_header 2 (Repr.string_of_pos_opt tm.Term.t.Type.pos);
       Format.printf
         "This source is unused, maybe it needs to@ be connected to an \
          output.@]@.";
       if !strict then raise Error
   | Term.Ignored tm ->
       flush_all ();
-      warning_header 3 (Type.string_of_pos_opt tm.Term.t.Type.pos);
+      warning_header 3 (Repr.string_of_pos_opt tm.Term.t.Type.pos);
       Format.printf "This expression should have type unit.@]@.";
       if !strict then raise Error
   | Term.Unused_variable (s, pos) ->
       flush_all ();
-      warning_header 4 (Type.string_of_single_pos pos);
+      warning_header 4 (Repr.string_of_single_pos pos);
       Format.printf "Unused variable %s@]@." s;
       if !strict then raise Error
   (* Errors *)
@@ -90,12 +90,12 @@ let throw print_error = function
       print_error 2 "Parse error";
       raise Error
   | Term.Parse_error (pos, s) ->
-      let pos = Type.string_of_pos pos in
+      let pos = Repr.string_of_pos pos in
       error_header 3 pos;
       Format.printf "%s@]@." s;
       raise Error
   | Term.Unbound (pos, s) ->
-      let pos = Type.string_of_pos_opt pos in
+      let pos = Repr.string_of_pos_opt pos in
       error_header 4 pos;
       Format.printf "Undefined variable %s@]@." s;
       raise Error
@@ -104,8 +104,8 @@ let throw print_error = function
       Repr.print_type_error (error_header 5) explain;
       raise Error
   | Term.No_label (f, lbl, first, x) ->
-      let pos_f = Type.string_of_pos_opt f.Term.t.Type.pos in
-      let pos_x = Type.string_of_pos_opt x.Term.t.Type.pos in
+      let pos_f = Repr.string_of_pos_opt f.Term.t.Type.pos in
+      let pos_x = Repr.string_of_pos_opt x.Term.t.Type.pos in
       flush_all ();
       error_header 6 pos_x;
       Format.printf
@@ -116,11 +116,11 @@ let throw print_error = function
         else Format.sprintf "argument labeled %S" lbl);
       raise Error
   | Error.Invalid_value (v, msg) ->
-      error_header 7 (Type.string_of_pos_opt v.Value.pos);
+      error_header 7 (Repr.string_of_pos_opt v.Value.pos);
       Format.printf "Invalid value:@ %s@]@." msg;
       raise Error
   | Lang_encoder.Encoder_error (pos, s) ->
-      error_header 8 (Type.string_of_pos_opt pos);
+      error_header 8 (Repr.string_of_pos_opt pos);
       Format.printf "%s@]@." (String.capitalize_ascii s);
       raise Error
   | Failure s ->
@@ -129,19 +129,19 @@ let throw print_error = function
   | Error.Clock_conflict (pos, a, b) ->
       (* TODO better printing of clock errors: we don't have position
        *   information, use the source's ID *)
-      error_header 10 (Type.string_of_pos_opt pos);
+      error_header 10 (Repr.string_of_pos_opt pos);
       Format.printf "A source cannot belong to two clocks (%s,@ %s).@]@." a b;
       raise Error
   | Error.Clock_loop (pos, a, b) ->
-      error_header 11 (Type.string_of_pos_opt pos);
+      error_header 11 (Repr.string_of_pos_opt pos);
       Format.printf "Cannot unify two nested clocks (%s,@ %s).@]@." a b;
       raise Error
   | Error.Kind_conflict (pos, a, b) ->
-      error_header 10 (Type.string_of_pos_opt pos);
+      error_header 10 (Repr.string_of_pos_opt pos);
       Format.printf "Source kinds don't match@ (%s vs@ %s).@]@." a b;
       raise Error
   | Term.Unsupported_format (pos, fmt) ->
-      let pos = Type.string_of_pos_opt pos in
+      let pos = Repr.string_of_pos_opt pos in
       error_header 12 pos;
       Format.printf
         "Unsupported format: %s.@ You must be missing an optional \
@@ -149,13 +149,13 @@ let throw print_error = function
         fmt;
       raise Error
   | Term.Internal_error (pos, e) ->
-      let pos = Type.string_of_pos_list pos in
+      let pos = Repr.string_of_pos_list pos in
       (* Bad luck, error 13 should never have happened. *)
       error_header 13 pos;
       Format.printf "Internal error: %s@]@." e;
       raise Error
   | Term.Runtime_error { Term.kind; msg; pos } ->
-      let pos = Type.string_of_pos_list pos in
+      let pos = Repr.string_of_pos_list pos in
       error_header 14 pos;
       Format.printf "Uncaught runtime error:@ type: %s,@ message: %s@]@." kind
         (Printf.sprintf "%s" (Utils.quote_string msg));

--- a/src/lang/runtime.ml
+++ b/src/lang/runtime.ml
@@ -59,27 +59,27 @@ let throw print_error = function
   (* Warnings *)
   | Term.Ignored tm when Term.is_fun (Type.deref tm.Term.t) ->
       flush_all ();
-      warning_header 1 (Type.print_pos_opt tm.Term.t.Type.pos);
+      warning_header 1 (Type.string_of_pos_opt tm.Term.t.Type.pos);
       Format.printf
         "This function application is partial,@ being of type %s.@ Maybe some \
          arguments are missing.@]@."
-        (Type.print tm.Term.t);
+        (Type.to_string tm.Term.t);
       if !strict then raise Error
   | Term.Ignored tm when Term.is_source (Type.deref tm.Term.t) ->
       flush_all ();
-      warning_header 2 (Type.print_pos_opt tm.Term.t.Type.pos);
+      warning_header 2 (Type.string_of_pos_opt tm.Term.t.Type.pos);
       Format.printf
         "This source is unused, maybe it needs to@ be connected to an \
          output.@]@.";
       if !strict then raise Error
   | Term.Ignored tm ->
       flush_all ();
-      warning_header 3 (Type.print_pos_opt tm.Term.t.Type.pos);
+      warning_header 3 (Type.string_of_pos_opt tm.Term.t.Type.pos);
       Format.printf "This expression should have type unit.@]@.";
       if !strict then raise Error
   | Term.Unused_variable (s, pos) ->
       flush_all ();
-      warning_header 4 (Type.print_single_pos pos);
+      warning_header 4 (Type.string_of_single_pos pos);
       Format.printf "Unused variable %s@]@." s;
       if !strict then raise Error
   (* Errors *)
@@ -90,22 +90,22 @@ let throw print_error = function
       print_error 2 "Parse error";
       raise Error
   | Term.Parse_error (pos, s) ->
-      let pos = Type.print_pos pos in
+      let pos = Type.string_of_pos pos in
       error_header 3 pos;
       Format.printf "%s@]@." s;
       raise Error
   | Term.Unbound (pos, s) ->
-      let pos = Type.print_pos_opt pos in
+      let pos = Type.string_of_pos_opt pos in
       error_header 4 pos;
       Format.printf "Undefined variable %s@]@." s;
       raise Error
-  | Type.Type_error explain ->
+  | Repr.Type_error explain ->
       flush_all ();
-      Type.print_type_error (error_header 5) explain;
+      Repr.print_type_error (error_header 5) explain;
       raise Error
   | Term.No_label (f, lbl, first, x) ->
-      let pos_f = Type.print_pos_opt f.Term.t.Type.pos in
-      let pos_x = Type.print_pos_opt x.Term.t.Type.pos in
+      let pos_f = Type.string_of_pos_opt f.Term.t.Type.pos in
+      let pos_x = Type.string_of_pos_opt x.Term.t.Type.pos in
       flush_all ();
       error_header 6 pos_x;
       Format.printf
@@ -116,11 +116,11 @@ let throw print_error = function
         else Format.sprintf "argument labeled %S" lbl);
       raise Error
   | Error.Invalid_value (v, msg) ->
-      error_header 7 (Type.print_pos_opt v.Value.pos);
+      error_header 7 (Type.string_of_pos_opt v.Value.pos);
       Format.printf "Invalid value:@ %s@]@." msg;
       raise Error
   | Lang_encoder.Encoder_error (pos, s) ->
-      error_header 8 (Type.print_pos_opt pos);
+      error_header 8 (Type.string_of_pos_opt pos);
       Format.printf "%s@]@." (String.capitalize_ascii s);
       raise Error
   | Failure s ->
@@ -129,19 +129,19 @@ let throw print_error = function
   | Error.Clock_conflict (pos, a, b) ->
       (* TODO better printing of clock errors: we don't have position
        *   information, use the source's ID *)
-      error_header 10 (Type.print_pos_opt pos);
+      error_header 10 (Type.string_of_pos_opt pos);
       Format.printf "A source cannot belong to two clocks (%s,@ %s).@]@." a b;
       raise Error
   | Error.Clock_loop (pos, a, b) ->
-      error_header 11 (Type.print_pos_opt pos);
+      error_header 11 (Type.string_of_pos_opt pos);
       Format.printf "Cannot unify two nested clocks (%s,@ %s).@]@." a b;
       raise Error
   | Error.Kind_conflict (pos, a, b) ->
-      error_header 10 (Type.print_pos_opt pos);
+      error_header 10 (Type.string_of_pos_opt pos);
       Format.printf "Source kinds don't match@ (%s vs@ %s).@]@." a b;
       raise Error
   | Term.Unsupported_format (pos, fmt) ->
-      let pos = Type.print_pos_opt pos in
+      let pos = Type.string_of_pos_opt pos in
       error_header 12 pos;
       Format.printf
         "Unsupported format: %s.@ You must be missing an optional \
@@ -149,13 +149,13 @@ let throw print_error = function
         fmt;
       raise Error
   | Term.Internal_error (pos, e) ->
-      let pos = Type.print_pos_list pos in
+      let pos = Type.string_of_pos_list pos in
       (* Bad luck, error 13 should never have happened. *)
       error_header 13 pos;
       Format.printf "Internal error: %s@]@." e;
       raise Error
   | Term.Runtime_error { Term.kind; msg; pos } ->
-      let pos = Type.print_pos_list pos in
+      let pos = Type.string_of_pos_list pos in
       error_header 14 pos;
       Format.printf "Uncaught runtime error:@ type: %s,@ message: %s@]@." kind
         (Printf.sprintf "%s" (Utils.quote_string msg));

--- a/src/lang/term.ml
+++ b/src/lang/term.ml
@@ -433,7 +433,7 @@ let make ?pos ?t e =
   let t = match t with Some t -> t | None -> Type.var ?pos () in
   if Lazy.force debug then
     Printf.eprintf "%s (%s): assigned type var %s\n"
-      (Type.string_of_pos_opt t.Type.pos)
+      (Repr.string_of_pos_opt t.Type.pos)
       (try to_string { t; term = e } with _ -> "<?>")
       (Repr.string_of_type t);
   { t; term = e }

--- a/src/lang/type.ml
+++ b/src/lang/type.ml
@@ -41,11 +41,6 @@ let debug_levels = ref false
 
 type pos = Runtime_error.pos
 
-let string_of_single_pos = Runtime_error.print_single_pos
-let string_of_pos = Runtime_error.print_pos
-let string_of_pos_opt = Runtime_error.print_pos_opt
-let string_of_pos_list = Runtime_error.print_pos_list
-
 (** Ground types *)
 
 type ground = ..

--- a/src/lang/type.ml
+++ b/src/lang/type.ml
@@ -23,9 +23,6 @@
 let debug = ref (Utils.getenv_opt "LIQUIDSOAP_DEBUG_LANG" <> None)
 let debug_levels = ref false
 
-(** Show generalized variables in records. *)
-let show_record_schemes = ref true
-
 (* Type information comes attached to the AST from the parsing,
  * with appropriate sharing of the type variables. Then the type inference
  * performs in-place unification.
@@ -44,10 +41,10 @@ let show_record_schemes = ref true
 
 type pos = Runtime_error.pos
 
-let print_single_pos = Runtime_error.print_single_pos
-let print_pos = Runtime_error.print_pos
-let print_pos_opt = Runtime_error.print_pos_opt
-let print_pos_list = Runtime_error.print_pos_list
+let string_of_single_pos = Runtime_error.print_single_pos
+let string_of_pos = Runtime_error.print_pos
+let string_of_pos_opt = Runtime_error.print_pos_opt
+let string_of_pos_list = Runtime_error.print_pos_list
 
 (** Ground types *)
 
@@ -86,7 +83,7 @@ let () =
     | "request" -> Some Request
     | _ -> None)
 
-let print_ground v =
+let string_of_ground v =
   try
     Queue.iter
       (fun fn -> match fn v with Some s -> raise (FoundName s) | None -> ())
@@ -117,7 +114,7 @@ let resolve_ground_opt name =
 type constr = Num | Ord | Dtools | InternalMedia
 type constraints = constr list
 
-let print_constr = function
+let string_of_constr = function
   | Num -> "a number type"
   | Ord -> "an orderable type"
   | Dtools -> "unit, bool, int, float, string or [string]"
@@ -162,26 +159,6 @@ and var = { name : int; mutable level : int; mutable constraints : constraints }
 and scheme = var list * t
 
 let unit = Tuple []
-
-type repr =
-  [ `Constr of string * (variance * repr) list
-  | `Ground of ground
-  | `List of repr
-  | `Tuple of repr list
-  | `Nullable of repr
-  | `Meth of string * (var_repr list * repr) * repr
-  | `Arrow of (bool * string * repr) list * repr
-  | `Getter of repr
-  | `EVar of var_repr (* existential variable *)
-  | `UVar of var_repr (* universal variable *)
-  | `Ellipsis (* omitted sub-term *)
-  | `Range_Ellipsis (* omitted sub-terms (in a list, e.g. list of args) *)
-  | `Debug of
-    string * repr * string
-    (* add annotations before / after, mostly used for debugging *) ]
-
-and var_repr = string * constraints
-
 let var_eq v v' = v.name = v'.name
 let make ?pos d = { pos; descr = d }
 
@@ -235,403 +212,6 @@ let split_meths t =
   in
   aux [] t
 
-(** Given a strictly positive integer, generate a name in [a-z]+:
-  * a, b, ... z, aa, ab, ... az, ba, ... *)
-let name =
-  let base = 26 in
-  let c i = char_of_int (int_of_char 'a' + i - 1) in
-  let add i suffix = Printf.sprintf "%c%s" (c i) suffix in
-  let rec n suffix i =
-    if i <= base then add i suffix
-    else (
-      let head = i mod base in
-      let head = if head = 0 then base else head in
-      n (add head suffix) ((i - head) / base))
-  in
-  n ""
-
-(** Generate a globally unique name for evars (used for debugging only). *)
-let evar_global_name =
-  let evars = Hashtbl.create 10 in
-  let n = ref (-1) in
-  fun i ->
-    try Hashtbl.find evars i
-    with Not_found ->
-      incr n;
-      let name = String.uppercase_ascii (name !n) in
-      Hashtbl.add evars i name;
-      name
-
-(** Compute the structure that a term [repr]esents, given the list of
-   universally quantified variables. Also takes care of computing the printing
-   name of variables, including constraint symbols, which are removed from
-   constraint lists. It supports a mechanism for filtering out parts of the
-   type, which are then translated as `Ellipsis. *)
-let repr ?(filter_out = fun _ -> false) ?(generalized = []) t : repr =
-  let split_constr c =
-    List.fold_left (fun (s, constraints) c -> (s, c :: constraints)) ("", []) c
-  in
-  let uvar g var =
-    let constr_symbols, c = split_constr var.constraints in
-    let rec index n = function
-      | v :: tl ->
-          if var_eq v var then Printf.sprintf "'%s%s" constr_symbols (name n)
-          else index (n + 1) tl
-      | [] -> assert false
-    in
-    let v = index 1 (List.rev g) in
-    (* let v = Printf.sprintf "'%d" i in *)
-    `UVar (v, c)
-  in
-  let counter =
-    let c = ref 0 in
-    fun () ->
-      incr c;
-      !c
-  in
-  let evars = Hashtbl.create 10 in
-  let evar var =
-    let constr_symbols, c = split_constr var.constraints in
-    if !debug then (
-      let v =
-        Printf.sprintf "'%s%s" constr_symbols (evar_global_name var.name)
-      in
-      let v =
-        if !debug_levels then (
-          let level = var.level in
-          let level = if level = max_int then "∞" else string_of_int level in
-          Printf.sprintf "%s[%s]" v level)
-        else v
-      in
-      `EVar (v, c))
-    else (
-      let s =
-        try Hashtbl.find evars var.name
-        with Not_found ->
-          let name = String.uppercase_ascii (name (counter ())) in
-          Hashtbl.add evars var.name name;
-          name
-      in
-      `EVar (Printf.sprintf "'%s%s" constr_symbols s, c))
-  in
-  let rec repr g t =
-    if filter_out t then `Ellipsis
-    else (
-      match t.descr with
-        | Ground g -> `Ground g
-        | Getter t -> `Getter (repr g t)
-        | List { t } -> `List (repr g t)
-        | Tuple l -> `Tuple (List.map (repr g) l)
-        | Nullable t -> `Nullable (repr g t)
-        | Meth ({ meth = l; scheme = g', u }, v) ->
-            let gen =
-              List.map
-                (fun v -> match uvar (g' @ g) v with `UVar v -> v)
-                (List.sort_uniq compare g')
-            in
-            `Meth (l, (gen, repr (g' @ g) u), repr g v)
-        | Constr { constructor; params } ->
-            `Constr (constructor, List.map (fun (l, t) -> (l, repr g t)) params)
-        | Arrow (args, t) ->
-            `Arrow
-              ( List.map (fun (opt, lbl, t) -> (opt, lbl, repr g t)) args,
-                repr g t )
-        | Var { contents = Free var } ->
-            if List.exists (var_eq var) g then uvar g var else evar var
-        | Var { contents = Link (Covariant, t) } when !debug ->
-            `Debug ("[>", repr g t, "]")
-        | Var { contents = Link (_, t) } -> repr g t)
-  in
-  repr generalized t
-
-(** Sets of type descriptions. *)
-module DS = Set.Make (struct
-  type t = string * constraints
-
-  let compare = compare
-end)
-
-(** Print a type representation.
-  * Unless in debug mode, variable identifiers are not shown,
-  * and variable names are generated.
-  * Names are only meaningful over one printing, as they are re-used. *)
-let print_repr f t =
-  (* Display the type and return the list of variables that occur in it.
-   * The [par] params tells whether (..)->.. should be surrounded by
-   * parenthesis or not. *)
-  let rec print ~par vars : repr -> DS.t = function
-    | `Constr ("stream_kind", params) -> (
-        (* Let's assume that stream_kind occurs only inside a source
-         * or format type -- this should be pretty much true with the
-         * current API -- and simplify the printing by labeling its
-         * parameters and omitting the stream_kind(...) to avoid
-         * source(stream_kind(pcm(stereo),none,none)). *)
-        match params with
-          | [(_, a); (_, v); (_, m)] ->
-              let first, has_ellipsis, vars =
-                List.fold_left
-                  (fun (first, has_ellipsis, vars) (lbl, t) ->
-                    if t = `Ellipsis then (false, true, vars)
-                    else (
-                      if not first then Format.fprintf f ",@ ";
-                      Format.fprintf f "%s=" lbl;
-                      let vars = print ~par:false vars t in
-                      (false, has_ellipsis, vars)))
-                  (true, false, vars)
-                  [("audio", a); ("video", v); ("midi", m)]
-              in
-              if not has_ellipsis then vars
-              else (
-                if not first then Format.fprintf f ",@,";
-                print ~par:false vars `Range_Ellipsis)
-          | _ -> assert false)
-    | `Constr ("none", _) ->
-        Format.fprintf f "none";
-        vars
-    | `Constr (_, [(_, `Ground (Format format))]) ->
-        Format.fprintf f "%s" (Frame_content.string_of_format format);
-        vars
-    | `Constr (name, params) ->
-        Format.open_box (1 + String.length name);
-        Format.fprintf f "%s(" name;
-        let vars = print_list vars params in
-        Format.fprintf f ")";
-        Format.close_box ();
-        vars
-    | `Ground g ->
-        Format.fprintf f "%s" (print_ground g);
-        vars
-    | `Tuple [] ->
-        Format.fprintf f "unit";
-        vars
-    | `Tuple l ->
-        if par then Format.fprintf f "@[<1>(" else Format.fprintf f "@[<0>";
-        let rec aux vars = function
-          | [a] -> print ~par:true vars a
-          | a :: l ->
-              let vars = print ~par:true vars a in
-              Format.fprintf f " *@ ";
-              aux vars l
-          | [] -> assert false
-        in
-        let vars = aux vars l in
-        if par then Format.fprintf f ")@]" else Format.fprintf f "@]";
-        vars
-    | `Nullable t ->
-        let vars = print ~par:true vars t in
-        Format.fprintf f "?";
-        vars
-    | `Meth (l, (_, a), b) as t ->
-        if not !debug then (
-          (* Find all methods. *)
-          let rec aux = function
-            | `Meth (l, t, u) ->
-                let m, u = aux u in
-                ((l, t) :: m, u)
-            | u -> ([], u)
-          in
-          let m, t = aux t in
-          (* Filter out duplicates. *)
-          let rec aux = function
-            | (l, t) :: m ->
-                (l, t) :: aux (List.filter (fun (l', _) -> l <> l') m)
-            | [] -> []
-          in
-          let m = aux m in
-          (* Put latest addition last. *)
-          let m = List.rev m in
-          (* First print the main value. *)
-          let vars =
-            if t = `Tuple [] then (
-              Format.fprintf f "@,@[<hv 2>{@,";
-              vars)
-            else (
-              let vars = print ~par:true vars t in
-              Format.fprintf f "@,@[<hv 2>.{@,";
-              vars)
-          in
-          let vars =
-            if m = [] then vars
-            else (
-              let rec gen = function
-                | (x, _) :: g -> x ^ "." ^ gen g
-                | [] -> ""
-              in
-              let gen g =
-                if !show_record_schemes then gen (List.sort compare g) else ""
-              in
-              let rec aux vars = function
-                | [(l, (g, t))] ->
-                    Format.fprintf f "%s : %s" l (gen g);
-                    print ~par:true vars t
-                | (l, (g, t)) :: m ->
-                    Format.fprintf f "%s : %s" l (gen g);
-                    let vars = print ~par:false vars t in
-                    Format.fprintf f ",@ ";
-                    aux vars m
-                | [] -> assert false
-              in
-              aux vars m)
-          in
-          Format.fprintf f "@]@,}";
-          vars)
-        else (
-          let vars = print ~par:true vars b in
-          Format.fprintf f ".{%s = " l;
-          let vars = print ~par:false vars a in
-          Format.fprintf f "}";
-          vars)
-    | `List t ->
-        Format.fprintf f "@[<1>[";
-        let vars = print ~par:false vars t in
-        Format.fprintf f "]@]";
-        vars
-    | `Getter t ->
-        Format.fprintf f "{";
-        let vars = print ~par:false vars t in
-        Format.fprintf f "}";
-        vars
-    | `EVar (a, [InternalMedia]) ->
-        Format.fprintf f "?internal(%s)" a;
-        vars
-    | `UVar (a, [InternalMedia]) ->
-        Format.fprintf f "internal(%s)" a;
-        vars
-    | `EVar (name, c) | `UVar (name, c) ->
-        Format.fprintf f "%s" name;
-        if c <> [] then DS.add (name, c) vars else vars
-    | `Arrow (p, t) ->
-        if par then Format.fprintf f "@[<hov 1>("
-        else Format.fprintf f "@[<hov 0>";
-        Format.fprintf f "@[<1>(";
-        let _, vars =
-          List.fold_left
-            (fun (first, vars) (opt, lbl, kind) ->
-              if not first then Format.fprintf f ",@ ";
-              if opt then Format.fprintf f "?";
-              if lbl <> "" then Format.fprintf f "%s : " lbl;
-              let vars = print ~par:true vars kind in
-              (false, vars))
-            (true, vars) p
-        in
-        Format.fprintf f ")@] ->@ ";
-        let vars = print ~par:false vars t in
-        if par then Format.fprintf f ")@]" else Format.fprintf f "@]";
-        vars
-    | `Ellipsis ->
-        Format.fprintf f "_";
-        vars
-    | `Range_Ellipsis ->
-        Format.fprintf f "...";
-        vars
-    | `Debug (a, b, c) ->
-        Format.fprintf f "%s" a;
-        let vars = print ~par:false vars b in
-        Format.fprintf f "%s" c;
-        vars
-  and print_list ?(first = true) ?(acc = []) vars = function
-    | [] -> vars
-    | (_, x) :: l ->
-        if not first then Format.fprintf f ",";
-        let vars = print ~par:false vars x in
-        print_list ~first:false ~acc:(x :: acc) vars l
-  in
-  Format.fprintf f "@[";
-  begin
-    match t with
-    (* We're only printing a variable: ignore its [repr]esentation. *)
-    | `EVar (_, c) when c <> [] ->
-        Format.fprintf f "something that is %s"
-          (String.concat " and " (List.map print_constr c))
-    | `UVar (_, c) when c <> [] ->
-        Format.fprintf f "anything that is %s"
-          (String.concat " and " (List.map print_constr c))
-    (* Print the full thing, then display constraints *)
-    | _ ->
-        let constraints = print ~par:false DS.empty t in
-        let constraints = DS.elements constraints in
-        if constraints <> [] then (
-          let constraints =
-            List.map
-              (fun (name, c) ->
-                (name, String.concat " and " (List.map print_constr c)))
-              constraints
-          in
-          let constraints =
-            List.stable_sort (fun (_, a) (_, b) -> compare a b) constraints
-          in
-          let group : ('a * 'b) list -> ('a list * 'b) list = function
-            | [] -> []
-            | (i, c) :: l ->
-                let rec group prev acc = function
-                  | [] -> [(List.rev acc, prev)]
-                  | (i, c) :: l ->
-                      if prev = c then group c (i :: acc) l
-                      else (List.rev acc, prev) :: group c [i] l
-                in
-                group c [i] l
-          in
-          let constraints = group constraints in
-          let constraints =
-            List.map
-              (fun (ids, c) -> String.concat ", " ids ^ " is " ^ c)
-              constraints
-          in
-          Format.fprintf f "@ @[<2>where@ ";
-          Format.fprintf f "%s" (List.hd constraints);
-          List.iter (fun s -> Format.fprintf f ",@ %s" s) (List.tl constraints);
-          Format.fprintf f "@]")
-  end;
-  Format.fprintf f "@]"
-
-let pp_type f t = print_repr f (repr t)
-
-let pp_scheme f (generalized, t) =
-  if !debug then
-    List.iter
-      (fun v ->
-        print_repr f (repr ~generalized (make (Var (ref (Free v)))));
-        Format.fprintf f ".")
-      generalized;
-  print_repr f (repr ~generalized t)
-
-let print ?generalized t : string =
-  print_repr Format.str_formatter (repr ?generalized t);
-  Format.fprintf Format.str_formatter "@?";
-  Format.flush_str_formatter ()
-
-let print_scheme (g, t) = print ~generalized:g t
-
-type explanation = bool * t * t * repr * repr
-
-exception Type_error of explanation
-
-let print_type_error error_header ((flipped, ta, tb, a, b) : explanation) =
-  error_header (print_pos_opt ta.pos);
-  match b with
-    | `Meth (l, ([], `Ellipsis), `Ellipsis) when not flipped ->
-        Format.printf "this value has no method %s@." l
-    | _ ->
-        let inferred_pos a =
-          let dpos = (deref a).pos in
-          if a.pos = dpos then ""
-          else (
-            match dpos with
-              | None -> ""
-              | Some p -> " (inferred at " ^ print_pos ~prefix:"" p ^ ")")
-        in
-        let ta, tb, a, b = if flipped then (tb, ta, b, a) else (ta, tb, a, b) in
-        Format.printf "this value has type@.@[<2>  %a@]%s@ " print_repr a
-          (inferred_pos ta);
-        Format.printf "but it should be a %stype of%s@.@[<2>  %a@]%s@]@."
-          (if flipped then "super" else "sub")
-          (match tb.pos with
-            | None -> ""
-            | Some p ->
-                Printf.sprintf " the type of the value at %s"
-                  (print_pos ~prefix:"" p))
-          print_repr b (inferred_pos tb)
-
 let var =
   let name =
     let c = ref (-1) in
@@ -671,23 +251,7 @@ let rec invokes t = function
       if ll = [] then (g, t) else invokes t ll
   | [] -> ([], t)
 
-(** {1 Documentation} *)
+let to_string_fun =
+  ref (fun ?generalized:_ _ -> failwith "Type.to_string not defined yet")
 
-let doc_of_type ~generalized t =
-  let margin = Format.pp_get_margin Format.str_formatter () in
-  Format.pp_set_margin Format.str_formatter 58;
-  Format.fprintf Format.str_formatter "%a@?"
-    (fun f t -> pp_scheme f (generalized, t))
-    t;
-  Format.pp_set_margin Format.str_formatter margin;
-  Doc.trivial (Format.flush_str_formatter ())
-
-let doc_of_meths m =
-  let items = new Doc.item "" in
-  List.iter
-    (fun { meth = m; scheme = generalized, t; doc } ->
-      let i = new Doc.item ~sort:false doc in
-      i#add_subsection "type" (doc_of_type ~generalized t);
-      items#add_subsection m i)
-    m;
-  items
+let to_string ?generalized (t : t) : string = !to_string_fun ?generalized t

--- a/src/lang/type.mli
+++ b/src/lang/type.mli
@@ -30,11 +30,6 @@ val debug_levels : bool ref
 
 type pos = Lexing.position * Lexing.position
 
-val string_of_single_pos : Lexing.position -> string
-val string_of_pos : ?prefix:string -> pos -> string
-val string_of_pos_opt : ?prefix:string -> pos option -> string
-val string_of_pos_list : ?prefix:string -> pos list -> string
-
 (** {1 Ground types} *)
 
 type variance = Covariant | Contravariant | Invariant

--- a/src/lang/type.mli
+++ b/src/lang/type.mli
@@ -30,10 +30,10 @@ val debug_levels : bool ref
 
 type pos = Lexing.position * Lexing.position
 
-val print_single_pos : Lexing.position -> string
-val print_pos : ?prefix:string -> pos -> string
-val print_pos_opt : ?prefix:string -> pos option -> string
-val print_pos_list : ?prefix:string -> pos list -> string
+val string_of_single_pos : Lexing.position -> string
+val string_of_pos : ?prefix:string -> pos -> string
+val string_of_pos_opt : ?prefix:string -> pos option -> string
+val string_of_pos_list : ?prefix:string -> pos list -> string
 
 (** {1 Ground types} *)
 
@@ -49,7 +49,7 @@ type ground +=
   | Format of Frame_content.format
 
 val register_ground_printer : (ground -> string option) -> unit
-val print_ground : ground -> string
+val string_of_ground : ground -> string
 val register_ground_resolver : (string -> ground option) -> unit
 val resolve_ground : string -> ground
 val resolve_ground_opt : string -> ground option
@@ -59,7 +59,7 @@ val resolve_ground_opt : string -> ground option
 type constr = Num | Ord | Dtools | InternalMedia
 type constraints = constr list
 
-val print_constr : constr -> string
+val string_of_constr : constr -> string
 
 type t = { pos : pos option; descr : descr }
 
@@ -132,45 +132,5 @@ val invoke : t -> string -> scheme
 (** Type of a submethod in a type. *)
 val invokes : t -> string list -> scheme
 
-(** {1 Representation of types} *)
-
-(** Representation of a type. *)
-type repr =
-  [ `Constr of string * (variance * repr) list
-  | `Ground of ground
-  | `List of repr
-  | `Tuple of repr list
-  | `Nullable of repr
-  | `Meth of string * (var_repr list * repr) * repr
-  | `Arrow of (bool * string * repr) list * repr
-  | `Getter of repr
-  | `EVar of var_repr  (** existential variable *)
-  | `UVar of var_repr  (** universal variable *)
-  | `Ellipsis  (** omitted sub-term *)
-  | `Range_Ellipsis  (** omitted sub-terms (in a list, e.g. list of args) *)
-  | `Debug of string * repr * string ]
-
-and var_repr = string * constraints
-
-(** Representation of a type. *)
-val repr : ?filter_out:(t -> bool) -> ?generalized:var list -> t -> repr
-
-(** Print the representation of a type. *)
-val print_repr : Format.formatter -> repr -> unit
-
-(** {1 Typing errors} *)
-
-type explanation = bool * t * t * repr * repr
-
-exception Type_error of explanation
-
-val print_type_error : (string -> unit) -> explanation -> unit
-
-(** {1 Printing and documentation} *)
-
-val pp_type : Format.formatter -> t -> unit
-val pp_scheme : Format.formatter -> scheme -> unit
-val print : ?generalized:var list -> t -> string
-val print_scheme : scheme -> string
-val doc_of_type : generalized:var list -> t -> Doc.item
-val doc_of_meths : meth list -> Doc.item
+val to_string_fun : (?generalized:var list -> t -> string) ref
+val to_string : ?generalized:var list -> t -> string

--- a/src/lang/type.mli
+++ b/src/lang/type.mli
@@ -133,4 +133,6 @@ val invoke : t -> string -> scheme
 val invokes : t -> string list -> scheme
 
 val to_string_fun : (?generalized:var list -> t -> string) ref
+
+(** String representation of a type. *)
 val to_string : ?generalized:var list -> t -> string

--- a/src/lang/value.ml
+++ b/src/lang/value.ml
@@ -92,7 +92,7 @@ let rec print_value v =
           match e.value with Tuple [] -> "" | _ -> print_value e ^ "."
         in
         e ^ "{" ^ m ^ "}"
-    | Fun ([], _, _, x) when Term.is_ground x -> "{" ^ Term.print x ^ "}"
+    | Fun ([], _, _, x) when Term.is_ground x -> "{" ^ Term.to_string x ^ "}"
     | Fun (l, _, _, x) when Term.is_ground x ->
         let f (label, _, value) =
           match (label, value) with
@@ -102,7 +102,8 @@ let rec print_value v =
             | label, None -> Printf.sprintf "~%s=_" label
         in
         let args = List.map f l in
-        Printf.sprintf "fun (%s) -> %s" (String.concat "," args) (Term.print x)
+        Printf.sprintf "fun (%s) -> %s" (String.concat "," args)
+          (Term.to_string x)
     | Fun _ | FFI _ -> "<fun>"
 
 (** Find a method in a value. *)

--- a/src/test/meth.ml
+++ b/src/test/meth.ml
@@ -19,7 +19,7 @@ let () =
 
 (* Test adding submethods. *)
 let () =
-  let print t = Printf.printf "%s\n%!" (Type.print t) in
+  let print t = Printf.printf "%s\n%!" (Type.to_string t) in
   let t = Type.make (Type.Ground Type.Int) in
   print t;
   let t = Type.meth "f" ([], Type.make (Type.Ground Type.Float)) t in

--- a/src/test/types.ml
+++ b/src/test/types.ml
@@ -4,9 +4,9 @@ let should_work t t' r =
   let t = make t in
   let t' = make t' in
   let r = make r in
-  Printf.printf "Finding min for %s and %s\n%!" (print t) (print t');
+  Printf.printf "Finding min for %s and %s\n%!" (to_string t) (to_string t');
   let m = Typing.sup ~pos:None t t' in
-  Printf.printf "Got: %s, expect %s\n%!" (print m) (print r);
+  Printf.printf "Got: %s, expect %s\n%!" (to_string m) (to_string r);
   Typing.(m <: r);
   Typing.(t <: m);
   Typing.(t' <: m)


### PR DESCRIPTION
More splitting of `Type` :
- we move representation-related operations to `Repr`
- we change `print` to the more standard `string_of`

This PR is mostly harmless and its purpose is only to make sure that we avoid conflicts with other current PRs.