### PR TITLE
Enhance ffmpeg copy encoder/decoder

### DIFF
--- a/liquidsoap.opam
+++ b/liquidsoap.opam
@@ -86,8 +86,8 @@ conflicts: [
   "dssi" {< "0.1.3"}
   "faad" {< "0.5.0"}
   "fdkaac" {< "0.3.1"}
-  "ffmpeg" {< "1.1.2"}
-  "ffmpeg-avutil" {< "1.1.2"}
+  "ffmpeg" {< "1.1.4"}
+  "ffmpeg-avutil" {< "1.1.4"}
   "flac" {< "0.3.0"}
   "frei0r" {< "0.1.0"}
   "gstreamer" {< "0.3.1"}

--- a/src/decoder/ffmpeg_copy_decoder.ml
+++ b/src/decoder/ffmpeg_copy_decoder.ml
@@ -69,10 +69,7 @@ let mk_audio_decoder ~stream_idx ~format container =
        Ffmpeg_copy_content.(Audio.lift_params (Some params)));
   let stream_time_base = Av.get_time_base stream in
   let lift_data = Ffmpeg_copy_content.Audio.lift_data in
-  let latest_keyframe =
-    Ffmpeg_copy_content.latest_keyframe
-      Avcodec.Audio.(descriptor (get_params_id params))
-  in
+  let latest_keyframe = Ffmpeg_copy_content.latest_keyframe params in
   ( idx,
     stream,
     mk_decoder ~stream_idx ~lift_data ~stream_time_base ~put_data:G.put_audio
@@ -86,10 +83,7 @@ let mk_video_decoder ~stream_idx ~format container =
        Ffmpeg_copy_content.(Video.lift_params (Some params)));
   let stream_time_base = Av.get_time_base stream in
   let lift_data = Ffmpeg_copy_content.Video.lift_data in
-  let latest_keyframe =
-    Ffmpeg_copy_content.latest_keyframe
-      Avcodec.Video.(descriptor (get_params_id params))
-  in
+  let latest_keyframe = Ffmpeg_copy_content.latest_keyframe params in
   ( idx,
     stream,
     mk_decoder ~stream_idx ~lift_data ~stream_time_base ~put_data:G.put_video

--- a/src/encoder.ml
+++ b/src/encoder.ml
@@ -64,7 +64,7 @@ let kind_of_format = function
       let audio =
         match m.Ffmpeg_format.audio_codec with
           | None -> Frame.none
-          | Some `Copy ->
+          | Some (`Copy _) ->
               `Format
                 Frame_content.(
                   default_format (kind_of_string "ffmpeg.audio.copy"))
@@ -88,7 +88,7 @@ let kind_of_format = function
       let video =
         match m.Ffmpeg_format.video_codec with
           | None -> Frame.none
-          | Some `Copy ->
+          | Some (`Copy _) ->
               `Format
                 Frame_content.(
                   default_format (kind_of_string "ffmpeg.video.copy"))

--- a/src/encoder/ffmpeg_copy_encoder.ml
+++ b/src/encoder/ffmpeg_copy_encoder.ml
@@ -43,6 +43,8 @@ let mk_stream_copy ~video_size ~get_stream ~keyframe_opt ~get_data output =
     let params = Option.get params in
     video_size_ref := video_size frame;
     let s = Av.new_stream_copy ~params output in
+    codec_attr := Av.codec_attr s;
+    bitrate := Av.bitrate s;
     (match Avcodec.descriptor params with
       | None -> ()
       | Some { Avcodec.name; properties } ->

--- a/src/encoder/ffmpeg_copy_encoder.ml
+++ b/src/encoder/ffmpeg_copy_encoder.ml
@@ -89,8 +89,11 @@ let mk_stream_copy ~video_size ~get_stream ~keyframe_opt ~get_data output =
          (fun dts ->
            current_position := Int64.add dts !current_stream.last_start)
          dts);
-    current_position :=
-      Int64.add !current_position (Option.value ~default:1L duration)
+    ignore
+      (Option.map
+         (fun duration ->
+           current_position := Int64.add !current_position duration)
+         duration)
   in
   let adjust_ts ~time_base =
     Option.map (fun ts ->

--- a/src/encoder/ffmpeg_copy_encoder.ml
+++ b/src/encoder/ffmpeg_copy_encoder.ml
@@ -25,8 +25,7 @@
 open Avcodec
 open Ffmpeg_encoder_common
 
-let mk_stream_copy ~format ~video_size ~get_stream ~keyframe_opt ~get_data
-    output =
+let mk_stream_copy ~video_size ~get_stream ~keyframe_opt ~get_data output =
   let stream = ref None in
   let video_size_ref = ref None in
   let codec_attr = ref None in
@@ -46,8 +45,7 @@ let mk_stream_copy ~format ~video_size ~get_stream ~keyframe_opt ~get_data
     bitrate := Av.bitrate s;
     (match Avcodec.descriptor params with
       | None -> ()
-      | Some { Avcodec.name; properties } ->
-          intra_only := List.mem `Intra_only properties);
+      | Some { properties } -> intra_only := List.mem `Intra_only properties);
     stream := Some s
   in
 
@@ -91,11 +89,8 @@ let mk_stream_copy ~format ~video_size ~get_stream ~keyframe_opt ~get_data
          (fun dts ->
            current_position := Int64.add dts !current_stream.last_start)
          dts);
-    ignore
-      (Option.map
-         (fun duration ->
-           current_position := Int64.add !current_position duration)
-         duration)
+    current_position :=
+      Int64.add !current_position (Option.value ~default:1L duration)
   in
   let adjust_ts ~time_base =
     Option.map (fun ts ->

--- a/src/encoder/ffmpeg_copy_encoder.ml
+++ b/src/encoder/ffmpeg_copy_encoder.ml
@@ -169,8 +169,10 @@ let mk_stream_copy ~video_size ~get_stream ~keyframe_opt ~get_data output =
                 (match latest_keyframe with
                   | `No_keyframe | `Not_seen -> ()
                   | `Seen keyframe ->
-                      Packet.set_pts keyframe (Packet.get_pts packet);
-                      Packet.set_dts keyframe (Packet.get_dts packet);
+                      Packet.set_pts keyframe
+                        (Option.map Int64.pred (Packet.get_pts packet));
+                      Packet.set_dts keyframe
+                        (Option.map Int64.pred (Packet.get_dts packet));
                       push ~time_base ~stream keyframe);
                 keyframe_action := `Ignore);
           if not !current_stream.waiting_for_keyframe then

--- a/src/encoder/ffmpeg_encoder.ml
+++ b/src/encoder/ffmpeg_encoder.ml
@@ -32,11 +32,11 @@ let () =
             let get_stream = mk_stream_store () in
             let mk_audio =
               match m.Ffmpeg_format.audio_codec with
-                | Some `Copy ->
+                | Some (`Copy keyframe_opt) ->
                     fun ~ffmpeg:_ ~options:_ ->
                       Ffmpeg_copy_encoder.mk_stream_copy
                         ~video_size:(fun _ -> None)
-                        ~get_stream
+                        ~get_stream ~keyframe_opt
                         ~get_data:(fun frame ->
                           Ffmpeg_copy_content.Audio.get_data
                             Frame.(frame.content.audio))
@@ -49,7 +49,7 @@ let () =
             in
             let mk_video =
               match m.Ffmpeg_format.video_codec with
-                | Some `Copy ->
+                | Some (`Copy keyframe_opt) ->
                     fun ~ffmpeg:_ ~options:_ ->
                       let get_data frame =
                         Ffmpeg_copy_content.Video.get_data
@@ -64,7 +64,7 @@ let () =
                           params
                       in
                       Ffmpeg_copy_encoder.mk_stream_copy ~video_size ~get_stream
-                        ~get_data
+                        ~get_data ~keyframe_opt
                 | None | Some (`Internal (Some _)) | Some (`Raw (Some _)) ->
                     Ffmpeg_internal_encoder.mk_video
                 | Some (`Internal None) ->

--- a/src/encoder/ffmpeg_encoder.ml
+++ b/src/encoder/ffmpeg_encoder.ml
@@ -36,7 +36,7 @@ let () =
                     fun ~ffmpeg:_ ~options:_ ->
                       Ffmpeg_copy_encoder.mk_stream_copy
                         ~video_size:(fun _ -> None)
-                        ~format:m.Ffmpeg_format.format ~get_stream ~keyframe_opt
+                        ~get_stream ~keyframe_opt
                         ~get_data:(fun frame ->
                           Ffmpeg_copy_content.Audio.get_data
                             Frame.(frame.content.audio))
@@ -64,7 +64,7 @@ let () =
                           params
                       in
                       Ffmpeg_copy_encoder.mk_stream_copy ~video_size ~get_stream
-                        ~get_data ~keyframe_opt ~format:m.Ffmpeg_format.format
+                        ~get_data ~keyframe_opt
                 | None | Some (`Internal (Some _)) | Some (`Raw (Some _)) ->
                     Ffmpeg_internal_encoder.mk_video
                 | Some (`Internal None) ->

--- a/src/encoder/ffmpeg_encoder.ml
+++ b/src/encoder/ffmpeg_encoder.ml
@@ -36,7 +36,7 @@ let () =
                     fun ~ffmpeg:_ ~options:_ ->
                       Ffmpeg_copy_encoder.mk_stream_copy
                         ~video_size:(fun _ -> None)
-                        ~get_stream ~keyframe_opt
+                        ~format:m.Ffmpeg_format.format ~get_stream ~keyframe_opt
                         ~get_data:(fun frame ->
                           Ffmpeg_copy_content.Audio.get_data
                             Frame.(frame.content.audio))
@@ -64,7 +64,7 @@ let () =
                           params
                       in
                       Ffmpeg_copy_encoder.mk_stream_copy ~video_size ~get_stream
-                        ~get_data ~keyframe_opt
+                        ~get_data ~keyframe_opt ~format:m.Ffmpeg_format.format
                 | None | Some (`Internal (Some _)) | Some (`Raw (Some _)) ->
                     Ffmpeg_internal_encoder.mk_video
                 | Some (`Internal None) ->

--- a/src/encoder/ffmpeg_encoder_common.ml
+++ b/src/encoder/ffmpeg_encoder_common.ml
@@ -27,7 +27,7 @@ let log = Ffmpeg_utils.log
 type encoder = {
   mk_stream : Frame.t -> unit;
   encode : Frame.t -> int -> int -> unit;
-  was_keyframe : unit -> bool;
+  can_split : unit -> bool;
   codec_attr : unit -> string option;
   bitrate : unit -> int option;
   video_size : unit -> (int * int) option;
@@ -207,7 +207,7 @@ let encoder ~mk_audio ~mk_video ffmpeg meta =
     encode ~encoder frame start len;
     let encoded = Strings.Mutable.flush buf in
     match encoder.video_stream with
-      | Some s when s.was_keyframe () -> `Ok (flushed, encoded)
+      | Some s when s.can_split () -> `Ok (flushed, encoded)
       | None -> `Ok (flushed, encoded)
       | _ -> `Nope (Strings.append flushed encoded)
   in

--- a/src/encoder/ffmpeg_encoder_common.ml
+++ b/src/encoder/ffmpeg_encoder_common.ml
@@ -40,7 +40,11 @@ type handler = {
   mutable started : bool;
 }
 
-type stream_data = { idx : Int64.t; mutable last_start : Int64.t }
+type stream_data = {
+  idx : Int64.t;
+  mutable last_start : Int64.t;
+  mutable waiting_for_keyframe : bool;
+}
 
 module Stream = Weak.Make (struct
   type t = stream_data
@@ -56,11 +60,17 @@ end)
      v: ----------->vls
    the last start should be vls so we end up with:
      a: ------>     -------->
-     v: ----------->--------> *)
+     v: ----------->-------->
+
+   Also, if one or more stream is waiting for a key frame,
+   we make the whole set of streams wait for the first key
+   frame. This makes sure that we avoid e.g. starting an
+   audio track with no keyframe before the video has started *)
 let mk_stream_store () =
   let store = Stream.create 1 in
-  fun ~last_start idx ->
-    let data = Stream.merge store { idx; last_start } in
+  fun ~last_start ~waiting_for_keyframe idx ->
+    let data = Stream.merge store { idx; last_start; waiting_for_keyframe } in
+    data.waiting_for_keyframe <- waiting_for_keyframe;
     if data.last_start < last_start then data.last_start <- last_start;
     data
 

--- a/src/encoder/ffmpeg_internal_encoder.ml
+++ b/src/encoder/ffmpeg_internal_encoder.ml
@@ -256,7 +256,7 @@ let mk_audio ~ffmpeg ~options output =
 
   let can_split =
     let params = Av.get_codec_params stream in
-    match Avcodec.Audio.(descriptor (get_params_id params)) with
+    match Avcodec.descriptor params with
       | None -> fun () -> true
       | Some { Avcodec.properties } when List.mem `Intra_only properties ->
           fun () -> true
@@ -469,7 +469,7 @@ let mk_video ~ffmpeg ~options output =
 
   let can_split =
     let params = Av.get_codec_params stream in
-    match Avcodec.Video.(descriptor (get_params_id params)) with
+    match Avcodec.descriptor params with
       | None -> fun () -> true
       | Some { Avcodec.properties } when List.mem `Intra_only properties ->
           fun () -> true

--- a/src/encoder/ffmpeg_internal_encoder.ml
+++ b/src/encoder/ffmpeg_internal_encoder.ml
@@ -243,12 +243,11 @@ let mk_audio ~ffmpeg ~options output =
     else Some (Av.get_frame_size stream)
   in
 
-  let write_frame frame =
+  let write_frame =
     try
       write_audio_frame ~time_base:(Av.get_time_base stream)
         ~sample_rate:target_samplerate ~channel_layout:target_channel_layout
         ~sample_format:target_sample_format ~frame_size (Av.write_frame stream)
-        frame
     with e ->
       log#severe "Error writing audio frame: %s." (Printexc.to_string e);
       raise e

--- a/src/lang/builtins_ffmpeg_encoder.ml
+++ b/src/lang/builtins_ffmpeg_encoder.ml
@@ -70,10 +70,7 @@ let encode_audio_frame ~kind_t ~mode ~opts ?codec ~format generator =
           in
 
           let params = Avcodec.params encoder in
-          let latest_keyframe =
-            Ffmpeg_copy_content.latest_keyframe
-              Avcodec.Audio.(descriptor (get_params_id params))
-          in
+          let latest_keyframe = Ffmpeg_copy_content.latest_keyframe params in
 
           let params = Some params in
           let effective_t =
@@ -246,10 +243,7 @@ let encode_video_frame ~kind_t ~mode ~opts ?codec ~format generator =
           in
 
           let params = Avcodec.params encoder in
-          let latest_keyframe =
-            Ffmpeg_copy_content.latest_keyframe
-              Avcodec.Video.(descriptor (get_params_id params))
-          in
+          let latest_keyframe = Ffmpeg_copy_content.latest_keyframe params in
 
           let params = Some params in
           let effective_t =

--- a/src/lang/builtins_ffmpeg_encoder.ml
+++ b/src/lang/builtins_ffmpeg_encoder.ml
@@ -69,7 +69,13 @@ let encode_audio_frame ~kind_t ~mode ~opts ?codec ~format generator =
               ~get_ts:Avcodec.Packet.get_dts
           in
 
-          let params = Some (Avcodec.params encoder) in
+          let params = Avcodec.params encoder in
+          let latest_keyframe =
+            Ffmpeg_copy_content.latest_keyframe
+              Avcodec.Audio.(descriptor (get_params_id params))
+          in
+
+          let params = Some params in
           let effective_t =
             Lang.kind_t (`Format (Ffmpeg_copy_content.Audio.lift_params params))
           in
@@ -85,6 +91,7 @@ let encode_audio_frame ~kind_t ~mode ~opts ?codec ~format generator =
                           {
                             Ffmpeg_copy_content.packet;
                             time_base = encoder_time_base;
+                            latest_keyframe = latest_keyframe ~pos packet;
                             stream_idx;
                           } ))
                       packets
@@ -238,7 +245,13 @@ let encode_video_frame ~kind_t ~mode ~opts ?codec ~format generator =
               ~width:target_width ~height:target_height ~time_base codec
           in
 
-          let params = Some (Avcodec.params encoder) in
+          let params = Avcodec.params encoder in
+          let latest_keyframe =
+            Ffmpeg_copy_content.latest_keyframe
+              Avcodec.Video.(descriptor (get_params_id params))
+          in
+
+          let params = Some params in
           let effective_t =
             Lang.kind_t (`Format (Ffmpeg_copy_content.Video.lift_params params))
           in
@@ -261,6 +274,7 @@ let encode_video_frame ~kind_t ~mode ~opts ?codec ~format generator =
                           {
                             Ffmpeg_copy_content.packet;
                             time_base = encoder_time_base;
+                            latest_keyframe = latest_keyframe ~pos packet;
                             stream_idx;
                           } ))
                       packets

--- a/src/lang/parser.mly
+++ b/src/lang/parser.mly
@@ -429,13 +429,15 @@ ffmpeg_params:
 
 ffmpeg_list_elem:
   | AUDIO_NONE                        { `Audio_none }
-  | AUDIO_COPY                        { `Audio_copy }
+  | AUDIO_COPY                        { `Audio_copy None }
+  | AUDIO_COPY LPAR VAR RPAR          { `Audio_copy (Some ($3, mk ~pos:$loc (Var $3))) }
   | AUDIO_RAW LPAR ffmpeg_params RPAR { `Audio_raw $3 }
   /* This is for inline encoders. */
   | AUDIO_RAW                         { `Audio_raw [] }
   | AUDIO LPAR ffmpeg_params RPAR     { `Audio  $3 }
   | VIDEO_NONE                        { `Video_none }
-  | VIDEO_COPY                        { `Video_copy }
+  | VIDEO_COPY                        { `Video_copy None }
+  | VIDEO_COPY LPAR VAR RPAR          { `Video_copy (Some ($3, mk ~pos:$loc (Var $3))) }
   /* This is for inline encoders. */
   | VIDEO_RAW                         { `Video_raw [] }
   | VIDEO_RAW LPAR ffmpeg_params RPAR { `Video_raw  $3 }


### PR DESCRIPTION
This PR adds some enhancement to the handling of keyframes when using the ffmpeg copy encoder, following issues raised in https://github.com/savonet/liquidsoap/discussions/2331#discussioncomment-2560399.

Ideally, we would like to be able to switch sources and tracks based on keyframe boundaries from encoded content to make sure that content is decodable immediately when concatenating different streams.

However, being a streaming model, liquidsoap makes switching decisions _before_ pulling content from a source and so would require some kind of look ahead mechanism to know if a keyframe is coming, which is pretty complex to implement, specially when sources are potentially shared between different operators.

This PR adds some ways to mitigate this issue at the `%ffmpeg` encoding level by adding 3 different options when switching content:
1. Ignore all keyframes issues.
2. Replay the latest known keyframe when switching to a new stream and the first packet is not a keyframe
3. Wait until at least one keyframe has been passed to start passing encoded packets from a new stream.

All 3 options apply to the cases where the `%ffmpeg` encoder has streams created using `%audio.copy` or `%video.copy`. In this situation, let's consider the case where the video content goes from one encoded stream to a new one.

* With option 1 we start passing encoded data right away. Content is immediately added but playback might get stuck until a new keyframe is passed.
* With option 2, we replay the latest  known keyframe for the new stream. This can happen if, e.g. the stream was stopped by a `switch` going to a different source and we are getting back to it. With this option, playback should be able to resume right away but there might still be decoding glitches due to missing frames between the latest keyframe and the current frame.
* With option 3, we discard any new packet until a keyframe is passed. This means that playback will be paused until it can be  resumed properly with no decoding glitches.

Option 3. is implemented globally when possible, i.e. in case of a video track with keyframes and an audio track with no keyframes, the audio track will discard packets until a video keyframe has been passed.

It is worth noting that some audio encoders may also have keyframes.

All 3 options can be set via the `%audio.copy` and `%video.copy` encoder:
* `%audio,copy(ignore_keyframe)` and `%video.copy(ignore_keyframe)`
* `%audio,copy(replay_keyframe)` and `%video.copy(replay_keyframe)`
* `%audio,copy(wait_for_keyframe)` and `%video.copy(wait_for_keyframe)`

Option 3, which seems what most user would expect, is the default so `%audio.copy` and `%video.copy` are also equivalent to, resp., `%audio,copy(wait_for_keyframe)` and `%video.copy(wait_for_keyframe)`

Lastly, this PR cleans up the logic around keyframes. While it appears that packets from format that do not have keyframes are currently marked as keyframes, it is preferable to look at wether the format actually has keyframes and. This is indicated by `AV_CODEC_PROP_INTRA_ONLY` in ffmpeg, meaning decoder only rely on the current content and no previous content to be able to decode it.

In this case, we should ignore all keyframe flags from encoded packets and proceed accordingly, which this PR also implements.

A simple test script is:
```ruby
log.level.set(4)

s1 = single("/tmp/s1.mp4")
s2 = single("/tmp/s2.mp4")

s = switch(track_sensitive=false, [
  ({file.exists("/tmp/s1")}, s1),
  ({true}, s2)
])

# Same as: enc = %ffmpeg(format="flv", %audio.copy, %video.copy(wait_for_keyframe))`
enc = %ffmpeg(format="flv", %audio.copy, %video.copy)
# Or:
# enc = %ffmpeg(format="flv", %audio.copy, %video.copy(ignore_keyframe))`
# enc = %ffmpeg(format="flv", %audio.copy, %video.copy(replay_keyframe))`

output.file(enc, "/tmp/out.flv", s)
```