### PR TITLE
Make `seek` method mandatory

### DIFF
--- a/src/core/io/alsa_io.ml
+++ b/src/core/io/alsa_io.ml
@@ -36,6 +36,7 @@ class virtual base dev mode =
   let samples_per_frame = AFrame.size () in
   let periods = Alsa_settings.periods#get in
   object (self)
+    inherit Source.no_seek
     method virtual log : Log.t
     method virtual audio_channels : int
     val mutable alsa_rate = -1

--- a/src/core/io/ffmpeg_filter_io.ml
+++ b/src/core/io/ffmpeg_filter_io.ml
@@ -41,6 +41,7 @@ class audio_output ~pass_metadata ~name ~kind source_val =
         ~infallible:false ~on_stop:noop ~on_start:noop ~content_kind:kind ~name
           ~output_kind:"ffmpeg.filter.input" source_val true
 
+    inherit Source.no_seek
     initializer Kind.unify (Lang.to_source source_val)#kind self#kind
     val mutable input = fun _ -> ()
     method set_input fn = input <- fn
@@ -181,6 +182,7 @@ class audio_input ~self_sync_type ~self_sync ~is_ready ~pull ~pass_metadata kind
   let stream_idx = Ffmpeg_content_base.new_stream_idx () in
   object (self)
     inherit Source.source kind ~name:"ffmpeg.filter.output"
+    inherit Source.no_seek
 
     inherit
       [[ `Audio ]] input_base
@@ -264,6 +266,7 @@ class video_input ~self_sync_type ~self_sync ~is_ready ~pull ~pass_metadata ~fps
   let stream_idx = Ffmpeg_content_base.new_stream_idx () in
   object (self)
     inherit Source.source kind ~name:"ffmpeg.filter.output"
+    inherit Source.no_seek
 
     inherit
       [[ `Video ]] input_base

--- a/src/core/io/ffmpeg_io.ml
+++ b/src/core/io/ffmpeg_io.ml
@@ -53,6 +53,7 @@ class input ?(name = "input.ffmpeg") ~autostart ~self_sync ~poll_delay ~debug
         ~name ~content_kind:kind ~fallible:true ~clock_safe ~on_start ~on_stop
           ~autostart () as super
 
+    inherit Source.no_seek
     val mutable connect_task = None
     val mutable container = None
     val generator = generator

--- a/src/core/io/gstreamer_io.ml
+++ b/src/core/io/gstreamer_io.ml
@@ -471,6 +471,7 @@ class audio_video_input p kind (pipeline, audio_pipeline, video_pipeline) =
   let gen = Generator.create ~log_overfull ~log:(fun x -> !rlog x) content in
   object (self)
     inherit Source.source ~name:"input.gstreamer.audio_video" kind as super
+    inherit Source.no_seek
     inherit [string sink, Gstreamer.data sink] element_factory ~on_error
     initializer rlog := fun s -> self#log#important "%s" s
     method set_state s = ignore (Element.set_state self#get_element.bin s)

--- a/src/core/io/oss_io.ml
+++ b/src/core/io/oss_io.ml
@@ -46,6 +46,8 @@ class output ~kind ~clock_safe ~on_start ~on_stop ~infallible ~start dev
         ~infallible ~on_stop ~on_start ~content_kind:(Kind.of_kind kind) ~name
           ~output_kind:"output.oss" val_source start as super
 
+    inherit Source.no_seek
+
     method private set_clock =
       super#set_clock;
       if clock_safe then
@@ -92,6 +94,7 @@ class input ~kind ~clock_safe ~start ~on_stop ~on_start ~fallible dev =
         ~name:(Printf.sprintf "oss_in(%s)" dev)
         ~on_start ~on_stop ~fallible ~autostart:start ()
 
+    inherit Source.no_seek
     val mutable fd = None
     method self_sync = (`Dynamic, fd <> None)
     method abort_track = ()

--- a/src/core/io/portaudio_io.ml
+++ b/src/core/io/portaudio_io.ml
@@ -29,6 +29,8 @@ let initialized = ref false
 
 class virtual base =
   object (self)
+    inherit Source.no_seek
+
     initializer
     if not !initialized then (
       Portaudio.init ();

--- a/src/core/io/pulseaudio_io.ml
+++ b/src/core/io/pulseaudio_io.ml
@@ -39,6 +39,7 @@ let () = Printexc.register_printer error_translator
 class virtual base ~client ~device =
   let device = if device = "" then None else Some device in
   object
+    inherit Source.no_seek
     val client_name = client
     val dev = device
     method virtual log : Log.t

--- a/src/core/operators/accelerate.ml
+++ b/src/core/operators/accelerate.ml
@@ -33,6 +33,7 @@ class accelerate ~kind ~ratio ~randomize source_val =
 
     method self_sync = source#self_sync
     method stype = source#stype
+    method seek = source#seek
 
     method remaining =
       let rem = source#remaining in

--- a/src/core/operators/cross.ml
+++ b/src/core/operators/cross.ml
@@ -407,6 +407,12 @@ class cross ~kind val_source ~duration_getter ~override_duration
         | `Limit -> -1
         | `After -> (Option.get transition_source)#remaining
 
+    method seek len =
+      match status with
+        | `Before | `Idle -> source#seek len
+        | `Limit -> -1
+        | `After -> (Option.get transition_source)#seek len
+
     method is_ready =
       match status with
         | `Idle | `Before -> source#is_ready

--- a/src/core/operators/cuepoint.ml
+++ b/src/core/operators/cuepoint.ml
@@ -49,6 +49,7 @@ class cue_cut ~kind ~m_cue_in ~m_cue_out ~on_cue_in ~on_cue_out source_val =
     method is_ready = source#is_ready
     method abort_track = source#abort_track
     method self_sync = source#self_sync
+    method seek = source#seek
 
     method remaining =
       let source_remaining = source#remaining in

--- a/src/core/operators/frei0r_op.ml
+++ b/src/core/operators/frei0r_op.ml
@@ -81,6 +81,7 @@ class frei0r_mixer ~kind ~name bgra instance params (source : source) source2 =
   let dt = 1. /. float fps in
   object (self)
     inherit operator ~name:("frei0r." ^ name) kind [source; source2] as super
+    inherit Source.no_seek
 
     method stype =
       match (source#stype, source2#stype) with
@@ -158,6 +159,7 @@ class frei0r_source ~kind ~name bgra instance params =
   let dt = 1. /. float fps in
   object
     inherit source ~name:("frei0r." ^ name) kind
+    inherit Source.no_seek
     method stype = `Infallible
     method is_ready = true
     method self_sync = (`Static, false)

--- a/src/core/operators/insert_metadata.ml
+++ b/src/core/operators/insert_metadata.ml
@@ -127,6 +127,7 @@ class replay ~kind meta src =
     method abort_track = src#abort_track
     method remaining = src#remaining
     method self_sync = src#self_sync
+    method seek = src#seek
 
     method private get_frame ab =
       let start = Frame.position ab in

--- a/src/core/operators/ladspa_op.ml
+++ b/src/core/operators/ladspa_op.ml
@@ -60,6 +60,7 @@ let port_t d p =
 class virtual base ~kind source =
   object
     inherit operator ~name:"ladspa" kind [source]
+    inherit Source.no_seek
     method stype = source#stype
     method remaining = source#remaining
     method seek = source#seek
@@ -71,6 +72,7 @@ class virtual base ~kind source =
 class virtual base_nosource ~kind =
   object
     inherit source ~name:"ladspa" kind
+    inherit Source.no_seek
     method stype = `Infallible
     method is_ready = true
     method self_sync = (`Static, false)

--- a/src/core/operators/lilv_op.ml
+++ b/src/core/operators/lilv_op.ml
@@ -36,6 +36,7 @@ let lilv_enabled =
 class virtual base ~kind source =
   object
     inherit operator ~name:"lilv" (Kind.of_kind kind) [source]
+    inherit Source.no_seek
     method stype = source#stype
     method remaining = source#remaining
     method seek = source#seek
@@ -47,6 +48,7 @@ class virtual base ~kind source =
 class virtual base_nosource ~kind =
   object
     inherit source ~name:"lilv" kind
+    inherit Source.no_seek
     method stype = `Infallible
     method is_ready = true
     val mutable must_fail = false

--- a/src/core/operators/max_duration.ml
+++ b/src/core/operators/max_duration.ml
@@ -47,6 +47,8 @@ class max_duration ~kind ~override_meta ~duration source =
         | _, -1 -> -1
         | rem, rem' -> min rem rem'
 
+    method seek len = source#seek (min remaining len)
+
     method private check_for_override ~offset buf =
       List.iter
         (fun (p, m) ->

--- a/src/core/operators/prepend.ml
+++ b/src/core/operators/prepend.ml
@@ -108,6 +108,11 @@ class prepend ~kind ~merge source f =
             let ( + ) a b = if a < 0 || b < 0 then -1 else a + b in
             if merge then s#remaining + source#remaining else s#remaining
 
+    method seek len =
+      match state with
+        | `Idle | `Replay | `Buffer _ -> source#seek len
+        | `Prepend (s, _) -> s#seek len
+
     method self_sync =
       match state with `Prepend (s, _) -> s#self_sync | _ -> source#self_sync
 

--- a/src/core/operators/resample.ml
+++ b/src/core/operators/resample.ml
@@ -42,6 +42,11 @@ class resample ~kind ~ratio source_val =
     method self_sync = source#self_sync
     method stype = source#stype
 
+    method seek len =
+      let glen = min (Generator.length generator) len in
+      Generator.remove generator glen;
+      (if glen < len then source#seek (len - glen) else 0) + glen
+
     method remaining =
       let rem = source#remaining in
       if rem = -1 then rem

--- a/src/core/operators/sequence.ml
+++ b/src/core/operators/sequence.ml
@@ -68,6 +68,8 @@ class sequence ~kind ?(merge = false) sources =
         List.fold_left ( + ) 0 (List.map (fun s -> s#remaining) seq_sources))
       else (List.hd seq_sources)#remaining
 
+    method seek len = match seq_sources with s :: _ -> s#seek len | [] -> 0
+
     method abort_track =
       if merge then (
         match List.rev seq_sources with
@@ -110,6 +112,7 @@ class merge_tracks ~kind source =
     method abort_track = source#abort_track
     method remaining = -1
     method self_sync = source#self_sync
+    method seek = source#seek
 
     method private get_frame buf =
       source#get buf;

--- a/src/core/operators/soundtouch_op.ml
+++ b/src/core/operators/soundtouch_op.ml
@@ -44,6 +44,7 @@ class soundtouch ~kind source_val rate tempo pitch =
     method stype = source#stype
     method self_sync = source#self_sync
     method is_ready = source#is_ready
+    method seek = source#seek
     method remaining = -1
 
     method abort_track =

--- a/src/core/operators/time_warp.ml
+++ b/src/core/operators/time_warp.ml
@@ -56,6 +56,11 @@ module Buffer = struct
       method remaining = proceed c (fun () -> Generator.remaining c.generator)
       method is_ready = proceed c (fun () -> not c.buffering)
 
+      method seek len =
+        let len = min (Generator.length c.generator) len in
+        Generator.remove c.generator len;
+        len
+
       method private get_frame frame =
         proceed c (fun () ->
             assert (not c.buffering);
@@ -203,6 +208,7 @@ module AdaptativeBuffer = struct
     let alpha = log 2. *. AFrame.duration () /. averaging in
     object (self)
       inherit Source.source kind ~name:"buffer.adaptative_producer"
+      inherit Source.no_seek
       method stype = `Fallible
       method self_sync = (`Static, false)
       method remaining = proceed c (fun () -> MG.remaining c.mg)

--- a/src/core/operators/video_fade.ml
+++ b/src/core/operators/video_fade.ml
@@ -36,6 +36,7 @@ class fade_in ~kind ?(meta = "liq_video_fade_in") duration fader fadefun source
     method abort_track = source#abort_track
     method remaining = source#remaining
     method self_sync = source#self_sync
+    method seek = source#seek
     val mutable state = `Idle
 
     method private get_frame ab =
@@ -89,6 +90,7 @@ class fade_out ~kind ?(meta = "liq_video_fade_out") duration fader fadefun
     method stype = source#stype
     method abort_track = source#abort_track
     method self_sync = source#self_sync
+    method seek = source#seek
 
     (* Fade-out length (in video frames) for the current track.
      * The value is set at the beginning of every track, depending on metadata. *)

--- a/src/core/outputs/output.mli
+++ b/src/core/outputs/output.mli
@@ -45,6 +45,7 @@ class virtual output :
        method is_ready : bool
        method state : Start_stop.state
        method transition_to : Start_stop.state -> unit
+       method seek : int -> int
        method private video_dimensions : int * int
        method private add_metadata : Request.metadata -> unit
        method private metadata_queue : Request.metadata Queue.t

--- a/src/core/source.ml
+++ b/src/core/source.ml
@@ -535,9 +535,7 @@ class virtual operator ?(name = "src") ?audio_in ?video_in ?midi_in out_kind
     (* [self#seek x] skips [x] main ticks.
      * returns the number of ticks actually skipped.
      * By default it always returns 0, refusing to seek at all. *)
-    method seek (_ : int) =
-      self#log#important "Seeking not supported by this source!";
-      0
+    method virtual seek : int -> int
 
     (* Is there some data available for the next [get]?
      * Must always be true while playing a track, i.e. all tracks
@@ -727,6 +725,15 @@ class virtual source ?name ?audio_in ?video_in ?midi_in content_kind =
 class virtual active_source ?name ?audio_in ?video_in ?midi_in content_kind =
   object
     inherit active_operator ?name ?audio_in ?video_in ?midi_in content_kind []
+  end
+
+class virtual no_seek =
+  object (self)
+    method virtual log : Log.t
+
+    method seek (_ : int) =
+      self#log#important "Seeking not supported by this source!";
+      0
   end
 
 (** Specialized shortcuts *)

--- a/src/core/source.mli
+++ b/src/core/source.mli
@@ -169,7 +169,7 @@ class virtual source :
            By default it always returns 0, refusing to seek at all.
            That method may be called from any thread, concurrently
            with [#get], so they should not interfer. *)
-       method seek : int -> int
+       method virtual seek : int -> int
 
        (** [is_ready] tells you if [get] can be called. *)
        method virtual is_ready : bool
@@ -251,6 +251,12 @@ class virtual active_operator :
   -> object
        inherit active_source
      end
+
+class virtual no_seek :
+  object
+    method virtual log : Log.t
+    method seek : int -> int
+  end
 
 val has_outputs : unit -> bool
 val iterate_new_outputs : (active_source -> unit) -> unit

--- a/src/core/sources/alsa_in.ml
+++ b/src/core/sources/alsa_in.ml
@@ -41,6 +41,7 @@ class mic ~kind ~clock_safe ~fallible ~on_start ~on_stop ~start device =
           ~clock_safe ~get_clock:Alsa_settings.get_clock
           ~content_kind:(Kind.of_kind kind) () as active_source
 
+    inherit Source.no_seek
     inherit [Content.Audio.data] IoRing.input ~nb_blocks as ioring
     val mutable initialized = false
     method self_sync = (`Static, true)

--- a/src/core/sources/bjack_in.ml
+++ b/src/core/sources/bjack_in.ml
@@ -38,6 +38,7 @@ class jack_in ~kind ~clock_safe ~on_start ~on_stop ~fallible ~autostart
         ~name:"input.jack" ~content_kind:kind ~clock_safe ~on_start ~on_stop
           ~fallible ~autostart () as active_source
 
+    inherit Source.no_seek
     inherit [Bytes.t] IoRing.input ~nb_blocks as ioring
 
     method private wake_up l =

--- a/src/core/sources/debug_sources.ml
+++ b/src/core/sources/debug_sources.ml
@@ -23,6 +23,7 @@
 class fail ~kind name =
   object
     inherit Source.source ~name kind
+    inherit Source.no_seek
     method stype = `Fallible
     method is_ready = false
     method self_sync = (`Static, false)

--- a/src/core/sources/request_source.mli
+++ b/src/core/sources/request_source.mli
@@ -44,6 +44,7 @@ class once :
        method private get_frame : Frame.t -> unit
        method resolve : bool
        method abort_track : unit
+       method seek : int -> int
      end
 
 class virtual unqueued :
@@ -62,6 +63,7 @@ class virtual unqueued :
        method remaining : int
        method self_sync : Source.self_sync
        method current : handler option
+       method seek : int -> int
      end
 
 type queue_item = {

--- a/src/core/synth/dssi_op.ml
+++ b/src/core/synth/dssi_op.ml
@@ -51,6 +51,7 @@ let all_chans = 16
 class dssi ~kind ?chan plugin descr outputs params source =
   object
     inherit operator ~name:"dssi" (Kind.of_kind kind) [source]
+    inherit Source.no_seek
     method stype = source#stype
     method remaining = source#remaining
     method is_ready = source#is_ready

--- a/src/core/synth/keyboard.ml
+++ b/src/core/synth/keyboard.ml
@@ -55,6 +55,7 @@ let note_of_char c = array_index c + 72
 class keyboard ~kind =
   object (self)
     inherit Source.active_source ~name:"input.keyboard" kind
+    inherit Source.no_seek
     method stype = `Infallible
     method is_ready = true
     method remaining = -1

--- a/src/core/synth/keyboard_sdl.ml
+++ b/src/core/synth/keyboard_sdl.ml
@@ -86,6 +86,7 @@ class keyboard ~kind velocity =
   let () = Sdl_utils.init [Sdl.Init.events; Sdl.Init.video] in
   object (self)
     inherit Source.active_source ~name:"input.keyboard.sdl" (Kind.of_kind kind)
+    inherit Source.no_seek
     method stype = `Infallible
     method is_ready = true
     method remaining = -1

--- a/src/core/synth/synth_op.ml
+++ b/src/core/synth/synth_op.ml
@@ -32,6 +32,7 @@ class synth ~kind (synth : Synth.synth) (source : source) chan volume =
     method remaining = source#remaining
     method is_ready = source#is_ready
     method abort_track = source#abort_track
+    method seek = source#seek
 
     method private get_frame buf =
       let offset = AFrame.position buf in

--- a/src/core/tools/producer_consumer.ml
+++ b/src/core/tools/producer_consumer.ml
@@ -78,6 +78,11 @@ class producer ~check_self_sync ~consumers ~name ~kind g =
 
     method stype = if infallible then `Infallible else `Fallible
 
+    method seek len =
+      let len = min (Generator.length g) len in
+      Generator.remove g len;
+      len
+
     method remaining =
       match List.fold_left (fun r p -> min r p#remaining) (-1) consumers with
         | -1 -> -1

--- a/src/core/visualization/midimeter.ml
+++ b/src/core/visualization/midimeter.ml
@@ -31,6 +31,7 @@ class midimeter ~kind source =
     method remaining = source#remaining
     method abort_track = source#abort_track
     method self_sync = source#self_sync
+    method seek = source#seek
 
     method get_frame buf =
       source#get buf;

--- a/src/core/visualization/video_volume.ml
+++ b/src/core/visualization/video_volume.ml
@@ -38,6 +38,7 @@ class visu ~kind source =
     method remaining = source#remaining
     method abort_track = source#abort_track
     method self_sync = source#self_sync
+    method seek = source#seek
 
     (* Ringbuffer for previous values, with its current position. *)
     val mutable vol = [||]


### PR DESCRIPTION
Looks like having `seek` methods optional lead to forgetting to implement it in a lot of places. This should remedy it. Fixes: #2514