### PR TITLE
Only cleanup transition source when it is not ready anymore.

### DIFF
--- a/src/operators/cross.ml
+++ b/src/operators/cross.ml
@@ -217,21 +217,7 @@ class cross ~kind val_source ~cross_length ~override_duration ~rms_width
               Frame.add_break frame (Frame.position frame)
         | `After when (Option.get transition_source)#is_ready ->
             (Option.get transition_source)#get frame;
-            needs_tick <- true;
-            if Frame.is_partial frame then (
-              status <- `Idle;
-              self#cleanup_transition_source;
-
-              (* If underlying source if ready, try to continue filling up the frame
-               * using it. Each call to [get_frame] must add exactly one break so
-               * call it again and then remove the intermediate break that was just
-               * just added. *)
-              if source#is_ready then (
-                self#get_frame frame;
-                Frame.set_breaks frame
-                  (match Frame.breaks frame with
-                    | b :: _ :: l -> b :: l
-                    | _ -> assert false)))
+            needs_tick <- true
         | `After ->
             (* Here, transition source went down so we switch back to main source.
                Our [is_ready] check ensures that we only get here when the main source

--- a/src/operators/cross.ml
+++ b/src/operators/cross.ml
@@ -92,7 +92,8 @@ class cross ~kind val_source ~cross_length ~override_duration ~rms_width
     (* Give a default value for the transition source. *)
     val mutable transition_source = None
 
-    (* This is used to track the state of the transition source and switch back to the current source w/o introducing artificial track marks. *)
+    (* This is used to track the state of the transition source and switch back
+       to the current source w/o introducing artificial track marks. *)
     val mutable pending_after = Generator.create ()
 
     method private prepare_transition_source s =

--- a/tests/regression/AC5109.liq
+++ b/tests/regression/AC5109.liq
@@ -1,0 +1,34 @@
+#!../../src/liquidsoap ../../libs/stdlib.liq ../../libs/deprecations.liq
+
+%include "test.liq"
+
+# See: https://github.com/AzuraCast/AzuraCast/issues/5109.
+# Crossfade transition sources with breaks where triggering
+# end of transition too early.
+
+s1 = sine(duration=20.)
+s2 = sine(duration=20.)
+s = sequence([s1,s2])
+
+def transition(a, b) =
+  s1 = sine(duration=0.5)
+  s1 = map_metadata(fun (_) -> [("type", "s1")], s1)
+
+  s2 = sine(duration=0.5)
+  s2 = map_metadata(fun (_) -> [("type", "s2")], s2)
+  sequence([(a.source:source), (s1:source), (s2:source), (b.source:source)])
+end
+
+s = cross(transition, s)
+
+def check(m) =
+  if m["type"] == "s2" then
+    test.pass()
+  end
+end
+
+s.on_metadata(check) 
+
+clock.assign_new(sync="none",[s])
+
+output.dummy(fallible=true,s)


### PR DESCRIPTION
Looks like some recent changes triggered an issue where the crossfade transition was cleaned up prematurely cf: https://github.com/AzuraCast/AzuraCast/issues/5109. This should fix it. Regression test included.