### PR TITLE
Undeprecate string.* regexp-related functions.

### DIFF
--- a/libs/deprecations.liq
+++ b/libs/deprecations.liq
@@ -498,34 +498,6 @@ def http_response_stream(%argsof(http.response.stream)) =
   http.response.stream(%argsof(http.response.stream))
 end
 
-# Deprecated: use regexp's test method instead
-# @flag deprecated
-def string.match(~pattern, s) =
-  deprecated("string.match", "r/_/.test(_)")
-  regexp(pattern).test(s)
-end
-
-# Deprecated: use regexp's exec method instead
-# @flag deprecated
-def string.extract(~pattern, s) =
-  deprecated("string.extract", "r/_/.exec(_)")
-  regexp(pattern).exec(s)
-end
-
-# Deprecated: use regexp's replace method instead
-# @flag deprecated
-def string.replace(~pattern, fn, s) =
-  deprecated("string.replace", "r/_/g.replace(_)")
-  regexp(flags=["g"], pattern).replace(fn, s)
-end
-
-# Deprecated: use regexp's split method instead
-# @flag deprecated
-def string.split(~separator, s) =
-  deprecated("string.split", "r/_/.split(_)")
-  regexp(separator).split(s)
-end
-
 # Deprecated: use error method instead
 # @flag deprecated
 def error.kind(err) =

--- a/libs/string.liq
+++ b/libs/string.liq
@@ -1,3 +1,38 @@
+# Match a string with an expression. Perl compatible regular expressions are
+# recognized. Hence, special characters should be escaped.
+# @category String
+def string.match(~pattern, s) =
+  deprecated("string.match", "r/_/.test(_)")
+  regexp(pattern).test(s)
+end
+
+# Extract substrings from a string. Perl compatible regular expressions are
+# recognized. Hence, special characters should be escaped. Returns a list of
+# (index,value). If the list does not have a pair associated to some index, it
+# means that the corresponding pattern was not found.
+# @category String
+def string.extract(~pattern, s) =
+  regexp(pattern).exec(s)
+end
+
+# Replace all substrings matched by a pattern by another string returned by a
+# function.
+# @category String
+# @param ~pattern Pattern (regular expression) of substrings which should be replaced.
+# @param f Function getting a matched substring an returning the string to replace it with.
+# @param s String whose substrings should be replaced.
+def string.replace(~pattern, f, s) =
+  regexp(flags=["g"], pattern).replace(f, s)
+end
+
+# Split a string at "separator". Perl compatible regular expressions are
+# recognized. Hence, special characters should be escaped.
+# @category String
+def string.split(~separator, s) =
+  deprecated("string.split", "r/_/.split(_)")
+  regexp(separator).split(s)
+end
+
 # Test whether a string contains a given prefix, substring or suffix.
 # @category String
 # @param ~prefix Prefix to look for.

--- a/libs/string.liq
+++ b/libs/string.liq
@@ -2,7 +2,6 @@
 # recognized. Hence, special characters should be escaped.
 # @category String
 def string.match(~pattern, s) =
-  deprecated("string.match", "r/_/.test(_)")
   regexp(pattern).test(s)
 end
 

--- a/libs/string.liq
+++ b/libs/string.liq
@@ -29,7 +29,6 @@ end
 # recognized. Hence, special characters should be escaped.
 # @category String
 def string.split(~separator, s) =
-  deprecated("string.split", "r/_/.split(_)")
   regexp(separator).split(s)
 end
 

--- a/libs/string.liq
+++ b/libs/string.liq
@@ -1,5 +1,6 @@
 # Match a string with an expression. Perl compatible regular expressions are
-# recognized. Hence, special characters should be escaped.
+# recognized. Hence, special characters should be escaped. Alternatively, one
+# can use the the `r/_/.test(_)` syntax for regular expressions.
 # @category String
 def string.match(~pattern, s) =
   regexp(pattern).test(s)
@@ -8,14 +9,16 @@ end
 # Extract substrings from a string. Perl compatible regular expressions are
 # recognized. Hence, special characters should be escaped. Returns a list of
 # (index,value). If the list does not have a pair associated to some index, it
-# means that the corresponding pattern was not found.
+# means that the corresponding pattern was not found. Alter natively, one can
+# use the `r/_/.exec(_)` syntax for regular expressions.
 # @category String
 def string.extract(~pattern, s) =
   regexp(pattern).exec(s)
 end
 
 # Replace all substrings matched by a pattern by another string returned by a
-# function.
+# function. Alternatively, one can use the `r/_/g.replace(_)` syntax for regular
+# expressions.
 # @category String
 # @param ~pattern Pattern (regular expression) of substrings which should be replaced.
 # @param f Function getting a matched substring an returning the string to replace it with.
@@ -25,7 +28,8 @@ def string.replace(~pattern, f, s) =
 end
 
 # Split a string at "separator". Perl compatible regular expressions are
-# recognized. Hence, special characters should be escaped.
+# recognized. Hence, special characters should be escaped. Alternatively, one
+# can use the `r/_/.split(_)` syntax for regular expressions.
 # @category String
 def string.split(~separator, s) =
   regexp(separator).split(s)


### PR DESCRIPTION
While I like the `regexp.function` syntax, it is a bit exotic and difficult to find in the doc. I propose that we keep the old functions for now, it does not cost anything and we can more easily find string-related functions.