### PR TITLE
Add support for keyframes in ffmpeg copy encoder

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,6 +24,8 @@ New:
 - Added new in-house parsing of metadata for some image and video formats
   (#2236).
 - Added `file.download`
+- Added new options for `%ffmpeg` copy encoder: `ignore_keyframes`
+  and `wait_for_keyframe` (#2382)
 
 Changes:
 

--- a/doc/content/encoding_formats.md
+++ b/doc/content/encoding_formats.md
@@ -173,13 +173,13 @@ The full syntax is as follows:
   # Or:
   %audio.raw(codec=<codec>,<option_name>=<option_value>,..),
   # Or:
-  %audio.copy,
+  %audio.copy(<option>),
   # Video section
   %video(codec=<codec>,<option_name>=<option_value>,..),
   # Or:
   %video.raw(codec=<codec>,<option_name>=<option_value>,..),
   # Or:
-  %video.copy,
+  %video.copy(<option>),
   # Generic options
   <option_name>=<option_value>,..
 )
@@ -202,6 +202,18 @@ The `%ffmpeg` encoder is the prime encoder for HLS output as it is the only one 
 Some encoding formats, for instance `mp4` require to rewing their stream and write a header after the fact, when encoding of the current track has finished. For historical reasons, such formats
 cannot be used with `output.file`. To remedy that, we have introduced the `output.url` operator. When using this operator, the encoder is fully in charge of the output file and can thus write headers
 after the fact. The `%ffmpeg` encoder is one such encoder that can be used with this operator.
+
+The `%audio.copy` and `%video.copy` encoders have two mutually exclusive options to handle keyframes:
+* `%audio.copy(wait_for_keyframe)` and `%video.copy(wait_for_keyframe)`: Wait until at least one keyframe has been passed to start passing encoded packets from a new stream.
+* `%audio.copy(ignore_keyframe)` and `%video.copy(ignore_keyframe)`: Ignore all keyframes.
+
+These options are useful when switching from one encoded stream to the next.
+
+With option `wait_for_keyframe`, the encoder discards any new packet at the beginning of a stream until a keyframe is passed. This means that playback will be paused until it can be resumed properly with no decoding glitches. This option is implemented globally when possible, i.e. in case of a video track with keyframes and an audio track with no keyframes, the audio track will discard packets until a video keyframe has been passed. This is the default option.
+
+With option `ignore_keyframe`, the encoder starts passing encoded data right away. Content is immediately added but playback might get stuck until a new keyframe is passed.
+
+It is worth noting that some audio encoders may also have keyframes.
 
 Ogg
 ---

--- a/liquidsoap.opam
+++ b/liquidsoap.opam
@@ -85,8 +85,8 @@ conflicts: [
   "dssi" {< "0.1.3"}
   "faad" {< "0.5.0"}
   "fdkaac" {< "0.3.1"}
-  "ffmpeg" {< "1.1.2"}
-  "ffmpeg-avutil" {< "1.1.2"}
+  "ffmpeg" {< "1.1.4"}
+  "ffmpeg-avutil" {< "1.1.4"}
   "flac" {< "0.3.0"}
   "frei0r" {< "0.1.0"}
   "gstreamer" {< "0.3.1"}

--- a/src/encoder.ml
+++ b/src/encoder.ml
@@ -64,7 +64,7 @@ let kind_of_format = function
       let audio =
         match m.Ffmpeg_format.audio_codec with
           | None -> Frame.none
-          | Some `Copy ->
+          | Some (`Copy _) ->
               `Format
                 Content.(default_format (kind_of_string "ffmpeg.audio.copy"))
           | Some (`Raw _) ->
@@ -86,7 +86,7 @@ let kind_of_format = function
       let video =
         match m.Ffmpeg_format.video_codec with
           | None -> Frame.none
-          | Some `Copy ->
+          | Some (`Copy _) ->
               `Format
                 Content.(default_format (kind_of_string "ffmpeg.video.copy"))
           | Some (`Raw _) ->

--- a/src/encoder/ffmpeg_encoder.ml
+++ b/src/encoder/ffmpeg_encoder.ml
@@ -32,11 +32,11 @@ let () =
             let get_stream = mk_stream_store () in
             let mk_audio =
               match m.Ffmpeg_format.audio_codec with
-                | Some `Copy ->
+                | Some (`Copy keyframe_opt) ->
                     fun ~ffmpeg:_ ~options:_ ->
                       Ffmpeg_copy_encoder.mk_stream_copy
                         ~video_size:(fun _ -> None)
-                        ~get_stream
+                        ~get_stream ~keyframe_opt
                         ~get_data:(fun frame ->
                           Ffmpeg_copy_content.Audio.get_data (Frame.audio frame))
                 | None | Some (`Internal (Some _)) | Some (`Raw (Some _)) ->
@@ -48,7 +48,7 @@ let () =
             in
             let mk_video =
               match m.Ffmpeg_format.video_codec with
-                | Some `Copy ->
+                | Some (`Copy keyframe_opt) ->
                     fun ~ffmpeg:_ ~options:_ ->
                       let get_data frame =
                         Ffmpeg_copy_content.Video.get_data (Frame.video frame)
@@ -62,7 +62,7 @@ let () =
                           params
                       in
                       Ffmpeg_copy_encoder.mk_stream_copy ~video_size ~get_stream
-                        ~get_data
+                        ~get_data ~keyframe_opt
                 | None | Some (`Internal (Some _)) | Some (`Raw (Some _)) ->
                     Ffmpeg_internal_encoder.mk_video
                 | Some (`Internal None) ->

--- a/src/encoder_formats/ffmpeg_format.ml
+++ b/src/encoder_formats/ffmpeg_format.ml
@@ -23,9 +23,13 @@
 type opt_val =
   [ `String of string | `Int of int | `Int64 of int64 | `Float of float ]
 
+type copy_opt = [ `Wait_for_keyframe | `Ignore_keyframe ]
 type output = [ `Stream | `Url of string ]
 type opts = (string, opt_val) Hashtbl.t
-type codec = [ `Copy | `Raw of string option | `Internal of string option ]
+
+type codec =
+  [ `Copy of copy_opt | `Raw of string option | `Internal of string option ]
+
 type hwaccel = [ `None | `Auto ]
 
 type t = {
@@ -63,6 +67,10 @@ let string_of_options
          v :: c)
        options [])
 
+let string_of_copy_opt = function
+  | `Wait_for_keyframe -> "wait_for_keyframe"
+  | `Ignore_keyframe -> "ignore_keyframe"
+
 let to_string m =
   let opts = [] in
   let opts =
@@ -73,7 +81,8 @@ let to_string m =
   let opts =
     match m.video_codec with
       | None -> opts
-      | Some `Copy -> "%video.copy" :: opts
+      | Some (`Copy opt) ->
+          Printf.sprintf "%%video.copy(%s)" (string_of_copy_opt opt) :: opts
       | Some (`Raw (Some c)) | Some (`Internal (Some c)) ->
           let video_opts =
             Hashtbl.fold
@@ -104,7 +113,8 @@ let to_string m =
   let opts =
     match m.audio_codec with
       | None -> opts
-      | Some `Copy -> "%audio.copy" :: opts
+      | Some (`Copy opt) ->
+          Printf.sprintf "%%audio.copy(%s)" (string_of_copy_opt opt) :: opts
       | Some (`Raw (Some c)) | Some (`Internal (Some c)) ->
           let audio_opts = Hashtbl.copy m.audio_opts in
           Hashtbl.add audio_opts "codec" (`String c);

--- a/tests/language/type_errors.pl
+++ b/tests/language/type_errors.pl
@@ -187,6 +187,8 @@ correct('%ffmpeg(
         frag_duration=10,
         %audio.copy,
         %video.copy)');
+correct('%ffmpeg(%audio.copy(ignore_keyframe), %video.copy(ignore_keyframe))');
+correct('%ffmpeg(%audio.copy(wait_for_keyframe), %video.copy(wait_for_keyframe))');
 
 # The following is not technically checking on type errors but runtime invalid values.
 section("INVALID VALUES");


### PR DESCRIPTION
This PR adds some enhancement to the handling of keyframes when using the ffmpeg copy encoder, following issues raised in https://github.com/savonet/liquidsoap/discussions/2331#discussioncomment-2560399.

Ideally, we would like to be able to switch sources and tracks based on keyframe boundaries from encoded content to make sure that content is decodable immediately when concatenating different streams.

However, being a streaming model, liquidsoap makes switching decisions _before_ pulling content from a source and so would require some kind of look ahead mechanism to know if a keyframe is coming, which is pretty complex to implement, specially when sources are potentially shared between different operators.

This PR adds some ways to mitigate this issue at the `%ffmpeg` encoding level by adding 3 different options when switching content:
1. Ignore all keyframes issues.
2. Wait until at least one keyframe has been passed to start passing encoded packets from a new stream.

Both options apply to the cases where the `%ffmpeg` encoder has streams created using `%audio.copy` or `%video.copy`. In this situation, let's consider the case where the video content goes from one encoded stream to a new one.

* With option 1 we start passing encoded data right away. Content is immediately added but playback might get stuck until a new keyframe is passed.
* With option 2, we discard any new packet until a keyframe is passed. This means that playback will be paused until it can be  resumed properly with no decoding glitches.

Option 2. is implemented globally when possible, i.e. in case of a video track with keyframes and an audio track with no keyframes, the audio track will discard packets until a video keyframe has been passed.

It is worth noting that some audio encoders may also have keyframes.

Both options can be set via the `%audio.copy` and `%video.copy` encoder:
* `%audio,copy(ignore_keyframe)` and `%video.copy(ignore_keyframe)`
* `%audio,copy(wait_for_keyframe)` and `%video.copy(wait_for_keyframe)`

Option 2, which seems what most user would expect, is the default so `%audio.copy` and `%video.copy` are also equivalent to, resp., `%audio,copy(wait_for_keyframe)` and `%video.copy(wait_for_keyframe)`

Lastly, this PR cleans up the logic around keyframes. While it appears that packets from format that do not have keyframes are currently marked as keyframes, it is preferable to look at wether the format actually has keyframes and. This is indicated by `AV_CODEC_PROP_INTRA_ONLY` in ffmpeg, meaning decoder only rely on the current content and no previous content to be able to decode it.

In this case, we should ignore all keyframe flags from encoded packets and proceed accordingly, which this PR also implements.

A simple test script is:
```ruby
log.level.set(4)

s1 = single("/tmp/s1.mp4")
s2 = single("/tmp/s2.mp4")

s = switch(track_sensitive=false, [
  ({file.exists("/tmp/s1")}, s1),
  ({true}, s2)
])

# Same as: enc = %ffmpeg(format="flv", %audio.copy, %video.copy(wait_for_keyframe))`
enc = %ffmpeg(format="flv", %audio.copy, %video.copy)
# Or:
# enc = %ffmpeg(format="flv", %audio.copy, %video.copy(ignore_keyframe))`
output.file(enc, "/tmp/out.flv", s)
```