### PR TITLE
Preserve tracks in soundtouch.

### DIFF
--- a/src/core/clock.ml
+++ b/src/core/clock.ml
@@ -349,14 +349,17 @@ let rec active_params c =
     | _ when Atomic.get global_stop -> raise Has_stopped
     | _ -> raise Invalid_state
 
-and _tick ~clock x =
+and _activate_pending_sources ~clock x =
   Queue.flush clock.pending_activations (fun s ->
       check_stopped ();
       s#wake_up;
       match s#source_type with
         | `Active _ -> WeakQueue.push x.active_sources s
         | `Output _ -> Queue.push x.outputs s
-        | `Passive -> WeakQueue.push x.passive_sources s);
+        | `Passive -> WeakQueue.push x.passive_sources s)
+
+and _tick ~clock x =
+  _activate_pending_sources ~clock x;
   let sub_clocks =
     List.map (fun c -> (c, ticks c)) (Queue.elements clock.sub_clocks)
   in
@@ -519,6 +522,9 @@ let self_sync c =
   match Atomic.get clock.state with
     | `Started params -> _self_sync ~clock params
     | _ -> false
+
+let activate_pending_sources clock =
+  _activate_pending_sources ~clock:(Unifier.deref clock) (active_params clock)
 
 let tick clock = _tick ~clock:(Unifier.deref clock) (active_params clock)
 

--- a/src/core/clock.mli
+++ b/src/core/clock.mli
@@ -99,6 +99,7 @@ val unify : pos:Liquidsoap_lang.Pos.Option.t -> t -> t -> unit
 val create_sub_clock : id:string -> t -> t
 val attach : t -> source -> unit
 val detach : t -> source -> unit
+val activate_pending_sources : t -> unit
 val ticks : t -> int
 val on_tick : t -> (unit -> unit) -> unit
 val tick : t -> unit

--- a/src/core/operators/soundtouch_op.ml
+++ b/src/core/operators/soundtouch_op.ml
@@ -36,7 +36,7 @@ class soundtouch source_val rate tempo pitch =
     Typing.(source#frame_type <: consumer#frame_type)
   in
   object (self)
-    inherit operator ~name:"soundtouch" [(consumer :> Source.source)]
+    inherit operator ~name:"soundtouch" []
     inherit Child_support.base ~check_self_sync:true [source_val]
     val mutable st = None
     method fallible = source#fallible

--- a/src/core/tools/child_support.ml
+++ b/src/core/tools/child_support.ml
@@ -41,6 +41,7 @@ class virtual base ~check_self_sync children_val =
     method virtual id : string
     method virtual clock : Clock.t
     method virtual pos : Pos.Option.t
+    method virtual on_before_streaming_cycle : (unit -> unit) -> unit
     val mutable child_clock = None
 
     initializer
@@ -48,7 +49,9 @@ class virtual base ~check_self_sync children_val =
         Some
           (Clock.create_sub_clock
              ~id:(Clock.id self#clock ^ ".child")
-             self#clock)
+             self#clock);
+      self#on_before_streaming_cycle (fun () ->
+          Clock.activate_pending_sources self#child_clock)
 
     method child_clock =
       match child_clock with Some c -> c | None -> assert false

--- a/tests/streams/dune.inc
+++ b/tests/streams/dune.inc
@@ -1677,6 +1677,37 @@
  (alias citest)
  (package liquidsoap)
  (deps
+  soundtouch-tracks.liq
+  ./file1.mp3
+  ./file2.mp3
+  ./file3.mp3
+  ./jingle1.mp3
+  ./jingle2.mp3
+  ./jingle3.mp3
+  ./file1.png
+  ./file2.png
+  ./jingles
+  ./playlist
+  ./huge_playlist
+  ./replaygain_track_gain.mp3
+  ./r128_track_gain.mp3
+  ./replaygain_r128_track_gain.mp3
+  ./replaygain_track_gain.opus
+  ./r128_track_gain.opus
+  ./replaygain_r128_track_gain.opus
+  ./without_replaygain_track_gain.mp3
+  ./crossfade-plot.old.txt
+  ./crossfade-plot.new.txt
+  ../../src/bin/liquidsoap.exe
+  (package liquidsoap)
+  (:test_liq ../test.liq)
+  (:run_test ../run_test.exe))
+ (action (run %{run_test} soundtouch-tracks.liq liquidsoap %{test_liq} soundtouch-tracks.liq)))
+
+(rule
+ (alias citest)
+ (package liquidsoap)
+ (deps
   source-cue.liq
   ./file1.mp3
   ./file2.mp3

--- a/tests/streams/soundtouch-tracks.liq
+++ b/tests/streams/soundtouch-tracks.liq
@@ -1,0 +1,19 @@
+# Ensure that soundtouch preserves tracks, see #2467.
+
+n = ref(0)
+def ot(_) =
+  print(
+    "New track!"
+  )
+  ref.incr(n)
+  if
+    n() >= 3
+  then
+    test.pass()
+    shutdown()
+  end
+end
+s = chop(every=1., sine())
+s = soundtouch(s)
+s = source.on_track(s, ot)
+output.dummy(fallible=true, s)


### PR DESCRIPTION
Can be tested with
```
s = chop(every=1., sine())
s = soundtouch(s)
s = source.on_track(s, fun(_) -> print("***** new track #{time.up()}"))
output(s)
```
Fixes #2467.