### PR TITLE
Use abstract type for module/builtin operator

### DIFF
--- a/src/lang/builtins_list.ml
+++ b/src/lang/builtins_list.ml
@@ -34,7 +34,7 @@ let randomize a =
       permute i (i + Random.int (l - i))
     done
 
-let () = Lang.add_module "list"
+let list_module = Lang.(add_module root_module "list")
 
 let () =
   let a = Lang.univ_t ~constraints:[Type.Ord] () in
@@ -61,7 +61,7 @@ let () =
 let () =
   let a = Lang.univ_t () in
   let b = Lang.univ_t () in
-  Lang.add_builtin "list.case" ~category:`List
+  Lang.add_builtin ~root_module:list_module "case" ~category:`List
     ~descr:
       "Define a function by case analysis, depending on whether a list is \
        empty or not."
@@ -87,7 +87,7 @@ let () =
 let () =
   let a = Lang.univ_t () in
   let b = Lang.univ_t () in
-  Lang.add_builtin "list.ind" ~category:`List
+  Lang.add_builtin ~root_module:list_module "ind" ~category:`List
     ~descr:
       "Define a function by induction on a list. This is slightly more \
        efficient than defining a recursive function. The list is scanned from \
@@ -123,22 +123,23 @@ let () =
 let () =
   let a = Lang.univ_t () in
   List.iter
-    (fun name ->
-      Lang.add_builtin name ~category:`List
-        ~descr:"Add an element at the top of a list."
-        [("", a, None, None); ("", Lang.list_t a, None, None)]
-        (Lang.list_t a)
-        (fun p ->
-          let x, l =
-            match p with [("", x); ("", l)] -> (x, l) | _ -> assert false
-          in
-          let l = Lang.to_list l in
-          Lang.list (x :: l)))
-    ["list.add"; "_::_"]
+    (fun (root_module, name) ->
+      ignore
+        (Lang.add_builtin name ~root_module ~category:`List
+           ~descr:"Add an element at the top of a list."
+           [("", a, None, None); ("", Lang.list_t a, None, None)]
+           (Lang.list_t a)
+           (fun p ->
+             let x, l =
+               match p with [("", x); ("", l)] -> (x, l) | _ -> assert false
+             in
+             let l = Lang.to_list l in
+             Lang.list (x :: l))))
+    [(list_module, "add"); (Lang.root_module, "_::_")]
 
 let () =
   let t = Lang.list_t (Lang.univ_t ()) in
-  Lang.add_builtin "list.randomize" ~category:`List
+  Lang.add_builtin ~root_module:list_module "randomize" ~category:`List
     ~descr:"Shuffle the content of a list." [("", t, None, None)] t (fun p ->
       let l = Array.of_list (Lang.to_list (List.assoc "" p)) in
       randomize l;
@@ -146,7 +147,7 @@ let () =
 
 let () =
   let a = Lang.univ_t () in
-  Lang.add_builtin "list.sort" ~category:`List
+  Lang.add_builtin ~root_module:list_module "sort" ~category:`List
     ~descr:"Sort a list according to a comparison function."
     [
       ( "",

--- a/src/lang/builtins_math.ml
+++ b/src/lang/builtins_math.ml
@@ -20,7 +20,7 @@
 
  *****************************************************************************)
 
-let () = Lang.add_module "random"
+let random_module = Lang.(add_module root_module "random")
 
 let () =
   let add op name descr =

--- a/src/lang/builtins_profiler.ml
+++ b/src/lang/builtins_profiler.ml
@@ -20,23 +20,23 @@
 
  *****************************************************************************)
 
-let () = Lang.add_module "profiler"
+let profiler_module = Lang.(add_module root_module "profiler")
 
-let () =
-  Lang.add_builtin "profiler.enable" ~category:`Liquidsoap
+let _ =
+  Lang.add_builtin ~root_module:profiler_module "enable" ~category:`Liquidsoap
     ~descr:"Record profiling statistics." [] Lang.unit_t (fun _ ->
       Term.profile := true;
       Lang.unit)
 
-let () =
-  Lang.add_builtin "profiler.disable" ~category:`Liquidsoap
+let _ =
+  Lang.add_builtin ~root_module:profiler_module "disable" ~category:`Liquidsoap
     ~descr:"Record profiling statistics." [] Lang.unit_t (fun _ ->
       Term.profile := false;
       Lang.unit)
 
-let () =
+let _ =
   let a = Lang.univ_t () in
-  Lang.add_builtin "profiler.run" ~category:`Liquidsoap
+  Lang.add_builtin ~root_module:profiler_module "run" ~category:`Liquidsoap
     ~descr:"Time a function with the profiler."
     [
       ("", Lang.string_t, None, Some "Name of the profiled function.");
@@ -49,8 +49,8 @@ let () =
       let f () = Lang.apply f [] in
       Profiler.time name f ())
 
-let () =
-  Lang.add_module "profiler.stats";
-  Lang.add_builtin "profiler.stats.string" ~category:`Liquidsoap
+let _ =
+  let stats_module = Lang.add_module profiler_module "stats" in
+  Lang.add_builtin ~root_module:stats_module "string" ~category:`Liquidsoap
     ~descr:"Profiling statistics." [] Lang.string_t (fun _ ->
       Lang.string (Profiler.stats ()))

--- a/src/lang/environment.mli
+++ b/src/lang/environment.mli
@@ -31,17 +31,21 @@ val get_builtin : string -> (Type.scheme * Value.t) option
 (** Documentation for builtins. *)
 val builtins : Doc.item
 
+(** Declare a module. *)
+type _module
+
+val root_module : _module
+val add_module : _module -> string -> _module
+
 (** Add a builtin value. *)
 val add_builtin :
+  ?root_module:_module ->
   ?override:bool ->
   ?register:bool ->
   ?doc:Doc.item Lazy.t ->
-  string list ->
+  string ->
   Type.scheme * Value.t ->
-  unit
-
-(** Declare a module. *)
-val add_module : string list -> unit
+  _module
 
 (** {1 Environments} *)
 

--- a/src/lang/lang.mli
+++ b/src/lang/lang.mli
@@ -77,10 +77,17 @@ val apply : value -> env -> value
 
 type proto = (string * t * value option * string option) list
 
+(** Declare a new module. *)
+type _module
+
+val add_module : _module -> string -> _module
+val root_module : _module
+
 (** Add an builtin to the language, high-level version for functions. *)
 val add_builtin :
   category:Documentation.category ->
   descr:string ->
+  ?root_module:_module ->
   ?flags:Documentation.flag list ->
   ?meth:(string * Type.scheme * string * value) list ->
   ?examples:string list ->
@@ -99,9 +106,6 @@ val add_builtin_base :
   in_value ->
   t ->
   unit
-
-(** Declare a new module. *)
-val add_module : string -> unit
 
 val empty : Frame.content_kind
 val any : Frame.content_kind

--- a/src/lang/lang_core.ml
+++ b/src/lang/lang_core.ml
@@ -181,8 +181,8 @@ let to_plugin_doc category flags examples main_doc proto return_t =
 
 let meth_fun = meth
 
-let add_builtin ~category ~descr ?(flags = []) ?(meth = []) ?(examples = [])
-    name proto return_t f =
+let add_builtin ~category ~descr ?root_module ?(flags = []) ?(meth = [])
+    ?(examples = []) name proto return_t f =
   let return_t =
     if meth = [] then return_t
     else (
@@ -205,11 +205,9 @@ let add_builtin ~category ~descr ?(flags = []) ?(meth = []) ?(examples = [])
   let generalized = Type.filter_vars (fun _ -> true) t in
   let doc () = to_plugin_doc category flags examples descr proto return_t in
   let doc = Lazy.from_fun doc in
-  Environment.add_builtin ~doc
-    (String.split_on_char '.' name)
-    ((generalized, t), value)
+  Environment.add_builtin ?root_module ~doc name ((generalized, t), value)
 
-let add_builtin_base ~category ~descr ?(flags = []) name value t =
+let add_builtin_base ~category ~descr ?root_module ?(flags = []) name value t =
   let value = { pos = t.Type.pos; value } in
   let generalized = Type.filter_vars (fun _ -> true) t in
   let doc () =
@@ -227,11 +225,13 @@ let add_builtin_base ~category ~descr ?(flags = []) name value t =
       flags;
     doc
   in
-  Environment.add_builtin ~doc:(Lazy.from_fun doc)
-    (String.split_on_char '.' name)
+  Environment.add_builtin ?root_module ~doc:(Lazy.from_fun doc) name
     ((generalized, t), value)
 
-let add_module name = Environment.add_module (String.split_on_char '.' name)
+type _module = Environment._module
+
+let root_module = Environment.root_module
+let add_module = Environment.add_module
 
 (* Delay this function in order not to have Lang depend on Evaluation. *)
 let apply_fun : (?pos:Pos.t -> value -> env -> value) ref =


### PR DESCRIPTION
Use an abstract type for representing a language module/operator, use it to make sure that module are registered by order of dependencies.