### PR TITLE
Remove positions in values.

### DIFF
--- a/.merlin
+++ b/.merlin
@@ -1,4 +1,4 @@
 S src/**
 B src/**
 B +threads
-PKG pcre dtools duppy mm ladspa bjack gstreamer lilv sedlex menhirLib alsa samplerate ffmpeg ffmpeg-av ffmpeg-avfilter ffmpeg-swresample ffmpeg-swscale taglib mad ogg ogg.decoder vorbis flac theora frei0r tsdl tsdl-image tsdl-ttf shine flac srt faad ao cry soundtouch lo prometheus pulseaudio portaudio inotify graphics dssi gd camlimages.core camlimages.freetype irc-client irc-client-unix
+PKG pcre dtools duppy mm ladspa bjack gstreamer lilv sedlex menhirLib alsa samplerate ffmpeg ffmpeg-av ffmpeg-avfilter ffmpeg-swresample ffmpeg-swscale taglib mad ogg ogg.decoder vorbis flac theora frei0r tsdl tsdl-image tsdl-ttf shine flac srt faad ao cry soundtouch lo prometheus pulseaudio portaudio inotify graphics dssi gd camlimages.core camlimages.freetype irc-client irc-client-unix curl

--- a/libs/request.liq
+++ b/libs/request.liq
@@ -12,7 +12,7 @@ def replaces request.dynamic(%argsof(request.dynamic), ~native=false, f) =
   end
 end
 
-# Play a queue of uris. Returns a function to push new uris in the queue as well as the resulting source.
+# Play a queue of requests (the first added request gets played first).
 # @category Source / Track Processing
 # @param ~id Force the value of the source ID.
 # @param ~interactive Should the queue be controllable via telnet?

--- a/src/Makefile
+++ b/src/Makefile
@@ -127,13 +127,14 @@ encoders = \
 	$(if $(W_TAGLIB),encoder/taglib_id3v2.ml) \
 	$(if $(W_GSTREAMER),encoder/gstreamer_encoder.ml)
 
-# lang_encoders = \
-	# lang_encoders/lang_avi.ml lang_encoders/lang_external_encoder.ml lang_encoders/lang_fdkaac.ml \
+lang_encoders = \
+	lang_encoders/lang_avi.ml lang_encoders/lang_external_encoder.ml lang_encoders/lang_fdkaac.ml \
+	lang_encoders/lang_flac.ml lang_encoders/lang_gstreamer.ml \
+	lang_encoders/lang_mp3.ml lang_encoders/lang_opus.ml lang_encoders/lang_shine.ml \
+	lang_encoders/lang_speex.ml lang_encoders/lang_theora.ml lang_encoders/lang_vorbis.ml \
+	lang_encoders/lang_wav.ml lang_encoders/lang_ogg.ml
+
 	# lang_encoders/lang_ffmpeg.ml $(if $(W_FFMPEG),lang_encoders/lang_ffmpeg_opt.ml) \
-	# lang_encoders/lang_flac.ml lang_encoders/lang_gstreamer.ml \
-	# lang_encoders/lang_mp3.ml lang_encoders/lang_opus.ml lang_encoders/lang_shine.ml \
-	# lang_encoders/lang_speex.ml lang_encoders/lang_theora.ml lang_encoders/lang_vorbis.ml \
-	# lang_encoders/lang_wav.ml lang_encoders/lang_ogg.ml
 
 encoder_formats = \
 	encoder_formats.ml \

--- a/src/Makefile
+++ b/src/Makefile
@@ -129,12 +129,11 @@ encoders = \
 
 lang_encoders = \
 	lang_encoders/lang_avi.ml lang_encoders/lang_external_encoder.ml lang_encoders/lang_fdkaac.ml \
+	lang_encoders/lang_ffmpeg.ml $(if $(W_FFMPEG),lang_encoders/lang_ffmpeg_opt.ml) \
 	lang_encoders/lang_flac.ml lang_encoders/lang_gstreamer.ml \
 	lang_encoders/lang_mp3.ml lang_encoders/lang_opus.ml lang_encoders/lang_shine.ml \
 	lang_encoders/lang_speex.ml lang_encoders/lang_theora.ml lang_encoders/lang_vorbis.ml \
 	lang_encoders/lang_wav.ml lang_encoders/lang_ogg.ml
-
-	# lang_encoders/lang_ffmpeg.ml $(if $(W_FFMPEG),lang_encoders/lang_ffmpeg_opt.ml) \
 
 encoder_formats = \
 	encoder_formats.ml \

--- a/src/Makefile
+++ b/src/Makefile
@@ -264,7 +264,7 @@ liquidsoap_sources += \
 	lang/profiler.ml lang/term.ml lang/value.ml \
 	lang/lang_encoder.ml $(lang_encoders) \
 	lang/environment.ml lang/typechecking.ml \
-	lang/evaluation.ml lang/error.ml \
+	lang/error.ml lang/evaluation.ml \
         lang/documentation.ml lang/lang_core.ml \
 	lang/lang_error.ml lang/lang_source.ml \
         lang/lang.ml lang/modules.ml \

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,4 +1,4 @@
-INCDIRS = builtins conversions converters decoder encoder encoder_formats harbor io lang lang_encoders ogg_formats operators outputs protocols sources stream tools
+	INCDIRS = builtins conversions converters decoder encoder encoder_formats harbor io lang lang_encoders ogg_formats operators outputs protocols sources stream tools
 
 liquidsoap_c_files = \
 	tools/unix_c.c \
@@ -127,13 +127,13 @@ encoders = \
 	$(if $(W_TAGLIB),encoder/taglib_id3v2.ml) \
 	$(if $(W_GSTREAMER),encoder/gstreamer_encoder.ml)
 
-lang_encoders = \
-	lang_encoders/lang_avi.ml lang_encoders/lang_external_encoder.ml lang_encoders/lang_fdkaac.ml \
-	lang_encoders/lang_ffmpeg.ml $(if $(W_FFMPEG),lang_encoders/lang_ffmpeg_opt.ml) \
-	lang_encoders/lang_flac.ml lang_encoders/lang_gstreamer.ml \
-	lang_encoders/lang_mp3.ml lang_encoders/lang_opus.ml lang_encoders/lang_shine.ml \
-	lang_encoders/lang_speex.ml lang_encoders/lang_theora.ml lang_encoders/lang_vorbis.ml \
-	lang_encoders/lang_wav.ml lang_encoders/lang_ogg.ml
+# lang_encoders = \
+	# lang_encoders/lang_avi.ml lang_encoders/lang_external_encoder.ml lang_encoders/lang_fdkaac.ml \
+	# lang_encoders/lang_ffmpeg.ml $(if $(W_FFMPEG),lang_encoders/lang_ffmpeg_opt.ml) \
+	# lang_encoders/lang_flac.ml lang_encoders/lang_gstreamer.ml \
+	# lang_encoders/lang_mp3.ml lang_encoders/lang_opus.ml lang_encoders/lang_shine.ml \
+	# lang_encoders/lang_speex.ml lang_encoders/lang_theora.ml lang_encoders/lang_vorbis.ml \
+	# lang_encoders/lang_wav.ml lang_encoders/lang_ogg.ml
 
 encoder_formats = \
 	encoder_formats.ml \

--- a/src/builtins/builtins_cry.ml
+++ b/src/builtins/builtins_cry.ml
@@ -96,7 +96,9 @@ let () =
           | _ ->
               raise
                 (Error.Invalid_value
-                   (v, "protocol should be one of: 'icy', 'http' or 'https'."))
+                   ( v,
+                     [],
+                     "protocol should be one of: 'icy', 'http' or 'https'." ))
       in
       let mount =
         match protocol with

--- a/src/builtins/builtins_ffmpeg_encoder.ml
+++ b/src/builtins/builtins_ffmpeg_encoder.ml
@@ -474,7 +474,9 @@ let mk_encoder mode =
           | _ ->
               raise
                 (Error.Invalid_value
-                   (format_val, "Only %ffmpeg encoder is currently supported!"))
+                   ( format_val,
+                     [],
+                     "Only %ffmpeg encoder is currently supported!" ))
       in
       let content =
         match mode with
@@ -488,6 +490,7 @@ let mk_encoder mode =
         raise
           (Error.Invalid_value
              ( format_val,
+               [],
                Printf.sprintf
                  "Muxer options are not supported for inline encoders: %s"
                  (Ffmpeg_format.string_of_options
@@ -496,7 +499,7 @@ let mk_encoder mode =
       if format.Ffmpeg_format.format <> None then
         raise
           (Error.Invalid_value
-             (format_val, "Format option is not supported inline encoders"));
+             (format_val, [], "Format option is not supported inline encoders"));
 
       let mk_encode_frame () =
         let audio_opts = Hashtbl.copy format.Ffmpeg_format.audio_opts in
@@ -537,6 +540,7 @@ let mk_encoder mode =
                   raise
                     (Error.Invalid_value
                        ( format_val,
+                         [],
                          "Operator expects an encoder of the form: " ^ encoder
                        )))
           else None
@@ -560,6 +564,7 @@ let mk_encoder mode =
                   raise
                     (Error.Invalid_value
                        ( format_val,
+                         [],
                          "Operator expects an encoder of the form: " ^ encoder
                        )))
           else None
@@ -604,6 +609,7 @@ let mk_encoder mode =
           raise
             (Error.Invalid_value
                ( format_val,
+                 [],
                  Printf.sprintf "Unrecognized options: %s"
                    (Ffmpeg_format.string_of_options original_opts) ));
 

--- a/src/builtins/builtins_ffmpeg_filters.ml
+++ b/src/builtins/builtins_ffmpeg_filters.ml
@@ -356,11 +356,9 @@ let apply_filter ~args_parser ~filter ~sources_t p =
           Lang.val_fun
             (List.map (fun (_, lbl, _) -> (lbl, lbl, None)) sources_t)
             (fun p ->
-              let v = List.assoc "" p in
               if !input_set then
-                Runtime_error.error
-                  ~pos:(match v.Value.pos with None -> [] | Some p -> [p])
-                  ~message:"Filter input already set!" "ffmpeg.filter";
+                Runtime_error.error ~message:"Filter input already set!"
+                  "ffmpeg.filter";
               let audio_inputs_c = List.length filter.io.inputs.audio in
               let get_input ~mode ~ofs idx =
                 if List.mem `Dynamic_inputs flags then (
@@ -592,7 +590,6 @@ let () =
             }
       in
       let name = uniq_name "abuffer" in
-      let pos = source_val.Lang.pos in
       let s =
         try
           Ffmpeg_filter_io.(

--- a/src/builtins/builtins_ffmpeg_filters.ml
+++ b/src/builtins/builtins_ffmpeg_filters.ml
@@ -185,13 +185,14 @@ let mk_options { Avfilter.options } =
           in
           let x =
             try from_value v
-            with _ -> raise (Error.Invalid_value (v, "Invalid value"))
+            with _ -> raise (Error.Invalid_value (v, [], "Invalid value"))
           in
           (match min with
             | Some m when x < m ->
                 raise
                   (Error.Invalid_value
                      ( v,
+                       [],
                        Printf.sprintf "%s must be more than %s" name
                          (to_string m) ))
             | _ -> ());
@@ -200,6 +201,7 @@ let mk_options { Avfilter.options } =
                 raise
                   (Error.Invalid_value
                      ( v,
+                       [],
                        Printf.sprintf "%s must be less than %s" name
                          (to_string m) ))
             | _ -> ());
@@ -208,6 +210,7 @@ let mk_options { Avfilter.options } =
                 raise
                   (Error.Invalid_value
                      ( v,
+                       [],
                        Printf.sprintf "%s should be one of: %s" name
                          (String.concat ", "
                             (List.map (fun (_, v) -> to_string v) values)) ))
@@ -305,6 +308,7 @@ let get_config graph =
         raise
           (Error.Invalid_value
              ( graph,
+               [],
                "Graph variables cannot be used outside of ffmpeg.filter.create!"
              ))
 
@@ -368,6 +372,7 @@ let apply_filter ~args_parser ~filter ~sources_t p =
                     raise
                       (Error.Invalid_value
                          ( v,
+                           [],
                            Printf.sprintf
                              "Invalid number of input for filter %s" filter.name
                          ));

--- a/src/builtins/builtins_ffmpeg_filters.ml
+++ b/src/builtins/builtins_ffmpeg_filters.ml
@@ -596,9 +596,9 @@ let () =
             new audio_output ~pass_metadata ~name ~kind source_val)
         with
           | Source.Clock_conflict (a, b) ->
-              raise (Error.Clock_conflict (pos, a, b))
-          | Source.Clock_loop (a, b) -> raise (Error.Clock_loop (pos, a, b))
-          | Kind.Conflict (a, b) -> raise (Error.Kind_conflict (pos, a, b))
+              raise (Error.Clock_conflict ([], a, b))
+          | Source.Clock_loop (a, b) -> raise (Error.Clock_loop ([], a, b))
+          | Kind.Conflict (a, b) -> raise (Error.Kind_conflict ([], a, b))
       in
       Queue.add s#clock graph.clocks;
 
@@ -705,16 +705,15 @@ let () =
             }
       in
       let name = uniq_name "buffer" in
-      let pos = source_val.Lang.pos in
       let s =
         try
           Ffmpeg_filter_io.(
             new video_output ~pass_metadata ~name ~kind source_val)
         with
           | Source.Clock_conflict (a, b) ->
-              raise (Error.Clock_conflict (pos, a, b))
-          | Source.Clock_loop (a, b) -> raise (Error.Clock_loop (pos, a, b))
-          | Kind.Conflict (a, b) -> raise (Error.Kind_conflict (pos, a, b))
+              raise (Error.Clock_conflict ([], a, b))
+          | Source.Clock_loop (a, b) -> raise (Error.Clock_loop ([], a, b))
+          | Kind.Conflict (a, b) -> raise (Error.Kind_conflict ([], a, b))
       in
       Queue.add s#clock graph.clocks;
 

--- a/src/builtins/builtins_getter.ml
+++ b/src/builtins/builtins_getter.ml
@@ -47,7 +47,7 @@ let () =
       let x = Lang.assoc "" 1 p in
       let f = Lang.assoc "" 2 p in
       let g = Lang.assoc "" 3 p in
-      match (Lang.demeth x).Lang.value with
+      match Lang.demeth x with
         | Lang.Fun ([], _, _) | Lang.FFI ([], _) -> Lang.apply g [("", x)]
         | _ -> Lang.apply f [("", x)])
 
@@ -74,7 +74,7 @@ let () =
     (fun p ->
       let f = Lang.assoc "" 1 p in
       let x = Lang.assoc "" 2 p in
-      match (Lang.demeth x).Lang.value with
+      match Lang.demeth x with
         | Lang.Fun ([], _, _) | Lang.FFI ([], _) ->
             Lang.val_fun [] (fun _ -> Lang.apply f [("", Lang.apply x [])])
         | _ -> Lang.apply f [("", x)])
@@ -95,7 +95,7 @@ let () =
     (fun p ->
       let f = Lang.assoc "" 1 p in
       let x = Lang.assoc "" 2 p in
-      match (Lang.demeth x).Lang.value with
+      match Lang.demeth x with
         | Lang.Fun ([], _, _) | Lang.FFI ([], _) ->
             let last_x = ref (Lang.apply x []) in
             let last_y = ref (Lang.apply f [("", !last_x)]) in

--- a/src/builtins/builtins_http.ml
+++ b/src/builtins/builtins_http.ml
@@ -28,7 +28,7 @@ let add_http_error kind =
   Lang.add_builtin_base ~category:`Liquidsoap
     ~descr:(Printf.sprintf "Base error for %s" kind)
     (Printf.sprintf "%s.error" kind)
-    (Lang.error { Runtime_error.kind; msg = ""; pos = [] }).Lang.value
+    (Lang.error { Runtime_error.kind; msg = ""; pos = [] })
     Lang.error_t
 
 let add_http_request ~stream_body ~descr ~request name =
@@ -126,7 +126,7 @@ let add_http_request ~stream_body ~descr ~request name =
         let data = List.assoc "data" p in
         let buf = Buffer.create 10 in
         let len, refill =
-          match (Lang.demeth data).Lang.value with
+          match Lang.demeth data with
             | Lang.Ground (Lang.Ground.String s) ->
                 Buffer.add_string buf s;
                 (Some (Int64.of_int (String.length s)), fun () -> ())
@@ -134,7 +134,7 @@ let add_http_request ~stream_body ~descr ~request name =
                 let fn = Lang.to_getter data in
                 ( None,
                   fun () ->
-                    match (Lang.demeth (fn ())).Lang.value with
+                    match Lang.demeth (fn ()) with
                       | Lang.Ground (Lang.Ground.String s) ->
                           Buffer.add_string buf s
                       | _ -> () ))

--- a/src/builtins/builtins_lang.ml
+++ b/src/builtins/builtins_lang.ml
@@ -130,15 +130,14 @@ let () =
           let clock = new Clock.clock ~sync id in
           List.iter
             (fun s ->
-              let s, pos = Lang.to_source_pos s in
-              let pos = List.nth_opt pos 0 in
+              let s = Lang.to_source s in
               try
                 Clock.unify s#clock (Clock.create_known (clock :> Clock.clock))
               with
                 | Source.Clock_conflict (a, b) ->
-                    raise (Error.Clock_conflict (pos, a, b))
+                    raise (Error.Clock_conflict ([], a, b))
                 | Source.Clock_loop (a, b) ->
-                    raise (Error.Clock_loop (pos, a, b)))
+                    raise (Error.Clock_loop ([], a, b)))
             sources;
           Lang.unit
   in
@@ -164,13 +163,7 @@ let () =
     [("", Lang.list_t (Lang.source_t (Lang.univ_t ())), None, None)]
     Lang.unit_t
     (fun p ->
-      let l = List.assoc "" p |> Lang.to_list |> List.map Lang.to_source_pos in
-      let pos =
-        List.fold_left
-          (fun pos (_, p) -> Pos.Option.sup pos (List.nth_opt p 0))
-          None l
-      in
-      let l = List.map fst l in
+      let l = List.assoc "" p |> Lang.to_list |> List.map Lang.to_source in
       try
         match l with
           | [] -> Lang.unit
@@ -179,8 +172,8 @@ let () =
               Lang.unit
       with
         | Source.Clock_conflict (a, b) ->
-            raise (Error.Clock_conflict (pos, a, b))
-        | Source.Clock_loop (a, b) -> raise (Error.Clock_loop (pos, a, b)))
+            raise (Error.Clock_conflict ([], a, b))
+        | Source.Clock_loop (a, b) -> raise (Error.Clock_loop ([], a, b)))
 
 let () =
   let t = Lang.product_t Lang.string_t Lang.int_t in

--- a/src/builtins/builtins_lang.ml
+++ b/src/builtins/builtins_lang.ml
@@ -125,7 +125,8 @@ let () =
               | s when s = "auto" -> `Auto
               | s when s = "cpu" -> `CPU
               | s when s = "none" -> `None
-              | _ -> raise (Error.Invalid_value (sync, "Invalid sync value"))
+              | _ ->
+                  raise (Error.Invalid_value (sync, [], "Invalid sync value"))
           in
           let clock = new Clock.clock ~sync id in
           List.iter

--- a/src/builtins/builtins_lastfm.ml
+++ b/src/builtins/builtins_lastfm.ml
@@ -79,7 +79,9 @@ let () =
               | _ ->
                   raise
                     (Error.Invalid_value
-                       (List.assoc "source" p, "unknown lastfm submission mode")))
+                       ( List.assoc "source" p,
+                         [],
+                         "unknown lastfm submission mode" )))
           else Liqfm.Unknown
         in
         let length = Lang.to_bool (List.assoc "length" p) in

--- a/src/builtins/builtins_lo.ml
+++ b/src/builtins/builtins_lo.ml
@@ -164,12 +164,11 @@ let register name osc_t liq_t =
       let path = Lang.to_string (Lang.assoc "" 1 p) in
       let v = Lang.assoc "" 2 p in
       let address = Lo.Address.create host port in
-      let osc_val v =
-        match v.Lang.value with
-          | Lang.(Ground (Ground.Bool b)) -> if b then [`True] else [`False]
-          | Lang.(Ground (Ground.String s)) -> [`String s]
-          | Lang.(Ground (Ground.Float x)) -> [`Float x]
-          | _ -> failwith "Unhandled value."
+      let osc_val = function
+        | Lang.(Ground (Ground.Bool b)) -> if b then [`True] else [`False]
+        | Lang.(Ground (Ground.String s)) -> [`String s]
+        | Lang.(Ground (Ground.Float x)) -> [`Float x]
+        | _ -> failwith "Unhandled value."
       in
       (* There was a bug in early versions of lo bindings and anyway we don't
          really want errors to show up here... *)

--- a/src/builtins/builtins_prometheus.ml
+++ b/src/builtins/builtins_prometheus.ml
@@ -69,7 +69,7 @@ let add_metric metric_name create register set =
           let labels = List.map Lang.to_string (Lang.to_list labels_v) in
           if List.length labels <> List.length label_names then
             raise
-              (Error.Invalid_value (labels_v, "Not enough labels provided!"));
+              (Error.Invalid_value (labels_v, [], "Not enough labels provided!"));
           let m = register m labels in
           Lang.val_fun [("", "", None)] (fun p ->
               let v = Lang.to_float (List.assoc "" p) in
@@ -226,6 +226,6 @@ let () =
           let labels = List.map Lang.to_string (Lang.to_list labels_v) in
           if List.length labels <> List.length label_names then
             raise
-              (Error.Invalid_value (labels_v, "Not enough labels provided!"));
+              (Error.Invalid_value (labels_v, [], "Not enough labels provided!"));
           source_monitor ~label_names ~labels ~window ~prefix s;
           Lang.unit))

--- a/src/builtins/builtins_regexp.ml
+++ b/src/builtins/builtins_regexp.ml
@@ -190,7 +190,8 @@ let () =
         List.map
           (fun v ->
             try regexp_flag_of_string (Lang.to_string v)
-            with _ -> raise (Error.Invalid_value (v, "Invalid regexp flag")))
+            with _ ->
+              raise (Error.Invalid_value (v, [], "Invalid regexp flag")))
           (Lang.to_list (List.assoc "flags" p))
       in
       let iflags = Pcre.cflags (cflags_of_flags flags) in

--- a/src/builtins/builtins_string.ml
+++ b/src/builtins/builtins_string.ml
@@ -234,11 +234,7 @@ let () =
       with Annotate.Error err ->
         raise
           (Runtime_error.Runtime_error
-             {
-               Runtime_error.kind = "string";
-               msg = err;
-               pos = (match v.Value.pos with None -> [] | Some p -> [p]);
-             }))
+             { Runtime_error.kind = "string"; msg = err; pos = [] }))
 
 let () =
   Lang.add_builtin "string.recode" ~category:`String
@@ -493,12 +489,10 @@ let () =
       let v = List.assoc "" p in
       let dv = Lang.demeth v in
       (* Always show records. *)
-      let show_fields =
-        if dv.Lang.value = Value.unit then true else show_fields
-      in
+      let show_fields = if dv = Value.unit then true else show_fields in
       let v = if show_fields then v else dv in
       match v with
-        | { Lang.value = Lang.(Ground (Ground.String s)); _ } -> Lang.string s
+        | Lang.(Ground (Ground.String s)) -> Lang.string s
         | v -> Lang.string (Value.to_string v))
 
 let () =

--- a/src/builtins/builtins_string.ml
+++ b/src/builtins/builtins_string.ml
@@ -115,6 +115,7 @@ let () =
               raise
                 (Error.Invalid_value
                    ( encoding,
+                     [],
                      "Encoding should be one of: \"ascii\" or \"utf8\"." ))
       in
       let special_char =
@@ -177,6 +178,7 @@ let () =
               raise
                 (Error.Invalid_value
                    ( format,
+                     [],
                      "Format should be one of: `\"octal\"`, `\"hex\"` or \
                       `\"utf8\"`." ))
       in
@@ -209,7 +211,9 @@ let () =
         | _ ->
             raise
               (Error.Invalid_value
-                 (encoding, "Encoding should be one of: \"ascii\" or \"utf8\".")))
+                 ( encoding,
+                   [],
+                   "Encoding should be one of: \"ascii\" or \"utf8\"." )))
 
 let () =
   Lang.add_builtin "string.unescape"

--- a/src/builtins/builtins_thread.ml
+++ b/src/builtins/builtins_thread.ml
@@ -136,7 +136,7 @@ let () =
     [("", t, None, None)] t (fun p ->
       let m = Mutex.create () in
       let v = List.assoc "" p in
-      match v.Lang.value with
+      match v with
         | Lang.Fun (p, env, body) ->
             let fn args =
               Tutils.mutexify m
@@ -145,12 +145,12 @@ let () =
                     List.map (fun (x, gv) -> (x, Lazy.from_val gv)) args
                   in
                   let env = List.rev_append args env in
-                  let v = { v with Lang.value = Lang.Fun ([], env, body) } in
+                  let v = Lang.Fun ([], env, body) in
                   Lang.apply v [])
                 ()
             in
-            { v with Lang.value = Lang.FFI (p, fn) }
+            Lang.FFI (p, fn)
         | Lang.FFI (p, fn) ->
             let fn args = Tutils.mutexify m (fun () -> fn args) () in
-            { v with Lang.value = Lang.FFI (p, fn) }
+            Lang.FFI (p, fn)
         | _ -> v)

--- a/src/builtins/builtins_time.ml
+++ b/src/builtins/builtins_time.ml
@@ -163,9 +163,7 @@ let () =
                 msg =
                   Printf.sprintf "Failed to parse %s as time predicate"
                     predicate;
-                pos =
-                  Option.value ~default:[]
-                    (Option.map (fun v -> [v]) v.Value.pos);
+                pos = [];
               }))
 
 let () =

--- a/src/converters/audio/libsamplerate_converter.ml
+++ b/src/converters/audio/libsamplerate_converter.ml
@@ -54,6 +54,7 @@ let quality_of_string v =
         raise
           (Error.Invalid_value
              ( Lang.string v,
+               [],
                "libsamplerate quality must be one of: \"best\", \"medium\", \
                 \"fast\", \"zero_order\", \"linear\"." ))
 

--- a/src/converters/audio/native_audio_converter.ml
+++ b/src/converters/audio/native_audio_converter.ml
@@ -43,6 +43,7 @@ let quality_of_string = function
       raise
         (Error.Invalid_value
            ( Lang.string s,
+             [],
              "Native resampling quality must either be \"nearest\" or \
               \"linear\"." ))
 

--- a/src/decoder/text/video_text_sdl.ml
+++ b/src/decoder/text/video_text_sdl.ml
@@ -34,7 +34,7 @@ let get_font font size =
   with e ->
     raise
       (Error.Invalid_value
-         (Lang.string font, Printexc.to_string e ^ "(font: " ^ font ^ ")"))
+         (Lang.string font, [], Printexc.to_string e ^ "(font: " ^ font ^ ")"))
 
 let render_text ~font ~size text =
   let text = if text = "" then " " else text in

--- a/src/io/ffmpeg_io.ml
+++ b/src/io/ffmpeg_io.ml
@@ -396,6 +396,7 @@ let register_input is_http =
                   raise
                     (Error.Invalid_value
                        ( Lang.string format,
+                         [],
                          "Could not find ffmpeg input format with that name" )))
           format
       in

--- a/src/io/srt_io.ml
+++ b/src/io/srt_io.ml
@@ -31,7 +31,7 @@ let mode_of_value v =
   match Lang.to_string v with
     | "listener" -> `Listener
     | "caller" -> `Caller
-    | _ -> raise (Error.Invalid_value (v, "Invalid mode!"))
+    | _ -> raise (Error.Invalid_value (v, [], "Invalid mode!"))
 
 let string_of_mode = function `Listener -> "listener" | `Caller -> "caller"
 
@@ -413,6 +413,7 @@ let parse_common_options p =
       raise
         (Error.Invalid_value
            ( List.assoc "bind_address" p,
+             [],
              Printf.sprintf "Invalid address: %s" (Printexc.to_string exn) ))
   in
   let port = Lang.to_int (List.assoc "port" p) in
@@ -1210,7 +1211,7 @@ let () =
         with Not_found ->
           raise
             (Error.Invalid_value
-               (format_val, "Cannot get a stream encoder for that format"))
+               (format_val, [], "Cannot get a stream encoder for that format"))
       in
       match mode with
         | `Caller ->

--- a/src/io/udp_io.ml
+++ b/src/io/udp_io.ml
@@ -229,7 +229,7 @@ let () =
         with Not_found ->
           raise
             (Error.Invalid_value
-               (fmt, "Cannot get a stream encoder for that format"))
+               (fmt, [], "Cannot get a stream encoder for that format"))
       in
       let source = Lang.assoc "" 2 p in
       let kind = Kind.of_kind kind in
@@ -272,6 +272,7 @@ let () =
               raise
                 (Error.Invalid_value
                    ( Lang.assoc "" 1 p,
+                     [],
                      "Cannot get a stream decoder for this MIME" ))
           | Some decoder_factory -> decoder_factory
       in

--- a/src/lang/environment.ml
+++ b/src/lang/environment.ml
@@ -75,7 +75,7 @@ let add_builtin ?(override = false) ?(register = true) ?doc name ((g, t), v) =
               in
               (* Update value for x.l1...li. *)
               let value = Value.Meth (l, lv, v) in
-              ((vg, t), { Value.pos = v.Value.pos; value })
+              ((vg, t), value)
           | [] -> ((g, t), v)
         in
         let (g, t), v = aux [] ll in
@@ -108,8 +108,7 @@ let add_module name =
           ignore (Value.invoke e l);
           failwith ("Module " ^ String.concat "." name ^ " already exists")
         with _ -> ()));
-  add_builtin ~register:false name
-    (([], Type.make Type.unit), { Value.pos = None; value = Value.unit })
+  add_builtin ~register:false name (([], Type.make Type.unit), Value.unit)
 
 (* Builtins are only used for documentation now. *)
 let builtins = (builtins :> Doc.item)

--- a/src/lang/error.ml
+++ b/src/lang/error.ml
@@ -23,21 +23,21 @@
 (** Runtime error, should eventually disappear. *)
 exception Invalid_value of Value.t * string
 
-exception Clock_conflict of (Pos.Option.t * string * string)
-exception Clock_loop of (Pos.Option.t * string * string)
-exception Kind_conflict of (Pos.Option.t * string * string)
+exception Clock_conflict of (Pos.List.t * string * string)
+exception Clock_loop of (Pos.List.t * string * string)
+exception Kind_conflict of (Pos.List.t * string * string)
 
 let () =
   Printexc.register_printer (function
     | Clock_conflict (pos, a, b) ->
-        let pos = Pos.Option.to_string pos in
+        let pos = Pos.List.to_string pos in
         Some
           (Printf.sprintf
              "Clock_conflict: At position: %s, a source cannot belong to two \
               clocks (%s, %s)"
              pos a b)
     | Clock_loop (pos, a, b) ->
-        let pos = Pos.Option.to_string pos in
+        let pos = Pos.List.to_string pos in
         Some
           (Printf.sprintf
              "Clock_loop: At position: %s, cannot unify two nested clocks \

--- a/src/lang/error.ml
+++ b/src/lang/error.ml
@@ -20,12 +20,10 @@
 
  *****************************************************************************)
 
-(** Runtime error, should eventually disappear. *)
-exception Invalid_value of Value.t * string
-
-exception Clock_conflict of (Pos.List.t * string * string)
-exception Clock_loop of (Pos.List.t * string * string)
-exception Kind_conflict of (Pos.List.t * string * string)
+exception Invalid_value of Value.t * Pos.List.t * string
+exception Clock_conflict of Pos.List.t * string * string
+exception Clock_loop of Pos.List.t * string * string
+exception Kind_conflict of Pos.List.t * string * string
 
 let () =
   Printexc.register_printer (function

--- a/src/lang/error.mli
+++ b/src/lang/error.mli
@@ -23,6 +23,6 @@
 (** Runtime error, should eventually disappear. *)
 exception Invalid_value of Value.t * string
 
-exception Clock_conflict of (Pos.Option.t * string * string)
-exception Clock_loop of (Pos.Option.t * string * string)
-exception Kind_conflict of (Pos.Option.t * string * string)
+exception Clock_conflict of (Pos.List.t * string * string)
+exception Clock_loop of (Pos.List.t * string * string)
+exception Kind_conflict of (Pos.List.t * string * string)

--- a/src/lang/error.mli
+++ b/src/lang/error.mli
@@ -20,9 +20,9 @@
 
  *****************************************************************************)
 
-(** Runtime error, should eventually disappear. *)
-exception Invalid_value of Value.t * string
+(** A runtime error. *)
+exception Invalid_value of Value.t * Pos.List.t * string
 
-exception Clock_conflict of (Pos.List.t * string * string)
-exception Clock_loop of (Pos.List.t * string * string)
-exception Kind_conflict of (Pos.List.t * string * string)
+exception Clock_conflict of Pos.List.t * string * string
+exception Clock_loop of Pos.List.t * string * string
+exception Kind_conflict of Pos.List.t * string * string

--- a/src/lang/evaluation.ml
+++ b/src/lang/evaluation.ml
@@ -304,6 +304,11 @@ and apply ?pos f l =
           Printexc.raise_with_backtrace
             (Internal_error (Option.to_list pos @ poss, e))
             bt
+      | Error.Invalid_value (v, poss, msg) ->
+          let bt = Printexc.get_raw_backtrace () in
+          Printexc.raise_with_backtrace
+            (Error.Invalid_value (v, Option.to_list pos @ poss, msg))
+            bt
       | Error.Clock_conflict (poss, a, b) ->
           let bt = Printexc.get_raw_backtrace () in
           Printexc.raise_with_backtrace

--- a/src/lang/evaluation.ml
+++ b/src/lang/evaluation.ml
@@ -159,7 +159,7 @@ let rec eval ~env tm =
             | v -> v
           in
           match demeth v with
-            | Value.Source (s, _) -> Kind.unify s#kind k
+            | Value.Source s -> Kind.unify s#kind k
             | _ ->
                 raise
                   (Internal_error
@@ -304,6 +304,21 @@ and apply ?pos f l =
           Printexc.raise_with_backtrace
             (Internal_error (Option.to_list pos @ poss, e))
             bt
+      | Error.Clock_conflict (poss, a, b) ->
+          let bt = Printexc.get_raw_backtrace () in
+          Printexc.raise_with_backtrace
+            (Error.Clock_conflict (Option.to_list pos @ poss, a, b))
+            bt
+      | Error.Clock_loop (poss, a, b) ->
+          let bt = Printexc.get_raw_backtrace () in
+          Printexc.raise_with_backtrace
+            (Error.Clock_loop (Option.to_list pos @ poss, a, b))
+            bt
+      | Error.Kind_conflict (poss, a, b) ->
+          let bt = Printexc.get_raw_backtrace () in
+          Printexc.raise_with_backtrace
+            (Error.Kind_conflict (Option.to_list pos @ poss, a, b))
+            bt
   in
   (* Provide given arguments. *)
   let pe, p =
@@ -322,10 +337,7 @@ and apply ?pos f l =
         (var, Option.get v) :: pe)
       pe p
   in
-  match f pe with
-    | Value.Source (s, poss) when pos <> None ->
-        Value.Source (s, Option.get pos :: poss)
-    | v -> v
+  f pe
 
 let eval ?env tm =
   let env =

--- a/src/lang/evaluation.mli
+++ b/src/lang/evaluation.mli
@@ -27,4 +27,4 @@ val eval : ?env:(string * (Type.scheme * Value.t)) list -> Term.t -> Value.t
 val eval_toplevel : ?interactive:bool -> Term.t -> Value.t
 
 (** Apply a function to arguments. *)
-val apply : Value.t -> (string * Value.t) list -> Value.t
+val apply : ?pos:Pos.t -> Value.t -> (string * Value.t) list -> Value.t

--- a/src/lang/lang.mli
+++ b/src/lang/lang.mli
@@ -49,7 +49,7 @@ end
 
 type value = Value.t =
   | Ground of Ground.t
-  | Source of Source.source * Pos.t list
+  | Source of Source.source
   | Encoder of Encoder.format
   | List of value list
   | Tuple of value list
@@ -170,7 +170,6 @@ val to_float : value -> float
 val to_float_getter : value -> unit -> float
 val to_error : value -> Runtime_error.runtime_error
 val to_source : value -> Source.source
-val to_source_pos : value -> Source.source * Pos.t list
 val to_format : value -> Encoder.format
 val to_int : value -> int
 val to_int_getter : value -> unit -> int

--- a/src/lang/lang.mli
+++ b/src/lang/lang.mli
@@ -47,15 +47,9 @@ module Ground : sig
   val to_string : t -> string
 end
 
-type value = Value.t = { pos : Pos.Option.t; value : in_value }
-
-and env = (string * value) list
-
-and lazy_env = (string * value Lazy.t) list
-
-and in_value = Value.in_value =
+type value = Value.t =
   | Ground of Ground.t
-  | Source of Source.source
+  | Source of Source.source * Pos.t list
   | Encoder of Encoder.format
   | List of value list
   | Tuple of value list
@@ -66,6 +60,10 @@ and in_value = Value.in_value =
   (* A function with given arguments (argument label, argument variable, default
      value), closure and value. *)
   | FFI of (string * string * value option) list * (env -> value)
+
+and env = (string * value) list
+
+and lazy_env = (string * value Lazy.t) list
 
 val demeth : value -> value
 
@@ -78,7 +76,7 @@ val iter_sources :
 
 (** {2 Computation} *)
 
-val apply_fun : (value -> env -> value) ref
+val apply_fun : (?pos:Pos.t -> value -> env -> value) ref
 
 (** Multiapply a value to arguments. The argument [t] is the type of the result
    of the application. *)
@@ -117,7 +115,7 @@ val add_builtin_base :
   descr:string ->
   ?flags:Documentation.flag list ->
   string ->
-  in_value ->
+  value ->
   t ->
   unit
 

--- a/src/lang/lang.mli
+++ b/src/lang/lang.mli
@@ -170,6 +170,7 @@ val to_float : value -> float
 val to_float_getter : value -> unit -> float
 val to_error : value -> Runtime_error.runtime_error
 val to_source : value -> Source.source
+val to_source_pos : value -> Source.source * Pos.t list
 val to_format : value -> Encoder.format
 val to_int : value -> int
 val to_int_getter : value -> unit -> int

--- a/src/lang/lang_core.ml
+++ b/src/lang/lang_core.ml
@@ -29,7 +29,7 @@ type scheme = Type.scheme
 
 type value = Value.t =
   | Ground of Ground.t
-  | Source of Source.source * Pos.t list
+  | Source of Source.source
   | Encoder of Encoder.format
   | List of value list
   | Tuple of value list
@@ -137,7 +137,7 @@ let list l = List l
 let null = Null
 let rec meth v0 = function [] -> v0 | (l, v) :: r -> Meth (l, v, meth v0 r)
 let record = meth unit
-let source s = Source (s, [])
+let source s = Source s
 let reference x = Ref x
 let val_fun p f = FFI (p, f)
 
@@ -326,7 +326,7 @@ let iter_sources ?on_reference ~static_analysis_failed f v =
          get an exponential blowup, see #1247. *)
       itered_values := v :: !itered_values;
       match v with
-        | Source (s, _) -> f s
+        | Source s -> f s
         | Ground _ | Encoder _ -> ()
         | List l -> List.iter iter_value l
         | Tuple l -> List.iter iter_value l
@@ -423,11 +423,7 @@ let to_float_getter t =
           match apply t [] with Ground (Float s) -> s | _ -> assert false)
     | _ -> assert false
 
-let to_source t = match demeth t with Source (s, _) -> s | _ -> assert false
-
-let to_source_pos t =
-  match demeth t with Source (s, pos) -> (s, pos) | _ -> assert false
-
+let to_source t = match demeth t with Source s -> s | _ -> assert false
 let to_format t = match demeth t with Encoder f -> f | _ -> assert false
 let to_int t = match demeth t with Ground (Int s) -> s | _ -> assert false
 

--- a/src/lang/lang_core.ml
+++ b/src/lang/lang_core.ml
@@ -424,6 +424,10 @@ let to_float_getter t =
     | _ -> assert false
 
 let to_source t = match demeth t with Source (s, _) -> s | _ -> assert false
+
+let to_source_pos t =
+  match demeth t with Source (s, pos) -> (s, pos) | _ -> assert false
+
 let to_format t = match demeth t with Encoder f -> f | _ -> assert false
 let to_int t = match demeth t with Ground (Int s) -> s | _ -> assert false
 

--- a/src/lang/lang_encoder.ml
+++ b/src/lang/lang_encoder.ml
@@ -40,10 +40,10 @@ let error ~pos msg =
               pos = (match pos with None -> [] | Some pos -> [pos]);
             })
 
-let generic_error (l, t) : exn =
+let generic_error (l, t, pos) : exn =
   match t with
     | `Value v ->
-        error ~pos:v.Value.pos
+        error ~pos
           (Printf.sprintf
              "unknown parameter name (%s) or invalid parameter value (%s)" l
              (Value.to_string v))
@@ -90,7 +90,7 @@ let type_of_encoder ~pos e =
   let midi = kind_t ?pos kind.Frame.midi in
   format_t ?pos (frame_kind_t ?pos audio video midi)
 
-let make_encoder ~pos t ((e, p) : Value.encoder) =
+let make_encoder t ((e, p, pos) : Value.encoder) =
   try
     let e = (find_encoder e).make p in
     let (_ : Encoder.factory) = Encoder.get_factory e in

--- a/src/lang/lang_source.ml
+++ b/src/lang/lang_source.ml
@@ -260,7 +260,6 @@ let add_operator =
       _meth v (List.map (fun (name, _, _, fn) -> (name, fn src)) meth)
     in
     let f env =
-      let pos = None in
       try
         let ret = f env in
         if category = `Output then (
@@ -269,9 +268,9 @@ let add_operator =
         else ret
       with
         | Source.Clock_conflict (a, b) ->
-            raise (Error.Clock_conflict (pos, a, b))
-        | Source.Clock_loop (a, b) -> raise (Error.Clock_loop (pos, a, b))
-        | Kind.Conflict (a, b) -> raise (Error.Kind_conflict (pos, a, b))
+            raise (Error.Clock_conflict ([], a, b))
+        | Source.Clock_loop (a, b) -> raise (Error.Clock_loop ([], a, b))
+        | Kind.Conflict (a, b) -> raise (Error.Kind_conflict ([], a, b))
     in
     let return_t = source_t ~methods:true return_t in
     let return_t =

--- a/src/lang/parser.mly
+++ b/src/lang/parser.mly
@@ -120,9 +120,9 @@ open Parser_helper
 %type <(bool * string * Type.t) list> argsty
 %type <bool * string * Type.t> argty
 %type <Parser_helper.binding> binding
-%type <Parser_helper.encoder_opt> encoder_opt
-%type <Parser_helper.encoder_param> encoder_param
-%type <Parser_helper.encoder_param list> encoder_params
+%type <Term.encoder_params> encoder_opt
+%type <Term.encoder_param> encoder_param
+%type <Term.encoder_params> encoder_params
 %type <Term.t> expr
 %type <Term.t> exprs
 %type <Term.t> exprss
@@ -519,7 +519,7 @@ encoder_param:
   | STRING GETS expr    { $1, `Term $3 }
   | VAR                 { "", `Term (mk ~pos:$loc (Ground (String $1))) }
   | STRING              { "", `Term (mk ~pos:$loc (Ground (String $1))) }
-  | ENCODER encoder_opt { "", `Encoder ($1, $2) }
+  | ENCODER encoder_opt { "", `Encoder (($1, $2), Some $loc) }
 
 encoder_params:
   |                                    { [] }

--- a/src/lang/parser_helper.ml
+++ b/src/lang/parser_helper.ml
@@ -48,11 +48,6 @@ type binding =
   * Term.t
   * Type.t option
 
-type encoder_param =
-  string * [ `Term of Term.t | `Encoder of string * encoder_opt ]
-
-and encoder_opt = encoder_param list
-
 type inner_list_item = [ `Ellipsis of Term.t | `Expr of Term.t ]
 type inner_list = [ `App of Term.t | `List of Term.t list ]
 type let_opt_el = string * Term.t
@@ -102,8 +97,8 @@ let args_of_json_stringify ~pos args =
 
 let gen_args_of ~only ~except ~pos get_args name =
   match Environment.get_builtin name with
-    | Some ((_, t), Value.{ value = Fun (args, _, _) })
-    | Some ((_, t), Value.{ value = FFI (args, _) }) ->
+    | Some ((_, t), Value.Fun (args, _, _)) | Some ((_, t), Value.FFI (args, _))
+      ->
         let filtered_args = List.filter (fun (n, _, _) -> n <> "") args in
         let filtered_args =
           if only <> [] then
@@ -168,7 +163,7 @@ let args_of, app_of =
     List.map
       (fun (n, _, _) -> (n, Term.{ t = Type.var ~pos (); term = Var n }))
       args
-  and term_of_value ~pos t ({ Value.value } as v) =
+  and term_of_value ~pos t value =
     let get_list_type () =
       match (Type.deref t).Type.descr with
         | Type.(List { t }) -> t
@@ -208,7 +203,7 @@ let args_of, app_of =
               (Parse_error
                  ( pos,
                    Printf.sprintf "Term %s cannot be represented as a term"
-                     (Value.to_string v) ))
+                     (Value.to_string value) ))
     in
     let t = Type.make ~pos t.Type.descr in
     Term.{ t; term }

--- a/src/lang/preprocessor.ml
+++ b/src/lang/preprocessor.ml
@@ -80,8 +80,8 @@ let eval_ifdefs tokenizer =
                 let token = fst (tokenizer ()) in
                 match token with
                   | Parser.ENCODER e ->
-                      Lang_encoder.make_encoder ~pos:None (Term.make Term.unit)
-                        (e, [])
+                      Lang_encoder.make_encoder (Term.make Term.unit)
+                        (e, [], None)
                   | _ -> failwith "expected an encoding format after %ifencoder"
               in
               let (_ : Encoder.factory) = Encoder.get_factory fmt in

--- a/src/lang/runtime.ml
+++ b/src/lang/runtime.ml
@@ -116,8 +116,8 @@ let throw print_error = function
         (if lbl = "" then "unlabeled argument"
         else Format.sprintf "argument labeled %S" lbl);
       raise Error
-  | Error.Invalid_value (v, msg) ->
-      error_header 7 v.Value.pos;
+  | Error.Invalid_value (_, msg) ->
+      error_header 7 None;
       Format.printf "Invalid value:@ %s@]@." msg;
       raise Error
   | Lang_encoder.Encoder_error (pos, s) ->

--- a/src/lang/runtime.ml
+++ b/src/lang/runtime.ml
@@ -116,9 +116,9 @@ let throw print_error = function
         (if lbl = "" then "unlabeled argument"
         else Format.sprintf "argument labeled %S" lbl);
       raise Error
-  | Error.Invalid_value (_, msg) ->
-      error_header 7 None;
-      Format.printf "Invalid value:@ %s@]@." msg;
+  | Error.Invalid_value (v, pos, msg) ->
+      error_header 7 (Some (Pos.List.to_pos pos));
+      Format.printf "Invalid value %s:@ %s@]@." (Value.to_string v) msg;
       raise Error
   | Lang_encoder.Encoder_error (pos, s) ->
       error_header 8 pos;

--- a/src/lang/runtime.ml
+++ b/src/lang/runtime.ml
@@ -128,18 +128,21 @@ let throw print_error = function
       print_error 9 (Printf.sprintf "Failure: %s" s);
       raise Error
   | Error.Clock_conflict (pos, a, b) ->
-      (* TODO better printing of clock errors: we don't have position
-       *   information, use the source's ID *)
-      error_header 10 pos;
-      Format.printf "A source cannot belong to two clocks (%s,@ %s).@]@." a b;
+      (* TODO: better printing of clock errors: if we don't have position
+         information, use the source's ID *)
+      error_header 10 (Some (Pos.List.to_pos pos));
+      Format.printf "A source cannot belong to two clocks (%s,@ %s) at %s.@]@."
+        a b (Pos.List.to_string pos);
       raise Error
   | Error.Clock_loop (pos, a, b) ->
-      error_header 11 pos;
-      Format.printf "Cannot unify two nested clocks (%s,@ %s).@]@." a b;
+      error_header 11 (Some (Pos.List.to_pos pos));
+      Format.printf "Cannot unify two nested clocks (%s,@ %s) at %s.@]@." a b
+        (Pos.List.to_string pos);
       raise Error
   | Error.Kind_conflict (pos, a, b) ->
-      error_header 10 pos;
-      Format.printf "Source kinds don't match@ (%s vs@ %s).@]@." a b;
+      error_header 10 (Some (Pos.List.to_pos pos));
+      Format.printf "Source kinds don't match@ (%s vs@ %s) at %s.@]@." a b
+        (Pos.List.to_string pos);
       raise Error
   | Term.Unsupported_format (pos, fmt) ->
       error_header 12 pos;

--- a/src/lang/term.ml
+++ b/src/lang/term.ml
@@ -286,7 +286,9 @@ and let_t = {
   body : t;
 }
 
-and encoder_params = (string * [ `Term of t | `Encoder of encoder ]) list
+and encoder_param = string * [ `Term of t | `Encoder of encoder * Pos.Option.t ]
+
+and encoder_params = encoder_param list
 
 (** A formal encoder. *)
 and encoder = string * encoder_params
@@ -365,7 +367,7 @@ let rec to_string v =
             |> List.map (function
                  | "", `Term v -> to_string v
                  | l, `Term v -> l ^ "=" ^ to_string v
-                 | _, `Encoder e -> aux e)
+                 | _, `Encoder (e, _) -> aux e)
             |> String.concat ", "
           in
           "%" ^ e ^ "(" ^ p ^ ")"
@@ -458,7 +460,7 @@ let rec free_vars tm =
             (fun v (_, t) ->
               match t with
                 | `Term t -> Vars.union v (free_vars t)
-                | `Encoder e -> Vars.union v (enc e))
+                | `Encoder (e, _) -> Vars.union v (enc e))
             Vars.empty p
         in
         enc e
@@ -528,7 +530,7 @@ let check_unused ~throw ~lib tm =
           let rec enc v (_, p) =
             List.fold_left
               (fun v (_, t) ->
-                match t with `Term t -> check v t | `Encoder e -> enc v e)
+                match t with `Term t -> check v t | `Encoder (e, _) -> enc v e)
               v p
           in
           enc v e

--- a/src/lang/term.ml
+++ b/src/lang/term.ml
@@ -312,16 +312,16 @@ and in_term =
    * restrict the environment captured when a closure is
    * formed. *)
   | Fun of Vars.t * (string * string * Type.t * t option) list * t
+  (* A recursive function, the first string is the name of the recursive
+     variable. *)
   | RFun of string * Vars.t * (string * string * Type.t * t option) list * t
 
-(* A recursive function, the first string is the name of the recursive
-   variable. *)
 and pattern =
   | PVar of string list  (** a field *)
   | PTuple of pattern list  (** a tuple *)
-  | PList of (pattern list * string option * pattern list) (* a list *)
+  | PList of (pattern list * string option * pattern list)  (** a list *)
   | PMeth of (pattern option * (string * pattern option) list)
-(* a value with methods *)
+      (** a value with methods *)
 
 type term = t
 

--- a/src/lang/typechecking.ml
+++ b/src/lang/typechecking.ml
@@ -162,7 +162,8 @@ let rec check ?(print_toplevel = false) ~throw ~level ~(env : Typing.env) e =
         let rec check_enc (_, p) =
           List.iter
             (function
-              | _, `Term t -> check ~level ~env t | _, `Encoder e -> check_enc e)
+              | _, `Term t -> check ~level ~env t
+              | _, `Encoder (e, _) -> check_enc e)
             p
         in
         check_enc f;

--- a/src/lang/value.ml
+++ b/src/lang/value.ml
@@ -25,6 +25,8 @@
 (** Ground values. *)
 module Ground = Term.Ground
 
+type pos = Pos.Option.t
+
 (** A value. *)
 type t =
   | Ground of Ground.t
@@ -50,10 +52,11 @@ and env = (string * t) list
 (* Some values have to be lazy in the environment because of recursive functions. *)
 and lazy_env = (string * t Lazy.t) list
 
-type encoder_params = (string * [ `Value of t | `Encoder of encoder ]) list
+type encoder_params =
+  (string * [ `Value of t | `Encoder of encoder ] * pos) list
 
 (** The type of evaluated encoder terms. *)
-and encoder = string * encoder_params
+and encoder = string * encoder_params * pos
 
 let unit : t = Tuple []
 

--- a/src/lang/value.ml
+++ b/src/lang/value.ml
@@ -30,7 +30,7 @@ type pos = Pos.Option.t
 (** A value. *)
 type t =
   | Ground of Ground.t
-  | Source of Source.source * Pos.t list
+  | Source of Source.source
   | Encoder of Encoder.format
   | List of t list
   | Tuple of t list

--- a/src/lang/value.ml
+++ b/src/lang/value.ml
@@ -25,14 +25,8 @@
 (** Ground values. *)
 module Ground = Term.Ground
 
-type t = { pos : Pos.Option.t; value : in_value }
-
-and env = (string * t) list
-
-(* Some values have to be lazy in the environment because of recursive functions. *)
-and lazy_env = (string * t Lazy.t) list
-
-and in_value =
+(** A value. *)
+type t =
   | Ground of Ground.t
   | Source of Source.source
   | Encoder of Encoder.format
@@ -51,61 +45,64 @@ and in_value =
      doesn't capture anything in the environment. *)
   | FFI of (string * string * t option) list * (env -> t)
 
+and env = (string * t) list
+
+(* Some values have to be lazy in the environment because of recursive functions. *)
+and lazy_env = (string * t Lazy.t) list
+
 type encoder_params = (string * [ `Value of t | `Encoder of encoder ]) list
 
 (** The type of evaluated encoder terms. *)
 and encoder = string * encoder_params
 
-let unit : in_value = Tuple []
+let unit : t = Tuple []
 
 let string_of_float f =
   let s = string_of_float f in
   if s.[String.length s - 1] = '.' then s ^ "0" else s
 
-let rec to_string v =
-  match v.value with
-    | Ground g -> Ground.to_string g
-    | Source _ -> "<source>"
-    | Encoder e -> Encoder.string_of_format e
-    | List l -> "[" ^ String.concat ", " (List.map to_string l) ^ "]"
-    | Ref a -> Printf.sprintf "ref(%s)" (to_string !a)
-    | Tuple l -> "(" ^ String.concat ", " (List.map to_string l) ^ ")"
-    | Null -> "null"
-    | Meth (l, v, e) when Lazy.force Term.debug ->
-        to_string e ^ ".{" ^ l ^ "=" ^ to_string v ^ "}"
-    | Meth _ ->
-        let rec split e =
-          match e.value with
-            | Meth (l, v, e) ->
-                let m, e = split e in
-                ((l, v) :: m, e)
-            | _ -> ([], e)
-        in
-        let m, e = split v in
-        let m =
-          List.rev m
-          |> List.map (fun (l, v) -> l ^ " = " ^ to_string v)
-          |> String.concat ", "
-        in
-        let e = match e.value with Tuple [] -> "" | _ -> to_string e ^ "." in
-        e ^ "{" ^ m ^ "}"
-    | Fun ([], _, x) when Term.is_ground x -> "{" ^ Term.to_string x ^ "}"
-    | Fun (l, _, x) when Term.is_ground x ->
-        let f (label, _, value) =
-          match (label, value) with
-            | "", None -> "_"
-            | "", Some v -> Printf.sprintf "_=%s" (to_string v)
-            | label, Some v -> Printf.sprintf "~%s=%s" label (to_string v)
-            | label, None -> Printf.sprintf "~%s=_" label
-        in
-        let args = List.map f l in
-        Printf.sprintf "fun (%s) -> %s" (String.concat "," args)
-          (Term.to_string x)
-    | Fun _ | FFI _ -> "<fun>"
+let rec to_string = function
+  | Ground g -> Ground.to_string g
+  | Source _ -> "<source>"
+  | Encoder e -> Encoder.string_of_format e
+  | List l -> "[" ^ String.concat ", " (List.map to_string l) ^ "]"
+  | Ref a -> Printf.sprintf "ref(%s)" (to_string !a)
+  | Tuple l -> "(" ^ String.concat ", " (List.map to_string l) ^ ")"
+  | Null -> "null"
+  | Meth (l, v, e) when Lazy.force Term.debug ->
+      to_string e ^ ".{" ^ l ^ "=" ^ to_string v ^ "}"
+  | Meth _ as v ->
+      let rec split = function
+        | Meth (l, v, e) ->
+            let m, e = split e in
+            ((l, v) :: m, e)
+        | e -> ([], e)
+      in
+      let m, e = split v in
+      let m =
+        List.rev m
+        |> List.map (fun (l, v) -> l ^ " = " ^ to_string v)
+        |> String.concat ", "
+      in
+      let e = match e with Tuple [] -> "" | _ -> to_string e ^ "." in
+      e ^ "{" ^ m ^ "}"
+  | Fun ([], _, x) when Term.is_ground x -> "{" ^ Term.to_string x ^ "}"
+  | Fun (l, _, x) when Term.is_ground x ->
+      let f (label, _, value) =
+        match (label, value) with
+          | "", None -> "_"
+          | "", Some v -> Printf.sprintf "_=%s" (to_string v)
+          | label, Some v -> Printf.sprintf "~%s=%s" label (to_string v)
+          | label, None -> Printf.sprintf "~%s=_" label
+      in
+      let args = List.map f l in
+      Printf.sprintf "fun (%s) -> %s" (String.concat "," args)
+        (Term.to_string x)
+  | Fun _ | FFI _ -> "<fun>"
 
 (** Find a method in a value. *)
 let rec invoke x l =
-  match x.value with
+  match x with
     | Meth (l', y, _) when l' = l -> y
     | Meth (_, _, x) -> invoke x l
     | _ -> failwith ("Could not find method " ^ l ^ " of " ^ to_string x)
@@ -114,23 +111,20 @@ let rec invoke x l =
 let rec invokes x = function l :: ll -> invokes (invoke x l) ll | [] -> x
 
 let split_meths e =
-  let rec aux hide e =
-    match e.value with
-      | Meth (l, v, e) ->
-          if List.mem l hide then aux hide e
-          else (
-            let m, e = aux (l :: hide) e in
-            ((l, v) :: m, e))
-      | _ -> ([], e)
+  let rec aux hide = function
+    | Meth (l, v, e) ->
+        if List.mem l hide then aux hide e
+        else (
+          let m, e = aux (l :: hide) e in
+          ((l, v) :: m, e))
+    | _ -> ([], e)
   in
   aux [] e
 
-let rec demeth v = match v.value with Meth (_, _, v) -> demeth v | _ -> v
+let rec demeth = function Meth (_, _, v) -> demeth v | v -> v
 
 let rec remeth t u =
-  match t.value with
-    | Meth (l, v, t) -> { t with value = Meth (l, v, remeth t u) }
-    | _ -> u
+  match t with Meth (l, v, t) -> Meth (l, v, remeth t u) | _ -> u
 
 let compare a b =
   let rec aux = function
@@ -157,7 +151,7 @@ let compare a b =
     let a' = demeth a in
     let b' = demeth b in
     (* For records, we compare the list ["label", field; ..] of common fields. *)
-    if a'.value = Tuple [] && b'.value = Tuple [] then (
+    if a' = Tuple [] && b' = Tuple [] then (
       let r a =
         let m, _ = split_meths a in
         m
@@ -175,28 +169,14 @@ let compare a b =
       let b = List.sort (fun x x' -> Stdlib.compare (fst x) (fst x')) b in
       let a =
         Tuple
-          (List.map
-             (fun (lbl, v) ->
-               {
-                 pos = None;
-                 value =
-                   Tuple [{ pos = None; value = Ground (Ground.String lbl) }; v];
-               })
-             a)
+          (List.map (fun (lbl, v) -> Tuple [Ground (Ground.String lbl); v]) a)
       in
       let b =
         Tuple
-          (List.map
-             (fun (lbl, v) ->
-               {
-                 pos = None;
-                 value =
-                   Tuple [{ pos = None; value = Ground (Ground.String lbl) }; v];
-               })
-             b)
+          (List.map (fun (lbl, v) -> Tuple [Ground (Ground.String lbl); v]) b)
       in
       aux (a, b))
-    else aux (a'.value, b'.value)
+    else aux (a', b')
   in
   compare a b
 
@@ -215,14 +195,13 @@ module type AbstractDef = Term.AbstractDef
 module MkAbstractFromTerm (Term : Term.Abstract) = struct
   include Term
 
-  let to_value c = { pos = None; value = Ground (to_ground c) }
+  let to_value c = Ground (to_ground c)
 
-  let of_value t =
-    match t.value with
-      | Ground g when is_ground g -> of_ground g
-      | _ -> assert false
+  let of_value = function
+    | Ground g when is_ground g -> of_ground g
+    | _ -> assert false
 
-  let is_value t = match t.value with Ground g -> is_ground g | _ -> false
+  let is_value = function Ground g -> is_ground g | _ -> false
 end
 
 module MkAbstract (Def : AbstractDef) = struct

--- a/src/lang/value.ml
+++ b/src/lang/value.ml
@@ -30,7 +30,7 @@ type pos = Pos.Option.t
 (** A value. *)
 type t =
   | Ground of Ground.t
-  | Source of Source.source
+  | Source of Source.source * Pos.t list
   | Encoder of Encoder.format
   | List of t list
   | Tuple of t list
@@ -53,10 +53,10 @@ and env = (string * t) list
 and lazy_env = (string * t Lazy.t) list
 
 type encoder_params =
-  (string * [ `Value of t | `Encoder of encoder ] * pos) list
+  (string * [ `Value of t | `Encoder of encoder ] * Pos.Option.t) list
 
 (** The type of evaluated encoder terms. *)
-and encoder = string * encoder_params * pos
+and encoder = string * encoder_params * Pos.Option.t
 
 let unit : t = Tuple []
 

--- a/src/lang_encoders/lang_avi.ml
+++ b/src/lang_encoders/lang_avi.ml
@@ -37,13 +37,13 @@ let make params =
   let avi =
     List.fold_left
       (fun f -> function
-        | "channels", `Value { value = Ground (Int c); _ } ->
+        | "channels", `Value (Ground (Int c)), _ ->
             { f with Avi_format.channels = c }
-        | "samplerate", `Value { value = Ground (Int i); _ } ->
+        | "samplerate", `Value (Ground (Int i)), _ ->
             { f with Avi_format.samplerate = Lazy.from_val i }
-        | "width", `Value { value = Ground (Int i); _ } ->
+        | "width", `Value (Ground (Int i)), _ ->
             { f with Avi_format.width = Lazy.from_val i }
-        | "height", `Value { value = Ground (Int i); _ } ->
+        | "height", `Value (Ground (Int i)), _ ->
             { f with Avi_format.height = Lazy.from_val i }
         | t -> raise (Lang_encoder.generic_error t))
       defaults params

--- a/src/lang_encoders/lang_external_encoder.ml
+++ b/src/lang_encoders/lang_external_encoder.ml
@@ -42,11 +42,11 @@ let make params =
   let ext =
     List.fold_left
       (fun f -> function
-        | "channels", `Value { value = Ground (Int c); _ } ->
+        | "channels", `Value (Ground (Int c)), _ ->
             { f with External_encoder_format.channels = c }
-        | "samplerate", `Value { value = Ground (Int i); _ } ->
+        | "samplerate", `Value (Ground (Int i)), _ ->
             { f with External_encoder_format.samplerate = Lazy.from_val i }
-        | "video", `Value { value = Ground (Bool b); _ } ->
+        | "video", `Value (Ground (Bool b)), _ ->
             let w, h =
               match f.External_encoder_format.video with
                 | None -> (Frame.video_width, Frame.video_height)
@@ -56,7 +56,7 @@ let make params =
               f with
               External_encoder_format.video = (if b then Some (w, h) else None);
             }
-        | "width", `Value { value = Ground (Int w); _ } ->
+        | "width", `Value (Ground (Int w)), _ ->
             let _, h =
               match f.External_encoder_format.video with
                 | None -> (Frame.video_width, Frame.video_height)
@@ -64,7 +64,7 @@ let make params =
             in
             let w = Lazy.from_val w in
             { f with External_encoder_format.video = Some (w, h) }
-        | "height", `Value { value = Ground (Int h); _ } ->
+        | "height", `Value (Ground (Int h)), _ ->
             let w, _ =
               match f.External_encoder_format.video with
                 | None -> (Frame.video_width, Frame.video_height)
@@ -72,24 +72,24 @@ let make params =
             in
             let h = Lazy.from_val h in
             { f with External_encoder_format.video = Some (w, h) }
-        | "header", `Value { value = Ground (Bool h); _ } ->
+        | "header", `Value (Ground (Bool h)), _ ->
             { f with External_encoder_format.header = h }
-        | "restart_on_crash", `Value { value = Ground (Bool h); _ } ->
+        | "restart_on_crash", `Value (Ground (Bool h)), _ ->
             { f with External_encoder_format.restart_on_crash = h }
-        | "", `Value { value = Ground (String s); _ }
+        | "", `Value (Ground (String s)), _
           when String.lowercase_ascii s = "restart_on_metadata" ->
             {
               f with
               External_encoder_format.restart = External_encoder_format.Metadata;
             }
-        | "restart_after_delay", `Value { value = Ground (Int i); _ } ->
+        | "restart_after_delay", `Value (Ground (Int i)), _ ->
             {
               f with
               External_encoder_format.restart = External_encoder_format.Delay i;
             }
-        | "process", `Value { value = Ground (String s); _ } ->
+        | "process", `Value (Ground (String s)), _ ->
             { f with External_encoder_format.process = s }
-        | "", `Value { value = Ground (String s); _ } ->
+        | "", `Value (Ground (String s)), _ ->
             { f with External_encoder_format.process = s }
         | t -> raise (Lang_encoder.generic_error t))
       defaults params

--- a/src/lang_encoders/lang_fdkaac.ml
+++ b/src/lang_encoders/lang_fdkaac.ml
@@ -72,16 +72,16 @@ let make params =
   let fdkaac =
     List.fold_left
       (fun f -> function
-        | "afterburner", `Value { value = Ground (Bool b); _ } ->
+        | "afterburner", `Value (Ground (Bool b)), _ ->
             { f with Fdkaac_format.afterburner = b }
-        | "aot", `Value { value = Ground (String s); pos } ->
+        | "aot", `Value (Ground (String s)), pos ->
             let aot =
               try Fdkaac_format.aot_of_string s
               with Not_found ->
                 raise (Lang_encoder.error ~pos "invalid aot value")
             in
             { f with Fdkaac_format.aot }
-        | "vbr", `Value { value = Ground (Int i); pos } ->
+        | "vbr", `Value (Ground (Int i)), pos ->
             if not (List.mem i valid_vbr) then (
               let err =
                 Printf.sprintf "invalid vbr mode. Possible values: %s"
@@ -89,33 +89,33 @@ let make params =
               in
               raise (Lang_encoder.error ~pos err));
             { f with Fdkaac_format.bitrate_mode = `Variable i }
-        | "bandwidth", `Value { value = Ground (Int i); _ } ->
+        | "bandwidth", `Value (Ground (Int i)), _ ->
             { f with Fdkaac_format.bandwidth = `Fixed i }
-        | "bandwidth", `Value { value = Ground (String s); _ }
+        | "bandwidth", `Value (Ground (String s)), _
           when String.lowercase_ascii s = "auto" ->
             { f with Fdkaac_format.bandwidth = `Auto }
-        | "bitrate", `Value { value = Ground (Int i); _ } ->
+        | "bitrate", `Value (Ground (Int i)), _ ->
             { f with Fdkaac_format.bitrate = i }
-        | "channels", `Value { value = Ground (Int i); _ } ->
+        | "channels", `Value (Ground (Int i)), _ ->
             { f with Fdkaac_format.channels = i }
-        | "samplerate", `Value { value = Ground (Int i); pos } ->
+        | "samplerate", `Value (Ground (Int i)), pos ->
             {
               f with
               Fdkaac_format.samplerate = check_samplerate ~pos (Lazy.from_val i);
             }
-        | "sbr_mode", `Value { value = Ground (Bool b); _ } ->
+        | "sbr_mode", `Value (Ground (Bool b)), _ ->
             { f with Fdkaac_format.sbr_mode = b }
-        | "transmux", `Value { value = Ground (String s); pos } ->
+        | "transmux", `Value (Ground (String s)), pos ->
             let transmux =
               try Fdkaac_format.transmux_of_string s
               with Not_found ->
                 raise (Lang_encoder.error ~pos "invalid transmux value")
             in
             { f with Fdkaac_format.transmux }
-        | "", `Value { value = Ground (String s); _ }
+        | "", `Value (Ground (String s)), _
           when String.lowercase_ascii s = "mono" ->
             { f with Fdkaac_format.channels = 1 }
-        | "", `Value { value = Ground (String s); _ }
+        | "", `Value (Ground (String s)), _
           when String.lowercase_ascii s = "stereo" ->
             { f with Fdkaac_format.channels = 2 }
         | t -> raise (Lang_encoder.generic_error t))

--- a/src/lang_encoders/lang_ffmpeg.ml
+++ b/src/lang_encoders/lang_ffmpeg.ml
@@ -23,18 +23,18 @@
 open Value
 open Ground
 
-let kind_of_encoder p =
+let kind_of_encoder (p : Term.encoder_params) =
   let audio =
     List.fold_left
       (fun audio p ->
         match p with
-          | "", `Encoder ("audio.copy", _) ->
+          | "", `Encoder (("audio.copy", _), _) ->
               `Format
                 Content.(default_format (kind_of_string "ffmpeg.audio.copy"))
-          | "", `Encoder ("audio.raw", _) ->
+          | "", `Encoder (("audio.raw", _), _) ->
               `Format
                 Content.(default_format (kind_of_string "ffmpeg.audio.raw"))
-          | "", `Encoder ("audio", p) ->
+          | "", `Encoder (("audio", p), _) ->
               let channels =
                 try
                   let channels =
@@ -64,13 +64,13 @@ let kind_of_encoder p =
     List.fold_left
       (fun audio p ->
         match p with
-          | "", `Encoder ("video.copy", _) ->
+          | "", `Encoder (("video.copy", _), _) ->
               `Format
                 Content.(default_format (kind_of_string "ffmpeg.video.copy"))
-          | "", `Encoder ("video.raw", _) ->
+          | "", `Encoder (("video.raw", _), _) ->
               `Format
                 Content.(default_format (kind_of_string "ffmpeg.video.raw"))
-          | "", `Encoder ("video", _) ->
+          | "", `Encoder (("video", _), _) ->
               `Format Content.(default_format Video.kind)
           | _ -> audio)
       Frame.none p

--- a/src/lang_encoders/lang_flac.ml
+++ b/src/lang_encoders/lang_flac.ml
@@ -40,24 +40,24 @@ let flac_gen params =
   in
   List.fold_left
     (fun f -> function
-      | "channels", `Value { value = Ground (Int i); _ } ->
+      | "channels", `Value (Ground (Int i)), _ ->
           { f with Flac_format.channels = i }
-      | "samplerate", `Value { value = Ground (Int i); _ } ->
+      | "samplerate", `Value (Ground (Int i)), _ ->
           { f with Flac_format.samplerate = Lazy.from_val i }
-      | "compression", `Value { value = Ground (Int i); pos } ->
+      | "compression", `Value (Ground (Int i)), pos ->
           if i < 0 || i > 8 then
             raise (Lang_encoder.error ~pos "invalid compression value");
           { f with Flac_format.compression = i }
-      | "bits_per_sample", `Value { value = Ground (Int i); pos } ->
+      | "bits_per_sample", `Value (Ground (Int i)), pos ->
           if not (List.mem i accepted_bits_per_sample) then
             raise (Lang_encoder.error ~pos "invalid bits_per_sample value");
           { f with Flac_format.bits_per_sample = i }
-      | "bytes_per_page", `Value { value = Ground (Int i); _ } ->
+      | "bytes_per_page", `Value (Ground (Int i)), _ ->
           { f with Flac_format.fill = Some i }
-      | "", `Value { value = Ground (String s); _ }
-        when String.lowercase_ascii s = "mono" ->
+      | "", `Value (Ground (String s)), _ when String.lowercase_ascii s = "mono"
+        ->
           { f with Flac_format.channels = 1 }
-      | "", `Value { value = Ground (String s); _ }
+      | "", `Value (Ground (String s)), _
         when String.lowercase_ascii s = "stereo" ->
           { f with Flac_format.channels = 2 }
       | t -> raise (Lang_encoder.generic_error t))

--- a/src/lang_encoders/lang_gstreamer.ml
+++ b/src/lang_encoders/lang_gstreamer.ml
@@ -51,25 +51,25 @@ let make ?pos params =
     let perhaps = function "" -> None | s -> Some s in
     List.fold_left
       (fun f -> function
-        | "channels", `Value { value = Ground (Int i); _ } ->
+        | "channels", `Value (Ground (Int i)), _ ->
             { f with Gstreamer_format.channels = i }
-        | "audio", `Value { value = Ground (String s); _ } ->
+        | "audio", `Value (Ground (String s)), _ ->
             { f with Gstreamer_format.audio = perhaps s }
-        | "has_video", `Value { value = Ground (Bool b); _ } ->
+        | "has_video", `Value (Ground (Bool b)), _ ->
             { f with Gstreamer_format.has_video = b }
-        | "video", `Value { value = Ground (String s); _ } ->
+        | "video", `Value (Ground (String s)), _ ->
             let video = perhaps s in
             let has_video =
               if video = None then false else f.Gstreamer_format.has_video
             in
             { f with Gstreamer_format.has_video; video }
-        | "muxer", `Value { value = Ground (String s); _ } ->
+        | "muxer", `Value (Ground (String s)), _ ->
             { f with Gstreamer_format.muxer = perhaps s }
-        | "metadata", `Value { value = Ground (String s); _ } ->
+        | "metadata", `Value (Ground (String s)), _ ->
             { f with Gstreamer_format.metadata = s }
-        | "log", `Value { value = Ground (Int i); _ } ->
+        | "log", `Value (Ground (Int i)), _ ->
             { f with Gstreamer_format.log = i }
-        | "pipeline", `Value { value = Ground (String s); _ } ->
+        | "pipeline", `Value (Ground (String s)), _ ->
             { f with Gstreamer_format.pipeline = perhaps s }
         | t -> raise (Lang_encoder.generic_error t))
       defaults params

--- a/src/lang_encoders/lang_opus.ml
+++ b/src/lang_encoders/lang_opus.ml
@@ -45,33 +45,29 @@ let make params =
   let opus =
     List.fold_left
       (fun f -> function
-        | "application", `Value { value = Ground (String "voip"); _ } ->
+        | "application", `Value (Ground (String "voip")), _ ->
             { f with Opus_format.application = Some `Voip }
-        | "application", `Value { value = Ground (String "audio"); _ } ->
+        | "application", `Value (Ground (String "audio")), _ ->
             { f with Opus_format.application = Some `Audio }
-        | ( "application",
-            `Value { value = Ground (String "restricted_lowdelay"); _ } ) ->
+        | "application", `Value (Ground (String "restricted_lowdelay")), _ ->
             { f with Opus_format.application = Some `Restricted_lowdelay }
-        | "complexity", `Value { value = Ground (Int c); pos } ->
+        | "complexity", `Value (Ground (Int c)), pos ->
             (* Doc say this should be from 0 to 10. *)
             if c < 0 || c > 10 then
               raise
                 (Lang_encoder.error ~pos "Opus complexity should be in 0..10");
             { f with Opus_format.complexity = Some c }
-        | "max_bandwidth", `Value { value = Ground (String "narrow_band"); _ }
-          ->
+        | "max_bandwidth", `Value (Ground (String "narrow_band")), _ ->
             { f with Opus_format.max_bandwidth = Some `Narrow_band }
-        | "max_bandwidth", `Value { value = Ground (String "medium_band"); _ }
-          ->
+        | "max_bandwidth", `Value (Ground (String "medium_band")), _ ->
             { f with Opus_format.max_bandwidth = Some `Medium_band }
-        | "max_bandwidth", `Value { value = Ground (String "wide_band"); _ } ->
+        | "max_bandwidth", `Value (Ground (String "wide_band")), _ ->
             { f with Opus_format.max_bandwidth = Some `Wide_band }
-        | ( "max_bandwidth",
-            `Value { value = Ground (String "super_wide_band"); _ } ) ->
+        | "max_bandwidth", `Value (Ground (String "super_wide_band")), _ ->
             { f with Opus_format.max_bandwidth = Some `Super_wide_band }
-        | "max_bandwidth", `Value { value = Ground (String "full_band"); _ } ->
+        | "max_bandwidth", `Value (Ground (String "full_band")), _ ->
             { f with Opus_format.max_bandwidth = Some `Full_band }
-        | "frame_size", `Value { value = Ground (Float size); pos } ->
+        | "frame_size", `Value (Ground (Float size)), pos ->
             let frame_sizes = [2.5; 5.; 10.; 20.; 40.; 60.] in
             if not (List.mem size frame_sizes) then
               raise
@@ -79,7 +75,7 @@ let make params =
                    "Opus frame size should be one of 2.5, 5., 10., 20., 40. or \
                     60.");
             { f with Opus_format.frame_size = size }
-        | "samplerate", `Value { value = Ground (Int i); pos } ->
+        | "samplerate", `Value (Ground (Int i)), pos ->
             let samplerates = [8000; 12000; 16000; 24000; 48000] in
             if not (List.mem i samplerates) then
               raise
@@ -87,42 +83,41 @@ let make params =
                    "Opus samplerate should be one of 8000, 12000, 16000, 24000 \
                     or 48000");
             { f with Opus_format.samplerate = i }
-        | "bitrate", `Value { value = Ground (Int i); pos } ->
+        | "bitrate", `Value (Ground (Int i)), pos ->
             let i = i * 1000 in
             (* Doc say this should be from 500 to 512000. *)
             if i < 500 || i > 512000 then
               raise (Lang_encoder.error ~pos "Opus bitrate should be in 5..512");
             { f with Opus_format.bitrate = `Bitrate i }
-        | "bitrate", `Value { value = Ground (String "auto"); _ } ->
+        | "bitrate", `Value (Ground (String "auto")), _ ->
             { f with Opus_format.bitrate = `Auto }
-        | "bitrate", `Value { value = Ground (String "max"); _ } ->
+        | "bitrate", `Value (Ground (String "max")), _ ->
             { f with Opus_format.bitrate = `Bitrate_max }
-        | "channels", `Value { value = Ground (Int i); pos } ->
+        | "channels", `Value (Ground (Int i)), pos ->
             if i < 1 || i > 2 then
               raise
                 (Lang_encoder.error ~pos
                    "only mono and stereo streams are supported for now");
             { f with Opus_format.channels = i }
-        | "vbr", `Value { value = Ground (String "none"); _ } ->
+        | "vbr", `Value (Ground (String "none")), _ ->
             { f with Opus_format.mode = Opus_format.CBR }
-        | "vbr", `Value { value = Ground (String "constrained"); _ } ->
+        | "vbr", `Value (Ground (String "constrained")), _ ->
             { f with Opus_format.mode = Opus_format.VBR true }
-        | "vbr", `Value { value = Ground (String "unconstrained"); _ } ->
+        | "vbr", `Value (Ground (String "unconstrained")), _ ->
             { f with Opus_format.mode = Opus_format.VBR false }
-        | "signal", `Value { value = Ground (String "voice"); _ } ->
+        | "signal", `Value (Ground (String "voice")), _ ->
             { f with Opus_format.signal = Some `Voice }
-        | "signal", `Value { value = Ground (String "music"); _ } ->
+        | "signal", `Value (Ground (String "music")), _ ->
             { f with Opus_format.signal = Some `Music }
-        | "bytes_per_page", `Value { value = Ground (Int i); _ } ->
+        | "bytes_per_page", `Value (Ground (Int i)), _ ->
             { f with Opus_format.fill = Some i }
-        | "dtx", `Value { value = Ground (Bool b); _ } ->
-            { f with Opus_format.dtx = b }
-        | "phase_inversion", `Value { value = Ground (Bool b); _ } ->
+        | "dtx", `Value (Ground (Bool b)), _ -> { f with Opus_format.dtx = b }
+        | "phase_inversion", `Value (Ground (Bool b)), _ ->
             { f with Opus_format.phase_inversion = b }
-        | "", `Value { value = Ground (String s); _ }
+        | "", `Value (Ground (String s)), _
           when String.lowercase_ascii s = "mono" ->
             { f with Opus_format.channels = 1 }
-        | "", `Value { value = Ground (String s); _ }
+        | "", `Value (Ground (String s)), _
           when String.lowercase_ascii s = "stereo" ->
             { f with Opus_format.channels = 2 }
         | t -> raise (Lang_encoder.generic_error t))

--- a/src/lang_encoders/lang_shine.ml
+++ b/src/lang_encoders/lang_shine.ml
@@ -38,16 +38,16 @@ let make params =
   let shine =
     List.fold_left
       (fun f -> function
-        | "channels", `Value { value = Ground (Int i); _ } ->
+        | "channels", `Value (Ground (Int i)), _ ->
             { f with Shine_format.channels = i }
-        | "samplerate", `Value { value = Ground (Int i); _ } ->
+        | "samplerate", `Value (Ground (Int i)), _ ->
             { f with Shine_format.samplerate = Lazy.from_val i }
-        | "bitrate", `Value { value = Ground (Int i); _ } ->
+        | "bitrate", `Value (Ground (Int i)), _ ->
             { f with Shine_format.bitrate = i }
-        | "", `Value { value = Ground (String s); _ }
+        | "", `Value (Ground (String s)), _
           when String.lowercase_ascii s = "mono" ->
             { f with Shine_format.channels = 1 }
-        | "", `Value { value = Ground (String s); _ }
+        | "", `Value (Ground (String s)), _
           when String.lowercase_ascii s = "stereo" ->
             { f with Shine_format.channels = 2 }
         | t -> raise (Lang_encoder.generic_error t))

--- a/src/lang_encoders/lang_speex.ml
+++ b/src/lang_encoders/lang_speex.ml
@@ -42,48 +42,46 @@ let make params =
   let speex =
     List.fold_left
       (fun f -> function
-        | "stereo", `Value { value = Ground (Bool b); _ } ->
+        | "stereo", `Value (Ground (Bool b)), _ ->
             { f with Speex_format.stereo = b }
-        | "mono", `Value { value = Ground (Bool b); _ } ->
+        | "mono", `Value (Ground (Bool b)), _ ->
             { f with Speex_format.stereo = not b }
-        | "samplerate", `Value { value = Ground (Int i); _ } ->
+        | "samplerate", `Value (Ground (Int i)), _ ->
             { f with Speex_format.samplerate = Lazy.from_val i }
-        | "abr", `Value { value = Ground (Int i); _ } ->
+        | "abr", `Value (Ground (Int i)), _ ->
             { f with Speex_format.bitrate_control = Speex_format.Abr i }
-        | "quality", `Value { value = Ground (Int q); pos } ->
+        | "quality", `Value (Ground (Int q)), pos ->
             (* Doc say this should be from 0 to 10. *)
             if q < 0 || q > 10 then
               raise (Lang_encoder.error ~pos "Speex quality should be in 0..10");
             { f with Speex_format.bitrate_control = Speex_format.Quality q }
-        | "vbr", `Value { value = Ground (Int q); _ } ->
+        | "vbr", `Value (Ground (Int q)), _ ->
             { f with Speex_format.bitrate_control = Speex_format.Vbr q }
-        | "mode", `Value { value = Ground (String s); _ }
+        | "mode", `Value (Ground (String s)), _
           when String.lowercase_ascii s = "wideband" ->
             { f with Speex_format.mode = Speex_format.Wideband }
-        | "mode", `Value { value = Ground (String s); _ }
+        | "mode", `Value (Ground (String s)), _
           when String.lowercase_ascii s = "narrowband" ->
             { f with Speex_format.mode = Speex_format.Narrowband }
-        | "mode", `Value { value = Ground (String s); _ }
+        | "mode", `Value (Ground (String s)), _
           when String.lowercase_ascii s = "ultra-wideband" ->
             { f with Speex_format.mode = Speex_format.Ultra_wideband }
-        | "frames_per_packet", `Value { value = Ground (Int i); _ } ->
+        | "frames_per_packet", `Value (Ground (Int i)), _ ->
             { f with Speex_format.frames_per_packet = i }
-        | "complexity", `Value { value = Ground (Int i); pos } ->
+        | "complexity", `Value (Ground (Int i)), pos ->
             (* Doc says this should be between 1 and 10. *)
             if i < 1 || i > 10 then
               raise
                 (Lang_encoder.error ~pos "Speex complexity should be in 1..10");
             { f with Speex_format.complexity = Some i }
-        | "bytes_per_page", `Value { value = Ground (Int i); _ } ->
+        | "bytes_per_page", `Value (Ground (Int i)), _ ->
             { f with Speex_format.fill = Some i }
-        | "dtx", `Value { value = Ground (Bool b); _ } ->
-            { f with Speex_format.dtx = b }
-        | "vad", `Value { value = Ground (Bool b); _ } ->
-            { f with Speex_format.vad = b }
-        | "", `Value { value = Ground (String s); _ }
+        | "dtx", `Value (Ground (Bool b)), _ -> { f with Speex_format.dtx = b }
+        | "vad", `Value (Ground (Bool b)), _ -> { f with Speex_format.vad = b }
+        | "", `Value (Ground (String s)), _
           when String.lowercase_ascii s = "mono" ->
             { f with Speex_format.stereo = false }
-        | "", `Value { value = Ground (String s); _ }
+        | "", `Value (Ground (String s)), _
           when String.lowercase_ascii s = "stereo" ->
             { f with Speex_format.stereo = true }
         | t -> raise (Lang_encoder.generic_error t))

--- a/src/lang_encoders/lang_theora.ml
+++ b/src/lang_encoders/lang_theora.ml
@@ -48,43 +48,43 @@ let make params =
   in
   List.fold_left
     (fun f -> function
-      | "quality", `Value { value = Ground (Int i); pos } ->
+      | "quality", `Value (Ground (Int i)), pos ->
           (* According to the doc, this should be a value between
            * 0 and 63. *)
           if i < 0 || i > 63 then
             raise (Lang_encoder.error ~pos "Theora quality should be in 0..63");
           { f with Theora_format.bitrate_control = Theora_format.Quality i }
-      | "bitrate", `Value { value = Ground (Int i); _ } ->
+      | "bitrate", `Value (Ground (Int i)), _ ->
           { f with Theora_format.bitrate_control = Theora_format.Bitrate i }
-      | "width", `Value { value = Ground (Int i); pos } ->
+      | "width", `Value (Ground (Int i)), pos ->
           (* According to the doc: must be a multiple of 16, and less than 1048576. *)
           if i mod 16 <> 0 || i >= 1048576 then
             raise
               (Lang_encoder.error ~pos
                  "invalid frame width value (should be a multiple of 16)");
           { f with Theora_format.width = lazy i; picture_width = lazy i }
-      | "height", `Value { value = Ground (Int i); pos } ->
+      | "height", `Value (Ground (Int i)), pos ->
           (* According to the doc: must be a multiple of 16, and less than 1048576. *)
           if i mod 16 <> 0 || i >= 1048576 then
             raise
               (Lang_encoder.error ~pos
                  "invalid frame height value (should be a multiple of 16)");
           { f with Theora_format.height = lazy i; picture_height = lazy i }
-      | "picture_width", `Value { value = Ground (Int i); pos } ->
+      | "picture_width", `Value (Ground (Int i)), pos ->
           (* According to the doc: must not be larger than width. *)
           if i > Lazy.force f.Theora_format.width then
             raise
               (Lang_encoder.error ~pos
                  "picture width must not be larger than width");
           { f with Theora_format.picture_width = lazy i }
-      | "picture_height", `Value { value = Ground (Int i); pos } ->
+      | "picture_height", `Value (Ground (Int i)), pos ->
           (* According to the doc: must not be larger than height. *)
           if i > Lazy.force f.Theora_format.height then
             raise
               (Lang_encoder.error ~pos
                  "picture height must not be larger than height");
           { f with Theora_format.picture_height = lazy i }
-      | "picture_x", `Value { value = Ground (Int i); pos } ->
+      | "picture_x", `Value (Ground (Int i)), pos ->
           (* According to the doc: must be no larger than width-picture_width
            * or 255, whichever is smaller. *)
           if
@@ -99,7 +99,7 @@ let make params =
                  "picture x must not be larger than width - picture width or \
                   255, whichever is smaller");
           { f with Theora_format.picture_x = i }
-      | "picture_y", `Value { value = Ground (Int i); pos } ->
+      | "picture_y", `Value (Ground (Int i)), pos ->
           (* According to the doc: must be no larger than width-picture_width
            * and frame_height-pic_height-pic_y must be no larger than 255. *)
           if
@@ -115,21 +115,21 @@ let make params =
               (Lang_encoder.error ~pos
                  "picture height - picture y must not be larger than 255");
           { f with Theora_format.picture_y = i }
-      | "aspect_numerator", `Value { value = Ground (Int i); _ } ->
+      | "aspect_numerator", `Value (Ground (Int i)), _ ->
           { f with Theora_format.aspect_numerator = i }
-      | "aspect_denominator", `Value { value = Ground (Int i); _ } ->
+      | "aspect_denominator", `Value (Ground (Int i)), _ ->
           { f with Theora_format.aspect_denominator = i }
-      | "keyframe_frequency", `Value { value = Ground (Int i); _ } ->
+      | "keyframe_frequency", `Value (Ground (Int i)), _ ->
           { f with Theora_format.keyframe_frequency = i }
-      | "vp3_compatible", `Value { value = Ground (Bool i); _ } ->
+      | "vp3_compatible", `Value (Ground (Bool i)), _ ->
           { f with Theora_format.vp3_compatible = Some i }
-      | "soft_target", `Value { value = Ground (Bool i); _ } ->
+      | "soft_target", `Value (Ground (Bool i)), _ ->
           { f with Theora_format.soft_target = i }
-      | "buffer_delay", `Value { value = Ground (Int i); _ } ->
+      | "buffer_delay", `Value (Ground (Int i)), _ ->
           { f with Theora_format.buffer_delay = Some i }
-      | "speed", `Value { value = Ground (Int i); _ } ->
+      | "speed", `Value (Ground (Int i)), _ ->
           { f with Theora_format.speed = Some i }
-      | "bytes_per_page", `Value { value = Ground (Int i); _ } ->
+      | "bytes_per_page", `Value (Ground (Int i)), _ ->
           { f with Theora_format.fill = Some i }
       | t -> raise (Lang_encoder.generic_error t))
     defaults params

--- a/src/lang_encoders/lang_vorbis.ml
+++ b/src/lang_encoders/lang_vorbis.ml
@@ -39,18 +39,18 @@ let make_cbr params =
   let vorbis =
     List.fold_left
       (fun f -> function
-        | "samplerate", `Value { value = Ground (Int i); _ } ->
+        | "samplerate", `Value (Ground (Int i)), _ ->
             { f with Vorbis_format.samplerate = Lazy.from_val i }
-        | "bitrate", `Value { value = Ground (Int i); _ } ->
+        | "bitrate", `Value (Ground (Int i)), _ ->
             { f with Vorbis_format.mode = Vorbis_format.CBR i }
-        | "channels", `Value { value = Ground (Int i); _ } ->
+        | "channels", `Value (Ground (Int i)), _ ->
             { f with Vorbis_format.channels = i }
-        | "bytes_per_page", `Value { value = Ground (Int i); _ } ->
+        | "bytes_per_page", `Value (Ground (Int i)), _ ->
             { f with Vorbis_format.fill = Some i }
-        | "", `Value { value = Ground (String s); _ }
+        | "", `Value (Ground (String s)), _
           when String.lowercase_ascii s = "mono" ->
             { f with Vorbis_format.channels = 1 }
-        | "", `Value { value = Ground (String s); _ }
+        | "", `Value (Ground (String s)), _
           when String.lowercase_ascii s = "stereo" ->
             { f with Vorbis_format.channels = 2 }
         | t -> raise (Lang_encoder.generic_error t))
@@ -75,25 +75,25 @@ let make_abr params =
   let vorbis =
     List.fold_left
       (fun f -> function
-        | "samplerate", `Value { value = Ground (Int i); _ } ->
+        | "samplerate", `Value (Ground (Int i)), _ ->
             { f with Vorbis_format.samplerate = Lazy.from_val i }
-        | "bitrate", `Value { value = Ground (Int i); _ } ->
+        | "bitrate", `Value (Ground (Int i)), _ ->
             let x, _, y = get_rates f in
             { f with Vorbis_format.mode = Vorbis_format.ABR (x, Some i, y) }
-        | "max_bitrate", `Value { value = Ground (Int i); _ } ->
+        | "max_bitrate", `Value (Ground (Int i)), _ ->
             let x, y, _ = get_rates f in
             { f with Vorbis_format.mode = Vorbis_format.ABR (x, y, Some i) }
-        | "min_bitrate", `Value { value = Ground (Int i); _ } ->
+        | "min_bitrate", `Value (Ground (Int i)), _ ->
             let _, x, y = get_rates f in
             { f with Vorbis_format.mode = Vorbis_format.ABR (Some i, x, y) }
-        | "channels", `Value { value = Ground (Int i); _ } ->
+        | "channels", `Value (Ground (Int i)), _ ->
             { f with Vorbis_format.channels = i }
-        | "bytes_per_page", `Value { value = Ground (Int i); _ } ->
+        | "bytes_per_page", `Value (Ground (Int i)), _ ->
             { f with Vorbis_format.fill = Some i }
-        | "", `Value { value = Ground (String s); _ }
+        | "", `Value (Ground (String s)), _
           when String.lowercase_ascii s = "mono" ->
             { f with Vorbis_format.channels = 1 }
-        | "", `Value { value = Ground (String s); _ }
+        | "", `Value (Ground (String s)), _
           when String.lowercase_ascii s = "stereo" ->
             { f with Vorbis_format.channels = 2 }
         | t -> raise (Lang_encoder.generic_error t))
@@ -101,7 +101,7 @@ let make_abr params =
   in
   Ogg_format.Vorbis vorbis
 
-let make params =
+let make (params : Value.encoder_params) =
   let defaults =
     {
       Vorbis_format.mode = Vorbis_format.VBR 0.3;
@@ -113,25 +113,25 @@ let make params =
   let vorbis =
     List.fold_left
       (fun f -> function
-        | "samplerate", `Value { value = Ground (Int i); _ } ->
+        | "samplerate", `Value (Ground (Int i)), _ ->
             { f with Vorbis_format.samplerate = Lazy.from_val i }
-        | "quality", `Value { value = Ground (Float q); pos } ->
+        | "quality", `Value (Ground (Float q)), pos ->
             if q < -0.2 || q > 1. then
               raise (Lang_encoder.error ~pos "quality should be in [(-0.2)..1]");
             { f with Vorbis_format.mode = Vorbis_format.VBR q }
-        | "quality", `Value { value = Ground (Int i); pos } ->
+        | "quality", `Value (Ground (Int i)), pos ->
             if i <> 0 && i <> 1 then
               raise (Lang_encoder.error ~pos "quality should be in [-(0.2)..1]");
             let q = float i in
             { f with Vorbis_format.mode = Vorbis_format.VBR q }
-        | "channels", `Value { value = Ground (Int i); _ } ->
+        | "channels", `Value (Ground (Int i)), _ ->
             { f with Vorbis_format.channels = i }
-        | "bytes_per_page", `Value { value = Ground (Int i); _ } ->
+        | "bytes_per_page", `Value (Ground (Int i)), _ ->
             { f with Vorbis_format.fill = Some i }
-        | "", `Value { value = Ground (String s); _ }
+        | "", `Value (Ground (String s)), _
           when String.lowercase_ascii s = "mono" ->
             { f with Vorbis_format.channels = 1 }
-        | "", `Value { value = Ground (String s); _ }
+        | "", `Value (Ground (String s)), _
           when String.lowercase_ascii s = "stereo" ->
             { f with Vorbis_format.channels = 2 }
         | t -> raise (Lang_encoder.generic_error t))

--- a/src/lang_encoders/lang_wav.ml
+++ b/src/lang_encoders/lang_wav.ml
@@ -40,27 +40,27 @@ let make params =
   let wav =
     List.fold_left
       (fun f -> function
-        | "stereo", `Value { value = Ground (Bool b); _ } ->
+        | "stereo", `Value (Ground (Bool b)), _ ->
             { f with Wav_format.channels = (if b then 2 else 1) }
-        | "mono", `Value { value = Ground (Bool b); _ } ->
+        | "mono", `Value (Ground (Bool b)), _ ->
             { f with Wav_format.channels = (if b then 1 else 2) }
-        | "", `Value { value = Ground (String s); _ }
+        | "", `Value (Ground (String s)), _
           when String.lowercase_ascii s = "stereo" ->
             { f with Wav_format.channels = 2 }
-        | "", `Value { value = Ground (String s); _ }
+        | "", `Value (Ground (String s)), _
           when String.lowercase_ascii s = "mono" ->
             { f with Wav_format.channels = 1 }
-        | "channels", `Value { value = Ground (Int c); _ } ->
+        | "channels", `Value (Ground (Int c)), _ ->
             { f with Wav_format.channels = c }
-        | "duration", `Value { value = Ground (Float d); _ } ->
+        | "duration", `Value (Ground (Float d)), _ ->
             { f with Wav_format.duration = Some d }
-        | "samplerate", `Value { value = Ground (Int i); _ } ->
+        | "samplerate", `Value (Ground (Int i)), _ ->
             { f with Wav_format.samplerate = Lazy.from_val i }
-        | "samplesize", `Value { value = Ground (Int i); pos } ->
+        | "samplesize", `Value (Ground (Int i)), pos ->
             if i <> 8 && i <> 16 && i <> 24 && i <> 32 then
               raise (Lang_encoder.error ~pos "invalid sample size");
             { f with Wav_format.samplesize = i }
-        | "header", `Value { value = Ground (Bool b); _ } ->
+        | "header", `Value (Ground (Bool b)), _ ->
             { f with Wav_format.header = b }
         | t -> raise (Lang_encoder.generic_error t))
       (defaults ()) params

--- a/src/operators/add.ml
+++ b/src/operators/add.ml
@@ -210,6 +210,7 @@ let () =
         raise
           (Error.Invalid_value
              ( List.assoc "weights" p,
+               [],
                "there should be as many weights as sources" ));
       let kind = Kind.of_kind kind in
       (new add
@@ -302,6 +303,7 @@ let () =
         raise
           (Error.Invalid_value
              ( List.assoc "weights" p,
+               [],
                "there should be as many weights as sources" ));
       let kind = Kind.of_kind kind in
       (new add

--- a/src/operators/echo.ml
+++ b/src/operators/echo.ml
@@ -87,7 +87,8 @@ let () =
         (* Check the initial value, wrap the getter with a converter. *)
         if feedback () > 0. then
           raise
-            (Error.Invalid_value (f "feedback", "feedback should be negative"));
+            (Error.Invalid_value
+               (f "feedback", [], "feedback should be negative"));
         fun () -> Audio.lin_of_dB (feedback ())
       in
       let kind = Kind.of_kind kind in

--- a/src/operators/filter.ml
+++ b/src/operators/filter.ml
@@ -133,7 +133,7 @@ let () =
           | _ ->
               raise
                 (Error.Invalid_value
-                   (mode, "valid values are low|high|band|notch"))
+                   (mode, [], "valid values are low|high|band|notch"))
       in
       let kind = Kind.of_kind kind in
       (new filter ~kind src freq q wet mode :> Source.source))

--- a/src/operators/filter_rc.ml
+++ b/src/operators/filter_rc.ml
@@ -112,7 +112,9 @@ let () =
         match Lang.to_string mode with
           | "low" -> Low_pass
           | "high" -> High_pass
-          | _ -> raise (Error.Invalid_value (mode, "valid values are low|high"))
+          | _ ->
+              raise
+                (Error.Invalid_value (mode, [], "valid values are low|high"))
       in
       let kind = Kind.of_kind kind in
       (new filter ~kind src freq wet mode :> Source.source))

--- a/src/operators/noblank.ml
+++ b/src/operators/noblank.ml
@@ -239,7 +239,7 @@ let extract p =
     let v = f "threshold" in
     let t = Lang.to_float v in
     if t > 0. then
-      raise (Error.Invalid_value (v, "threshold should be negative"));
+      raise (Error.Invalid_value (v, [], "threshold should be negative"));
     Audio.lin_of_dB t
   in
   let ts = Lang.to_bool (f "track_sensitive") in

--- a/src/operators/switch.ml
+++ b/src/operators/switch.ml
@@ -419,7 +419,7 @@ let () =
         if ltr > l then
           raise
             (Error.Invalid_value
-               (List.assoc "transitions" p, "Too many transitions"));
+               (List.assoc "transitions" p, [], "Too many transitions"));
         if ltr < l then tr @ List.init (l - ltr) (fun _ -> default_transition)
         else tr
       in
@@ -447,6 +447,7 @@ let () =
           raise
             (Error.Invalid_value
                ( List.assoc "single" p,
+                 [],
                  "there should be exactly one flag per children" ))
       in
       let kind = Kind.of_kind kind in

--- a/src/operators/switch.ml
+++ b/src/operators/switch.ml
@@ -279,12 +279,7 @@ let default_transition =
 let satisfied f = Lang.to_bool (Lang.apply f [])
 
 let trivially_true = function
-  | {
-      Lang.value =
-        Lang.Fun (_, _, { Term.term = Term.(Ground (Ground.Bool true)); _ });
-      _;
-    } ->
-      true
+  | Lang.Fun (_, _, { Term.term = Term.(Ground (Ground.Bool true)); _ }) -> true
   | _ -> false
 
 let third (_, _, s) = s

--- a/src/operators/video_fade.ml
+++ b/src/operators/video_fade.ml
@@ -231,7 +231,7 @@ let rec transition_of_string p transition =
     | _ ->
         raise
           (Error.Invalid_value
-             (List.assoc "transition" p, "Invalid transition kind"))
+             (List.assoc "transition" p, [], "Invalid transition kind"))
 
 let extract p =
   ( Lang.to_float (List.assoc "duration" p),
@@ -257,7 +257,7 @@ let extract p =
              let msg =
                "The 'type' parameter should be 'lin','sin','log' or 'exp'!"
              in
-             raise (Error.Invalid_value (mode, msg))
+             raise (Error.Invalid_value (mode, [], msg))
      in
      fun l ->
        let l = float l in

--- a/src/outputs/harbor_output.ml
+++ b/src/outputs/harbor_output.ml
@@ -336,12 +336,14 @@ module Make (T : T) = struct
         raise
           (Error.Invalid_value
              ( List.assoc "buffer" p,
+               [],
                "Maximum buffering inferior to chunk length" ))
       else ();
       if burst > buflen then
         raise
           (Error.Invalid_value
              ( List.assoc "buffer" p,
+               [],
                "Maximum buffering inferior to burst length" ))
       else ()
     in

--- a/src/outputs/hls_output.ml
+++ b/src/outputs/hls_output.ml
@@ -254,7 +254,7 @@ class hls_output p =
     then
       raise
         (Error.Invalid_value
-           (Lang.assoc "" 1 p, "The target directory does not exist"))
+           (Lang.assoc "" 1 p, [], "The target directory does not exist"))
   in
   let persist_at =
     Option.map
@@ -271,6 +271,7 @@ class hls_output p =
            raise
              (Error.Invalid_value
                 ( List.assoc "persist_at" p,
+                  [],
                   Printf.sprintf
                     "Error while creating directory %s for persisting state: %s"
                     (Utils.quote_string dir) (Printexc.to_string exn) )));
@@ -323,7 +324,7 @@ class hls_output p =
     let l = Lang.to_list streams in
     if l = [] then
       raise
-        (Error.Invalid_value (streams, "The list of streams cannot be empty"));
+        (Error.Invalid_value (streams, [], "The list of streams cannot be empty"));
     l
   in
   let mk_streams, streams =
@@ -334,7 +335,7 @@ class hls_output p =
       let encoder_factory =
         try Encoder.get_factory format
         with Not_found ->
-          raise (Error.Invalid_value (fmt, "Unsupported format"))
+          raise (Error.Invalid_value (fmt, [], "Unsupported format"))
       in
       let encoder = encoder_factory name Meta_format.empty_metadata in
       let bandwidth, codecs, extname, video_size =
@@ -350,6 +351,7 @@ class hls_output p =
                       raise
                         (Error.Invalid_value
                            ( fmt,
+                             [],
                              "Bandwidth cannot be inferred from codec, please \
                               specify it in `streams_info`" ))))
           in
@@ -363,6 +365,7 @@ class hls_output p =
                       raise
                         (Error.Invalid_value
                            ( fmt,
+                             [],
                              Printf.sprintf
                                "Stream info for stream %S cannot be inferred \
                                 from codec, please specify it in \
@@ -375,6 +378,7 @@ class hls_output p =
               raise
                 (Error.Invalid_value
                    ( fmt,
+                     [],
                      "File extension cannot be inferred from codec, please \
                       specify it in `streams_info`" ))
           in

--- a/src/outputs/icecast2.ml
+++ b/src/outputs/icecast2.ml
@@ -301,7 +301,7 @@ class output ~kind p =
         | _ ->
             raise
               (Error.Invalid_value
-                 (m, "Valid values are: 'source' 'put' or 'post'."))
+                 (m, [], "Valid values are: 'source' 'put' or 'post'."))
     in
     let v = List.assoc "protocol" p in
     match Lang.to_string v with
@@ -311,7 +311,7 @@ class output ~kind p =
       | _ ->
           raise
             (Error.Invalid_value
-               (v, "Valid values are 'http' (icecast) and 'icy' (shoutcast)"))
+               (v, [], "Valid values are 'http' (icecast) and 'icy' (shoutcast)"))
   in
   let icy_metadata =
     let v = List.assoc "icy_metadata" p in
@@ -323,7 +323,7 @@ class output ~kind p =
         | _ ->
             raise
               (Error.Invalid_value
-                 (v, "Valid values are 'guess', 'true' or 'false'"))
+                 (v, [], "Valid values are 'guess', 'true' or 'false'"))
     in
     match (data.format, icy) with
       | _, `True -> true
@@ -335,6 +335,7 @@ class output ~kind p =
           raise
             (Error.Invalid_value
                ( List.assoc "icy_metadata" p,
+                 [],
                  "Could not guess icy_metadata for this format, please specify \
                   either 'true' or 'false'." ))
   in
@@ -353,6 +354,7 @@ class output ~kind p =
           raise
             (Error.Invalid_value
                ( List.assoc "mount" p,
+                 [],
                  "Either name or mount must be defined for icecast sources." ))
       | Cry.Icy, name, _ when name = no_name ->
           (Cry.Icy_id icy_id, Printf.sprintf "sc#%i" icy_id)

--- a/src/outputs/output.ml
+++ b/src/outputs/output.ml
@@ -49,7 +49,7 @@ class virtual output ~content_kind ~output_kind ?(name = "") ~infallible
     (* This should be done before the active_operator initializer
      * attaches us to a clock. *)
     if infallible && source#stype <> `Infallible then
-      raise (Error.Invalid_value (val_source, "That source is fallible"))
+      raise (Error.Invalid_value (val_source, [], "That source is fallible"))
 
     inherit active_operator ~name:output_kind content_kind [source] as super
     inherit Start_stop.base ~on_start ~on_stop as start_stop

--- a/src/outputs/pipe_output.ml
+++ b/src/outputs/pipe_output.ml
@@ -28,7 +28,7 @@ let encoder_factory ?format format_val =
   in
   try Encoder.get_factory format
   with Not_found ->
-    raise (Error.Invalid_value (format_val, "Unsupported encoding format"))
+    raise (Error.Invalid_value (format_val, [], "Unsupported encoding format"))
 
 class virtual base ~kind ~source ~name p =
   let e f v = f (List.assoc v p) in
@@ -101,7 +101,7 @@ class url_output p =
     if not (Encoder.url_output format) then
       raise
         (Error.Invalid_value
-           (format_val, "Encoding format does not support output url!"))
+           (format_val, [], "Encoding format does not support output url!"))
   in
   let format = Encoder.with_url_output format url in
   let kind = Kind.of_kind (Encoder.kind_of_format format) in

--- a/src/sources/external_input_audio.ml
+++ b/src/sources/external_input_audio.ml
@@ -109,7 +109,8 @@ let () =
         try Audio_converter.Channel_layout.layout_of_channels channels
         with _ ->
           raise
-            (Error.Invalid_value (channels_v, "unsupported number of channels"))
+            (Error.Invalid_value
+               (channels_v, [], "unsupported number of channels"))
       in
       let kind =
         Lang.audio_params

--- a/src/sources/harbor_input.ml
+++ b/src/sources/harbor_input.ml
@@ -174,6 +174,7 @@ module Make (Harbor : T) = struct
             raise
               (Error.Invalid_value
                  ( List.assoc "" p,
+                   [],
                    (* TODO: raise two script values ? *)
                    let port = Lang.to_int (List.assoc "port" p) in
                    Printf.sprintf
@@ -467,6 +468,7 @@ module Make (Harbor : T) = struct
           raise
             (Error.Invalid_value
                ( List.assoc "max" p,
+                 [],
                  "Maximum buffering inferior to pre-buffered data" ));
         let on_connect l =
           let l =

--- a/src/tools/child_support.ml
+++ b/src/tools/child_support.ml
@@ -37,6 +37,7 @@ class virtual base ~check_self_sync children_val =
             raise
               (Error.Invalid_value
                  ( c,
+                   [],
                    "This source may control its own latency and cannot be used \
                     with this operator." )))
         children_val

--- a/src/tools/icecast_utils.ml
+++ b/src/tools/icecast_utils.ml
@@ -184,7 +184,7 @@ module Icecast_v (M : Icecast_t) = struct
     let encoder_factory =
       try Encoder.get_factory enc
       with Not_found ->
-        raise (Error.Invalid_value (v, "No encoder found for that format"))
+        raise (Error.Invalid_value (v, [], "No encoder found for that format"))
     in
     let format =
       let f = Lang.to_string (List.assoc "format" p) in
@@ -196,6 +196,7 @@ module Icecast_v (M : Icecast_t) = struct
               raise
                 (Error.Invalid_value
                    ( Lang.assoc "" 1 p,
+                     [],
                      "No format (mime) found, please specify one." )))
     in
     { factory = encoder_factory; format; info }

--- a/src/tools/pos.ml
+++ b/src/tools/pos.ml
@@ -64,6 +64,8 @@ module List = struct
       is the external caller and the last one is the callee. *)
   type nonrec t = t list
 
+  let of_option : Option.t -> t = function Some pos -> [pos] | None -> []
+
   (** The most relevant position in a call stack. *)
   let rec to_pos = function
     | [x] -> x

--- a/src/tools/pos.ml
+++ b/src/tools/pos.ml
@@ -50,6 +50,13 @@ module Option = struct
   let to_string ?prefix : t -> string = function
     | Some pos -> to_string ?prefix pos
     | None -> "unknown position"
+
+  let sup (p : t) (q : t) : t =
+    match (p, q) with
+      | Some (p, _), Some (_, q) -> Some (p, q)
+      | Some p, None -> Some p
+      | None, Some q -> Some q
+      | None, None -> None
 end
 
 module List = struct


### PR DESCRIPTION
It is not very reasonable to propagate positions in values at runtime. This PR removes those. We only add back positions when exceptions are raised at function application. The locations are a bit less precise (we get the whole function application instead of the precise argument), but I think that this is still reasonable (and more efficient).