### PR TITLE
Finish switch to immutable content

### DIFF
--- a/src/stream/frame.ml
+++ b/src/stream/frame.ml
@@ -94,7 +94,7 @@ let metadata_of_list l =
 type t = {
   (* Presentation time, in multiple of frame size. *)
   mutable pts : int64 option;
-  content : Content.data;
+  mutable content : Content.data;
 }
 
 (** Create a content chunk. All chunks have the same size. *)
@@ -126,7 +126,7 @@ let content_type frame =
 
 (* TODO: historically, breaks are ordered with most recent first. *)
 let breaks { content } = List.rev (Content.Frame.get_breaks content)
-let position b = match breaks b with [] -> 0 | a :: _ -> a
+let position { content } = Content.length content
 let is_partial b = position b < !!size
 let set_breaks { content } = Content.Frame.set_breaks content
 let add_break { content } = Content.Frame.add_break content


### PR DESCRIPTION
- [x] Make frame a mutable content buffer
- [x] Use frame content length for frame position
- [ ] Remove content `blit` API (alludes to copy), implement immutable equivalent
- [ ] Remove content `empty` API (not needed anymore)
- [ ] Devise new API for operators:
  * Operators who manipulate content in place should copy content.
  * Operators that create new content should append content
- [ ] Update operators

Q&A:
- [ ] Test for performance!
- [ ] Test for content sharing. See: https://github.com/savonet/liquidsoap/issues/2170