### PR TITLE
Restore `on_track` and `on_metadata` as operators

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,9 @@ New:
 Changes:
 - `output.youtube.live` renamed `output.youtube.live.rtmp`, remove `bitrate` and
   `quality` arguments and added a single encoder argument to allow stream copy and more.
+- `source.on_metadata` and `source.on_track` now return a source as this was the
+  case in previous versions, and associated handlers are triggered only when the
+  returned source is pulled (#2103).
 
 2.0.1 (27-11-2021)
 =====

--- a/libs/audio.liq
+++ b/libs/audio.liq
@@ -72,7 +72,7 @@ def replaces normalize(~id=null(), ~target=getter(-13.), ~up=getter(10.), ~down=
       s
     end
   s = source.on_frame(s, update)
-  if track_sensitive then source.on_track(s, fun (_) -> v := 1.) end
+  s = if track_sensitive then source.on_track(s, fun (_) -> v := 1.) else s end
   amplify(id=id, {!v}, delay_line(lookahead, s)).{ rms = rms, gain = fun() -> !v, target_gain = target_gain }
 end
 

--- a/libs/fades.liq
+++ b/libs/fades.liq
@@ -129,15 +129,17 @@ def fade.out(~id="fade.out",~duration=3.,
     end
   end
 
-  source.on_metadata(s, update_fade)
+  s = source.on_metadata(s, update_fade)
   delay = fun () -> !duration
-  if track_sensitive then
-    source.on_track(s, stop_fade)
-  else
-    start_fade(!duration, [])
-  end
-  s = if track_sensitive then source.on_end(s,delay=delay,start_fade) else s end
-  fade.scale(id=id,apply,s)
+  s =
+    if track_sensitive then
+      source.on_track(s, stop_fade)
+    else
+      start_fade(!duration, [])
+      s
+    end
+  s = if track_sensitive then source.on_end(s, delay=delay, start_fade) else s end
+  fade.scale(id=id, apply, s)
 end
 
 # Fade when the metadata trigger is received and then skip.
@@ -191,9 +193,9 @@ def fade.skip(~id="fade.skip",~duration=5.,
     end
   end
 
-  source.on_metadata(s, update_fade)
-  source.on_track(s, stop_fade)
-  fade.scale(id=id,apply,s)
+  s = source.on_metadata(s, update_fade)
+  s = source.on_track(s, stop_fade)
+  fade.scale(id=id, apply, s)
 end
 
 # Fade the beginning of tracks.
@@ -236,8 +238,8 @@ def fade.in(~id="fade.in",~duration=3.,
     end
   end
 
-  source.on_metadata(s, update_fade)
-  if track_sensitive then source.on_track(s, start_fade) else start_fade([]) end
+  s = source.on_metadata(s, update_fade)
+  s = if track_sensitive then source.on_track(s, start_fade) else start_fade([]); s end
 
   fade.scale(id=id,apply,s)
 end

--- a/libs/lastfm.liq
+++ b/libs/lastfm.liq
@@ -67,7 +67,7 @@ def audioscrobbler.submit.full(
   f = audioscrobbler.nowplaying(
         user=user,password=password,
         host=host,port=port,length=length)
-  source_on_metadata(s, f)
+  s = source_on_metadata(s, f)
   f = fun (rem,m) ->
       # Avoid skipped songs
       if rem > 0. or force then

--- a/libs/metadata.liq
+++ b/libs/metadata.liq
@@ -13,7 +13,7 @@ def metadata.getter.base(init, map, metadata, s)
     v = m[metadata]
     if v != "" then x := map(v) end
   end
-  source.on_metadata(s, f)
+  s.on_metadata(f)
   {!x}
 end
 

--- a/libs/native.liq
+++ b/libs/native.liq
@@ -8,7 +8,7 @@ let native = ()
 def native.once(s)
   # source.available(track_sensitive=true, s, predicate.first({true}))
   a = ref(true)
-  source.on_track(s, fun(_) -> a := false)
+  s = source.on_track(s, fun(_) -> a := false)
   source.available(s, {!a})
 end
 
@@ -59,7 +59,7 @@ def native.sequence(~id=null(), sources)
     end
   end
 
-  source.on_track(s, ot)
+  s = source.on_track(s, ot)
   s
 end
 

--- a/libs/switches.liq
+++ b/libs/switches.liq
@@ -84,7 +84,7 @@ def rotate(~id=null(), ~override="liq_transition_length", ~replay_metadata=true,
     # Weight of the source
     weight = list.nth(default=default_weight, weights, index)
 
-    source.on_track(s, fun(_) -> ref.incr(tracks_played))
+    s = source.on_track(s, fun(_) -> ref.incr(tracks_played))
 
     def cond() =
       if !picked_index == -1 then pick() end
@@ -171,7 +171,7 @@ def replaces random(~id=null(), ~override="liq_transition_length", ~replay_metad
       next_index := -1
     end 
 
-    source.on_track(s, f)
+    s = source.on_track(s, f)
 
     def cond() =
       if !next_index == -1 then pick() end

--- a/src/Makefile
+++ b/src/Makefile
@@ -78,6 +78,7 @@ sources = \
 operators = \
 	operators/insert_metadata.ml operators/map_metadata.ml \
 	operators/on_end.ml operators/on_frame.ml operators/delay.ml \
+	operators/on_track.ml operators/on_metadata.ml \
 	operators/max_duration.ml operators/sequence.ml operators/add.ml \
 	operators/switch.ml operators/cross.ml \
 	operators/pitch.ml operators/pipe.ml operators/filter.ml \

--- a/src/builtins/builtins_source.ml
+++ b/src/builtins/builtins_source.ml
@@ -146,34 +146,6 @@ let () =
       Lang.float (frame_position +. in_frame_position))
 
 let () =
-  Lang.add_builtin "source.on_metadata" ~category:`Liquidsoap
-    ~descr:"Call a given handler on metadata packets."
-    [
-      ("", Lang.source_t (Lang.univ_t ()), None, None);
-      ("", Lang.fun_t [(false, "", Lang.metadata_t)] Lang.unit_t, None, None);
-    ]
-    Lang.unit_t
-    (fun p ->
-      let s = Lang.assoc "" 1 p |> Lang.to_source in
-      let f = Lang.assoc "" 2 p in
-      s#on_metadata (fun m -> ignore (Lang.apply f [("", Lang.metadata m)]));
-      Lang.unit)
-
-let () =
-  Lang.add_builtin "source.on_track" ~category:`Liquidsoap
-    ~descr:"Call a given handler on new tracks."
-    [
-      ("", Lang.source_t (Lang.univ_t ()), None, None);
-      ("", Lang.fun_t [(false, "", Lang.metadata_t)] Lang.unit_t, None, None);
-    ]
-    Lang.unit_t
-    (fun p ->
-      let s = Lang.assoc "" 1 p |> Lang.to_source in
-      let f = Lang.assoc "" 2 p in
-      s#on_track (fun m -> ignore (Lang.apply f [("", Lang.metadata m)]));
-      Lang.unit)
-
-let () =
   Lang.add_builtin "source.on_leave" ~category:`System
     [
       ("", Lang.source_t (Lang.univ_t ()), None, None);

--- a/src/lang/typing.ml
+++ b/src/lang/typing.ml
@@ -146,8 +146,6 @@ exception Unsatisfied_constraint of constr * t
 (** Check that [a] (a dereferenced type variable) does not occur in [b] and
     prepare the instantiation [a<-b] by adjusting the levels. *)
 let rec occur_check (a : var) b =
-  let b0 = b in
-  let b = deref b in
   match b.descr with
     | Constr c -> List.iter (fun (_, x) -> occur_check a x) c.params
     | Tuple l -> List.iter (occur_check a) l
@@ -165,10 +163,10 @@ let rec occur_check (a : var) b =
         List.iter (fun (_, _, t) -> occur_check a t) p;
         occur_check a t
     | Ground _ -> ()
-    | Var { contents = Free b } ->
-        if Type.Var.eq a b then raise (Occur_check (a, b0));
-        b.level <- min a.level b.level
-    | Var { contents = Link _ } -> assert false
+    | Var { contents = Free x } ->
+        if Type.Var.eq a x then raise (Occur_check (a, b));
+        x.level <- min a.level x.level
+    | Var { contents = Link (_, b) } -> occur_check a b
 
 (** Ensure that a type satisfies a given constraint, i.e. morally that b <: c. *)
 let satisfies_constraint b = function

--- a/src/operators/on_metadata.ml
+++ b/src/operators/on_metadata.ml
@@ -45,8 +45,9 @@ class on_metadata ~kind f s =
 let () =
   let kind = Lang.any in
   let return_t = Lang.kind_type_of_kind_format kind in
-  Lang.add_operator "on_metadata"
+  Lang.add_operator "source.on_metadata"
     [
+      ("", Lang.source_t return_t, None, None);
       ( "",
         Lang.fun_t
           [
@@ -57,12 +58,11 @@ let () =
         Some
           "Function called on every metadata packet in the stream. It should \
            be fast because it is executed in the main streaming thread." );
-      ("", Lang.source_t return_t, None, None);
     ]
     ~category:`Track ~descr:"Call a given handler on metadata packets."
     ~return_t
     (fun p ->
-      let f = Lang.assoc "" 1 p in
-      let s = Lang.to_source (Lang.assoc "" 2 p) in
+      let s = Lang.assoc "" 1 p |> Lang.to_source in
+      let f = Lang.assoc "" 2 p in
       let kind = Kind.of_kind kind in
       new on_metadata ~kind f s)

--- a/src/operators/on_metadata.ml
+++ b/src/operators/on_metadata.ml
@@ -1,0 +1,68 @@
+(*****************************************************************************
+
+  Liquidsoap, a programmable audio stream generator.
+  Copyright 2003-2019 Savonet team
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details, fully stated in the COPYING
+  file at the root of the liquidsoap distribution.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA
+
+ *****************************************************************************)
+
+class on_metadata ~kind f s =
+  object (self)
+    inherit Source.operator ~name:"on_metadata" kind [s]
+    method stype = s#stype
+    method is_ready = s#is_ready
+    method abort_track = s#abort_track
+    method remaining = s#remaining
+    method seek n = s#seek n
+    method self_sync = s#self_sync
+
+    method private get_frame ab =
+      let p = Frame.position ab in
+      s#get ab;
+      List.iter
+        (fun (i, m) ->
+          if i >= p then begin
+            self#log#debug "Got metadata at position %d: calling handler..." i;
+            ignore (Lang.apply f [("", Lang.metadata m)])
+          end)
+        (Frame.get_all_metadata ab)
+  end
+
+let () =
+  let kind = Lang.any in
+  let return_t = Lang.kind_type_of_kind_format kind in
+  Lang.add_operator "on_metadata"
+    [
+      ( "",
+        Lang.fun_t
+          [
+            (false, "", Lang.list_t (Lang.product_t Lang.string_t Lang.string_t));
+          ]
+          Lang.unit_t,
+        None,
+        Some
+          "Function called on every metadata packet in the stream. It should \
+           be fast because it is executed in the main streaming thread." );
+      ("", Lang.source_t return_t, None, None);
+    ]
+    ~category:`Track ~descr:"Call a given handler on metadata packets."
+    ~return_t
+    (fun p ->
+      let f = Lang.assoc "" 1 p in
+      let s = Lang.to_source (Lang.assoc "" 2 p) in
+      let kind = Kind.of_kind kind in
+      new on_metadata ~kind f s)

--- a/src/operators/on_track.ml
+++ b/src/operators/on_track.ml
@@ -1,0 +1,73 @@
+(*****************************************************************************
+
+  Liquidsoap, a programmable audio stream generator.
+  Copyright 2003-2019 Savonet team
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details, fully stated in the COPYING
+  file at the root of the liquidsoap distribution.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA
+
+ *****************************************************************************)
+
+class on_track ~kind f s =
+  object
+    inherit Source.operator ~name:"on_track" kind [s]
+    method stype = s#stype
+    method is_ready = s#is_ready
+    method abort_track = s#abort_track
+    method remaining = s#remaining
+    method seek n = s#seek n
+    method self_sync = s#self_sync
+    val mutable called = false
+
+    method private get_frame ab =
+      let p = Frame.position ab in
+      s#get ab;
+      if not called then begin
+        let m =
+          match Frame.get_metadata ab p with
+            | None -> Lang.list []
+            | Some m -> Lang.metadata m
+        in
+        ignore (Lang.apply f [("", m)]);
+        called <- true
+      end;
+      if Frame.is_partial ab then called <- false
+  end
+
+let () =
+  let kind = Lang.any in
+  let return_t = Lang.kind_type_of_kind_format kind in
+  Lang.add_operator "on_track"
+    [
+      ( "",
+        Lang.fun_t
+          [
+            (false, "", Lang.list_t (Lang.product_t Lang.string_t Lang.string_t));
+          ]
+          Lang.unit_t,
+        None,
+        Some
+          "Function called on every beginning of track in the stream, with the \
+           corresponding metadata as argument. If there is no metadata at the \
+           beginning of track, the empty list is passed. That function should \
+           be fast because it is executed in the main streaming thread." );
+      ("", Lang.source_t return_t, None, None);
+    ]
+    ~category:`Track ~descr:"Call a given handler on new tracks." ~return_t
+    (fun p ->
+      let f = Lang.assoc "" 1 p in
+      let s = Lang.to_source (Lang.assoc "" 2 p) in
+      let kind = Kind.of_kind kind in
+      new on_track ~kind f s)

--- a/src/operators/on_track.ml
+++ b/src/operators/on_track.ml
@@ -49,8 +49,9 @@ class on_track ~kind f s =
 let () =
   let kind = Lang.any in
   let return_t = Lang.kind_type_of_kind_format kind in
-  Lang.add_operator "on_track"
+  Lang.add_operator "source.on_track"
     [
+      ("", Lang.source_t return_t, None, None);
       ( "",
         Lang.fun_t
           [
@@ -63,11 +64,10 @@ let () =
            corresponding metadata as argument. If there is no metadata at the \
            beginning of track, the empty list is passed. That function should \
            be fast because it is executed in the main streaming thread." );
-      ("", Lang.source_t return_t, None, None);
     ]
     ~category:`Track ~descr:"Call a given handler on new tracks." ~return_t
     (fun p ->
-      let f = Lang.assoc "" 1 p in
-      let s = Lang.to_source (Lang.assoc "" 2 p) in
+      let s = Lang.assoc "" 1 p |> Lang.to_source in
+      let f = Lang.assoc "" 2 p in
       let kind = Kind.of_kind kind in
       new on_track ~kind f s)

--- a/tests/streams/on_metadata.liq
+++ b/tests/streams/on_metadata.liq
@@ -1,0 +1,19 @@
+#!../../src/liquidsoap ../../libs/stdlib.liq ../../libs/deprecations.liq
+
+%include "test.liq"
+
+log.level.set(4)
+
+def f(_)
+  print("Got metadata!")
+  test.pass()
+  shutdown()
+end
+
+s = sine()
+s = source.on_metadata(s,f)
+s = insert_metadata(s)
+
+thread.run(delay=1., {s.insert_metadata([("test", "bla")])})
+
+output.dummy(s)

--- a/tests/streams/on_metadata.liq
+++ b/tests/streams/on_metadata.liq
@@ -12,8 +12,14 @@ end
 
 s = sine()
 s = source.on_metadata(s,f)
+# s.on_metadata(f)
 s = insert_metadata(s)
 
-thread.run(delay=1., {s.insert_metadata([("test", "bla")])})
+def insert()
+  print("Inserting metadata")
+  s.insert_metadata([("test", "bla")])
+end
+
+thread.run(delay=1., insert)
 
 output.dummy(s)

--- a/tests/streams/on_metadata.liq
+++ b/tests/streams/on_metadata.liq
@@ -11,14 +11,14 @@ def f(_)
 end
 
 s = sine()
-s = source.on_metadata(s,f)
-# s.on_metadata(f)
 s = insert_metadata(s)
 
 def insert()
   print("Inserting metadata")
   s.insert_metadata([("test", "bla")])
 end
+
+s = source.on_metadata(s,f)
 
 thread.run(delay=1., insert)
 

--- a/tests/streams/on_track.liq
+++ b/tests/streams/on_track.liq
@@ -1,0 +1,16 @@
+#!../../src/liquidsoap ../../libs/stdlib.liq ../../libs/deprecations.liq
+
+%include "test.liq"
+
+log.level.set(4)
+
+def f(_)
+  print("Got track!")
+  test.pass()
+  shutdown()
+end
+
+s = sequence([sine(duration=1.), sine()])
+s = source.on_track(s,f)
+
+output.dummy(s)


### PR DESCRIPTION
The current implementation makes it so that handlers are called even if the source is not used locally, which is bad.