### PR TITLE
Documentation - update Beets examples to Liquidsoap 2.x

### DIFF
--- a/doc/content/beets.md
+++ b/doc/content/beets.md
@@ -4,33 +4,41 @@ Integrating a music library: an example with Beets
 Liquidsoap's native sources can read from files and folders,
 but if your radio uses an important music library
 (more than a thousand tracks)
-sorting this library by folders may not be enough.
-In that case you would better maintain a music library
+sorting by folders may not be enough.
+You will also need to adjust the playout gain per track (ReplayGain).
+In that case you would better have a music library
 queried by Liquidsoap.
 In this section we'll do this with [Beets](http://beets.io/).
 Beets holds your music catalog,
 cleans tracks' tags before importing,
+can compute each track's ReplayGain,
 and most importantly has a command-line interface we can leverage from Liquidsoap.
+The following examples may also inspire you to integrate another library or your own scripts.
 
-The following examples may also inspire you to integrate another library program or your own scripts.
-If you're going with Beets,
-you'll need an installation having the `random`
-[plug-in enabled](https://beets.readthedocs.io/en/stable/plugins/index.html#using-plugins).
-We'll examine how you can pick Beets tracks (local files) from Liquidsoap,
-using 3 techniques fitting different Liquidsoap sources :
+After installing Beets,
+enable the `random` plug-in
+(see [Beets documentation on plug-ins](https://beets.readthedocs.io/en/stable/plugins/index.html#using-plugins)).
+To enable gain normalization, install and configure the 
+[`replaygain`](https://beets.readthedocs.io/en/stable/plugins/replaygain.html) plug-in.
+To easily add single tracks to you library,
+you might also be interested in the
+[drop2beets](https://github.com/martinkirch/drop2beets#drop2beets) plug-in.
+The following examples suppose you defined a `BEET` constant,
+which contains the complete path to your `beet` executable (on UNIX systems, find it with `which beet`). For example:
 
- * The most intuitive is an infite track source,
-   that queries Beets for each track via `request.dynamic.list`.
- * We can also add Beets as a protocol so you can query beets from [requests](requests.html)
- * Finally we use Beets to generate a file suitable for `playlist`.
+```
+BEET = "/home/radio/.local/bin/beet"
+```
 
-Before that, let's see Beets queries that are the most interesting for a radio.
 
-Beet queries
-------------
+Before creating a Liquidsoap source,
+let's see why Beets queries are interesting for a radio.
 
-Queries are parameters that you usually append to the `beet ls` command :
-Beets will use them to find matching tracks.
+Beets queries
+-------------
+
+Queries are parameters that you usually provide to the `beet ls` command :
+Beets will find matching tracks.
 The `random` plug-in works the same, except that it returns only one track matching the query
 (see [the plug-in's documentation](https://beets.readthedocs.io/en/stable/plugins/random.html)).
 Once your library is imported,
@@ -41,7 +49,7 @@ so it will select an hour worth of tracks matching your query.
 
 Without selectors, queries search in a track’s title, artist, album name,
 album artist, genre and comments. Typing an artist name or a complete title
-usually match the exact track, by you could do a lovely playlist just by querying `love`.
+usually match the exact track, and you could do a lovely playlist just by querying `love`.
 
 But in a radio you'll usually query on other fields.
 You can select tracks by genre with the `genre:` selector.
@@ -49,7 +57,7 @@ Be careful that `genre:Rock` also matches `Indie Rock`, `Punk Rock`, etc.
 To select songs having english lyrics, use `language:eng`.
 Or pick 80s songs with `year:1980..1990`.
 
-Beets also holds internal meta-data, like `added` :
+Beets also holds internal meta-data, like `added`:
 the date and time when you imported each song.
 You can use it to query tracks inserted over the past month with `added:-1m..`.
 Or you can query track imported more than a year ago with `added:..-1y`.
@@ -60,63 +68,85 @@ You can use the `info` plug-in to see everything Beets knows about title(s) matc
 by typing `beet info -l [query]`.
 See also [the Beets' documentation](https://beets.readthedocs.io/en/stable/reference/query.html)
 for more details on queries operators.
-All these options should allow you to create both general and specialiazed sources.
-
-To use the following examples,
-replace the `beet` path by the complete path on your own installation (on UNIX systems, find it with `which beet`).
-We also always add the `-f '$path'` option,
-so beets only returns the matching track's path.
-
+All these options should allow you to create both general and specialiazed Liquidsoap sources.
 
 A source querying each next track from Beets
 --------------------------------------------
 
-As of Liquidsoap 1.4.2 we can use the `request.dynamic.list`
-to create a source calling Beets every time it needs to prepare its the next track:
+As of Liquidsoap 2.x we can create a function that creates a dynamic source,
+given its `id` and a Beet query.
+We rely on `request.dynamic` to call `beet random`
+(with `-f '$path'` option so beets only returns the matching track's path)
+every time the source must prepare a new track:
 
 ```liquidsoap
-def beets() =
-  list.map(fun(item) -> request.create(item),
-    process.read.lines(
-      "/home/me/path/to/beet random -f '$path' my_own_query"
-    )
-  )
+def beets(id, query) =
+  beets_src =
+    request.dynamic(id=id, retry_delay=1., {
+      request.create(
+        string.trim(
+          process.read("#{BEET} random -f '$path' #{query}")
+        )
+      )
+    })
+  (beets_src:source) 
 end
 
-from_beets = request.dynamic.list(beets)
+all_music = beets("all_music", "")
+recent_music = beets("recent_music", "added:-1m..")
+rock_music = beets("rock_music", "genre:Rock")
 ```
 
-`process.read.lines` returns the command's output as a list of strings.
-Each item in this list (so, each line returned by `beet random`)
-is processed (`list.map`) by an anonymous function that turns it into a `request`.
-Thus our function returns a list of requests,
-as needed by `request.dynamic.list`. 
+Note that
 
-A more re-usable implementation
-would store `beet`'s path in a constant and make a function returning a function,
-so you can re-use it for all queries to Beets:
+* `query` can be empty, it will match all tracks in the library.
+* we set `retry_delay` to a second, to avoid looping on `beet` calls if something goes wrong.
+* The final type hint (`:source`) will avoid false typing errors when the source is integrated in complex operators.
+
+
+Applying ReplayGain
+-------------------
+
+When the [`replaygain` plug-in](https://beets.readthedocs.io/en/stable/plugins/replaygain.html)
+is enabled, all tracks will have an additional metadata field called `replaygain_track_gain`.
+Check that Beet is configured to
+[write ID3 tags](https://beets.readthedocs.io/en/stable/reference/config.html#importer-options)
+so Liquidsoap will be able to read this metadata -
+your Beet configuration should include something like:
+
+```
+import:
+    write: yes
+```
+
+Then  we only need to add `amplify` to our source creation function. In the example below we also add `blank.eat`, to automatically cut silence at the beginning or end of tracks.
 
 ```liquidsoap
-BEET = "/home/me/path/to/beet"
-
-def beets(arg="") =
-  fun() -> list.map(fun(item) -> request.create(item),
-    process.read.lines(
-      "#{BEET} random -f '$path' #{arg}"
+def beets(id, query) =
+  beets_src =
+    blank.eat(id="#{id}_", start_blank=true, max_blank=1.0, threshold=-45.0,
+      amplify(override="replaygain_track_gain", 1.0,
+        request.dynamic(id=id, retry_delay=1., {
+          request.create(
+            string.trim(
+              process.read("#{BEET} random -f '$path' #{query}")
+            )
+          )
+        })
+      )
     )
-  )
+  (beets_src:source)
 end
-
-music = request.dynamic.list(beets())
-recent_music = request.dynamic.list(beets("added:-1m.."))
-rock_music = request.dynamic.list(beets("genre:Rock"))
 ```
 
+This is the recommended Beets integration ;
+such source will provide music continuously,
+at a regular volume.
 
 Beets as a requests protocol
-----------------------------
+-----------------------------
 
-If you're queueing tracks with `request.equeue`,
+If you're queueing tracks with `request.queue`,
 you may prefer to integrate Beets as a protocol.
 In that case,
 the list of paths returned by `beet random -f '$path'` fits directly
@@ -124,88 +154,34 @@ what's needed by protocol resolution:
 
 ```liquidsoap
 def beets_protocol(~rlog,~maxtime,arg) =
-  process.read.lines(
-    "/home/me/path/to/beet random -f '$path' #{arg}"
-  )
+  timeout = maxtime - time()
+  command = "#{BEET} random -f '$path' #{arg}"
+  p = process.run(timeout=timeout, command)
+  if p.status == "exit" and p.status.code == 0 then
+    [string.trim(p.stdout)]
+  else
+    rlog("Failed to execute #{command}: #{p.status} (#{p.status.code}) #{p.stderr}")
+    []
+  end
 end
-```
-
-Then declare the `beets` protocol with
-
-```liquidsoap
 add_protocol("beets", beets_protocol,
-  syntax = "Beets queries, see https://beets.readthedocs.io/en/stable/reference/query.html"
+  syntax = "same arguments as beet's random module, see https://beets.readthedocs.io/en/stable/reference/query.html"
 )
 ```
 
+
 Once this is done,
-you can push a beets query from [the telnet server](server.html) :
-if you created `request.equeue(id="userrequested")`,
+you can push a beets query from [the telnet server](server.html):
+if you created `request.queue(id="userrequested")`,
 the server command 
 `userrequested.push beets:All along the watchtower`
 will push the Jimi Hendrix's song.
 
-
-Generate playlists with Beets
------------------------------
-
-For Liquidsoap versions prior to 1.4.2,
-or if you don't want to call Beets before every track,
-you can ask `beet random` to return a track list and save this to a temporary file
-suitable for `playlist` sources.
-Note that this example uses a redirection that is only supported by UNIX systems.
-Also it's hacky and error-prone, we just leave it here as an example.
-
-To do this we will again integrate Beets as a protocol ;
-the difference with the above protocol resolution is that our function will
-only return the path to the playlist's temporary file.
-To use both protocols,
-be careful to give different protocol names (the first argument in `add_protocol`).
+With this method, you can benefit from replay gain metadata too, by wrapping
+the recipient queue in an `amplify` operator, like
 
 ```liquidsoap
-def beets_protocol(~rlog,~maxtime,arg) =
-  tmp_playlist = file.temp("beetsplaylist", ".m3u8")
-  ignore(process.read.lines(
-    "/home/me/path/to/beet random -f '$path' #{arg} > #{tmp_playlist}"
-  ))
-  [tmp_playlist]
-end
-
-add_protocol("beets", beets_protocol)
-```
-
-Before cleaning files created by `file.temp`:
-`beet random` returns only one track matching the query, remember ?
-We can add `-t 60` to the query,
-so it will return at most one hour of music matching the query.
-Sources would look like:
-
-```liquidsoap
-music = playlist("beets:-t 60", mode="normal", reload=3600)
-recent_music = playlist("beets:-t 60 added:-1m..", mode="normal", reload=3600)
-rock_music = playlist("beets:-t 60 genre:Rock", mode="normal", reload=3600)
-```
-
-We use `mode="normal"` because we don't need Liquidsoap to re-randomize.
-`reload=3600` will cause Liquidsoap to ask Beets for a new playlist every hour.
-
-If you're playing from only one `playlist`,
-be careful that `beet random -t 60` returns a list of 60 minutes _at most_
-but it's usually less : it's likely that the first song will play again at the end of the hour.
-Also Beets tends to fill the last minutes with short songs,
-therefore short songs are picked more frequently than others.
-You can mitigate these two problems by reloading before the playlist end,
-by increasing `60` decreasing `3600`.
-
-Another downside of this technique is that it creates a different playlist file
-each time we reload the playlist.
-After a while, your `/tmp` will be filled of files like `beetsplaylistXXXX123.m3u8`.
-On UNIX we can add a cleanup function that regularly calls `find -delete`:
-
-```liquidsoap
-exec_at(freq=3600., pred={ true },
-  fun () -> list.iter(fun(msg) -> log(msg, label="playlists_cleaner"),
-    process.read.lines("find /tmp -iname beetsplaylist*m3u8 -mtime +0 -delete"),
-  )
+userrequested = amplify(override="replaygain_track_gain", 1.0, 
+  request.queue(id="userrequested")
 )
 ```


### PR DESCRIPTION
I removed the playlist generator example because it's a weird approach, whereas `request.dynamic` with replaygain does wonders :ok_hand: 

not sure I'm targeting the right branch ; this is valid for Liquidsoap 2.x