### PR TITLE
Use an array of immutable chunks for internal contents

### DIFF
--- a/src/decoder/ffmpeg_copy_decoder.ml
+++ b/src/decoder/ffmpeg_copy_decoder.ml
@@ -55,7 +55,9 @@ let mk_decoder ~stream_time_base ~lift_data ~put_data params =
               } ))
           packets
       in
-      let data = { Ffmpeg_content_base.params = Some params; data } in
+      let data =
+        { Ffmpeg_content_base.params = Some params; data; size = duration }
+      in
       let data = lift_data data in
       put_data ?pts:None buffer.Decoder.generator data 0 duration
     with Empty | Corrupt (* Might want to change that later. *) -> ()

--- a/src/decoder/ffmpeg_raw_decoder.ml
+++ b/src/decoder/ffmpeg_raw_decoder.ml
@@ -44,7 +44,13 @@ let mk_decoder ~stream_time_base ~mk_params ~lift_data ~put_data params =
                   } ))
               frames
           in
-          let data = { Ffmpeg_content_base.params = mk_params params; data } in
+          let data =
+            {
+              Ffmpeg_content_base.params = mk_params params;
+              data;
+              size = duration;
+            }
+          in
           let data = lift_data data in
           put_data ?pts:None buffer.Decoder.generator data 0 duration
       | None -> ()

--- a/src/io/ffmpeg_filter_io.ml
+++ b/src/io/ffmpeg_filter_io.ml
@@ -180,10 +180,12 @@ class audio_input ~pass_metadata ~bufferize kind =
               stream_idx;
             }
           in
+          let duration = get_duration ffmpeg_frame in
           let content =
             {
               Ffmpeg_content_base.params =
                 Ffmpeg_raw_content.AudioSpecs.frame_params frame;
+              size = duration;
               data = [(0, frame)];
             }
           in
@@ -195,8 +197,7 @@ class audio_input ~pass_metadata ~bufferize kind =
           in
           Generator.put_audio ?pts generator
             (Ffmpeg_raw_content.Audio.lift_data content)
-            0
-            (get_duration ffmpeg_frame);
+            0 duration;
           f ()
         with Avutil.Error `Eagain -> ()
       in
@@ -286,12 +287,17 @@ class video_input ~pass_metadata ~bufferize ~fps kind =
               (Ffmpeg_utils.best_pts ffmpeg_frame)
           in
           let params = Ffmpeg_raw_content.VideoSpecs.frame_params frame in
+          let duration = Lazy.force duration in
           let content =
-            { Ffmpeg_raw_content.VideoSpecs.params; data = [(0, frame)] }
+            {
+              Ffmpeg_raw_content.VideoSpecs.params;
+              size = duration;
+              data = [(0, frame)];
+            }
           in
           Generator.put_video ?pts generator
             (Ffmpeg_raw_content.Video.lift_data content)
-            0 (Lazy.force duration);
+            0 duration;
           f ()
         with Avutil.Error `Eagain -> ()
       in

--- a/src/lang/builtins_ffmpeg_encoder.ml
+++ b/src/lang/builtins_ffmpeg_encoder.ml
@@ -89,7 +89,9 @@ let encode_audio_frame ~kind_t ~mode ~opts ?codec ~format generator =
                           } ))
                       packets
                   in
-                  let data = { Ffmpeg_content_base.params; data } in
+                  let data =
+                    { Ffmpeg_content_base.params; data; size = duration }
+                  in
                   let data = Ffmpeg_copy_content.Audio.lift_data data in
                   Producer_consumer.(
                     Generator.put_audio generator data 0 duration)
@@ -137,7 +139,9 @@ let encode_audio_frame ~kind_t ~mode ~opts ?codec ~format generator =
                               } ))
                           frames
                       in
-                      let data = { Ffmpeg_content_base.params; data } in
+                      let data =
+                        { Ffmpeg_content_base.params; data; size = duration }
+                      in
                       let data = Ffmpeg_raw_content.Audio.lift_data data in
                       Producer_consumer.(
                         Generator.put_audio generator data 0 duration)
@@ -262,7 +266,9 @@ let encode_video_frame ~kind_t ~mode ~opts ?codec ~format generator =
                           } ))
                       packets
                   in
-                  let data = { Ffmpeg_content_base.params; data } in
+                  let data =
+                    { Ffmpeg_content_base.params; data; size = duration }
+                  in
                   let data = Ffmpeg_copy_content.Video.lift_data data in
                   Producer_consumer.(
                     Generator.put_video generator data 0 duration)
@@ -313,7 +319,9 @@ let encode_video_frame ~kind_t ~mode ~opts ?codec ~format generator =
                           ))
                         frames
                     in
-                    let data = { Ffmpeg_content_base.params; data } in
+                    let data =
+                      { Ffmpeg_content_base.params; data; size = duration }
+                    in
                     let data = Ffmpeg_raw_content.Video.lift_data data in
                     Producer_consumer.(
                       Generator.put_video generator data 0 duration)

--- a/src/operators/accelerate.ml
+++ b/src/operators/accelerate.ml
@@ -41,7 +41,7 @@ class accelerate ~kind ~ratio ~randomize source_val =
     method abort_track = source#abort_track
 
     (** Frame used for dropping samples. *)
-    val mutable null = Frame.dummy
+    val mutable null = Frame.dummy ()
 
     method private wake_up x =
       super#wake_up x;

--- a/src/operators/add.ml
+++ b/src/operators/add.ml
@@ -75,7 +75,7 @@ class add ~kind ~renorm ~power (sources : ((unit -> float) * source) list)
      * wanted, even if they end a track -- this is quite needed. There is an
      * exception when there is only one active source, then the end of tracks
      * are not hidden anymore, which is useful for transitions, for example. *)
-    val mutable tmp = Frame.dummy
+    val mutable tmp = Frame.dummy ()
 
     method wake_up a =
       super#wake_up a;

--- a/src/operators/cross.ml
+++ b/src/operators/cross.ml
@@ -70,7 +70,7 @@ class cross ~kind val_source ~cross_length ~override_duration ~rms_width
     (* An audio frame for intermediate computations. It is used to buffer the
        end and beginnings of tracks. Its past metadata should mimic that of the
        main stream in order to avoid metadata duplication. *)
-    val mutable buf_frame = Frame.dummy
+    val mutable buf_frame = Frame.dummy ()
 
     method private reset_analysis =
       gen_before <- Generator.create ();

--- a/src/operators/frei0r_op.ml
+++ b/src/operators/frei0r_op.ml
@@ -104,7 +104,7 @@ class frei0r_mixer ~kind ~name bgra instance params (source : source) source2 =
       source2#abort_track
 
     val mutable t = 0.
-    val mutable tmp = Frame.dummy
+    val mutable tmp = Frame.dummy ()
 
     method private wake_up a =
       super#wake_up a;

--- a/src/operators/resample.ml
+++ b/src/operators/resample.ml
@@ -77,8 +77,8 @@ class resample ~kind ~ratio source_val =
         let len = Audio.length pcm in
         ( {
             Frame.audio = Frame_content.Audio.lift_data pcm;
-            video = Frame_content.None.data;
-            midi = Frame_content.None.data;
+            video = Frame_content.None.data len;
+            midi = Frame_content.None.data len;
           },
           len )
       in

--- a/src/stream/ffmpeg_content_base.ml
+++ b/src/stream/ffmpeg_content_base.ml
@@ -20,9 +20,13 @@
 
  *****************************************************************************)
 
-type ('a, 'b) content = { mutable params : 'a; mutable data : (int * 'b) list }
+type ('a, 'b) content = {
+  mutable params : 'a;
+  mutable size : int;
+  mutable data : (int * 'b) list;
+}
 
-let make ~size:_ params = { params; data = [] }
+let make ~size params = { params; size; data = [] }
 let clear d = d.data <- []
 let is_empty { data } = data = []
 let stream_idx = ref 0L
@@ -30,6 +34,9 @@ let stream_idx = ref 0L
 let new_stream_idx () =
   stream_idx := Int64.succ !stream_idx;
   !stream_idx
+
+let sort : 'a. (int * 'a) list -> (int * 'a) list =
+ fun data -> List.sort (fun (p, _) (p', _) -> Stdlib.compare p p') data
 
 let sub c ofs len =
   {
@@ -50,34 +57,24 @@ let blit :
   (* No compatibility check here, it's
      assumed to have been done beforehand. *)
   dst.params <- src.params;
-  let data =
-    List.filter (fun (pos, _) -> pos <= dst_pos || dst_pos + len < pos) dst.data
-  in
   let src_end = src_pos + len in
-  let data =
-    List.fold_left
-      (fun data (pos, p) ->
-        if src_pos <= pos && pos < src_end then (
-          let pos = dst_pos + (pos - src_pos) in
-          (pos, copy p) :: data)
-        else data)
-      data src.data
-  in
-  dst.data <- List.sort (fun (pos, _) (pos', _) -> Stdlib.compare pos pos') data
+  dst.data <-
+    sort
+      (List.fold_left
+         (fun data (pos, p) ->
+           if src_pos <= pos && pos < src_end then (
+             let pos = dst_pos + (pos - src_pos) in
+             (pos, copy p) :: data)
+           else data)
+         dst.data src.data)
 
 let fill :
       'a 'b. ('a, 'b) content -> int -> ('a, 'b) content -> int -> int -> unit =
  fun src src_pos dst dst_pos len ->
   blit ~copy:(fun x -> x) src src_pos dst dst_pos len
 
-let copy ~copy { data; params } =
-  { data = List.map (fun (pos, x) -> (pos, copy x)) data; params }
+let copy ~copy d =
+  { d with data = List.map (fun (pos, x) -> (pos, copy x)) d.data }
 
 let params { params } = params
-
-(* We don't account for content block length yet to total length is
-   the largest pts. *)
-let length { data } =
-  match List.sort (fun (p, _) (p', _) -> Stdlib.compare p' p) data with
-    | (pos, _) :: _ -> pos
-    | [] -> 0
+let length { size } = size

--- a/src/stream/frame.ml
+++ b/src/stream/frame.ml
@@ -125,8 +125,8 @@ let create_content ctype = map_fields (make ~size:!!size) ctype
 let create ctype =
   { pts = 0L; breaks = []; metadata = []; content = create_content ctype }
 
-let dummy =
-  let data = Frame_content.None.data in
+let dummy () =
+  let data = Frame_content.None.data !!size in
   {
     pts = 0L;
     breaks = [];

--- a/src/stream/frame.mli
+++ b/src/stream/frame.mli
@@ -91,7 +91,7 @@ val create : content_type -> t
 
 (** A dummy frame which should never written to or read from. This is however
     useful as a placeholder before initialization of references. *)
-val dummy : t
+val dummy : unit -> t
 
 (** Get a frame's content type. *)
 val content_type : t -> content_type

--- a/src/stream/frame_content.mli
+++ b/src/stream/frame_content.mli
@@ -57,16 +57,10 @@ module type ContentSpecs = sig
    * into [dst]. *)
   val blit : data -> int -> data -> int -> int -> unit
 
-  (* [fill src src_pos dst dst_pos len] assigns data from [src]
-   * into [dst] without copying when possible. *)
-  val fill : data -> int -> data -> int -> int -> unit
-
   (* Returns length in main ticks. *)
   val length : data -> int
-  val sub : data -> int -> int -> data
   val copy : data -> data
   val clear : data -> unit
-  val is_empty : data -> bool
 
   (** Params *)
 
@@ -152,7 +146,7 @@ val kind_of_string : string -> kind
 (* None content type is abstract and only used
    via its params and data. *)
 module None : sig
-  val data : Contents.data
+  val data : int -> Contents.data
   val format : Contents.format
   val is_format : Contents.format -> bool
 end

--- a/src/stream/generator.ml
+++ b/src/stream/generator.ml
@@ -554,7 +554,8 @@ module From_audio_video = struct
       | `Audio ->
           t.current_video_pts <-
             put_frames ~pts ~current_pts:t.current_video_pts t.current_video
-              Frame_content.None.data 0 l
+              Frame_content.None.(data l)
+              0 l
       | `Both -> ()
       | _ -> assert false
     end;
@@ -573,7 +574,8 @@ module From_audio_video = struct
       | `Video ->
           t.current_audio_pts <-
             put_frames ~pts ~current_pts:t.current_audio_pts t.current_audio
-              Frame_content.None.data 0 l
+              Frame_content.None.(data l)
+              0 l
       | _ -> ()
     end;
     sync_content t


### PR DESCRIPTION
This PR is another preliminary work for ongoing larger changes. It replaces out internal content types by immutable arrays of chunks with offset and duration.

This provide two features for future changes:
* It moves us closer to supporting fully immutable end-to-end content pipeline
* It makes it possible to slice and append data to existing content, a feature that I plan on using in the reworked streaming model.

This PR focuses on keeping calling APIs as untouched as possible. However, future work on this include merging the generator layer with this new content format since they now essentially share the same layout.