### PR TITLE
Only load external plugins when needed

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1,7 +1,7 @@
 SUBDIRS=tools \
 	decoder playlists encoder protocols stream lang \
 	ogg_formats converters operators sources conversions outputs io \
-	visualization synth harbor lang_encoders encoder_formats
+	visualization synth harbor lang_encoders encoder_formats externals
 
 DISTFILES = $(wildcard *.mli) Makefile $(wildcard *.ml) META.in
 
@@ -98,9 +98,6 @@ operators = \
 	operators/still_frame.ml operators/dtmf.ml \
 	$(if $(W_SOUNDTOUCH),operators/soundtouch_op.ml) \
 	$(if $(W_SOUNDTOUCH),operators/st_bpm.ml) \
-	$(if $(W_LADSPA),operators/ladspa_op.ml) \
-	$(if $(W_LILV),operators/lilv_op.ml) \
-	$(if $(W_FREI0R),operators/frei0r_op.ml) \
 	$(if $(W_GD),operators/video_text_gd.ml) \
 	$(if $(W_SDL_TTF),operators/video_text_sdl.ml) \
 	$(if $(W_GSTREAMER),operators/video_text_gstreamer.ml)
@@ -207,8 +204,13 @@ visualization = \
 	$(if $(W_GRAPHICS),visualization/vis_volume.ml)
 
 synth = synth/keyboard.ml synth/synth_op.ml \
-	$(if $(W_DSSI),synth/dssi_op.ml) \
 	$(if $(W_SDL),synth/keyboard_sdl.ml)
+
+externals = \
+	$(if $(W_FREI0R),operators/frei0r_op.ml) \
+	$(if $(W_LILV),operators/lilv_op.ml) \
+	$(if $(W_DSSI),synth/dssi_op.ml) \
+	$(if $(W_LADSPA),operators/ladspa_op.ml)
 
 builtins = lang/lang_builtins.ml \
            lang/builtins_ref.ml lang/builtins_socket.ml \
@@ -260,6 +262,7 @@ liquidsoap_sources += \
         lang/documentation.ml lang/lang_core.ml \
 	lang/lang_error.ml lang/lang_source.ml \
         lang/lang.ml lang/modules.ml \
+	lang/external_plugins.ml \
 	lang/parser_helper.ml lang/parser.ml lang/lexer.ml \
 	lang/preprocessor.ml lang/runtime.ml \
         lang/builtins_request.ml \

--- a/src/externals/Makefile
+++ b/src/externals/Makefile
@@ -1,0 +1,4 @@
+DISTFILES = $(wildcard *.ml) $(wildcard *.mli) Makefile
+
+top_srcdir=../..
+include $(top_srcdir)/Makefile.rules

--- a/src/externals/dssi_op.ml
+++ b/src/externals/dssi_op.ml
@@ -32,12 +32,6 @@ let dssi_enable =
     venv = "1" || venv = "true"
   with Not_found -> true
 
-let dssi_load =
-  try
-    let venv = Unix.getenv "LIQ_DSSI_LOAD" in
-    Pcre.split ~pat:":" venv
-  with Not_found -> []
-
 let plugin_dirs =
   try
     let path = Unix.getenv "LIQ_DSSI_PATH" in
@@ -224,10 +218,11 @@ let dssi_init =
       inited := true)
 
 let () =
-  if dssi_enable then (
+  let register_plugins () =
     dssi_init ();
-    register_plugins ());
-  List.iter (register_plugin ~log_errors:true) dssi_load
+    register_plugins ()
+  in
+  External_plugins.register ~keyword:"dssi" register_plugins
 
 let () =
   Lang.add_builtin "dssi.register"

--- a/src/externals/frei0r_op.ml
+++ b/src/externals/frei0r_op.ml
@@ -30,12 +30,6 @@ type t = Float | Int | Bool
 
 let log = Log.make ["frei0r"]
 
-let frei0r_enable =
-  try
-    let venv = Unix.getenv "LIQ_FREI0R" in
-    venv = "1" || venv = "true"
-  with Not_found -> true
-
 let plugin_dirs =
   try
     let path = Unix.getenv "LIQ_FREI0R_PATH" in
@@ -353,5 +347,4 @@ let register_plugins () =
   in
   List.iter add plugin_dirs
 
-let () =
-  Lifecycle.before_init (fun () -> if frei0r_enable then register_plugins ())
+let () = External_plugins.register ~keyword:"frei0r" register_plugins

--- a/src/externals/ladspa_op.ml
+++ b/src/externals/ladspa_op.ml
@@ -41,12 +41,6 @@ type t = Float | Int | Bool
 
 let log = Log.make ["LADSPA extension"]
 
-let ladspa_enabled =
-  try
-    let venv = Unix.getenv "LIQ_LADSPA" in
-    venv = "1" || venv = "true"
-  with Not_found -> true
-
 let ladspa_dirs =
   try String.split_on_char ':' (Unix.getenv "LIQ_LADSPA_DIRS")
   with Not_found ->
@@ -389,5 +383,4 @@ let register_plugins () =
   in
   List.iter add ladspa_dirs
 
-let () =
-  Lifecycle.before_init (fun () -> if ladspa_enabled then register_plugins ())
+let () = External_plugins.register ~keyword:"ladspa" register_plugins

--- a/src/externals/lilv_op.ml
+++ b/src/externals/lilv_op.ml
@@ -27,12 +27,6 @@ open Lilv
 let () = Lang.add_module "lv2"
 let log = Log.make ["Lilv LV2"]
 
-let lilv_enabled =
-  try
-    let venv = Unix.getenv "LIQ_LILV" in
-    venv = "1" || venv = "true"
-  with Not_found -> true
-
 class virtual base ~kind source =
   object
     inherit operator ~name:"lilv" (Kind.of_kind kind) [source]
@@ -354,5 +348,4 @@ let register_plugins () =
   World.load_all world;
   Plugins.iter register_plugin (World.plugins world)
 
-let () =
-  Lifecycle.before_init (fun () -> if lilv_enabled then register_plugins ())
+let () = External_plugins.register ~keyword:"lv2" register_plugins

--- a/src/lang/builtins_ffmpeg_filters.ml
+++ b/src/lang/builtins_ffmpeg_filters.ml
@@ -408,7 +408,7 @@ let apply_filter ~args_parser ~filter ~sources_t p =
     in
     Lang.meth Lang.unit meths)
 
-let () =
+let register_filters () =
   Avfilter.(
     let mk_av_t ~flags ~mode { audio; video } =
       match mode with
@@ -511,6 +511,8 @@ let () =
           ~flags:[`Extra] args_t return_t
           (apply_filter ~args_parser ~filter ~sources_t))
       filters)
+
+let () = External_plugins.register ~keyword:"ffmpeg.filter" register_filters
 
 let abuffer_args frame =
   let sample_rate = Avutil.Audio.frame_get_sample_rate frame in

--- a/src/lang/external_plugins.ml
+++ b/src/lang/external_plugins.ml
@@ -23,6 +23,9 @@
 let loader = ref (fun () -> ())
 let keywords : (string, unit -> unit) Hashtbl.t = Hashtbl.create 10
 
+(** Register a function to be called to register external plugins when a
+    particular keyword is present. We need a particular mechanism here because
+    those plugins have to be loaded very early (before typing time). *)
 let register ?keyword f =
   let f =
     let already = ref false in
@@ -40,8 +43,10 @@ let register ?keyword f =
 
 let trigger_enabled = ref false
 
+(** Launch the function associated with a keyword (if any). *)
 let trigger k =
   if !trigger_enabled then (
     match Hashtbl.find_opt keywords k with Some f -> f () | None -> ())
 
+(** Load all the external plugins. *)
 let load () = !loader ()

--- a/src/lang/external_plugins.ml
+++ b/src/lang/external_plugins.ml
@@ -1,0 +1,44 @@
+(*****************************************************************************
+
+  Liquidsoap, a programmable audio stream generator.
+  Copyright 2003-2021 Savonet team
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details, fully stated in the COPYING
+  file at the root of the liquidsoap distribution.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA
+
+ *****************************************************************************)
+
+let loader = ref (fun () -> ())
+let keywords : (string, unit -> unit) Hashtbl.t = Hashtbl.create 10
+
+let register ?keyword f =
+  let f =
+    let already = ref false in
+    fun () ->
+      if not !already then (
+        already := true;
+        f ())
+  in
+  let prev = !loader in
+  (loader :=
+     fun () ->
+       prev ();
+       f ());
+  match keyword with None -> () | Some k -> Hashtbl.add keywords k f
+
+let trigger k =
+  match Hashtbl.find_opt keywords k with Some f -> f () | None -> ()
+
+let load () = !loader ()

--- a/src/lang/external_plugins.ml
+++ b/src/lang/external_plugins.ml
@@ -38,7 +38,10 @@ let register ?keyword f =
        f ());
   match keyword with None -> () | Some k -> Hashtbl.add keywords k f
 
+let trigger_enabled = ref false
+
 let trigger k =
-  match Hashtbl.find_opt keywords k with Some f -> f () | None -> ()
+  if !trigger_enabled then (
+    match Hashtbl.find_opt keywords k with Some f -> f () | None -> ())
 
 let load () = !loader ()

--- a/src/lang/parser.mly
+++ b/src/lang/parser.mly
@@ -144,7 +144,7 @@ expr:
   | BOOL                             { mk ~pos:$loc (Ground (Bool $1)) }
   | FLOAT                            { mk ~pos:$loc (Ground (Float  $1)) }
   | STRING                           { mk ~pos:$loc (Ground (String $1)) }
-  | VAR                              { mk ~pos:$loc (Var $1) }
+  | VAR                              { External_plugins.trigger $1; mk ~pos:$loc (Var $1) }
   | varlist                          { mk_list ~pos:$loc $1 }
   | GET expr                         { mk ~pos:$loc (App (mk ~pos:$loc($1) (Invoke (mk ~pos:$loc($1) (Var "ref"), "get")), ["", $2])) }
   | expr SET expr                    { mk ~pos:$loc (App (mk ~pos:$loc($2) (Invoke (mk ~pos:$loc($1) (Var "ref"), "set")), ["", $1; "", $3])) }
@@ -154,7 +154,7 @@ expr:
   | expr DOT LCUR record RCUR        { $4 ~pos:$loc $1 }
   | LCUR record RCUR                 { $2 ~pos:$loc (mk ~pos:$loc (Tuple [])) }
   | LCUR RCUR                        { mk ~pos:$loc (Tuple []) }
-  | expr DOT VAR                     { mk ~pos:$loc (Invoke ($1, $3)) }
+  | expr DOT VAR                     { External_plugins.trigger $3; mk ~pos:$loc (Invoke ($1, $3)) }
   | expr DOT VARLPAR app_list RPAR   { mk ~pos:$loc (App (mk ~pos:($startpos($1),$endpos($3)) (Invoke ($1, $3)), $4)) }
   | VARLPAR app_list RPAR            { mk ~pos:$loc (App (mk ~pos:$loc($1) (Var $1), $2)) }
   | expr COLONCOLON expr             { mk ~pos:$loc (App (mk ~pos:$loc($2) (Var "_::_"), ["", $1; "", $3])) }

--- a/src/lang/parser.mly
+++ b/src/lang/parser.mly
@@ -144,7 +144,7 @@ expr:
   | BOOL                             { mk ~pos:$loc (Ground (Bool $1)) }
   | FLOAT                            { mk ~pos:$loc (Ground (Float  $1)) }
   | STRING                           { mk ~pos:$loc (Ground (String $1)) }
-  | VAR                              { External_plugins.trigger $1; mk ~pos:$loc (Var $1) }
+  | VAR                              { mk ~pos:$loc (Var $1) }
   | varlist                          { mk_list ~pos:$loc $1 }
   | GET expr                         { mk ~pos:$loc (App (mk ~pos:$loc($1) (Invoke (mk ~pos:$loc($1) (Var "ref"), "get")), ["", $2])) }
   | expr SET expr                    { mk ~pos:$loc (App (mk ~pos:$loc($2) (Invoke (mk ~pos:$loc($1) (Var "ref"), "set")), ["", $1; "", $3])) }
@@ -154,7 +154,7 @@ expr:
   | expr DOT LCUR record RCUR        { $4 ~pos:$loc $1 }
   | LCUR record RCUR                 { $2 ~pos:$loc (mk ~pos:$loc (Tuple [])) }
   | LCUR RCUR                        { mk ~pos:$loc (Tuple []) }
-  | expr DOT VAR                     { External_plugins.trigger $3; mk ~pos:$loc (Invoke ($1, $3)) }
+  | expr DOT VAR                     { mk ~pos:$loc (Invoke ($1, $3)) }
   | expr DOT VARLPAR app_list RPAR   { mk ~pos:$loc (App (mk ~pos:($startpos($1),$endpos($3)) (Invoke ($1, $3)), $4)) }
   | VARLPAR app_list RPAR            { mk ~pos:$loc (App (mk ~pos:$loc($1) (Var $1), $2)) }
   | expr COLONCOLON expr             { mk ~pos:$loc (App (mk ~pos:$loc($2) (Var "_::_"), ["", $1; "", $3])) }

--- a/src/lang/parser_helper.ml
+++ b/src/lang/parser_helper.ml
@@ -190,7 +190,9 @@ let args_of, app_of =
   let app_of = gen_args_of get_app in
   (args_of, app_of)
 
-let mk = Term.make
+let mk ~pos e =
+  (match e with Var x -> External_plugins.trigger x | _ -> ());
+  Term.make ~pos e
 
 let append_list ~pos x v =
   match (x, v) with

--- a/src/lang/parser_helper.ml
+++ b/src/lang/parser_helper.ml
@@ -191,7 +191,10 @@ let args_of, app_of =
   (args_of, app_of)
 
 let mk ~pos e =
-  (match e with Var x -> External_plugins.trigger x | _ -> ());
+  (match e with
+    | Var x -> External_plugins.trigger x
+    | Invoke ({ term = Var x }, y) -> External_plugins.trigger (x ^ "." ^ y)
+    | _ -> ());
   Term.make ~pos e
 
 let append_list ~pos x v =

--- a/src/main.ml
+++ b/src/main.ml
@@ -90,7 +90,10 @@ let load_libs =
       Runtime.load_libs ~error_on_no_stdlib ~deprecated:!deprecated
         ~parse_only:!parse_only ();
       loaded := true;
-      Configure.display_types := save)
+      Configure.display_types := save);
+    (* Once the standard library loaded, we want the keyword to trigger the
+       loading of external libraries. *)
+    External_plugins.trigger_enabled := true
 
 (** Evaluate a script or expression.
   * This used to be done immediately, which made it possible to


### PR DESCRIPTION
(This is a redo of https://github.com/savonet/liquidsoap/pull/2087)

This PR makes external plugins loaded only when needed. This means all
- LADSPA
- DSSI
- LV2
- frei0r
plugins. They are loaded when some keyword is used for a variable (eg `ladspa` for LADSPA plugings. This is hackish but should bug effective. Fixes #2019.
