### PR TITLE
Make last_start shared between all muxed streams in ffmpeg copy encoder.

### DIFF
--- a/src/encoder/ffmpeg_encoder.ml
+++ b/src/encoder/ffmpeg_encoder.ml
@@ -29,12 +29,14 @@ let () =
     | Encoder.Ffmpeg m ->
         Some
           (fun _ ->
+            let get_stream = mk_stream_store () in
             let mk_audio =
               match m.Ffmpeg_format.audio_codec with
                 | Some `Copy ->
                     fun ~ffmpeg:_ ~options:_ ->
                       Ffmpeg_copy_encoder.mk_stream_copy
                         ~video_size:(fun _ -> None)
+                        ~get_stream
                         ~get_data:(fun frame ->
                           Ffmpeg_copy_content.Audio.get_data
                             Frame.(frame.content.audio))
@@ -61,7 +63,8 @@ let () =
                               Avcodec.Video.get_height params ))
                           params
                       in
-                      Ffmpeg_copy_encoder.mk_stream_copy ~video_size ~get_data
+                      Ffmpeg_copy_encoder.mk_stream_copy ~video_size ~get_stream
+                        ~get_data
                 | None | Some (`Internal (Some _)) | Some (`Raw (Some _)) ->
                     Ffmpeg_internal_encoder.mk_video
                 | Some (`Internal None) ->


### PR DESCRIPTION
Make sure ffmpeg copy encoder always applies the same offset to all muxed streams.