### PR TITLE
Switch frames content to generic maps

### DIFF
--- a/src/core/builtins/builtins_ffmpeg_bitstream_filters.ml
+++ b/src/core/builtins/builtins_ffmpeg_bitstream_filters.ml
@@ -173,36 +173,24 @@ let () =
             match mode with
               | `Audio ->
                   ( name ^ ".audio",
-                    Frame.
-                      {
-                        audio = `Kind Ffmpeg_copy_content.Audio.kind;
-                        video = `Any;
-                        midi = Frame.none;
-                      } )
+                    Frame.mk_fields
+                      ~audio:(`Kind Ffmpeg_copy_content.Audio.kind) ~video:`Any
+                      ~midi:Frame.none () )
               | `Audio_only ->
                   ( name,
-                    Frame.
-                      {
-                        audio = `Kind Ffmpeg_copy_content.Audio.kind;
-                        video = `Any;
-                        midi = Frame.none;
-                      } )
+                    Frame.mk_fields
+                      ~audio:(`Kind Ffmpeg_copy_content.Audio.kind) ~video:`Any
+                      ~midi:Frame.none () )
               | `Video ->
                   ( name ^ ".video",
-                    Frame.
-                      {
-                        audio = `Any;
-                        video = `Kind Ffmpeg_copy_content.Video.kind;
-                        midi = Frame.none;
-                      } )
+                    Frame.mk_fields ~audio:`Any
+                      ~video:(`Kind Ffmpeg_copy_content.Video.kind)
+                      ~midi:Frame.none () )
               | `Video_only ->
                   ( name,
-                    Frame.
-                      {
-                        audio = `Any;
-                        video = `Kind Ffmpeg_copy_content.Video.kind;
-                        midi = Frame.none;
-                      } )
+                    Frame.mk_fields ~audio:`Any
+                      ~video:(`Kind Ffmpeg_copy_content.Video.kind)
+                      ~midi:Frame.none () )
           in
           let source_t = Lang.kind_type_of_kind_format source_kind in
           let args_t = ("", Lang.source_t source_t, None, None) :: args in

--- a/src/core/builtins/builtins_ffmpeg_decoder.ml
+++ b/src/core/builtins/builtins_ffmpeg_decoder.ml
@@ -419,31 +419,27 @@ let mk_encoder mode =
   let has_encoded_audio = List.mem mode [`Audio_encoded; `Both_encoded] in
   let has_encoded_video = List.mem mode [`Video_encoded; `Both_encoded] in
   let source_kind =
-    Frame.
-      {
-        audio =
-          (match mode with
-            | `Audio_encoded | `Both_encoded ->
-                `Kind Ffmpeg_copy_content.Audio.kind
-            | `Audio_raw | `Both_raw -> `Kind Ffmpeg_raw_content.Audio.kind
-            | _ -> none);
-        video =
-          (match mode with
-            | `Video_encoded | `Both_encoded ->
-                `Kind Ffmpeg_copy_content.Video.kind
-            | `Video_raw | `Both_raw -> `Kind Ffmpeg_raw_content.Video.kind
-            | _ -> none);
-        midi = none;
-      }
+    Frame.mk_fields
+      ~audio:
+        (match mode with
+          | `Audio_encoded | `Both_encoded ->
+              `Kind Ffmpeg_copy_content.Audio.kind
+          | `Audio_raw | `Both_raw -> `Kind Ffmpeg_raw_content.Audio.kind
+          | _ -> Frame.none)
+      ~video:
+        (match mode with
+          | `Video_encoded | `Both_encoded ->
+              `Kind Ffmpeg_copy_content.Video.kind
+          | `Video_raw | `Both_raw -> `Kind Ffmpeg_raw_content.Video.kind
+          | _ -> Frame.none)
+      ~midi:Frame.none ()
   in
   let source_t = Lang.kind_type_of_kind_format source_kind in
   let return_kind =
-    Frame.
-      {
-        audio = (if has_audio then audio_pcm else none);
-        video = (if has_video then video_yuva420p else none);
-        midi = none;
-      }
+    Frame.mk_fields
+      ~audio:(if has_audio then Frame.audio_pcm else Frame.none)
+      ~video:(if has_video then Frame.video_yuva420p else Frame.none)
+      ~midi:Frame.none ()
   in
   let return_t = Lang.kind_type_of_kind_format return_kind in
   let extension =

--- a/src/core/builtins/builtins_ffmpeg_filters.ml
+++ b/src/core/builtins/builtins_ffmpeg_filters.ml
@@ -597,10 +597,12 @@ let () =
   let raw_audio_format = `Kind Ffmpeg_raw_content.Audio.kind in
   let raw_video_format = `Kind Ffmpeg_raw_content.Video.kind in
   let audio_frame =
-    { Frame.audio = raw_audio_format; video = Frame.none; midi = Frame.none }
+    Frame.mk_fields ~audio:raw_audio_format ~video:Frame.none ~midi:Frame.none
+      ()
   in
   let video_frame =
-    { Frame.audio = Frame.none; video = raw_video_format; midi = Frame.none }
+    Frame.mk_fields ~audio:Frame.none ~video:raw_video_format ~midi:Frame.none
+      ()
   in
   let audio_t =
     Lang.(source_t ~methods:false (kind_type_of_kind_format audio_frame))
@@ -629,16 +631,13 @@ let () =
 
       let kind =
         Kind.of_kind
-          Frame.
-            {
-              (* We need to make sure that we are using a format here to
-                 ensure that its params are properly unified with the underlying source. *)
-              audio =
-                `Format
-                  Ffmpeg_raw_content.Audio.(lift_params (default_params `Raw));
-              video = Frame.none;
-              midi = Frame.none;
-            }
+          (Frame.mk_fields
+           (* We need to make sure that we are using a format here to
+              ensure that its params are properly unified with the underlying source. *)
+             ~audio:
+               (`Format
+                 Ffmpeg_raw_content.Audio.(lift_params (default_params `Raw)))
+             ~video:Frame.none ~midi:Frame.none ())
       in
       let name = uniq_name "abuffer" in
       let pos = source_val.Lang.pos in
@@ -677,7 +676,11 @@ let () =
 
       Audio.to_value (`Output audio));
 
-  let return_kind = Frame.{ audio_frame with video = none; midi = none } in
+  let return_kind =
+    Frame.mk_fields
+      ~audio:(Frame.find_audio audio_frame)
+      ~video:Frame.none ~midi:Frame.none ()
+  in
   let return_t = Lang.kind_type_of_kind_format return_kind in
   Lang.add_operator "ffmpeg.filter.audio.output" ~category:`Audio
     ~descr:"Return an audio source from a filter's output" ~return_t
@@ -697,12 +700,8 @@ let () =
 
       let kind =
         Kind.of_kind
-          Frame.
-            {
-              audio = `Kind Ffmpeg_raw_content.Audio.kind;
-              video = none;
-              midi = none;
-            }
+          (Frame.mk_fields ~audio:(`Kind Ffmpeg_raw_content.Audio.kind)
+             ~video:Frame.none ~midi:Frame.none ())
       in
       let s =
         new Ffmpeg_filter_io.audio_input
@@ -749,16 +748,14 @@ let () =
 
       let kind =
         Kind.of_kind
-          Frame.
-            {
-              (* We need to make sure that we are using a format here to
-                 ensure that its params are properly unified with the underlying source. *)
-              audio = Frame.none;
-              video =
-                `Format
-                  Ffmpeg_raw_content.Video.(lift_params (default_params `Raw));
-              midi = Frame.none;
-            }
+          (Frame.mk_fields
+           (* We need to make sure that we are using a format here to
+              ensure that its params are properly unified with the underlying source. *)
+             ~audio:Frame.none
+             ~video:
+               (`Format
+                 Ffmpeg_raw_content.Video.(lift_params (default_params `Raw)))
+             ~midi:Frame.none ())
       in
       let name = uniq_name "buffer" in
       let pos = source_val.Lang.pos in
@@ -796,7 +793,11 @@ let () =
 
       Video.to_value (`Output video));
 
-  let return_kind = Frame.{ video_frame with audio = none; midi = none } in
+  let return_kind =
+    Frame.mk_fields ~audio:Frame.none
+      ~video:(Frame.find_video video_frame)
+      ~midi:Frame.none ()
+  in
   let return_t = Lang.kind_type_of_kind_format return_kind in
   Lang.add_operator "ffmpeg.filter.video.output" ~category:`Video
     ~descr:"Return a video source from a filter's output" ~return_t
@@ -824,12 +825,8 @@ let () =
 
       let kind =
         Kind.of_kind
-          Frame.
-            {
-              audio = none;
-              video = `Kind Ffmpeg_raw_content.Video.kind;
-              midi = none;
-            }
+          (Frame.mk_fields ~audio:Frame.none
+             ~video:(`Kind Ffmpeg_raw_content.Video.kind) ~midi:Frame.none ())
       in
       let s =
         new Ffmpeg_filter_io.video_input

--- a/src/core/conversions/audio_to_stereo.ml
+++ b/src/core/conversions/audio_to_stereo.ml
@@ -61,9 +61,10 @@ class basic source =
 let () =
   let input_kind = Lang.audio_pcm in
   let input_type = Lang.kind_type_of_kind_format input_kind in
-  let { Frame.video; midi } = Lang.of_frame_kind_t input_type in
+  let fields = Lang.of_frame_kind_t input_type in
   let output_type =
-    Lang.frame_kind_t ~audio:(Lang.kind_t Frame.audio_stereo) ~video ~midi
+    Lang.frame_kind_t
+      (Frame.set_audio_field fields (Lang.kind_t Frame.audio_stereo))
   in
   Lang.add_operator "audio_to_stereo" ~category:`Conversion
     ~descr:"Convert any pcm audio source into a stereo source."

--- a/src/core/conversions/drop.ml
+++ b/src/core/conversions/drop.ml
@@ -26,11 +26,11 @@ class drop ?(audio = false) ?(video = false) ?(midi = false) ~name source =
   let video_in = f video in
   let midi_in = f midi in
   let kind =
-    {
-      Frame.audio = (if audio then Frame.none else `Any);
-      video = (if video then Frame.none else `Any);
-      midi = (if midi then Frame.none else `Any);
-    }
+    Frame.mk_fields
+      ~audio:(if audio then Frame.none else `Any)
+      ~video:(if video then Frame.none else `Any)
+      ~midi:(if midi then Frame.none else `Any)
+      ()
   in
   let kind = Kind.of_kind kind in
   object
@@ -47,27 +47,30 @@ let () =
   List.iter
     (fun content ->
       let input = Lang.kind_type_of_kind_format Lang.any in
-      let { Frame.audio; video; midi } = Lang.of_frame_kind_t input in
+      let input_kind = Lang.of_frame_kind_t input in
       let name, descr, output, source =
         match content with
           | `Audio ->
               ( "drop_audio",
                 "Drop all audio content of a stream.",
-                Lang.frame_kind_t ~audio:(Lang.kind_t Frame.none) ~video ~midi,
+                Lang.frame_kind_t
+                  (Frame.set_audio_field input_kind (Lang.kind_t Frame.none)),
                 fun p ->
                   let source = Lang.to_source (List.assoc "" p) in
                   new drop ~audio:true ~name:"drop_audio" source )
           | `Video ->
               ( "drop_video",
                 "Drop all video content of a stream.",
-                Lang.frame_kind_t ~audio ~video:(Lang.kind_t Frame.none) ~midi,
+                Lang.frame_kind_t
+                  (Frame.set_video_field input_kind (Lang.kind_t Frame.none)),
                 fun p ->
                   let source = Lang.to_source (List.assoc "" p) in
                   new drop ~video:true ~name:"drop_video" source )
           | `Midi ->
               ( "drop_midi",
                 "Drop all midi content of a stream.",
-                Lang.frame_kind_t ~audio ~video ~midi:(Lang.kind_t Frame.none),
+                Lang.frame_kind_t
+                  (Frame.set_midi_field input_kind (Lang.kind_t Frame.none)),
                 fun p ->
                   let source = Lang.to_source (List.assoc "" p) in
                   new drop ~midi:true ~name:"drop_midi" source )

--- a/src/core/conversions/mean.ml
+++ b/src/core/conversions/mean.ml
@@ -53,12 +53,14 @@ class mean ~normalize source =
 let () =
   let in_kind =
     Lang.frame_kind_t
-      ~audio:(Lang.kind_t Frame.audio_pcm)
-      ~video:(Lang.univ_t ()) ~midi:(Lang.univ_t ())
+      (Frame.mk_fields
+         ~audio:(Lang.kind_t Frame.audio_pcm)
+         ~video:(Lang.univ_t ()) ~midi:(Lang.univ_t ()) ())
   in
   let out_kind =
-    let { Frame.video; midi } = Lang.of_frame_kind_t in_kind in
-    Lang.frame_kind_t ~audio:(Lang.kind_t Frame.audio_mono) ~video ~midi
+    let fields = Lang.of_frame_kind_t in_kind in
+    Lang.frame_kind_t
+      (Frame.set_audio_field fields (Lang.kind_t Frame.audio_mono))
   in
   Lang.add_operator "mean"
     [

--- a/src/core/decoder/aac_decoder.ml
+++ b/src/core/decoder/aac_decoder.ml
@@ -160,11 +160,9 @@ let file_type ~ctype:_ filename =
         (Lang_string.quote_string filename)
         rate channels;
       Some
-        {
-          Frame.audio = Content.Audio.format_of_channels channels;
-          video = Content.None.format;
-          midi = Content.None.format;
-        })
+        (Frame.mk_fields
+           ~audio:(Content.Audio.format_of_channels channels)
+           ~video:Content.None.format ~midi:Content.None.format ()))
 
 let file_decoder ~metadata:_ ~ctype filename =
   Decoder.opaque_file_decoder ~filename ~ctype create_decoder
@@ -238,11 +236,9 @@ let file_type ~ctype:_ filename =
         (Lang_string.quote_string filename)
         rate channels;
       Some
-        {
-          Frame.audio = Content.Audio.format_of_channels channels;
-          video = Content.None.format;
-          midi = Content.None.format;
-        })
+        (Frame.mk_fields
+           ~audio:(Content.Audio.format_of_channels channels)
+           ~video:Content.None.format ~midi:Content.None.format ()))
 
 let mp4_mime_types =
   Dtools.Conf.list

--- a/src/core/decoder/external_decoder.ml
+++ b/src/core/decoder/external_decoder.ml
@@ -107,14 +107,12 @@ let test_ctype f filename =
   if ret = 0 then None
   else
     Some
-      {
-        Frame.video = Content.None.format;
-        midi = Content.None.format;
-        (* TODO: this is not perfect *)
-        audio =
-          (if ret < 0 then audio_n (Lazy.force Frame.audio_channels)
-          else audio_n ret);
-      }
+      (Frame.mk_fields ~video:Content.None.format
+         ~midi:Content.None.format (* TODO: this is not perfect *)
+         ~audio:
+           (if ret < 0 then audio_n (Lazy.force Frame.audio_channels)
+           else audio_n ret)
+         ())
 
 let register_stdin ~name ~sdoc ~priority ~mimes ~file_extensions ~test process =
   Decoder.decoders#register name ~sdoc
@@ -163,11 +161,9 @@ let external_input_oblivious process filename prebuf =
   let input = { Decoder.read; tell = None; length = None; lseek = None } in
   (* TODO: is this really what we want for audio channels? *)
   let ctype =
-    {
-      Frame.audio = audio_n (Lazy.force Frame.audio_channels);
-      video = Content.None.format;
-      midi = Content.None.format;
-    }
+    Frame.mk_fields
+      ~audio:(audio_n (Lazy.force Frame.audio_channels))
+      ~video:Content.None.format ~midi:Content.None.format ()
   in
   let gen = Generator.create ~log_overfull:false ~log:(log#info "%s") `Audio in
   let buffer = Decoder.mk_buffer ~ctype gen in

--- a/src/core/decoder/image_decoder.ml
+++ b/src/core/decoder/image_decoder.ml
@@ -149,25 +149,22 @@ let () =
         (fun ~ctype filename ->
           if
             Decoder.get_image_file_decoder filename <> None
-            && Content.is_internal_format ctype.Frame.audio
+            && Content.is_internal_format (Frame.find_audio ctype)
           then
             Some
-              Frame.
-                {
-                  audio = ctype.audio;
-                  video = Content.(default_format Video.kind);
-                  midi = Content.None.format;
-                }
+              (Frame.mk_fields ~audio:(Frame.find_audio ctype)
+                 ~video:Content.(default_format Video.kind)
+                 ~midi:Content.None.format ())
           else None);
       file_decoder =
         Some
           (fun ~metadata ~ctype filename ->
             let img = Option.get (Decoder.get_image_file_decoder filename) in
             let width, height =
-              Content.Video.dimensions_of_format ctype.Frame.video
+              Content.Video.dimensions_of_format (Frame.find_video ctype)
             in
             create_decoder
-              ~audio:(Content.Audio.is_format ctype.Frame.audio)
+              ~audio:(Content.Audio.is_format (Frame.find_audio ctype))
               ~width ~height ~metadata img);
       stream_decoder = None;
     }

--- a/src/core/decoder/liq_flac_decoder.ml
+++ b/src/core/decoder/liq_flac_decoder.ml
@@ -125,11 +125,9 @@ let file_type filename =
         (Lang_string.quote_string filename)
         rate channels;
       Some
-        {
-          Frame.audio = Content.Audio.format_of_channels channels;
-          video = Content.None.format;
-          midi = Content.None.format;
-        })
+        (Frame.mk_fields
+           ~audio:(Content.Audio.format_of_channels channels)
+           ~video:Content.None.format ~midi:Content.None.format ()))
 
 let file_decoder ~metadata:_ ~ctype filename =
   Decoder.opaque_file_decoder ~filename ~ctype create_decoder

--- a/src/core/decoder/liq_ogg_decoder.ml
+++ b/src/core/decoder/liq_ogg_decoder.ml
@@ -250,7 +250,7 @@ let file_type ~ctype:_ filename =
         if video = 0 then Content.None.format
         else Content.(default_format Video.kind)
       in
-      Some { Frame.audio; video; midi = Content.None.format })
+      Some (Frame.mk_fields ~audio ~video ~midi:Content.None.format ()))
 
 let mime_types =
   Dtools.Conf.list

--- a/src/core/decoder/mad_decoder.ml
+++ b/src/core/decoder/mad_decoder.ml
@@ -158,11 +158,9 @@ let file_type filename =
          channels)."
         filename layer (f.Mad.bitrate / 1000) f.Mad.samplerate f.Mad.channels;
       Some
-        {
-          Frame.audio = Content.Audio.format_of_channels f.Mad.channels;
-          video = Content.None.format;
-          midi = Content.None.format;
-        })
+        (Frame.mk_fields
+           ~audio:(Content.Audio.format_of_channels f.Mad.channels)
+           ~video:Content.None.format ~midi:Content.None.format ()))
 
 let create_file_decoder ~metadata:_ ~ctype filename =
   Decoder.opaque_file_decoder ~filename ~ctype create_decoder

--- a/src/core/decoder/midi_decoder.ml
+++ b/src/core/decoder/midi_decoder.ml
@@ -69,12 +69,10 @@ let () =
       file_type =
         (fun ~ctype:_ _ ->
           Some
-            Frame.
-              {
-                audio = Content.None.format;
-                video = Content.None.format;
-                midi = Content.(Midi.lift_params { Content.channels = 16 });
-              });
+            (Frame.mk_fields ~audio:Content.None.format
+               ~video:Content.None.format
+               ~midi:Content.(Midi.lift_params { Content.channels = 16 })
+               ()));
       file_decoder =
         Some (fun ~metadata:_ ~ctype:_ filename -> decoder filename);
       stream_decoder = None;

--- a/src/core/decoder/srt_decoder.ml
+++ b/src/core/decoder/srt_decoder.ml
@@ -50,12 +50,8 @@ let () =
         (fun ~ctype fname ->
           if Srt_parser.check_file fname then
             Some
-              Frame.
-                {
-                  audio = ctype.audio;
-                  video = ctype.video;
-                  midi = Content.None.format;
-                }
+              (Frame.mk_fields ~audio:(Frame.find_audio ctype)
+                 ~video:(Frame.find_video ctype) ~midi:Content.None.format ())
           else None);
       file_decoder =
         Some

--- a/src/core/decoder/wav_aiff_decoder.ml
+++ b/src/core/decoder/wav_aiff_decoder.ml
@@ -147,19 +147,17 @@ let file_type ~ctype:_ filename =
               0
       in
       Some
-        {
-          Frame.video = Content.None.format;
-          midi = Content.None.format;
-          audio =
-            Content.(
-              Audio.lift_params
-                {
-                  Content.channel_layout =
-                    lazy
-                      (Audio_converter.Channel_layout.layout_of_channels
-                         channels);
-                });
-        })
+        (Frame.mk_fields ~video:Content.None.format ~midi:Content.None.format
+           ~audio:
+             Content.(
+               Audio.lift_params
+                 {
+                   Content.channel_layout =
+                     lazy
+                       (Audio_converter.Channel_layout.layout_of_channels
+                          channels);
+                 })
+           ()))
 
 let wav_mime_types =
   Dtools.Conf.list

--- a/src/core/encoder.ml
+++ b/src/core/encoder.ml
@@ -46,13 +46,11 @@ let audio_kind n =
                 lazy (Audio_converter.Channel_layout.layout_of_channels n);
             })
   in
-  { Frame.audio; video = Frame.none; midi = Frame.none }
+  Frame.mk_fields ~audio ~video:Frame.none ~midi:Frame.none ()
 
 let audio_video_kind n =
-  {
-    (audio_kind n) with
-    Frame.video = `Format Content.(default_format Video.kind);
-  }
+  Frame.set_video_field (audio_kind n)
+    (`Format Content.(default_format Video.kind))
 
 let kind_of_format = function
   | WAV w -> audio_kind w.Wav_format.channels
@@ -94,7 +92,7 @@ let kind_of_format = function
                 Content.(default_format (kind_of_string "ffmpeg.video.raw"))
           | Some (`Internal _) -> `Format Content.(default_format Video.kind)
       in
-      { Frame.audio; video; midi = Frame.none }
+      Frame.mk_fields ~audio ~video ~midi:Frame.none ()
   | FdkAacEnc m -> audio_kind m.Fdkaac_format.channels
   | Ogg { Ogg_format.audio; video } ->
       let channels =

--- a/src/core/encoder.mli
+++ b/src/core/encoder.mli
@@ -34,9 +34,9 @@ type format =
   | External of External_encoder_format.t
   | GStreamer of Gstreamer_format.t
 
-val audio_kind : int -> Frame.kind Frame.fields
-val audio_video_kind : int -> Frame.kind Frame.fields
-val kind_of_format : format -> Frame.kind Frame.fields
+val audio_kind : int -> Frame.kind Frame.Fields.t
+val audio_video_kind : int -> Frame.kind Frame.Fields.t
+val kind_of_format : format -> Frame.kind Frame.Fields.t
 val string_of_format : format -> string
 
 (** ISO Base Media File Format, see RFC 6381 section 3.3. *)

--- a/src/core/io/ffmpeg_filter_io.ml
+++ b/src/core/io/ffmpeg_filter_io.ml
@@ -197,7 +197,8 @@ class audio_input ~self_sync_type ~self_sync ~is_ready ~pull ~pass_metadata kind
           sample_format = Some Avfilter.(sample_format v.context);
         }
       in
-      Content.merge self#ctype.Frame.audio
+      Content.merge
+        (Frame.find_audio self#ctype)
         (Ffmpeg_raw_content.Audio.lift_params output_format);
       output <- Some v
 
@@ -277,7 +278,8 @@ class video_input ~self_sync_type ~self_sync ~is_ready ~pull ~pass_metadata ~fps
           pixel_aspect = Avfilter.(pixel_aspect v.context);
         }
       in
-      Content.merge self#ctype.Frame.video
+      Content.merge
+        (Frame.find_video self#ctype)
         (Ffmpeg_raw_content.Video.lift_params output_format);
       output <- Some v
 

--- a/src/core/io/gstreamer_io.ml
+++ b/src/core/io/gstreamer_io.ml
@@ -327,7 +327,7 @@ let () =
   Lang.add_module "input.gstreamer"
 
 let () =
-  let kind = { Frame.audio = Frame.audio_pcm; video = `Any; midi = `Any } in
+  let kind = Frame.mk_fields ~audio:Frame.audio_pcm ~video:`Any ~midi:`Any () in
   let return_t = Lang.kind_type_of_kind_format kind in
   Lang.add_operator "output.gstreamer.audio"
     (output_proto ~return_t ~pipeline:"autoaudiosink")
@@ -358,7 +358,7 @@ let () =
         :> Output.output))
 
 let () =
-  let kind = { Frame.audio = Frame.audio_pcm; video = `Any; midi = `Any } in
+  let kind = Frame.mk_fields ~audio:Frame.audio_pcm ~video:`Any ~midi:`Any () in
   let return_t = Lang.kind_type_of_kind_format kind in
   Lang.add_operator "output.gstreamer.video"
     (output_proto ~return_t ~pipeline:"videoconvert ! autovideosink")
@@ -390,7 +390,8 @@ let () =
 
 let () =
   let kind =
-    { Frame.audio = Frame.audio_pcm; video = Frame.video_yuva420p; midi = `Any }
+    Frame.mk_fields ~audio:Frame.audio_pcm ~video:Frame.video_yuva420p
+      ~midi:`Any ()
   in
   let return_t = Lang.kind_type_of_kind_format kind in
   Lang.add_operator "output.gstreamer.audio_video"
@@ -656,7 +657,8 @@ let input_proto =
 let () =
   let kind =
     (* TODO: be more flexible on audio *)
-    Frame.{ audio = audio_stereo; video = video_yuva420p; midi = none }
+    Frame.mk_fields ~audio:Frame.audio_stereo ~video:Frame.video_yuva420p
+      ~midi:Frame.none ()
   in
   let return_t = Lang.kind_type_of_kind_format kind in
   let proto =

--- a/src/core/lang.ml
+++ b/src/core/lang.ml
@@ -3,30 +3,28 @@ include Lang_source
 include Lang_encoder.L
 module Doc = Liquidsoap_lang.Doc
 
-let audio_pcm = { Frame.audio = Frame.audio_pcm; video = `Any; midi = `Any }
+let audio_pcm = Frame.mk_fields ~audio:Frame.audio_pcm ~video:`Any ~midi:`Any ()
 
 let audio_params p =
-  {
-    Frame.audio = `Format (Content.Audio.lift_params p);
-    video = `Any;
-    midi = `Any;
-  }
+  Frame.mk_fields
+    ~audio:(`Format (Content.Audio.lift_params p))
+    ~video:`Any ~midi:`Any ()
 
-let audio_n n = { Frame.audio = Frame.audio_n n; video = `Any; midi = `Any }
+let audio_n n =
+  Frame.mk_fields ~audio:(Frame.audio_n n) ~video:`Any ~midi:`Any ()
+
 let audio_mono = audio_params { Content.channel_layout = lazy `Mono }
 let audio_stereo = audio_params { Content.channel_layout = lazy `Stereo }
 
 let video_yuva420p =
-  { Frame.audio = `Any; video = Frame.video_yuva420p; midi = `Any }
+  Frame.mk_fields ~audio:`Any ~video:Frame.video_yuva420p ~midi:`Any ()
 
-let midi = { Frame.audio = `Any; video = `Any; midi = Frame.midi_native }
+let midi = Frame.mk_fields ~audio:`Any ~video:`Any ~midi:Frame.midi_native ()
 
 let midi_n n =
-  {
-    Frame.audio = `Any;
-    video = `Any;
-    midi = `Format (Content.Midi.lift_params { Content.channels = n });
-  }
+  Frame.mk_fields ~audio:`Any ~video:`Any
+    ~midi:(`Format (Content.Midi.lift_params { Content.channels = n }))
+    ()
 
 (** Helpers for defining protocols. *)
 

--- a/src/core/lang.mli
+++ b/src/core/lang.mli
@@ -218,8 +218,8 @@ val of_source_t : t -> t
 val format_t : t -> t
 val kind_t : Frame.kind -> t
 val kind_none_t : t
-val frame_kind_t : audio:t -> video:t -> midi:t -> t
-val of_frame_kind_t : t -> t Frame.fields
+val frame_kind_t : t Frame.Fields.t -> t
+val of_frame_kind_t : t -> t Frame.Fields.t
 
 (** [fun_t args r] is the type of a function taking [args] as parameters
   * and returning values of type [r].

--- a/src/core/lang_encoder.ml
+++ b/src/core/lang_encoder.ml
@@ -74,7 +74,7 @@ let generic_error (l, t) : exn =
 
 (** An encoder. *)
 type encoder = {
-  kind_of_encoder : Term.encoder_params -> Frame.kind Frame.fields;
+  kind_of_encoder : Term.encoder_params -> Frame.kind Frame.Fields.t;
       (** Compute the kind of the encoder. *)
   make : Hooks.encoder_params -> Encoder.format;
       (** Actually create the encoder. *)
@@ -108,9 +108,9 @@ let kind_of_encoder ((e, p) : Term.encoder) = (find_encoder e).kind_of_encoder p
 
 let type_of_encoder ~pos e =
   let kind = kind_of_encoder e in
-  let audio = kind_t ?pos kind.Frame.audio in
-  let video = kind_t ?pos kind.Frame.video in
-  let midi = kind_t ?pos kind.Frame.midi in
+  let audio = kind_t ?pos (Frame_base.find_audio kind) in
+  let video = kind_t ?pos (Frame_base.find_video kind) in
+  let midi = kind_t ?pos (Frame_base.find_midi kind) in
   format_t ?pos (frame_kind_t ?pos audio video midi)
 
 let make_encoder ~pos t ((e, p) : Hooks.encoder) =

--- a/src/core/lang_encoders/lang_ffmpeg.ml
+++ b/src/core/lang_encoders/lang_ffmpeg.ml
@@ -75,7 +75,7 @@ let kind_of_encoder p =
           | _ -> audio)
       Frame.none p
   in
-  { Frame.audio; video; midi = Frame.none }
+  Frame.mk_fields ~audio ~video ~midi:Frame.none ()
 
 let flag_qscale = ref 0
 let qp2lambda = ref 0

--- a/src/core/operators/chord.ml
+++ b/src/core/operators/chord.ml
@@ -118,7 +118,7 @@ let () =
   let in_k = Lang.kind_type_of_kind_format Lang.any in
   let out_k =
     Lang.kind_type_of_kind_format
-      { Frame.audio = `Any; video = `Any; midi = Frame.midi_n 1 }
+      (Frame.mk_fields ~audio:`Any ~video:`Any ~midi:(Frame.midi_n 1) ())
   in
   Lang.add_operator "midi.chord"
     [

--- a/src/core/operators/ladspa_op.ml
+++ b/src/core/operators/ladspa_op.ml
@@ -101,7 +101,8 @@ class ladspa_mono ~kind (source : source) plugin descr input output params =
       let p = Plugin.load plugin in
       let d = Descriptor.descriptor p descr in
       let i =
-        Array.init (Content.Audio.channels_of_format self#ctype.Frame.audio)
+        Array.init
+          (Content.Audio.channels_of_format (Frame.find_audio self#ctype))
           (fun _ -> instantiate d (Lazy.force Frame.audio_rate))
       in
       Array.iter Descriptor.activate i;
@@ -316,7 +317,8 @@ let register_descr plugin_name descr_n d inputs outputs =
   let maker = Pcre.substitute ~pat:"@" ~subst:(fun _ -> "(at)") maker in
   let descr = Printf.sprintf "%s by %s." (Descriptor.name d) maker in
   let output_kind =
-    if mono then input_kind else Frame.{ input_kind with audio = audio_n no }
+    if mono then input_kind
+    else Frame.set_audio_field input_kind (Frame.audio_n no)
   in
   let label = Descriptor.label d |> Utils.normalize_parameter_string in
   let label =

--- a/src/core/operators/lilv_op.ml
+++ b/src/core/operators/lilv_op.ml
@@ -69,7 +69,8 @@ class lilv_mono ~kind (source : source) plugin input output params =
     method wake_up a =
       super#wake_up a;
       let i =
-        Array.init (Content.Audio.channels_of_format self#ctype.Frame.audio)
+        Array.init
+          (Content.Audio.channels_of_format (Frame.find_audio self#ctype))
           (fun _ ->
             Plugin.instantiate plugin
               (float_of_int (Lazy.force Frame.audio_rate)))
@@ -318,8 +319,9 @@ let register_plugin plugin =
   in
   let descr = descr ^ " See <" ^ Plugin.uri plugin ^ ">." in
   let return_t =
-    let { Frame.video; midi } = Lang.of_frame_kind_t input_t in
-    Lang.frame_kind_t ~audio:(Lang.kind_t (Frame.audio_n no)) ~video ~midi
+    let input_kind = Lang.of_frame_kind_t input_t in
+    Lang.frame_kind_t
+      (Frame.set_audio_field input_kind (Lang.kind_t (Frame.audio_n no)))
   in
   Lang.add_operator
     ("lv2." ^ Utils.normalize_parameter_string (Plugin.name plugin))

--- a/src/core/operators/midi_routing.ml
+++ b/src/core/operators/midi_routing.ml
@@ -58,7 +58,9 @@ class remove ~kind (source : source) t =
   end
 
 let () =
-  let kind = { Frame.audio = `Any; video = `Any; midi = Frame.midi_native } in
+  let kind =
+    Frame.mk_fields ~audio:`Any ~video:`Any ~midi:Frame.midi_native ()
+  in
   let k = Lang.kind_type_of_kind_format kind in
   Lang.add_operator "midi.merge_all"
     [
@@ -74,7 +76,9 @@ let () =
       new merge ~kind src out)
 
 let () =
-  let kind = { Frame.audio = `Any; video = `Any; midi = Frame.midi_native } in
+  let kind =
+    Frame.mk_fields ~audio:`Any ~video:`Any ~midi:Frame.midi_native ()
+  in
   let k = Lang.kind_type_of_kind_format kind in
   Lang.add_operator "midi.remove"
     [

--- a/src/core/operators/resample.ml
+++ b/src/core/operators/resample.ml
@@ -78,11 +78,11 @@ class resample ~kind ~ratio source_val =
         in
         let offset = Frame_settings.main_of_audio offset in
         let length = Frame_settings.main_of_audio length in
-        ( {
-            Frame.audio = Content.Audio.lift_data ~offset ~length pcm;
-            video = Content.None.lift_data ~length ();
-            midi = Content.None.lift_data ~length ();
-          },
+        ( Frame.mk_fields
+            ~audio:(Content.Audio.lift_data ~offset ~length pcm)
+            ~video:(Content.None.lift_data ~length ())
+            ~midi:(Content.None.lift_data ~length ())
+            (),
           length )
       in
       let convert x = int_of_float (float x *. ratio) in

--- a/src/core/operators/st_bpm.ml
+++ b/src/core/operators/st_bpm.ml
@@ -38,7 +38,7 @@ class bpm ~kind (source : source) =
       bpm <-
         Some
           (Soundtouch.BPM.make
-             (Content.Audio.channels_of_format self#ctype.Frame.audio)
+             (Content.Audio.channels_of_format (Frame.find_audio self#ctype))
              (Lazy.force Frame.audio_rate))
 
     method private get_frame buf =

--- a/src/core/operators/video_fade.ml
+++ b/src/core/operators/video_fade.ml
@@ -142,7 +142,7 @@ class fade_out ~kind ?(meta = "liq_video_fade_out") duration fader fadefun
 
 (** Lang interface *)
 
-let kind = { Frame.audio = `Any; video = Frame.video_yuva420p; midi = `Any }
+let kind = Frame.mk_fields ~audio:`Any ~video:Frame.video_yuva420p ~midi:`Any ()
 let return_t = Lang.kind_type_of_kind_format kind
 
 (* TODO: share more with fade.ml *)

--- a/src/core/operators/window_op.ml
+++ b/src/core/operators/window_op.ml
@@ -134,7 +134,9 @@ let () =
   let stereo value =
     Lang.product (Lang.float value.(0)) (Lang.float value.(1))
   in
-  let kind = { Frame.audio = Frame.audio_stereo; video = `Any; midi = `Any } in
+  let kind =
+    Frame.mk_fields ~audio:Frame.audio_stereo ~video:`Any ~midi:`Any ()
+  in
   declare RMS "" Lang.audio_pcm Lang.float_t mean;
   declare RMS ".stereo" kind (Lang.product_t Lang.float_t Lang.float_t) stereo;
   declare Peak "" Lang.audio_pcm Lang.float_t mean;

--- a/src/core/source.ml
+++ b/src/core/source.ml
@@ -363,10 +363,10 @@ class virtual operator ?(name = "src") ?audio_in ?video_in ?midi_in out_kind
             ct
 
     method private audio_channels =
-      Content.Audio.channels_of_format self#ctype.Frame.audio
+      Content.Audio.channels_of_format (Frame.find_audio self#ctype)
 
     method private video_dimensions =
-      Content.Video.dimensions_of_format self#ctype.Frame.video
+      Content.Video.dimensions_of_format (Frame.find_video self#ctype)
 
     (** Startup/shutdown.
     *

--- a/src/core/sources/external_input_video.ml
+++ b/src/core/sources/external_input_video.ml
@@ -77,7 +77,7 @@ class video ~name ~kind ~restart ~bufferize ~log_overfull ~restart_on_error ~max
       (* Now we can create the log function *)
       log_ref := self#log#info "%s";
       log_error := self#log#severe "%s";
-      if self#ctype.Frame.audio = Content.None.format then
+      if Frame.find_audio self#ctype = Content.None.format then
         Generator.set_mode abg `Video;
       Generator.set_content_type abg self#ctype;
       self#log#debug "Generator mode: %s."
@@ -93,7 +93,10 @@ class video ~name ~kind ~restart ~bufferize ~log_overfull ~restart_on_error ~max
 let log = Log.make ["input"; "external"; "video"]
 
 let () =
-  let kind = Frame.{ audio = audio_pcm; video = video_yuva420p; midi = none } in
+  let kind =
+    Frame.mk_fields ~audio:Frame.audio_pcm ~video:Frame.video_yuva420p
+      ~midi:Frame.none ()
+  in
   let return_t = Lang.kind_type_of_kind_format kind in
   Lang.add_operator "input.external.avi" ~category:`Input ~flags:[`Experimental]
     ~meth:

--- a/src/core/sources/video_text.ml
+++ b/src/core/sources/video_text.ml
@@ -71,7 +71,7 @@ class text ~kind init render_text ttf ttf_size color duration text =
 
 let register name init render_text =
   let kind =
-    { Frame.audio = `Any; video = Frame.video_yuva420p; midi = `Any }
+    Frame.mk_fields ~audio:`Any ~video:Frame.video_yuva420p ~midi:`Any ()
   in
   let k = Lang.kind_type_of_kind_format kind in
   let add_operator op =

--- a/src/core/stream/frame.mli
+++ b/src/core/stream/frame.mli
@@ -21,14 +21,31 @@
  *****************************************************************************)
 
 open Liquidsoap_lang
+module Fields = Frame.Fields
 
 (** Operations on frames, which are small portions of streams. *)
 
 (** {2 Frame definitions} *)
 
-type 'a fields = 'a Frame.fields = { audio : 'a; video : 'a; midi : 'a }
+type field = Frame.field
 
-val map_fields : ('a -> 'b) -> 'a fields -> 'b fields
+val audio_field : field
+val video_field : field
+val midi_field : field
+
+(* The following raise [Not_found] when the field does not exist. *)
+val find_audio : 'a Fields.t -> 'a
+val find_video : 'a Fields.t -> 'a
+val find_midi : 'a Fields.t -> 'a
+val set_audio_field : 'a Fields.t -> 'a -> 'a Fields.t
+val set_video_field : 'a Fields.t -> 'a -> 'a Fields.t
+val set_midi_field : 'a Fields.t -> 'a -> 'a Fields.t
+val mk_fields : audio:'a -> video:'a -> midi:'a -> unit -> 'a Fields.t
+val string_of_field : field -> string
+val field_of_string : string -> field
+val register_field : string -> field
+val map_fields : ('a -> 'b) -> 'a Fields.t -> 'b Fields.t
+val mapi_fields : (field -> 'a -> 'b) -> 'a Fields.t -> 'b Fields.t
 
 (** High-level description of the content. *)
 type kind =
@@ -44,10 +61,10 @@ val video_yuva420p : kind
 val midi_native : kind
 val midi_n : int -> kind
 
-type content_kind = kind fields
+type content_kind = kind Fields.t
 
 (** Precise description of the channel types for the current track. *)
-type content_type = Content.format fields
+type content_type = Content.format Fields.t
 
 (** Metadata of a frame. *)
 type metadata = (string, string) Hashtbl.t

--- a/src/core/stream/generator.mli
+++ b/src/core/stream/generator.mli
@@ -33,7 +33,7 @@
     number of audio channels, etc.). *)
 exception Incorrect_stream_type
 
-type content = Content.data Frame.fields
+type content = Content.data Frame.Fields.t
 
 val content : Frame.t -> content
 

--- a/src/core/stream/kind.mli
+++ b/src/core/stream/kind.mli
@@ -25,7 +25,7 @@
   * that works through a content production pipeline. *)
 
 type kind
-type t = kind Frame.fields
+type t = kind Frame.Fields.t
 
 val of_kind : Frame.content_kind -> t
 val to_string : t -> string

--- a/src/core/synth/dssi_op.ml
+++ b/src/core/synth/dssi_op.ml
@@ -131,7 +131,8 @@ let register_descr plugin_name descr_n descr outputs =
   let liq_params, params = Ladspa_op.params_of_descr ladspa_descr in
   let chans = Array.length outputs in
   let kind =
-    { Frame.audio = Frame.audio_n chans; video = `Any; midi = Frame.midi_n 1 }
+    Frame.mk_fields ~audio:(Frame.audio_n chans) ~video:`Any
+      ~midi:(Frame.midi_n 1) ()
   in
   let k = Lang.kind_type_of_kind_format kind in
   let liq_params = liq_params in
@@ -152,11 +153,8 @@ let register_descr plugin_name descr_n descr outputs =
       let params = params p in
       new dssi ~kind plugin_name descr_n outputs params ~chan source);
   let kind =
-    {
-      Frame.audio = Frame.audio_n chans;
-      video = `Any;
-      midi = Frame.midi_n all_chans;
-    }
+    Frame.mk_fields ~audio:(Frame.audio_n chans) ~video:`Any
+      ~midi:(Frame.midi_n all_chans) ()
   in
   let k = Lang.kind_type_of_kind_format kind in
   Lang.add_operator

--- a/src/core/synth/synth_op.ml
+++ b/src/core/synth/synth_op.ml
@@ -52,7 +52,8 @@ class synth ~kind (synth : Synth.synth) (source : source) chan volume =
 
 let register obj name descr =
   let kind =
-    { Frame.audio = Frame.audio_mono; video = `Any; midi = Frame.midi_n 1 }
+    Frame.mk_fields ~audio:Frame.audio_mono ~video:`Any ~midi:(Frame.midi_n 1)
+      ()
   in
   let k = Lang.kind_type_of_kind_format kind in
   Lang.add_operator ("synth." ^ name)
@@ -98,7 +99,8 @@ let register obj name descr =
       let kind = Kind.of_kind kind in
       (new synth ~kind (obj adsr) src chan volume :> Source.source));
   let kind =
-    { Frame.audio = Frame.audio_mono; video = `Any; midi = Frame.midi_n 16 }
+    Frame.mk_fields ~audio:Frame.audio_mono ~video:`Any ~midi:(Frame.midi_n 16)
+      ()
   in
   let k = Lang.kind_type_of_kind_format kind in
   Lang.add_operator ("synth.all." ^ name)

--- a/src/core/visualization/video_volume.ml
+++ b/src/core/visualization/video_volume.ml
@@ -78,11 +78,9 @@ class visu ~kind source =
         let vFrame =
           Frame.(
             create
-              {
-                audio = Content.None.format;
-                video = Content.(default_format Video.kind);
-                midi = Content.None.format;
-              })
+              (Frame.mk_fields ~audio:Content.None.format
+                 ~video:Content.(default_format Video.kind)
+                 ~midi:Content.None.format ()))
         in
         Frame.set_video frame (VFrame.content vFrame);
 

--- a/src/lang/evaluation.ml
+++ b/src/lang/evaluation.ml
@@ -167,11 +167,11 @@ and eval (env : Env.t) tm =
           in
           let k = of_frame_kind_t k in
           let k =
-            {
-              Frame.audio = frame_content_of_t k.Frame.audio;
-              video = frame_content_of_t k.Frame.video;
-              midi = frame_content_of_t k.Frame.midi;
-            }
+            Frame.mk_fields
+              ~audio:(frame_content_of_t (Frame.find_audio k))
+              ~video:(frame_content_of_t (Frame.find_video k))
+              ~midi:(frame_content_of_t (Frame.find_midi k))
+              ()
           in
           let fn = !Hooks.source_eval_check in
           fn ~k ~pos:tm.t.Type.pos v

--- a/src/lang/frame.ml
+++ b/src/lang/frame.ml
@@ -24,18 +24,63 @@
 
 (** {2 Frame definitions} *)
 
-type 'a fields = { audio : 'a; video : 'a; midi : 'a }
+type field = int
+
+let field_idx = Atomic.make 0
+
+module FieldNames = Hashtbl.Make (struct
+  type t = int
+
+  let equal x y = x = y
+  let hash x = x
+end)
+
+module Fields = Map.Make (struct
+  type t = field
+
+  let compare = Stdlib.compare
+end)
+
+let field_names = FieldNames.create 0
+let name_fields = Hashtbl.create 0
+let string_of_field = FieldNames.find field_names
+let field_of_string = Hashtbl.find name_fields
+
+let register_field name =
+  (try
+     ignore (field_of_string name);
+     failwith "Field already registered!"
+   with Not_found -> ());
+  let field = Atomic.fetch_and_add field_idx 1 in
+  FieldNames.replace field_names field name;
+  Hashtbl.replace name_fields name field;
+  field
 
 (** High-level description of the content. *)
 type kind =
   [ `Any | `Internal | `Kind of Content.kind | `Format of Content.format ]
 
-type content_kind = kind fields
+type content_kind = kind Fields.t
 
 (** Precise description of the channel types for the current track. *)
-type content_type = Content.format fields
+type content_type = Content.format Fields.t
 
 (** Metadata of a frame. *)
 type metadata = (string, string) Hashtbl.t
 
 let none = `Format Content.None.format
+let audio_field = register_field "audio"
+let video_field = register_field "video"
+let midi_field = register_field "midi"
+let find_audio c = Fields.find audio_field c
+let find_video c = Fields.find video_field c
+let find_midi c = Fields.find midi_field c
+let set_audio_field fields value = Fields.add audio_field value fields
+let set_video_field fields value = Fields.add video_field value fields
+let set_midi_field fields value = Fields.add midi_field value fields
+
+let mk_fields ~audio ~video ~midi () =
+  List.fold_left
+    (fun fields (field, v) -> Fields.add field v fields)
+    Fields.empty
+    [(audio_field, audio); (video_field, video); (midi_field, midi)]

--- a/src/lang/frame.ml
+++ b/src/lang/frame.ml
@@ -31,14 +31,14 @@ let field_idx = Atomic.make 0
 module FieldNames = Hashtbl.Make (struct
   type t = int
 
-  let equal x y = x = y
-  let hash x = x
+  let equal (x : int) (y : int) = x = y [@@inline always]
+  let hash (x : int) = x [@@inline always]
 end)
 
 module Fields = Map.Make (struct
   type t = field
 
-  let compare = Stdlib.compare
+  let compare (x : int) (y : int) = Stdlib.compare x y [@@inline always]
 end)
 
 let field_names = FieldNames.create 0

--- a/src/lang/frame.mli
+++ b/src/lang/frame.mli
@@ -24,7 +24,13 @@
 
 (** {2 Frame definitions} *)
 
-type 'a fields = { audio : 'a; video : 'a; midi : 'a }
+type field
+
+val string_of_field : field -> string
+val field_of_string : string -> field
+val register_field : string -> field
+
+module Fields : Map.S with type key = field
 
 (** High-level description of the content. *)
 type kind =
@@ -32,10 +38,23 @@ type kind =
 
 val none : kind
 
-type content_kind = kind fields
+type content_kind = kind Fields.t
 
 (** Precise description of the channel types for the current track. *)
-type content_type = Content.format fields
+type content_type = Content.format Fields.t
 
 (** Metadata of a frame. *)
 type metadata = (string, string) Hashtbl.t
+
+val audio_field : field
+val video_field : field
+val midi_field : field
+
+(* The following raise [Not_found] when the field does not exist. *)
+val find_audio : 'a Fields.t -> 'a
+val find_video : 'a Fields.t -> 'a
+val find_midi : 'a Fields.t -> 'a
+val set_audio_field : 'a Fields.t -> 'a -> 'a Fields.t
+val set_video_field : 'a Fields.t -> 'a -> 'a Fields.t
+val set_midi_field : 'a Fields.t -> 'a -> 'a Fields.t
+val mk_fields : audio:'a -> video:'a -> midi:'a -> unit -> 'a Fields.t

--- a/src/lang/lang.mli
+++ b/src/lang/lang.mli
@@ -164,8 +164,8 @@ val of_source_t : t -> t
 val format_t : t -> t
 val kind_t : Frame.kind -> t
 val kind_none_t : t
-val frame_kind_t : audio:t -> video:t -> midi:t -> t
-val of_frame_kind_t : t -> t Frame.fields
+val frame_kind_t : t Frame.Fields.t -> t
+val of_frame_kind_t : t -> t Frame.Fields.t
 
 (** [fun_t args r] is the type of a function taking [args] as parameters
   * and returning values of type [r].

--- a/src/lang/lang_core.ml
+++ b/src/lang/lang_core.ml
@@ -66,22 +66,31 @@ let ref_t t = Term.ref_t t
 let metadata_t = list_t (product_t string_t string_t)
 let univ_t ?(constraints = []) () = Type.var ~constraints ()
 let getter_t a = Type.make (Type.Getter a)
-let frame_kind_t ~audio ~video ~midi = Term.frame_kind_t audio video midi
+
+let frame_kind_t kind =
+  Term.frame_kind_t (Frame.find_audio kind) (Frame.find_video kind)
+    (Frame.find_midi kind)
+
 let of_frame_kind_t t = Term.of_frame_kind_t t
 let source_t t = Term.source_t t
 let of_source_t t = Term.of_source_t t
 let format_t t = Term.format_t t
 let kind_t k = Term.kind_t k
 let kind_none_t = Term.kind_t Frame.none
-let empty = { Frame.audio = Frame.none; video = Frame.none; midi = Frame.none }
-let any = { Frame.audio = `Any; video = `Any; midi = `Any }
-let internal = { Frame.audio = `Internal; video = `Internal; midi = `Internal }
+
+let empty =
+  Frame.mk_fields ~audio:Frame.none ~video:Frame.none ~midi:Frame.none ()
+
+let any = Frame.mk_fields ~audio:`Any ~video:`Any ~midi:`Any ()
+
+let internal =
+  Frame.mk_fields ~audio:`Internal ~video:`Internal ~midi:`Internal ()
 
 let kind_type_of_kind_format fields =
-  let audio = Term.kind_t fields.Frame.audio in
-  let video = Term.kind_t fields.Frame.video in
-  let midi = Term.kind_t fields.Frame.midi in
-  frame_kind_t ~audio ~video ~midi
+  let audio = Term.kind_t (Frame.find_audio fields) in
+  let video = Term.kind_t (Frame.find_video fields) in
+  let midi = Term.kind_t (Frame.find_midi fields) in
+  frame_kind_t (Frame.mk_fields ~audio ~video ~midi ())
 
 (** Value construction *)
 

--- a/src/lang/term.ml
+++ b/src/lang/term.ml
@@ -119,13 +119,13 @@ let of_frame_kind_t t =
           Type.constructor = "stream_kind";
           Type.params = [(_, audio); (_, video); (_, midi)];
         } ->
-        { Frame.audio; video; midi }
+        Frame.mk_fields ~audio ~video ~midi ()
     | Type.Var ({ contents = Type.Free _ } as var) ->
         let audio = kind_t `Any in
         let video = kind_t `Any in
         let midi = kind_t `Any in
         var := Type.Link (Type.Invariant, frame_kind_t audio video midi);
-        { Frame.audio; video; midi }
+        Frame.mk_fields ~audio ~video ~midi ()
     | _ -> assert false
 
 (** Type of audio formats that can encode frame of a given kind. *)

--- a/tests/core/decoder_test.ml
+++ b/tests/core/decoder_test.ml
@@ -1,5 +1,3 @@
-open Frame
-
 let channel_layout_converter src dst =
   match (src, dst) with
     | `Mono, `Mono
@@ -34,39 +32,39 @@ let () =
   let midi = Content.(Midi.lift_params { Content.channels = 1 }) in
   assert (
     Decoder.can_decode_type
-      { audio = stereo; video = none; midi = none }
-      { audio = stereo; video = none; midi = none });
+      (Frame.mk_fields ~audio:stereo ~video:none ~midi:none ())
+      (Frame.mk_fields ~audio:stereo ~video:none ~midi:none ()));
   assert (
     Decoder.can_decode_type
-      { audio = mono; video = none; midi = none }
-      { audio = stereo; video = none; midi = none });
+      (Frame.mk_fields ~audio:mono ~video:none ~midi:none ())
+      (Frame.mk_fields ~audio:stereo ~video:none ~midi:none ()));
   assert (
     Decoder.can_decode_type
-      { audio = five_point_one; video = none; midi = none }
-      { audio = stereo; video = none; midi = none });
+      (Frame.mk_fields ~audio:five_point_one ~video:none ~midi:none ())
+      (Frame.mk_fields ~audio:stereo ~video:none ~midi:none ()));
   assert (
     not
       (Decoder.can_decode_type
-         { audio = mono; video = none; midi = none }
-         { audio = stereo; video = yuva420p; midi = none }));
+         (Frame.mk_fields ~audio:mono ~video:none ~midi:none ())
+         (Frame.mk_fields ~audio:stereo ~video:yuva420p ~midi:none ())));
   assert (
     Decoder.can_decode_type
-      { audio = mono; video = yuva420p; midi = none }
-      { audio = stereo; video = yuva420p; midi = none });
+      (Frame.mk_fields ~audio:mono ~video:yuva420p ~midi:none ())
+      (Frame.mk_fields ~audio:stereo ~video:yuva420p ~midi:none ()));
   assert (
     not
       (Decoder.can_decode_type
-         { audio = mono; video = none; midi = none }
-         { audio = stereo; video = none; midi }));
+         (Frame.mk_fields ~audio:mono ~video:none ~midi:none ())
+         (Frame.mk_fields ~audio:stereo ~video:none ~midi ())));
   assert (
     Decoder.can_decode_type
-      { audio = stereo; video = yuva420p; midi }
-      { audio = stereo; video = none; midi = none });
+      (Frame.mk_fields ~audio:stereo ~video:yuva420p ~midi ())
+      (Frame.mk_fields ~audio:stereo ~video:none ~midi ()));
   assert (
     Decoder.can_decode_type
-      { audio = stereo; video = yuva420p; midi }
-      { audio = stereo; video = yuva420p; midi });
+      (Frame.mk_fields ~audio:stereo ~video:yuva420p ~midi ())
+      (Frame.mk_fields ~audio:stereo ~video:yuva420p ~midi ()));
   assert (
     Decoder.can_decode_type
-      { audio = stereo; video = yuva420p; midi = none }
-      { audio = none; video = yuva420p; midi = none })
+      (Frame.mk_fields ~audio:stereo ~video:yuva420p ~midi ())
+      (Frame.mk_fields ~audio:none ~video:yuva420p ~midi ()))

--- a/tests/core/frame_test.ml
+++ b/tests/core/frame_test.ml
@@ -5,7 +5,9 @@ let () =
   Frame_settings.lazy_config_eval := true;
 
   let src =
-    create { audio = None.format; video = None.format; midi = None.format }
+    create
+      (Frame.mk_fields ~audio:None.format ~video:None.format ~midi:None.format
+         ())
   in
   add_break src (Lazy.force size);
   let m = Hashtbl.create 1 in
@@ -15,7 +17,9 @@ let () =
   (* First check that last meta from src is
      set when dst does not have one. *)
   let dst =
-    create { audio = None.format; video = None.format; midi = None.format }
+    create
+      (Frame.mk_fields ~audio:None.format ~video:None.format ~midi:None.format
+         ())
   in
   add_break dst 1;
   get_chunk dst src;
@@ -24,7 +28,9 @@ let () =
   (* Then check that is not set when it has
      one that is the same. *)
   let dst =
-    create { audio = None.format; video = None.format; midi = None.format }
+    create
+      (Frame.mk_fields ~audio:None.format ~video:None.format ~midi:None.format
+         ())
   in
   add_break dst 1;
   let m' = Hashtbl.create 1 in
@@ -36,7 +42,9 @@ let () =
   (* Then check that it is set when it has one
      but it is different. *)
   let dst =
-    create { audio = None.format; video = None.format; midi = None.format }
+    create
+      (Frame.mk_fields ~audio:None.format ~video:None.format ~midi:None.format
+         ())
   in
   add_break dst 1;
   let m' = Hashtbl.create 1 in

--- a/tests/core/stream_decoder_test.ml
+++ b/tests/core/stream_decoder_test.ml
@@ -19,11 +19,8 @@ let () =
   let write = Strings.iter (output_substring out_fd) in
   let format = "application/ffmpeg" in
   let ctype =
-    {
-      Frame.audio = Content.default_audio ();
-      video = Content.None.format;
-      midi = Content.None.format;
-    }
+    Frame.mk_fields ~audio:(Content.default_audio ()) ~video:Content.None.format
+      ~midi:Content.None.format ()
   in
   let frame = Frame.create ctype in
   let create_decoder = Option.get (Decoder.get_stream_decoder ~ctype format) in


### PR DESCRIPTION
This PR makes frames content a generic mapping between extensible type of content field and content. 

This should allow for extensible content such as:
* Subtitle
* Multiple audio track
* Optional midi content


The script of these changes is only to replace the existing record with a immutable mapping, leaving everything else untouched. Next, we'll have to look at making the mapping extensible, which will require a different approach to type/kind/content type resolving, most likely by introducing a row variable to account for all possible types instead of making the assumption that types are only audio/video/midi.