### PR TITLE
Make documentation lazy.

### DIFF
--- a/src/lang/environment.mli
+++ b/src/lang/environment.mli
@@ -35,7 +35,7 @@ val builtins : Doc.item
 val add_builtin :
   ?override:bool ->
   ?register:bool ->
-  ?doc:Doc.item ->
+  ?doc:Doc.item Lazy.t ->
   string list ->
   Type.scheme * Value.t ->
   unit

--- a/src/lang/evaluation.ml
+++ b/src/lang/evaluation.ml
@@ -370,7 +370,7 @@ let eval ?env tm =
 (** Add toplevel definitions to [builtins] so they can be looked during the
     evaluation of the next scripts. Also try to generate a structured
     documentation from the source code. *)
-let toplevel_add (doc, params, methods) pat ~t v =
+let toplevel_add ((doc : Doc.item), params, methods) pat ~t v =
   let generalized, t = t in
   let rec ptypes t =
     match (Type.deref t).Type.descr with
@@ -398,15 +398,22 @@ let toplevel_add (doc, params, methods) pat ~t v =
             (`Known (List.assoc label pvalues), List.remove_assoc label pvalues)
           with Not_found -> (`Unknown, pvalues)
         in
-        let item = Doc.trivial (if descr = "" then "(no doc)" else descr) in
-        item#add_subsection "type" (Repr.doc_of_type ~generalized t);
-        item#add_subsection "default"
-          (Doc.trivial
-             (match default with
-               | `Unknown -> "???"
-               | `Known (Some v) -> Value.print_value v
-               | `Known None -> "None"));
-        doc#add_subsection (if label = "" then "(unlabeled)" else label) item;
+        let item () =
+          let item = Doc.trivial (if descr = "" then "(no doc)" else descr) in
+          item#add_subsection "type"
+            (Lazy.from_fun (fun () -> Repr.doc_of_type ~generalized t));
+          item#add_subsection "default"
+            (Lazy.from_fun (fun () ->
+                 Doc.trivial
+                   (match default with
+                     | `Unknown -> "???"
+                     | `Known (Some v) -> Value.print_value v
+                     | `Known None -> "None")));
+          item
+        in
+        doc#add_subsection
+          (if label = "" then "(unlabeled)" else label)
+          (Lazy.from_fun item);
         (params, pvalues))
       (params, pvalues) ptypes
   in
@@ -429,7 +436,8 @@ let toplevel_add (doc, params, methods) pat ~t v =
            (meths, { t with Type.descr = Type.Arrow (p, a) })
        | _ -> (meths, t)
    in
-   doc#add_subsection "_type" (Repr.doc_of_type ~generalized t);
+   doc#add_subsection "_type"
+     (Lazy.from_fun (fun () -> Repr.doc_of_type ~generalized t));
    let meths =
      List.map
        (fun Type.({ meth = l; doc = d } as m) ->
@@ -438,13 +446,16 @@ let toplevel_add (doc, params, methods) pat ~t v =
          Type.{ m with doc = d })
        meths
    in
-   if meths <> [] then doc#add_subsection "_methods" (Repr.doc_of_meths meths));
+   if meths <> [] then
+     doc#add_subsection "_methods"
+       (Lazy.from_fun (fun () -> Repr.doc_of_meths meths)));
   let env, pa = Typechecking.type_of_pat ~level:max_int ~pos:None pat in
   Typing.(t <: pa);
   List.iter
     (fun (x, v) ->
       let t = List.assoc x env in
-      Environment.add_builtin ~override:true ~doc x ((generalized, t), v))
+      Environment.add_builtin ~override:true ~doc:(Lazy.from_val doc) x
+        ((generalized, t), v))
     (eval_pat pat v)
 
 let rec eval_toplevel ?(interactive = false) t =

--- a/src/lang/evaluation.ml
+++ b/src/lang/evaluation.ml
@@ -370,7 +370,7 @@ let eval ?env tm =
 (** Add toplevel definitions to [builtins] so they can be looked during the
     evaluation of the next scripts. Also try to generate a structured
     documentation from the source code. *)
-let toplevel_add ((doc : Doc.item), params, methods) pat ~t v =
+let toplevel_add (doc, params, methods) pat ~t v =
   let generalized, t = t in
   let rec ptypes t =
     match (Type.deref t).Type.descr with

--- a/src/lang/preprocessor.ml
+++ b/src/lang/preprocessor.ml
@@ -370,8 +370,9 @@ let parse_comments tokenizer =
     in
     List.iter
       (function
-        | `Category c -> doc#add_subsection "_category" (Doc.trivial c)
-        | `Flag c -> doc#add_subsection "_flag" (Doc.trivial c))
+        | `Category c ->
+            doc#add_subsection "_category" (Lazy.from_val (Doc.trivial c))
+        | `Flag c -> doc#add_subsection "_flag" (Lazy.from_val (Doc.trivial c)))
       special;
     (Parser.DEF ((doc, params, methods), decoration), (startp, endp))
   in

--- a/src/lang/repr.ml
+++ b/src/lang/repr.ml
@@ -534,8 +534,12 @@ let doc_of_meths m =
   let items = new Doc.item "" in
   List.iter
     (fun { meth = m; scheme = generalized, t; doc } ->
-      let i = new Doc.item ~sort:false doc in
-      i#add_subsection "type" (doc_of_type ~generalized t);
-      items#add_subsection m i)
+      let i () =
+        let i = new Doc.item ~sort:false doc in
+        i#add_subsection "type"
+          (Lazy.from_fun (fun () -> doc_of_type ~generalized t));
+        i
+      in
+      items#add_subsection m (Lazy.from_fun i))
     m;
   items

--- a/src/operators/ladspa_op.ml
+++ b/src/operators/ladspa_op.ml
@@ -343,6 +343,10 @@ let register_descr plugin_name descr_n d inputs outputs =
 let register_descr plugin_name descr_n d inputs outputs =
   (* We do not register plugins without outputs for now. *)
   try
+    ignore
+      (Audio_converter.Channel_layout.layout_of_channels (Array.length inputs));
+    ignore
+      (Audio_converter.Channel_layout.layout_of_channels (Array.length outputs));
     if outputs <> [||] then register_descr plugin_name descr_n d inputs outputs
   with Audio_converter.Channel_layout.Unsupported ->
     log#info

--- a/src/operators/lilv_op.ml
+++ b/src/operators/lilv_op.ml
@@ -291,6 +291,9 @@ let register_plugin plugin =
   let inputs, outputs = get_audio_ports plugin in
   let ni = Array.length inputs in
   let no = Array.length outputs in
+  (* Ensure that we support the number of channels. *)
+  ignore (Audio_converter.Channel_layout.layout_of_channels ni);
+  ignore (Audio_converter.Channel_layout.layout_of_channels no);
   let liq_params, params = params_of_plugin plugin in
   let mono = ni = 1 && no = 1 in
   let input_kind = Lang.audio_n ni in

--- a/src/tools/doc.ml
+++ b/src/tools/doc.ml
@@ -28,9 +28,12 @@ class item ?(sort = true) (doc : string) =
   object
     val doc = doc
     method get_doc = doc
-    val mutable subsections : (string * item) list = []
-    method get_subsections = sort subsections
-    method get_subsection name = List.assoc name subsections
+    val mutable subsections : (string * item Lazy.t) list = []
+
+    method get_subsections =
+      sort subsections |> List.map (fun (k, v) -> (k, Lazy.force v))
+
+    method get_subsection name = Lazy.force (List.assoc name subsections)
     method has_subsection name = List.mem_assoc name subsections
 
     method add_subsection label item =

--- a/src/tools/plug.ml
+++ b/src/tools/plug.ml
@@ -33,18 +33,19 @@ class ['a] plug ?(register_hook = fun _ -> ()) doc insensitive duplicates =
       let plugin =
         if insensitive then String.uppercase_ascii plugin else plugin
       in
-      let doc =
+      let doc () =
         match (doc, sdoc) with
           | Some d, _ -> d
           | _, None -> Doc.trivial "(no doc)"
           | _, Some s -> Doc.trivial s
       in
       if duplicates then (
-        subsections <- (plugin, doc) :: subsections;
+        subsections <- (plugin, Lazy.from_fun doc) :: subsections;
         plugins <- (plugin, v) :: plugins)
       else (
         subsections <-
-          (plugin, doc) :: List.filter (fun (k, _) -> k <> plugin) subsections;
+          (plugin, Lazy.from_fun doc)
+          :: List.filter (fun (k, _) -> k <> plugin) subsections;
         plugins <-
           (plugin, v) :: List.filter (fun (k, _) -> k <> plugin) plugins);
       register_hook (plugin, v);
@@ -78,7 +79,7 @@ let create ?(duplicates = true) ?register_hook ?insensitive ?doc plugname =
   let insensitive = match insensitive with Some true -> true | _ -> false in
   let doc = match doc with None -> "(no doc)" | Some d -> d in
   let plug = new plug ?register_hook doc insensitive duplicates in
-  plugs#add_subsection plugname (plug :> Doc.item);
+  plugs#add_subsection plugname (Lazy.from_val (plug :> Doc.item));
   plug
 
 let list () = plugs#list_subsections

--- a/src/tools/plug.ml
+++ b/src/tools/plug.ml
@@ -35,9 +35,9 @@ class ['a] plug ?(register_hook = fun _ -> ()) doc insensitive duplicates =
       in
       let doc () =
         match (doc, sdoc) with
-          | Some d, _ -> d
-          | _, None -> Doc.trivial "(no doc)"
-          | _, Some s -> Doc.trivial s
+          | Some d, _ -> Lazy.force d
+          | None, None -> Doc.trivial "(no doc)"
+          | None, Some s -> Doc.trivial s
       in
       if duplicates then (
         subsections <- (plugin, Lazy.from_fun doc) :: subsections;


### PR DESCRIPTION
We spend quite some time on startup generating the documentation for plugins whereas it is usually not used. I am thus making it lazy: this way it will only be computed if needed.
```
$ time ./liquidsoap 
No output defined, nothing to do.

real	0m0,697s
user	0m0,614s
sys	0m0,082s
```
vs
```
$ time liquidsoap 
No output defined, nothing to do.

real	0m0,922s
user	0m0,854s
sys	0m0,067s
```