### PR TITLE
Use R128 gain as replaygain for opus.

### DIFF
--- a/libs/audio.liq
+++ b/libs/audio.liq
@@ -181,6 +181,23 @@ end
 # @category Source / Sound Processing
 # @param s Source to be amplified.
 def replaygain(s)
+  s = insert_metadata(s)
+  # Normalize opus gain
+  def f(m)
+    def f(m)
+      let (k, v) = m
+      if k == "r128_track_gain" then
+        v = int_of_string(v)
+        v = v + 5 # normalize to -18 dB as usual replaygain instead of -23 dB
+        v = lin_of_dB(float(v) / 256.)
+        ("replaygain_track_gain", string_of_float(v))
+      else
+        (k, v)
+      end
+    end
+    list.map(f, m)
+  end
+  s = map_metadata(f, s)
   amplify(override="replaygain_track_gain", 1., s)
 end
 

--- a/libs/audio.liq
+++ b/libs/audio.liq
@@ -179,8 +179,9 @@ end
 # compute itself the replaygain: you can use either `enable_replaygain_metadata`
 # or the `replaygain:` protocol for this.
 # @category Source / Sound Processing
+# @param ~ebu_r128 Also amplify according to EBU R128 tags.
 # @param s Source to be amplified.
-def replaygain(s)
+def replaygain(~ebu_r128=true, s)
   s = insert_metadata(s)
   # Normalize opus gain
   def f(m)
@@ -195,7 +196,7 @@ def replaygain(s)
         (k, v)
       end
     end
-    list.map(f, m)
+    if ebu_r128 then list.map(f, m) else m end
   end
   s = map_metadata(f, s)
   amplify(override="replaygain_track_gain", 1., s)


### PR DESCRIPTION
Let's discuss my fix for #2172 here.

Replaygain and EBU R128 standards are different ones. However, opus only uses the second one, and you'd expect a unified way of handling both. This is done by default, but I have added an argument to `replaygain` to disable that.