### PR TITLE
Add let deletes, optimize let replaces.

### DIFF
--- a/src/lang/lexer.ml
+++ b/src/lang/lexer.ml
@@ -190,6 +190,7 @@ let rec token lexbuf =
     | "catch" -> CATCH
     | "do" -> DO
     | "let", Plus skipped, "replaces" -> LET `Replaces
+    | "let", Plus skipped, "deletes" -> LET `Deletes
     | "let", Plus skipped, "eval" -> LET `Eval
     | "let", Plus skipped, "json.parse", Star skipped, '[' ->
         LETLBRA `Json_parse

--- a/src/lang/parser.mly
+++ b/src/lang/parser.mly
@@ -460,12 +460,13 @@ binding:
   | _let LPAR pattern COLON ty RPAR GETS expr
                              { (Doc.none (),[],[]), $1,     $3,        None,    $8, Some $5 }
   | _let subfield GETS expr  { (Doc.none (),[],[]), $1,     PVar $2,   None,    $4, None }
+  | _let VAR DOT VAR         { (Doc.none (),[],[]), $1,     PVar [$2;$4],        None,  mk ~pos:$loc (Tuple []), None } 
   | DEF pattern g exprs END  { fst $1,              snd $1, $2,        None,    $4, None }
   | DEF LPAR pattern COLON ty RPAR g exprs END 
                              { fst $1,              snd $1, $3,        None,    $8, Some $5 }
   | DEF subfield g exprs END { fst $1,              snd $1, PVar $2,   None,    $4, None }
   | DEF varlpar arglist RPAR g exprs END
-                             { fst $1,              snd $1, PVar $2, Some $3,   $6, None }
+                             { fst $1,              snd $1, PVar $2,   Some $3,   $6, None }
 
 varlpar:
   | VARLPAR         { [$1] }

--- a/src/lang/term.ml
+++ b/src/lang/term.ml
@@ -264,10 +264,12 @@ type t = { mutable t : Type.t; term : in_term }
 (** Documentation for declarations: general documentation, parameters, methods. *)
 and doc = Doc.item * (string * string) list * (string * string) list
 
+and mutate = [ `None | `Replaces | `Deletes of string ]
+
 and let_t = {
   doc : doc;
   (* name, arguments, methods *)
-  replace : bool;
+  mutate : mutate;
   (* whether the definition replaces a previously existing one (keeping methods) *)
   pat : pattern;
   mutable gen : Type.var list;

--- a/src/lang/type.ml
+++ b/src/lang/type.ml
@@ -197,6 +197,14 @@ let rec remeth t u =
     | Meth (m, t) -> { t with descr = Meth (m, remeth t u) }
     | _ -> u
 
+(* Remove a method from the given type. *)
+let rec unmeth t m =
+  let t = deref t in
+  match t.descr with
+    | Meth ({ meth = m' }, t) when m = m' -> unmeth t m
+    | Meth (m', t) -> { t with descr = Meth (m', unmeth t m) }
+    | _ -> t
+
 (** Type of a method in a type. *)
 let rec invoke t l =
   match (deref t).descr with

--- a/src/lang/value.ml
+++ b/src/lang/value.ml
@@ -133,12 +133,14 @@ let rec remeth t u =
     | _ -> u
 
 let uniq_meth t =
-  let rec f (meths, t) =
-    match meths with
-      | [] -> t
-      | (m, v) :: meths -> f (meths, { t with value = Meth (m, v, t) })
+  let rec f meths t =
+    match t.value with
+      | Meth (m, _, t') when List.mem m meths ->
+          { t with value = (f meths t').value }
+      | Meth (m, v, t') -> { t with value = Meth (m, v, f (m :: meths) t') }
+      | _ -> t
   in
-  f (split_meths t)
+  f [] t
 
 let rec unmeth t m =
   match t.value with

--- a/src/lang/value.ml
+++ b/src/lang/value.ml
@@ -132,6 +132,20 @@ let rec remeth t u =
     | Meth (l, v, t) -> { t with value = Meth (l, v, remeth t u) }
     | _ -> u
 
+let uniq_meth t =
+  let rec f (meths, t) =
+    match meths with
+      | [] -> t
+      | (m, v) :: meths -> f (meths, { t with value = Meth (m, v, t) })
+  in
+  f (split_meths t)
+
+let rec unmeth t m =
+  match t.value with
+    | Meth (m', _, t) when m = m' -> unmeth t m
+    | Meth (m', v, t) -> { t with value = Meth (m', v, unmeth t m) }
+    | _ -> t
+
 let compare a b =
   let rec aux = function
     | Ground a, Ground b -> Ground.compare a b

--- a/tests/language/record.liq
+++ b/tests/language/record.liq
@@ -91,6 +91,19 @@ def f() =
   t([{a = 5}] == [{a = 5}], true)
   t(({a = 5}) == ({a = 5}), true)
 
+  # Test delete field
+  x = {foo = 123, bla = "baz", gni = "gno"}
+  let deletes x.foo
+  t(x, {bla = "baz", gni = "gno"})
+  
+  x = { x = x, gni = "gno"}
+  let deletes x.x
+  t(x, {gni = "gno"})
+
+  let x = { x = x, blu = 2.34}
+  let deletes x.blu
+  t(x, { x = {gni = "gno"}})
+
   if !success then test.pass() else test.fail() end
 end
 


### PR DESCRIPTION
This PR adds a new syntactic construct:
```ruby
# x = { foo = 123, bla = "bar" };;
x : {bla : string, foo : int} = {foo = 123, bla = "bar"}
# let deletes x.foo;;
x : {bla : string} = {bla = "bar"}
```
Syntax is limited to the first level for now. I'm not sure if I want to go deeper for now, this would complicate the code and there's no use for it except to remove individual record methods as in https://github.com/savonet/liquidsoap/issues/2295

It also makes sure that methods are always de-duplicated at runtime. I was not able to see obvious reduction in memory usage with trivial use of the standard library but that seems like a good practice anyways.