### PR TITLE
Memtrace optims

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
 Changed:
 * Switch to bigarray APIs for ogg/vorbis and ogg/opus
   encoder and decoder to save memory allocations and data copy.
+* Optimized memory usage when accessing frame content (#2266)
 
 2.0.3 (11-02-2022)
 =====

--- a/src/encoder/lame_encoder.ml
+++ b/src/encoder/lame_encoder.ml
@@ -214,12 +214,8 @@ module Register (Lame : Lame_t) = struct
 
           (* Yes, lame requires this absurd scaling... *)
           let scale buf =
-            let len = Audio.Mono.length buf in
-            let sbuf = Audio.Mono.create len in
-            for i = 0 to len - 1 do
-              Bigarray.Array1.unsafe_set sbuf i
-                (Bigarray.Array1.unsafe_get buf i *. 32768.)
-            done;
+            let sbuf = Audio.Mono.copy buf in
+            Audio.Mono.amplify 32768. sbuf;
             sbuf
           in
           if channels = 1 then (

--- a/src/io/ffmpeg_filter_io.ml
+++ b/src/io/ffmpeg_filter_io.ml
@@ -60,7 +60,8 @@ class audio_output ~pass_metadata ~name ~kind source_val =
           init frame;
           let pts =
             Int64.add
-              ((Lazy.force convert_frame_pts) (Frame.pts memo))
+              ((Lazy.force convert_frame_pts)
+                 (Int64.of_nativeint (Frame.pts memo)))
               (Int64.of_int pos)
           in
           Avutil.Frame.set_pts frame (Some pts);
@@ -107,7 +108,8 @@ class video_output ~pass_metadata ~kind ~name source_val =
           init frame;
           let pts =
             Int64.add
-              ((Lazy.force convert_frame_pts) (Frame.pts memo))
+              ((Lazy.force convert_frame_pts)
+                 (Int64.of_nativeint (Frame.pts memo)))
               (Int64.of_int pos)
           in
           Avutil.Frame.set_pts frame (Some pts);

--- a/src/stream/frame.ml
+++ b/src/stream/frame.ml
@@ -105,7 +105,7 @@ let metadata_of_list l =
 
 type t = {
   (* Presentation time, in multiple of frame size. *)
-  mutable pts : int64;
+  mutable pts : nativeint;
   (* End of track markers.
    * A break at the end of the buffer is not an end of track.
    * So maybe we should rather call that an end-of-fill marker,
@@ -123,12 +123,12 @@ type t = {
 let create_content ctype = map_fields (make ~size:!!size) ctype
 
 let create ctype =
-  { pts = 0L; breaks = []; metadata = []; content = create_content ctype }
+  { pts = 0n; breaks = []; metadata = []; content = create_content ctype }
 
 let dummy =
   let data = Frame_content.None.data in
   {
-    pts = 0L;
+    pts = 0n;
     breaks = [];
     metadata = [];
     content = { audio = data; video = data; midi = data };
@@ -166,7 +166,7 @@ let advance b =
   Frame_content.clear b.content.audio;
   Frame_content.clear b.content.video;
   Frame_content.clear b.content.midi;
-  b.pts <- Int64.succ b.pts;
+  Utils.incr_nativeint b.pts;
   b.breaks <- [];
   b.metadata <- []
 

--- a/src/stream/frame.mli
+++ b/src/stream/frame.mli
@@ -71,7 +71,7 @@ val metadata_of_list : (string * string) list -> metadata
 (** A frame. *)
 type t = {
   (* Presentation time, in multiple of frame size. *)
-  mutable pts : int64;
+  mutable pts : nativeint;
   (* End of track markers. A break at the end of the
      buffer is not an end of track (if needed, the
      end-of-track needs to be put at the beginning
@@ -134,10 +134,10 @@ val advance : t -> unit
 (** {3 Presentation time} *)
 
 (** Frame presentation time, in multiple of a frame's size. *)
-val pts : t -> int64
+val pts : t -> nativeint
 
 (** Set presentation time. *)
-val set_pts : t -> int64 -> unit
+val set_pts : t -> nativeint -> unit
 
 (** {3 Breaks} *)
 

--- a/src/stream/generator.ml
+++ b/src/stream/generator.ml
@@ -596,7 +596,7 @@ module From_audio_video = struct
           (List.filter (fun x -> x < size) (Frame.breaks frame));
 
     (* Feed all content layers into the generator. *)
-    let pts = Frame.pts frame in
+    let pts = Int64.of_nativeint (Frame.pts frame) in
     let mode = match mode with Some mode -> mode | None -> t.mode in
     let pos = Frame.position frame in
     let content = frame.Frame.content in

--- a/src/tools/unix_c.c
+++ b/src/tools/unix_c.c
@@ -79,3 +79,9 @@ CAMLprim value liquidsoap_get_pagesize() {
   return Val_int(getpagesize());
 #endif
 }
+
+CAMLprim value liquidsoap_incr_intnat(value v) {
+  CAMLparam1(v);
+  Nativeint_val(v) = Nativeint_val(v)+1;
+  CAMLreturn(Val_unit);
+}

--- a/src/tools/utils.ml
+++ b/src/tools/utils.ml
@@ -853,3 +853,5 @@ let self_sync_type sources =
               | _ -> (`Dynamic, None))
           (`Static, None)
           sources))
+
+external incr_nativeint : nativeint -> unit = "liquidsoap_incr_intnat"


### PR DESCRIPTION
These changes implement a couple of memory allocation optimization found via `memtrace` (see: https://blog.janestreet.com/finding-memory-leaks-with-memtrace)

1. Switch more routines using float bigarray to C implementation to avoid the cost of boxing/unboxing floats back and forth (minor)
2. Optimize memory allocation with extensible types.

Item 2 is the most important. Existing code is using patterns of the form:
```ocaml
type t = ..

type handler = {
  do_something : unit -> int
}

let handlers = Queue.create
let register_handler fn = Queue.add fn handlers

exception Found of handler

let find_handler d =
  try
    Queue.iter (fun fn -> match fn d with Some h -> raise (Found h) | None -> ());
    raise Not_found
  with Found h -> g 

type t += Foo of string
let () =
  register_handler (function
    | Foo s -> Some { do_something = (fun () -> foo_do_something s) }
    | _ -> None)
```
This works and mirrors how extensible types are implemented for exceptions. However, this leads to a _shitload_ of memory allocations, namely all the partial functions used when resolving from the extensible type down to the implementation type and, when used with critical implementations such as stream frame content, this results in a lot of CPU and memory allocation work.

This PR changes the coding pattern for critical code path, i.e. frame content to a more efficient lookup pattern that looks like this:
```ocaml
type kind = ...
type value = ..
type t = kind * value

type handler = {
  do_something : value -> int
}

let handlers = Hashtbl.create 10
let register_handler = Hashtbl.add handlers

let find_handler (kind, _) = Hashtbl.find handlers kind

type kind += FooKind
type value += FooValue of string

let () =
  register_handler FooKind {  do_something = (function | FooValue v -> foo_do_something v | _ -> assert false) }
```
Using this pattern, no memory allocations are required when looking up for a specific implementation handler.