### PR TITLE
Honnor `perms`, `dir_perms` and `append` when using the encoder to output to files

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,10 @@ Fixes:
 * Account for internal caching in `request.dynamic.list`'s `queue` and `set_queue` methods.
 * Keep buffering for crossfade when new source has track mark but is still ready.
 * Added missing output `start`/`stop` commands.
+* Fixed `perms`, `dir_perms` and `append` not bring honored when delegating file output
+  to the encoder.
+* Fixed base directory not being created when delegating file output to the encoder.
+  (#2069)
 
 2.0.0 (03-10-2021)
 =====

--- a/src/encoder.ml
+++ b/src/encoder.ml
@@ -201,9 +201,16 @@ let bitrate = function
 (** Encoders that can output to a file. *)
 let file_output = function Ffmpeg _ -> true | _ -> false
 
-let with_file_output encoder file =
+let with_file_output ?(append = false) encoder file =
   match encoder with
-    | Ffmpeg opts -> Ffmpeg { opts with Ffmpeg_format.output = `Url file }
+    | Ffmpeg opts ->
+        Hashtbl.replace opts.Ffmpeg_format.other_opts "truncate"
+          (`Int (if append then 0 else 1));
+        Ffmpeg
+          {
+            opts with
+            Ffmpeg_format.output = `Url (Printf.sprintf "file:%s" file);
+          }
     | _ -> failwith "No file output!"
 
 (** Encoders that can output to a arbitrary url. *)

--- a/src/encoder.mli
+++ b/src/encoder.mli
@@ -57,7 +57,7 @@ val bitrate : format -> int
 (** Encoders that can output to a file. *)
 val file_output : format -> bool
 
-val with_file_output : format -> string -> format
+val with_file_output : ?append:bool -> format -> string -> format
 
 (** Encoders that can output to a arbitrary url. *)
 val url_output : format -> bool


### PR DESCRIPTION
This PR should also fix #2069.

The class hierarchy for piped output is clearly over-engineered but this'll do for now.

Also, `append` won't work with ffmpeg. I believe this is a bug there: https://trac.ffmpeg.org/ticket/9525