### PR TITLE
Make request pool a weak hash

### DIFF
--- a/.github/scripts/build-win32.sh
+++ b/.github/scripts/build-win32.sh
@@ -37,7 +37,7 @@ export CC=""
 eval `opam config env`
 opam repository set-url default https://github.com/ocaml/opam-repository.git
 cd /home/opam/opam-cross-windows/
-opam upgrade -y --verbose `echo $OPAM_DEPS | sed -e 's#,# #g'` ffmpeg-windows.1.1.2 ffmpeg-avutil-windows.1.1.2 liquidsoap-windows
+opam upgrade -j 1 -y --verbose `echo $OPAM_DEPS | sed -e 's#,# #g'` ffmpeg-windows.1.1.2 ffmpeg-avutil-windows.1.1.2 liquidsoap-windows
 
 cd ~
 cp -rf ${BASE_DIR}/.github/win32 liquidsoap-$BUILD

--- a/.github/scripts/build-win32.sh
+++ b/.github/scripts/build-win32.sh
@@ -37,6 +37,7 @@ export CC=""
 eval `opam config env`
 opam repository set-url default https://github.com/ocaml/opam-repository.git
 cd /home/opam/opam-cross-windows/
+opam upgrade -y ocamlfind
 opam upgrade -y --verbose `echo $OPAM_DEPS | sed -e 's#,# #g'` ffmpeg-windows.1.1.2 ffmpeg-avutil-windows.1.1.2 liquidsoap-windows
 
 cd ~

--- a/.github/scripts/build-win32.sh
+++ b/.github/scripts/build-win32.sh
@@ -37,7 +37,7 @@ export CC=""
 eval `opam config env`
 opam repository set-url default https://github.com/ocaml/opam-repository.git
 cd /home/opam/opam-cross-windows/
-opam upgrade -j 1 -y --verbose `echo $OPAM_DEPS | sed -e 's#,# #g'` ffmpeg-windows.1.1.2 ffmpeg-avutil-windows.1.1.2 liquidsoap-windows
+opam upgrade -y --verbose `echo $OPAM_DEPS | sed -e 's#,# #g'` ffmpeg-windows.1.1.2 ffmpeg-avutil-windows.1.1.2 liquidsoap-windows
 
 cd ~
 cp -rf ${BASE_DIR}/.github/win32 liquidsoap-$BUILD

--- a/.github/scripts/build-win32.sh
+++ b/.github/scripts/build-win32.sh
@@ -37,7 +37,6 @@ export CC=""
 eval `opam config env`
 opam repository set-url default https://github.com/ocaml/opam-repository.git
 cd /home/opam/opam-cross-windows/
-opam upgrade -y ocamlfind
 opam upgrade -y --verbose `echo $OPAM_DEPS | sed -e 's#,# #g'` ffmpeg-windows.1.1.2 ffmpeg-avutil-windows.1.1.2 liquidsoap-windows
 
 cd ~

--- a/src/request.ml
+++ b/src/request.ml
@@ -27,11 +27,6 @@
 let conf =
   Dtools.Conf.void ~p:(Configure.conf#plug "request") "requests configuration"
 
-let grace_time =
-  Dtools.Conf.float ~p:(conf#plug "grace_time") ~d:600.
-    "Time (in seconds) after which a destroyed request cannot be accessed \
-     anymore."
-
 let log = Log.make ["request"]
 
 (** File utilities. *)
@@ -457,6 +452,26 @@ let get_root_metadata t =
 module Pool = Pool.Make (struct
   type req = t
   type t = req
+
+  let id { id } = id
+
+  let destroyed =
+    {
+      id = 0;
+      initial_uri = "";
+      ctype = None;
+      persistent = false;
+      status = Destroyed;
+      resolving = None;
+      on_air = None;
+      log = Queue.create ();
+      root_metadata = Hashtbl.create 0;
+      indicators = [];
+      decoder = None;
+    }
+
+  let destroyed id = { destroyed with id }
+  let is_destroyed { status } = status = Destroyed
 end)
 
 let get_id t = t.id
@@ -482,6 +497,29 @@ let leak_warning =
   Dtools.Conf.int ~p:(conf#plug "leak_warning") ~d:100
     "Number of requests at which a leak warning should be issued."
 
+let destroy ?force t =
+  if t.status <> Destroyed then (
+    if t.status = Playing then t.status <- Ready;
+    if force = Some true || not t.persistent then (
+      t.on_air <- None;
+      t.status <- Idle;
+
+      (* Freeze the metadata *)
+      t.root_metadata <- get_all_metadata t;
+
+      (* Remove the URIs, unlink temporary files *)
+      while t.indicators <> [] do
+        pop_indicator t
+      done;
+      t.status <- Destroyed;
+      add_log t "Request finished."))
+
+let finalise = destroy ~force:true
+
+let clean () =
+  Pool.iter (fun _ r -> if r.status <> Destroyed then destroy ~force:true r);
+  Pool.clear ()
+
 let create ?(metadata = []) ?(persistent = false) ?(indicators = []) u =
   (* Find instantaneous request loops *)
   let () =
@@ -489,57 +527,37 @@ let create ?(metadata = []) ?(persistent = false) ?(indicators = []) u =
     if n > 0 && n mod leak_warning#get = 0 then
       log#severe
         "There are currently %d RIDs, possible request leak! Please check that \
-         you don't have a loop on empty/unavailable requests, or creating \
-         requests without destroying them. Decreasing request.grace_time can \
-         also help."
+         you don't have a loop on empty/unavailable requests."
         n
   in
   let t =
-    Pool.add (fun rid ->
-        {
-          id = rid;
-          initial_uri = u;
-          ctype = None;
-          (* This is fixed when resolving the request. *)
-          persistent;
-          on_air = None;
-          resolving = None;
-          status = Idle;
-          decoder = None;
-          log = Queue.create ();
-          root_metadata = Hashtbl.create 10;
-          indicators = [];
-        })
+    let req =
+      {
+        id = 0;
+        initial_uri = u;
+        ctype = None;
+        (* This is fixed when resolving the request. *)
+        persistent;
+        on_air = None;
+        resolving = None;
+        status = Idle;
+        decoder = None;
+        log = Queue.create ();
+        root_metadata = Hashtbl.create 10;
+        indicators = [];
+      }
+    in
+    Pool.add (fun id -> { req with id })
   in
   List.iter (fun (k, v) -> Hashtbl.replace t.root_metadata k v) metadata;
   push_indicators t (if indicators = [] then [indicator u] else indicators);
+  Gc.finalise finalise t;
   t
 
 let on_air t =
   t.on_air <- Some (Unix.time ());
   t.status <- Playing;
   add_log t "Currently on air."
-
-let destroy ?force t =
-  assert (t.status <> Destroyed);
-  t.on_air <- None;
-  if t.status = Playing then t.status <- Ready;
-  if force = Some true || not t.persistent then (
-    t.status <- Idle;
-
-    (* Freeze the metadata *)
-    t.root_metadata <- get_all_metadata t;
-
-    (* Remove the URIs, unlink temporary files *)
-    while t.indicators <> [] do
-      pop_indicator t
-    done;
-    t.status <- Destroyed;
-    add_log t "Request finished.";
-    Pool.kill t.id grace_time#get)
-
-let clean () =
-  Pool.iter (fun _ r -> if r.status <> Destroyed then destroy ~force:true r)
 
 let get_decoder r = match r.decoder with None -> None | Some d -> Some (d ())
 

--- a/src/test/pool_test.ml
+++ b/src/test/pool_test.ml
@@ -1,15 +1,26 @@
-type req = int
+type req = { id : int; destroyed : bool }
 
 module Pool = Pool.Make (struct
   type t = req
+
+  let id { id } = id
+  let destroyed id = { id; destroyed = true }
+  let is_destroyed { destroyed } = destroyed
 end)
 
 let () =
   (* Create a bunch of requests. *)
-  ignore (List.init 100 (fun _ -> Pool.add (fun i -> i)));
+  let l =
+    List.init 100 (fun _ -> Pool.add (fun id -> { id; destroyed = false }))
+  in
   (* Delete 15th one. *)
-  Pool.kill 15 0.1;
-  Unix.sleepf 1.;
+  Pool.remove 15;
+  Gc.full_major ();
   assert (Pool.size () = 99);
-  let id = Pool.add (fun i -> i) in
-  assert (id = 15)
+  let r = Pool.add (fun id -> { id; destroyed = false }) in
+  assert (r.id = 15);
+  Gc.full_major ();
+  assert (List.length l = 100);
+  assert (Pool.size () = 99);
+  Gc.full_major ();
+  assert (Pool.size () = 0)

--- a/src/tools/pool.ml
+++ b/src/tools/pool.ml
@@ -26,89 +26,60 @@
 module type T = sig
   (** Type of objects stored in the pool. *)
   type t
+
+  val id : t -> int
+  val destroyed : int -> t
+  val is_destroyed : t -> bool
 end
 
 module type S = sig
   type t
 
   val add : (int -> t) -> t
-  val kill : int -> float -> unit
   val find : int -> t option
   val fold : (int -> t -> 'a -> 'a) -> 'a -> 'a
   val iter : (int -> t -> unit) -> unit
   val remove : int -> unit
   val size : unit -> int
+  val clear : unit -> unit
 end
 
 module Make (P : T) : S with type t = P.t = struct
   type t = P.t
-  type entry = { death_time : float option; value : t option }
 
-  let m = Mutex.create ()
-  let h : (int, entry) Hashtbl.t = Hashtbl.create 100
+  module WeakHash = Weak.Make (struct
+    type t = P.t
 
-  let find =
-    Tutils.mutexify m (fun i ->
-        try (Hashtbl.find h i).value with Not_found -> None)
+    let equal t t' = P.id t = P.id t'
+    let hash = P.id
+  end)
 
-  let fold f x =
-    Tutils.mutexify m
-      (fun f x ->
-        Hashtbl.fold
-          (fun i entry x ->
-            match entry.value with Some t -> f i t x | None -> x)
-          h x)
-      f x
+  let h = WeakHash.create 10
 
-  let iter f =
-    Tutils.mutexify m
-      (fun f ->
-        Hashtbl.iter
-          (fun i entry ->
-            match entry.value with
-              | Some t ->
-                  Mutex.unlock m;
-                  f i t;
-                  Mutex.lock m
-              | None -> ())
-          h)
-      f
+  let find id =
+    match WeakHash.find_opt h (P.destroyed id) with
+      | Some v when not (P.is_destroyed v) -> Some v
+      | _ -> None
 
-  let remove i = Hashtbl.remove h i
-
-  let kill i grace =
-    Tutils.mutexify m
-      (fun () ->
-        Hashtbl.replace h i
-          { (Hashtbl.find h i) with death_time = Some (Unix.time () +. grace) })
-      ()
-
-  let clear () =
-    let time = Unix.time () in
-    Hashtbl.filter_map_inplace
-      (fun _ -> function
-        | { death_time = Some f } when f <= time -> None
-        | v -> Some v)
+  let fold f =
+    WeakHash.fold
+      (fun v cur -> if P.is_destroyed v then cur else f (P.id v) v cur)
       h
 
-  let next () =
-    clear ();
-    let rec find i =
-      match Hashtbl.find_opt h i with None -> i | Some _ -> find (i + 1)
-    in
-    find 0
+  let iter f =
+    WeakHash.iter
+      (fun entry -> if not (P.is_destroyed entry) then f (P.id entry) entry)
+      h
+
+  let remove id = WeakHash.remove h (P.destroyed id)
 
   let add fn =
-    Tutils.mutexify m
-      (fun () ->
-        let i = next () in
-        let v = fn i in
-        Hashtbl.replace h i { death_time = None; value = Some v };
-        v)
-      ()
+    let rec f id =
+      let v = fn id in
+      match WeakHash.merge h v with v' when v == v' -> v | _ -> f (id + 1)
+    in
+    f 0
 
-  let size =
-    Tutils.mutexify m (fun () ->
-        clear ();
-        Hashtbl.length h)
+  let size () = WeakHash.count h
+  let clear () = WeakHash.clear h
 end


### PR DESCRIPTION
I'm not sure why requests are structured the way they are. This is some of the oldest part of the code. In particular, it's not clear why we need a grace period and, hence, an explicit destroy.

This PR replaces the requests pool hash with a weak hash, leaving to the GC the task of destroying them without having to make an explicit call. The call to `destroy` is left and can still be done to speed up request cleanup but it is made idempotent so that it can be called by the user ahead of the GC.