### PR TITLE
Allow decoding images with blank audio.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -46,6 +46,8 @@ Changes:
   using `video.add_text(speed=70, ...)`.
 - Default implementation of `video.testsrc` is now builtin, previous
   implementation can be found under `video.testsrc.ffmpeg`.
+- Images can now generate blank audio if needed, no need to add
+  `mux_audio(audio=blank(),image)` anymore (#2230).
 
 2.0.2 (28-12-2021)
 =====

--- a/src/lang/typing.ml
+++ b/src/lang/typing.ml
@@ -214,12 +214,12 @@ let satisfies_constraint b = function
       let is_internal name =
         try
           let kind = Content.kind_of_string name in
-          Content.is_internal kind
+          Content.is_internal_kind kind
         with Content.Invalid -> false
       in
       match b.descr with
         | Constr { constructor } when is_internal constructor -> ()
-        | Ground (Format f) when Content.(is_internal (kind f)) -> ()
+        | Ground (Format f) when Content.(is_internal_format f) -> ()
         | Var { contents = Free v } ->
             if not (List.mem InternalMedia v.constraints) then
               v.constraints <- InternalMedia :: v.constraints

--- a/src/stream/content.mli
+++ b/src/stream/content.mli
@@ -255,7 +255,7 @@ end
 val default_audio : unit -> Contents.format
 val default_video : unit -> Contents.format
 val default_midi : unit -> Contents.format
-val is_internal : kind -> bool
+val is_internal_kind : kind -> bool
 val is_internal_format : format -> bool
 
 (* Some tools *)

--- a/src/stream/content.mli
+++ b/src/stream/content.mli
@@ -256,6 +256,7 @@ val default_audio : unit -> Contents.format
 val default_video : unit -> Contents.format
 val default_midi : unit -> Contents.format
 val is_internal : kind -> bool
+val is_internal_format : format -> bool
 
 (* Some tools *)
 val merge_param : name:string -> 'a option * 'a option -> 'a option

--- a/src/stream/content_internal.ml
+++ b/src/stream/content_internal.ml
@@ -294,3 +294,6 @@ let default_midi () =
 
 let is_internal f =
   None.is_kind f || Audio.is_kind f || Video.is_kind f || Midi.is_kind f
+
+let is_internal_format f =
+  None.is_format f || Audio.is_format f || Video.is_format f || Midi.is_format f

--- a/src/stream/content_internal.ml
+++ b/src/stream/content_internal.ml
@@ -292,7 +292,7 @@ let default_midi () =
   let channels = Lazy.force Frame_base.midi_channels in
   if channels = 0 then None.format else Midi.lift_params { Contents.channels }
 
-let is_internal f =
+let is_internal_kind f =
   None.is_kind f || Audio.is_kind f || Video.is_kind f || Midi.is_kind f
 
 let is_internal_format f =

--- a/src/stream/kind.ml
+++ b/src/stream/kind.ml
@@ -76,11 +76,13 @@ let unify_kind k k' =
       | `Format f, `Kind ki when Content.kind f = ki -> Unifier.(k' <-- k)
       (* `Internal/'a *)
       | `Internal, `Internal -> Unifier.(k <-- k')
-      | `Internal, `Kind ki when Content.is_internal ki -> Unifier.(k <-- k')
-      | `Internal, `Format f when Content.(is_internal (kind f)) ->
+      | `Internal, `Kind ki when Content.is_internal_kind ki ->
           Unifier.(k <-- k')
-      | `Kind ki, `Internal when Content.is_internal ki -> Unifier.(k' <-- k)
-      | `Format f, `Internal when Content.(is_internal (kind f)) ->
+      | `Internal, `Format f when Content.(is_internal_format f) ->
+          Unifier.(k <-- k')
+      | `Kind ki, `Internal when Content.is_internal_kind ki ->
+          Unifier.(k' <-- k)
+      | `Format f, `Internal when Content.(is_internal_format f) ->
           Unifier.(k' <-- k)
       (* Any/'a *)
       | `Any, _ -> Unifier.(k <-- k')


### PR DESCRIPTION
The attached patch allows generating blank audio when decoding images in order not to have to uselessly mux blank when decoding. This really makes life much easier. Fixes #1568.