### PR TITLE
Adapt to menhir with infered types

### DIFF
--- a/Makefile.rules
+++ b/Makefile.rules
@@ -73,11 +73,12 @@ all-auto-ocaml-prog:
 ifdef PROG
 $(PROG)_mly=$(wildcard $($(PROG)_sources:.ml=.mly))
 $(PROG)_headers=$(wildcard $($(PROG)_sources:.ml=.mli)) $($(PROG)_mly:.mly=.mli)
+$(PROG)_depends=$(PROG)_depend $($(PROG)_mly:.mly=_depend)
 # Grab program-specific flags
 _OCAML_CFLAGS=$($(PROG)_ocamlcflags)
 _OCAML_LFLAGS=$($(PROG)_ocamllflags)
 
--include $(PROG)_depend
+-include $($(PROG)_depends)
 
 $(PROG)_depend: $($(PROG)_sources) $($(PROG)_headers)
 	$(V)echo OCAMLDEP
@@ -112,10 +113,17 @@ $(PROG)$(EXEEXT): $($(PROG)_sources:.ml=.$(o)) $(c_objs)
 		$(c_link)
 endif
 
+%_depend: %.mly
+	@echo $@ >> auto_clean
+	$(V)echo MENHIRDEP $<
+	$(V)$(MENHIR) --ocamldep "$(OCAMLDEP) $(DEP_OPTS)" --depend --unused-tokens $< | sed 's/cmo/cmx/g' > $@
+
 %.ml %.mli: %.mly
+	@echo "*** from $< to $@"
+	@echo "PROG: $(PROG)"
 	@echo $(<:.mly=.mli) $(<:.mly=.ml) $(<:.mly=.conflicts) >> auto_clean
 	$(V)echo MENHIR $<
-	$(V)$(MENHIR) --unused-tokens --explain $<
+	$(V)$(MENHIR) --ocamlc '$(OCAMLC) $(_OCAML_CFLAGS) $(OCAML_CFLAGS)' --infer --unused-tokens --explain $<
 
 %.$(o): %.ml
 	$(V)echo $(OCAMLCOMP) -c $<

--- a/Makefile.rules
+++ b/Makefile.rules
@@ -73,7 +73,7 @@ all-auto-ocaml-prog:
 ifdef PROG
 $(PROG)_mly=$(wildcard $($(PROG)_sources:.ml=.mly))
 $(PROG)_headers=$(wildcard $($(PROG)_sources:.ml=.mli)) $($(PROG)_mly:.mly=.mli)
-$(PROG)_depends=$(PROG)_depend $($(PROG)_mly:.mly=_depend)
+$(PROG)_depends=$($(PROG)_mly:.mly=_depend) $(PROG)_depend
 # Grab program-specific flags
 _OCAML_CFLAGS=$($(PROG)_ocamlcflags)
 _OCAML_LFLAGS=$($(PROG)_ocamllflags)
@@ -119,6 +119,7 @@ endif
 
 %.ml %.mli: %.mly
 	@echo "*** from $< to $@"
+	@echo "need $^"
 	@echo "PROG: $(PROG)"
 	@echo $(<:.mly=.mli) $(<:.mly=.ml) $(<:.mly=.conflicts) >> auto_clean
 	$(V)echo MENHIR $<

--- a/Makefile.rules
+++ b/Makefile.rules
@@ -82,8 +82,7 @@ _OCAML_LFLAGS=$($(PROG)_ocamllflags)
 
 $(PROG)_depend: $($(PROG)_sources) $($(PROG)_headers)
 	$(V)echo OCAMLDEP
-	$(V)$(OCAMLDEP) $(_DEP_OPTS) $(DEP_OPTS) \
-		$($(PROG)_sources) $($(PROG)_headers) > $@
+	$(V)$(OCAMLDEP) $(_DEP_OPTS) $(DEP_OPTS) $($(PROG)_sources) $($(PROG)_headers) > $@
 
 dll$(PROG).so: $($(PROG)_c_files:.c=.o)
 	$(V)echo OCAMLMKLIB -o dll$(PROG).so
@@ -116,7 +115,7 @@ endif
 %_depend: %.mly
 	@echo $@ >> auto_clean
 	$(V)echo MENHIRDEP $<
-	$(V)$(MENHIR) --ocamldep "$(OCAMLDEP) $(DEP_OPTS)" --depend --unused-tokens $< | sed 's/cmo/cmx/g' > $@
+	$(V)$(MENHIR) --ocamldep "$(OCAMLDEP) $(DEP_OPTS)" --depend --unused-tokens $< | sed 's/cmo/$(o)/g' > $@
 
 %.ml %.mli: %.mly
 	@echo "*** from $< to $@"
@@ -204,8 +203,7 @@ endif
 ifdef ocaml_progs
 doc-auto: all-auto-ocaml-prog
 	for prog in $(ocaml_progs) ; do \
-		PROG=$$prog $(MAKE) $(top_srcdir)/autodoc/$$prog/index.html \
-                || exit $$? ; \
+		PROG=$$prog $(MAKE) $(top_srcdir)/autodoc/$$prog/index.html || exit $$? ; \
 	done
 endif
 


### PR DESCRIPTION
The new version of menhir apparently infer types for generated ml files. This branch is a try to adapt and use `--infer`.