### PR TITLE
Test that muxing preserves metadata.

### DIFF
--- a/tests/streams/mux-meta.liq
+++ b/tests/streams/mux-meta.liq
@@ -1,0 +1,14 @@
+#!../../src/liquidsoap ../../libs/stdlib.liq
+
+# Ensure that muxing video preserves metadata
+
+%include "test.liq"
+
+log.level.set(4)
+
+s = sine()
+s = insert_metadata(s)
+thread.run(delay=1., {s.insert_metadata([("a","b")])})
+s = mux_video(video=blank(), s)
+s = source.on_metadata(s, fun(_) -> begin test.pass(); shutdown() end)
+output.dummy(s)


### PR DESCRIPTION
It seems that muxing video to an audio track drops the metadata from the track, whereas we would expect that they are preserved. This needs to be fixed.