### PR TITLE
Generic language types

### DIFF
--- a/src/core/lang.mli
+++ b/src/core/lang.mli
@@ -40,7 +40,7 @@ module Ground : sig
     descr : t -> string;
     to_json : t -> Json.t;
     compare : t -> t -> int;
-    typ : Liquidsoap_lang.Type.ground;
+    typ : (module Liquidsoap_lang.Type.Ground.Custom);
   }
 
   val register : (t -> bool) -> content -> unit

--- a/src/lang/dune
+++ b/src/lang/dune
@@ -88,6 +88,7 @@
   runtime_error
   term
   type
+  type_alias
   type_base
   typechecking
   typing

--- a/src/lang/dune
+++ b/src/lang/dune
@@ -63,6 +63,8 @@
   error
   evaluation
   frame
+  format_type
+  ground_type
   hooks
   json_base
   json_lexer
@@ -86,6 +88,7 @@
   runtime_error
   term
   type
+  type_base
   typechecking
   typing
   unifier

--- a/src/lang/evaluation.ml
+++ b/src/lang/evaluation.ml
@@ -157,7 +157,8 @@ and eval (env : Env.t) tm =
               | Type.Var _ -> `Any
               | Type.Constr { Type.constructor; params = [(_, t)] } -> (
                   match (Type.deref t).Type.descr with
-                    | Type.Ground (Type.Ground.Format fmt) -> `Format fmt
+                    | Type.Custom { Type.typ = Format_type.Type fmt } ->
+                        `Format fmt
                     | Type.Var _ -> `Kind (Content.kind_of_string constructor)
                     | _ -> failwith ("Unhandled content: " ^ Type.to_string tm.t)
                   )

--- a/src/lang/lang.mli
+++ b/src/lang/lang.mli
@@ -38,7 +38,7 @@ module Ground : sig
     descr : t -> string;
     to_json : t -> Json.t;
     compare : t -> t -> int;
-    typ : Type.ground;
+    typ : (module Type.Ground.Custom);
   }
 
   val register : (t -> bool) -> content -> unit

--- a/src/lang/lang_core.ml
+++ b/src/lang/lang_core.ml
@@ -30,12 +30,11 @@ type value = Value.t = { pos : Pos.Option.t; value : in_value }
 
 (** Type construction *)
 
-let ground_t x = Type.make (Type.Ground x)
-let int_t = ground_t Type.Ground.Int
+let int_t = Type.make Type.Ground.int
 let unit_t = Type.make Type.unit
-let float_t = ground_t Type.Ground.Float
-let bool_t = ground_t Type.Ground.Bool
-let string_t = ground_t Type.Ground.String
+let float_t = Type.make Type.Ground.float
+let bool_t = Type.make Type.Ground.bool
+let string_t = Type.make Type.Ground.string
 let tuple_t l = Type.make (Type.Tuple l)
 let product_t a b = tuple_t [a; b]
 
@@ -116,19 +115,19 @@ let val_fun p f = mk (FFI (p, f))
 let val_cst_fun p c =
   let p = List.map (fun (l, d) -> (l, "_", d)) p in
   let f t tm = mk (Fun (p, [], { Term.t; Term.term = tm })) in
-  let mkg t = Type.make (Type.Ground t) in
+  let mkg g = Type.make g in
   (* Convert the value into a term if possible, to enable introspection, mostly
      for printing. *)
   match c.value with
     | Tuple [] -> f (Type.make Type.unit) Term.unit
     | Ground (Int i) ->
-        f (mkg Type.Ground.Int) (Term.Ground (Term.Ground.Int i))
+        f (mkg Type.Ground.int) (Term.Ground (Term.Ground.Int i))
     | Ground (Bool i) ->
-        f (mkg Type.Ground.Bool) (Term.Ground (Term.Ground.Bool i))
+        f (mkg Type.Ground.bool) (Term.Ground (Term.Ground.Bool i))
     | Ground (Float i) ->
-        f (mkg Type.Ground.Float) (Term.Ground (Term.Ground.Float i))
+        f (mkg Type.Ground.float) (Term.Ground (Term.Ground.Float i))
     | Ground (String i) ->
-        f (mkg Type.Ground.String) (Term.Ground (Term.Ground.String i))
+        f (mkg Type.Ground.string) (Term.Ground (Term.Ground.String i))
     | _ -> mk (FFI (p, fun _ -> c))
 
 let metadata m =

--- a/src/lang/lexer.ml
+++ b/src/lang/lexer.ml
@@ -196,6 +196,7 @@ let rec token lexbuf =
     | "let", Plus skipped, "json.stringify", Star skipped, '[' ->
         LETLBRA `Json_stringify
     | "let", Plus skipped, "json.stringify", Plus skipped -> LET `Json_stringify
+    | "let", Plus skipped, "type", Plus skipped -> TYPEDEF
     | "let" -> LET `None
     | "fun" -> FUN
     | '=' -> GETS

--- a/src/lang/parser.mly
+++ b/src/lang/parser.mly
@@ -41,6 +41,7 @@ open Parser_helper
 %token <int option list * int option list> INTERVAL
 %token <string> ENCODER
 %token EOF
+%token TYPEDEF
 %token <Parser_helper.lexer_let_decoration> LET
 %token <Parser_helper.lexer_let_decoration> LETLBRA
 %token BEGIN END GETS TILD QUESTION
@@ -195,6 +196,8 @@ exprss:
 
 (* General expressions. *)
 expr:
+  | TYPEDEF VAR GETS ty              { Type.register_custom_type ~pos:$loc $2 (Type_alias.handler ~name:$2 $4);
+                                       mk ~pos:$loc (Tuple []) }
   | LPAR expr COLON ty RPAR          { mk ~pos:$loc (Cast ($2, $4)) }
   | UMINUS FLOAT                     { mk ~pos:$loc (Ground (Float (-. $2))) }
   | UMINUS INT                       { mk ~pos:$loc (Ground (Int (- $2))) }

--- a/src/lang/parser_helper.ml
+++ b/src/lang/parser_helper.ml
@@ -505,8 +505,8 @@ let mk_ty ~pos name =
     | "source" -> mk_source_ty ~pos "source" []
     | "source_methods" -> !Term.source_methods_t ()
     | name -> (
-        match Type.Ground.resolve_opt name with
-          | Some c -> Type.make c
+        match Type.find_custom_type_opt name with
+          | Some c -> Type.make (Type.Custom c)
           | None ->
               raise
                 (Parse_error (pos, "Unknown type constructor: " ^ name ^ ".")))

--- a/src/lang/parser_helper.ml
+++ b/src/lang/parser_helper.ml
@@ -476,7 +476,11 @@ let mk_source_ty ~pos name args =
 let mk_json_assoc_object_ty ~pos = function
   | ( {
         Type.descr =
-          Type.Tuple [{ Type.descr = Type.Ground Type.Ground.String }; ty];
+          Type.Tuple
+            [
+              { Type.descr = Type.Custom { Type.typ = Type.Ground.String.Type } };
+              ty;
+            ];
       },
       "as",
       "json",
@@ -485,7 +489,7 @@ let mk_json_assoc_object_ty ~pos = function
         make ~pos
           (List
              {
-               t = make ~pos (Tuple [make (Ground Ground.String); ty]);
+               t = make ~pos (Tuple [make Type.Ground.string; ty]);
                json_repr = `Object;
              }))
   | _ -> raise (Parse_error (pos, "Invalid type constructor"))
@@ -494,15 +498,15 @@ let mk_ty ~pos name =
   match name with
     | "_" -> Type.var ()
     | "unit" -> Type.make Type.unit
-    | "bool" -> Type.make (Type.Ground Type.Ground.Bool)
-    | "int" -> Type.make (Type.Ground Type.Ground.Int)
-    | "float" -> Type.make (Type.Ground Type.Ground.Float)
-    | "string" -> Type.make (Type.Ground Type.Ground.String)
+    | "bool" -> Type.make Type.Ground.bool
+    | "int" -> Type.make Type.Ground.int
+    | "float" -> Type.make Type.Ground.float
+    | "string" -> Type.make Type.Ground.string
     | "source" -> mk_source_ty ~pos "source" []
     | "source_methods" -> !Term.source_methods_t ()
     | name -> (
         match Type.Ground.resolve_opt name with
-          | Some g -> Type.make (Type.Ground g)
+          | Some c -> Type.make c
           | None ->
               raise
                 (Parse_error (pos, "Unknown type constructor: " ^ name ^ ".")))

--- a/src/lang/runtime.ml
+++ b/src/lang/runtime.ml
@@ -188,6 +188,10 @@ let throw ?(formatter = Format.std_formatter) lexbuf =
       Format.fprintf formatter
         "Missing arguments in function application: %s.@]@." args;
       raise Error
+  | Type.Exists (pos, typ) ->
+      error_header ~formatter 16 pos;
+      Format.fprintf formatter "Type %s already exists.@]@." typ;
+      raise Error
   | End_of_file -> raise End_of_file
   | e ->
       let bt = Printexc.get_backtrace () in

--- a/src/lang/type.mli
+++ b/src/lang/type.mli
@@ -1,0 +1,122 @@
+(*****************************************************************************
+
+  Liquidsoap, a programmable audio stream generator.
+  Copyright 2003-2022 Savonet team
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details, fully stated in the COPYING
+  file at the root of the liquidsoap distribution.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA
+
+ *****************************************************************************)
+
+val debug : bool ref
+val debug_levels : bool ref
+val debug_variance : bool ref
+
+type constr = Type_base.constr = Num | Ord | Dtools | InternalMedia
+type constraints = constr list
+
+module DS = Type_base.DS
+
+val string_of_constr : constr -> string
+
+type variance = Type_base.variance = Covariant | Contravariant | Invariant
+
+type t = Type_base.t = { pos : Pos.Option.t; descr : descr }
+
+and constructed = Type_base.constructed = {
+  constructor : string;
+  params : (variance * t) list;
+}
+
+and meth = Type_base.meth = {
+  meth : string;
+  scheme : scheme;
+  doc : string;
+  json_name : string option;
+}
+
+and repr_t = Type_base.repr_t = { t : t; json_repr : [ `Object | `Tuple ] }
+
+and descr = Type_base.descr = ..
+
+and invar = Type_base.invar = Free of var | Link of variance * t
+
+and var = Type_base.var = {
+  name : int;
+  mutable level : int;
+  mutable constraints : constraints;
+}
+
+and scheme = var list * t
+
+module Subst = Type_base.Subst
+
+type custom = Type_base.custom = ..
+
+type custom_handler = Type_base.custom_handler = {
+  typ : custom;
+  copy_with : (t -> t) -> Subst.t -> custom -> custom;
+  occur_check : var -> custom -> unit;
+  filter_vars :
+    (var list -> t -> var list) ->
+    var list ->
+    (var -> bool) ->
+    custom ->
+    var list;
+  print : Format.formatter -> custom -> DS.t;
+  satisfies_constraint : (t -> unit) -> t -> custom -> unit;
+  subtype : (t -> t -> unit) -> t -> t -> unit;
+  sup : (t -> t -> t) -> t -> t -> t;
+  to_string : custom -> string;
+}
+
+type descr +=
+  | Custom of custom_handler
+  | Constr of constructed
+  | Getter of t
+  | List of repr_t
+  | Tuple of t list
+  | Nullable of t
+  | Meth of meth * t
+  | Arrow of (bool * string * t) list * t
+  | Var of invar ref
+
+exception NotImplemented
+
+val unit : descr
+
+module Var = Type_base.Var
+module Vars = Type_base.Vars
+
+val make : ?pos:Pos.t -> descr -> t
+val deref : t -> t
+val demeth : t -> t
+val remeth : t -> t -> t
+val invoke : t -> string -> scheme
+val has_meth : t -> string -> bool
+val invokes : t -> string list -> var list * t
+
+val meth :
+  ?pos:Pos.t -> ?json_name:string -> string -> scheme -> ?doc:string -> t -> t
+
+val meths : ?pos:Pos.t -> string list -> scheme -> t -> t
+val split_meths : t -> meth list * t
+val var : ?constraints:constraints -> ?level:int -> ?pos:Pos.t -> unit -> t
+val to_string_fun : (?generalized:var list -> t -> string) ref
+val to_string : ?generalized:var list -> t -> string
+val is_fun : t -> bool
+val is_source : t -> bool
+
+module Ground = Ground_type

--- a/src/lang/type.mli
+++ b/src/lang/type.mli
@@ -62,23 +62,24 @@ and var = Type_base.var = {
 and scheme = var list * t
 
 module Subst = Type_base.Subst
+module R = Type_base.R
 
 type custom = Type_base.custom = ..
 
 type custom_handler = Type_base.custom_handler = {
   typ : custom;
-  copy_with : (t -> t) -> Subst.t -> custom -> custom;
-  occur_check : var -> custom -> unit;
+  copy_with : (t -> t) -> custom -> custom;
+  occur_check : (var -> t -> unit) -> var -> custom -> unit;
   filter_vars :
     (var list -> t -> var list) ->
     var list ->
     (var -> bool) ->
     custom ->
     var list;
-  print : Format.formatter -> custom -> DS.t;
-  satisfies_constraint : (t -> unit) -> t -> custom -> unit;
-  subtype : (t -> t -> unit) -> t -> t -> unit;
-  sup : (t -> t -> t) -> t -> t -> t;
+  repr : (var list -> t -> Repr.t) -> var list -> custom -> Repr.t;
+  satisfies_constraint : (t -> constr -> unit) -> custom -> constr -> unit;
+  subtype : (t -> t -> unit) -> custom -> custom -> unit;
+  sup : (t -> t -> t) -> custom -> custom -> custom;
   to_string : custom -> string;
 }
 
@@ -94,6 +95,7 @@ type descr +=
   | Var of invar ref
 
 exception NotImplemented
+exception Exists of Pos.Option.t * string
 
 val unit : descr
 
@@ -120,3 +122,6 @@ val is_fun : t -> bool
 val is_source : t -> bool
 
 module Ground = Ground_type
+
+val register_custom_type : ?pos:Pos.t -> string -> custom_handler -> unit
+val find_custom_type_opt : string -> custom_handler option

--- a/src/lang/typechecking.ml
+++ b/src/lang/typechecking.ml
@@ -136,7 +136,7 @@ let rec check ?(print_toplevel = false) ~throw ~level ~(env : Typing.env) e =
      to loose it. *)
   let pos = e.t.Type.pos in
   let mk t = Type.make ?pos t in
-  let mkg t = mk (Type.Ground t) in
+  let mkg t = mk t in
   let check_fun ~proto ~env e body =
     let base_check = check ~level ~env in
     let proto_t, env =
@@ -157,7 +157,7 @@ let rec check ?(print_toplevel = false) ~throw ~level ~(env : Typing.env) e =
     e.t >: mk (Type.Arrow (proto_t, body.t))
   in
   match e.term with
-    | Ground g -> e.t >: mkg (Ground.to_type g)
+    | Ground g -> e.t >: mkg (Ground.to_descr g)
     | Encoder f ->
         (* Ensure that we only use well-formed terms. *)
         let rec check_enc (_, p) =

--- a/src/lang/types/format_type.ml
+++ b/src/lang/types/format_type.ml
@@ -1,0 +1,65 @@
+(*****************************************************************************
+
+  Liquidsoap, a programmable audio stream generator.
+  Copyright 2003-2022 Savonet team
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details, fully stated in the COPYING
+  file at the root of the liquidsoap distribution.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA
+
+ *****************************************************************************)
+
+type Type_base.custom += Type of Content.format
+
+let get = function Type c -> c | _ -> assert false
+
+let handler f =
+  {
+    Type_base.typ = Type f;
+    copy_with = (fun _ _ c -> Type (Content.duplicate (get c)));
+    occur_check = (fun _ c -> ignore (get c));
+    filter_vars =
+      (fun _ l _ c ->
+        ignore (get c);
+        l);
+    print =
+      (fun f c ->
+        Format.fprintf f "%s" (Content.string_of_format (get c));
+        Type_base.DS.empty);
+    satisfies_constraint = (fun _ _ c -> ignore (get c));
+    subtype =
+      (fun _ c c' ->
+        match
+          ( (Type_base.deref c).Type_base.descr,
+            (Type_base.deref c').Type_base.descr )
+        with
+          | ( Type_base.Custom { Type.typ = Type f },
+              Type_base.Custom { Type.typ = Type f' } ) ->
+              Content.merge f f'
+          | _ -> assert false);
+    sup =
+      (fun _ c c' ->
+        match
+          ( (Type_base.deref c).Type_base.descr,
+            (Type_base.deref c').Type_base.descr )
+        with
+          | ( Type_base.Custom { Type.typ = Type f },
+              Type_base.Custom { Type.typ = Type f' } ) ->
+              Content.merge f f';
+              c
+          | _ -> assert false);
+    to_string = (fun c -> Content.string_of_format (get c));
+  }
+
+let descr f = Type_base.Custom (handler f)

--- a/src/lang/types/format_type.mli
+++ b/src/lang/types/format_type.mli
@@ -20,5 +20,6 @@
 
  *****************************************************************************)
 
-include Type_base
-module Ground = Ground_type
+type Type_base.custom += Type of Content.format
+
+val descr : Content.format -> Type.descr

--- a/src/lang/types/ground_type.ml
+++ b/src/lang/types/ground_type.ml
@@ -1,0 +1,118 @@
+(*****************************************************************************
+
+  Liquidsoap, a programmable audio stream generator.
+  Copyright 2003-2022 Savonet team
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details, fully stated in the COPYING
+  file at the root of the liquidsoap distribution.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA
+
+ *****************************************************************************)
+
+let types = Hashtbl.create 10
+let resolve_opt t = Hashtbl.find_opt types t
+
+module type Spec = sig
+  type t
+
+  val name : string
+end
+
+module type Custom = sig
+  type Type_base.custom += Type
+
+  val descr : Type_base.descr
+end
+
+module Make (S : Spec) = struct
+  type Type_base.custom += Type
+
+  let get = function Type -> Type | _ -> assert false
+
+  let handler =
+    {
+      Type_base.typ = Type;
+      copy_with = (fun _ _ c -> get c);
+      occur_check = (fun _ c -> ignore (get c));
+      filter_vars =
+        (fun _ l _ c ->
+          ignore (get c);
+          l);
+      print =
+        (fun f c ->
+          ignore (get c);
+          Format.fprintf f "%s" S.name;
+          Type_base.DS.empty);
+      satisfies_constraint = (fun _ _ c -> ignore (get c));
+      subtype =
+        (fun _ c c' ->
+          match
+            ( (Type_base.deref c).Type_base.descr,
+              (Type_base.deref c').Type_base.descr )
+          with
+            | ( Type_base.Custom { Type_base.typ = Type },
+                Type_base.Custom { Type_base.typ = Type } ) ->
+                ()
+            | _ -> assert false);
+      sup =
+        (fun _ c c' ->
+          match
+            ( (Type_base.deref c).Type_base.descr,
+              (Type_base.deref c').Type_base.descr )
+          with
+            | ( Type_base.Custom { Type_base.typ = Type },
+                Type_base.Custom { Type_base.typ = Type } ) ->
+                c
+            | _ -> assert false);
+      to_string =
+        (fun c ->
+          ignore (get c);
+          S.name);
+    }
+
+  let descr = Type_base.Custom handler
+  let () = Hashtbl.add types S.name descr
+end
+
+module Int = Make (struct
+  type t = int
+
+  let name = "int"
+end)
+
+let int = Int.descr
+
+module Float = Make (struct
+  type t = float
+
+  let name = "float"
+end)
+
+let float = Float.descr
+
+module String = Make (struct
+  type t = string
+
+  let name = "string"
+end)
+
+let string = String.descr
+
+module Bool = Make (struct
+  type t = bool
+
+  let name = "bool"
+end)
+
+let bool = Bool.descr

--- a/src/lang/types/ground_type.mli
+++ b/src/lang/types/ground_type.mli
@@ -20,5 +20,32 @@
 
  *****************************************************************************)
 
-include Type_base
-module Ground = Ground_type
+module type Spec = sig
+  type t
+
+  val name : string
+end
+
+module type Custom = sig
+  type Type_base.custom += Type
+
+  val descr : Type_base.descr
+end
+
+module Make (S : Spec) : Custom
+module Int : Custom
+
+val int : Type_base.descr
+
+module Float : Custom
+
+val float : Type_base.descr
+
+module String : Custom
+
+val string : Type_base.descr
+
+module Bool : Custom
+
+val bool : Type_base.descr
+val resolve_opt : string -> Type_base.descr option

--- a/src/lang/types/type_alias.mli
+++ b/src/lang/types/type_alias.mli
@@ -20,32 +20,7 @@
 
  *****************************************************************************)
 
-module type Spec = sig
-  type t
+type alias = { name : string; typ : Type_base.t }
+type Type_base.custom += Type of alias
 
-  val name : string
-end
-
-module type Custom = sig
-  type Type_base.custom += Type
-
-  val descr : Type_base.descr
-end
-
-module Make (S : Spec) : Custom
-module Int : Custom
-
-val int : Type_base.descr
-
-module Float : Custom
-
-val float : Type_base.descr
-
-module String : Custom
-
-val string : Type_base.descr
-
-module Bool : Custom
-
-val bool : Type_base.descr
-val is_ground : Type_base.custom -> bool
+val handler : name:string -> Type_base.t -> Type_base.custom_handler

--- a/src/lang/types/type_base.ml
+++ b/src/lang/types/type_base.ml
@@ -1,0 +1,274 @@
+(*****************************************************************************
+
+  Liquidsoap, a programmable audio stream generator.
+  Copyright 2003-2022 Savonet team
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details, fully stated in the COPYING
+  file at the root of the liquidsoap distribution.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA
+
+ *****************************************************************************)
+
+(** Show debugging information. *)
+let debug = ref (Sys.getenv_opt "LIQUIDSOAP_DEBUG_LANG" <> None)
+
+(** Show variables levels. *)
+let debug_levels = ref false
+
+let debug_variance = ref false
+
+(* Type information comes attached to the AST from the parsing,
+ * with appropriate sharing of the type variables. Then the type inference
+ * performs in-place unification.
+ *
+ * In order to report precise type error messages, we put very dense
+ * parsing location information in the type. Every layer of it can have
+ * a location. Destructive unification introduces links in such a way
+ * that the old location is still accessible.
+ *
+ * The level annotation represents the number of abstractions which surround
+ * the type in the AST -- function arguments and let-in definitions.
+ * It is used to safely generalize types.
+ *
+ * Finally, constraints can be attached to existential (unknown, '_a)
+ * and universal ('a) type variables. *)
+
+(** Type constraints *)
+
+(** Constraint on the types a type variable can be substituted with. *)
+type constr =
+  | Num  (** a number *)
+  | Ord  (** an orderable type *)
+  | Dtools  (** something useable by dtools *)
+  | InternalMedia  (** a media type *)
+
+(** Constraints on a type variable. *)
+type constraints = constr list
+
+(** Sets of type descriptions. *)
+module DS = Set.Make (struct
+  type t = string * constraints
+
+  let compare = compare
+end)
+
+let string_of_constr = function
+  | Num -> "a number type"
+  | Ord -> "an orderable type"
+  | Dtools -> "unit, bool, int, float, string or [string]"
+  | InternalMedia -> "an internal media type (none, pcm, yuva420p or midi)"
+
+(** {2 Types} *)
+
+type variance = Covariant | Contravariant | Invariant
+
+type t = { pos : Pos.Option.t; descr : descr }
+
+(** A type constructor applied to arguments (e.g. source). *)
+and constructed = { constructor : string; params : (variance * t) list }
+
+(** A method. *)
+and meth = {
+  meth : string;  (** name of the method *)
+  scheme : scheme;  (** type sheme *)
+  doc : string;  (** documentation *)
+  json_name : string option;  (** name when represented as JSON *)
+}
+
+and repr_t = { t : t; json_repr : [ `Tuple | `Object ] }
+
+and descr = ..
+
+(** Contents of a variable. *)
+and invar =
+  | Free of var  (** the variable is free *)
+  | Link of variance * t  (** the variable has bee substituted *)
+
+and var = { name : int; mutable level : int; mutable constraints : constraints }
+
+(** A type scheme (i.e. a type with universally quantified variables). *)
+and scheme = var list * t
+
+(** Substitutions. *)
+module Subst = struct
+  module M = Map.Make (struct
+    type t = var
+
+    (* We can compare variables with their indices. *)
+    let compare (v : var) (v' : var) = compare v.name v'.name
+  end)
+
+  type subst = t M.t
+  type t = subst
+
+  let of_list l : t = M.of_seq (List.to_seq l)
+
+  (** Retrieve the value of a variable. *)
+  let value (s : t) (i : var) = M.find i s
+
+  (* let filter f (s : t) = M.filter (fun i t -> f i t) s *)
+
+  (** Whether we have the identity substitution. *)
+  let is_identity (s : t) = M.is_empty s
+end
+
+type custom = ..
+
+type custom_handler = {
+  typ : custom;
+  copy_with : (t -> t) -> Subst.t -> custom -> custom;
+  occur_check : var -> custom -> unit;
+  filter_vars :
+    (var list -> t -> var list) ->
+    var list ->
+    (var -> bool) ->
+    custom ->
+    var list;
+  print : Format.formatter -> custom -> DS.t;
+  satisfies_constraint : (t -> unit) -> t -> custom -> unit;
+  subtype : (t -> t -> unit) -> t -> t -> unit;
+  sup : (t -> t -> t) -> t -> t -> t;
+  to_string : custom -> string;
+}
+
+type descr +=
+  | Custom of custom_handler
+  | Constr of constructed
+  | Getter of t
+  | List of repr_t
+  | Tuple of t list
+  | Nullable of t
+  | Meth of meth * t
+  | Arrow of (bool * string * t) list * t
+  | Var of invar ref
+
+exception NotImplemented
+
+let unit = Tuple []
+
+(** Operations on variables. *)
+module Var = struct
+  type t = var
+
+  (** Compare two variables for equality. This comparison should always be used
+      to compare variables (as opposed to =). *)
+  let eq v v' = v.name = v'.name
+
+  let compare v v' = compare v.name v'.name
+end
+
+(** Sets of variables. *)
+module Vars = struct
+  include Set.Make (Var)
+
+  let add_list l v = add_seq (List.to_seq l) v
+end
+
+(** Create a type from its value. *)
+let make ?pos d = { pos; descr = d }
+
+(** Dereferencing gives you the meaning of a term, going through links created
+    by instantiations. One should (almost) never work on a non-dereferenced
+    type. *)
+let rec deref t =
+  match t.descr with Var { contents = Link (_, t) } -> deref t | _ -> t
+
+(** Remove methods. This function also removes links. *)
+let rec demeth t =
+  let t = deref t in
+  match t.descr with Meth (_, t) -> demeth t | _ -> t
+
+(** Put the methods of the first type around the second type. *)
+let rec remeth t u =
+  let t = deref t in
+  match t.descr with
+    | Meth (m, t) -> { t with descr = Meth (m, remeth t u) }
+    | _ -> u
+
+(** Type of a method in a type. *)
+let rec invoke t l =
+  match (deref t).descr with
+    | Meth (m, _) when m.meth = l -> m.scheme
+    | Meth (_, t) -> invoke t l
+    | _ -> raise Not_found
+
+(** Do we have a method with given label? *)
+let has_meth t l =
+  try
+    ignore (invoke t l);
+    true
+  with Not_found -> false
+
+(** Type of a submethod in a type. *)
+let rec invokes t = function
+  | l :: ll ->
+      let g, t = invoke t l in
+      if ll = [] then (g, t) else invokes t ll
+  | [] -> ([], t)
+
+(** Add a method to a type. *)
+let meth ?pos ?json_name meth scheme ?(doc = "") t =
+  make ?pos (Meth ({ meth; scheme; doc; json_name }, t))
+
+(** Add a submethod to a type. *)
+let rec meths ?pos l v t =
+  match l with
+    | [] -> assert false
+    | [l] -> meth ?pos l v t
+    | l :: ll ->
+        let g, tl = invoke t l in
+        let v = meths ?pos ll v tl in
+        meth ?pos l (g, v) t
+
+(** Split the methods from the type. *)
+let split_meths t =
+  let rec aux hide t =
+    let t = deref t in
+    match t.descr with
+      | Meth (m, t) ->
+          let meth, t = aux (m.meth :: hide) t in
+          let meth = if List.mem m.meth hide then meth else m :: meth in
+          (meth, t)
+      | _ -> ([], t)
+  in
+  aux [] t
+
+(** Create a fresh variable. *)
+let var =
+  let name =
+    let c = ref (-1) in
+    fun () ->
+      incr c;
+      !c
+  in
+  let f ?(constraints = []) ?(level = max_int) ?pos () =
+    let name = name () in
+    make ?pos (Var (ref (Free { name; level; constraints })))
+  in
+  f
+
+let to_string_fun =
+  ref (fun ?(generalized : var list option) _ ->
+      ignore generalized;
+      failwith "Type.to_string not defined yet")
+
+(** String representation of a type. *)
+let to_string ?generalized (t : t) : string = !to_string_fun ?generalized t
+
+let is_fun t = match (demeth t).descr with Arrow _ -> true | _ -> false
+
+let is_source t =
+  match (demeth t).descr with
+    | Constr { constructor = "source"; _ } -> true
+    | _ -> false

--- a/tests/core/meth.ml
+++ b/tests/core/meth.ml
@@ -20,21 +20,15 @@ let () =
 (* Test adding submethods. *)
 let () =
   let print t = Printf.printf "%s\n%!" (Type.to_string t) in
-  let t = Type.make (Type.Ground Type.Ground.Int) in
+  let t = Type.make Type.Ground.int in
   print t;
-  let t = Type.meth "f" ([], Type.make (Type.Ground Type.Ground.Float)) t in
+  let t = Type.meth "f" ([], Type.make Type.Ground.float) t in
   print t;
-  let t = Type.meth "ff" ([], Type.make (Type.Ground Type.Ground.Float)) t in
+  let t = Type.meth "ff" ([], Type.make Type.Ground.float) t in
   print t;
-  let t =
-    Type.meths ["f"; "s"] ([], Type.make (Type.Ground Type.Ground.String)) t
-  in
+  let t = Type.meths ["f"; "s"] ([], Type.make Type.Ground.string) t in
   print t;
-  let t =
-    Type.meths ["f"; "s"; "f'"]
-      ([], Type.make (Type.Ground Type.Ground.Float))
-      t
-  in
+  let t = Type.meths ["f"; "s"; "f'"] ([], Type.make Type.Ground.float) t in
   print t
 
 (* Test subtyping. *)
@@ -43,10 +37,10 @@ let () =
      We do: t = ('a).{ f : int } <: t' = int.{ ff : int, f : float }
      and make sure that this fails. *)
   let t = Type.var () in
-  let t = Type.meth "f" ([], Type.make (Type.Ground Type.Ground.Int)) t in
-  let t' = Type.make (Type.Ground Type.Ground.Int) in
-  let t' = Type.meth "f" ([], Type.make (Type.Ground Type.Ground.Float)) t' in
-  let t' = Type.meth "ff" ([], Type.make (Type.Ground Type.Ground.Int)) t' in
+  let t = Type.meth "f" ([], Type.make Type.Ground.int) t in
+  let t' = Type.make Type.Ground.int in
+  let t' = Type.meth "f" ([], Type.make Type.Ground.float) t' in
+  let t' = Type.meth "ff" ([], Type.make Type.Ground.int) t' in
   assert (
     try
       Typing.(t <: t');

--- a/tests/core/types.ml
+++ b/tests/core/types.ml
@@ -18,31 +18,31 @@ let should_fail t t' =
   with _ -> ()
 
 let () =
-  should_work (var ()).descr (Ground Ground.Bool) (Ground Ground.Bool);
-  should_work (Ground Ground.Bool) (var ()).descr (Ground Ground.Bool);
+  should_work (var ()).descr Ground.bool Ground.bool;
+  should_work Ground.bool (var ()).descr Ground.bool;
 
-  should_fail (Ground Ground.Bool) (Ground Ground.Int);
+  should_fail Ground.bool Ground.int;
   should_fail
-    (List { t = make (Ground Ground.Bool); json_repr = `Tuple })
-    (List { t = make (Ground Ground.Int); json_repr = `Tuple });
+    (List { t = make Ground.bool; json_repr = `Tuple })
+    (List { t = make Ground.int; json_repr = `Tuple });
 
   let mk_meth meth ty t =
     Meth ({ meth; scheme = ([], make ty); doc = ""; json_name = None }, make t)
   in
 
-  let m = mk_meth "aa" (Ground Ground.Int) (Ground Ground.Bool) in
+  let m = mk_meth "aa" Ground.int Ground.bool in
 
-  should_work m (Ground Ground.Bool) (Ground Ground.Bool);
+  should_work m Ground.bool Ground.bool;
 
-  let n = mk_meth "b" (Ground Ground.Bool) m in
+  let n = mk_meth "b" Ground.bool m in
 
   should_work m n m;
 
-  let n = mk_meth "aa" (Ground Ground.Int) (Ground Ground.Int) in
+  let n = mk_meth "aa" Ground.int Ground.int in
 
   should_fail m n;
 
-  let n = mk_meth "aa" (Ground Ground.Bool) (Ground Ground.Bool) in
+  let n = mk_meth "aa" Ground.bool Ground.bool in
 
   should_fail m n;
 

--- a/tests/language/typing.liq
+++ b/tests/language/typing.liq
@@ -172,6 +172,19 @@ def f() =
   (123.{foo=3.14,gni="aabbcc"}:int.{"✨ name ✨" as foo:float,gni:string})
   (():{})
   (():unit.{})
+
+  let type foo = int
+  let x = (123:foo)
+  let y = (x:int)
+  let z = x+y+1
+
+  let type gni = [foo]
+  let x = ([1,2,3]:gni)
+  let y = (x:[int])
+
+  let type gno = { gni: gni, foo: foo}
+  let x = ({gni=[1,2,3], foo=123}:{gni:[int], foo:int})
+  let y = (x:gno)
  
   test.pass()
 end


### PR DESCRIPTION
This PR extracts the operational logic required when working with types to allow modular type definition. This makes it possible to implement new types in isolation from the main operational code.

As an example application, type alias are added to the language, currently limited to ground types:
```ruby
  let type foo = int
  let x = (123:foo)
  let y = (x:int)
  let z = x+y+1

  let type gni = [foo]
  let x = ([1,2,3]:gni)
  let y = (x:[int])

  let type gno = { gni: gni, foo: foo}
  let x = ({gni=[1,2,3], foo=123}:{gni:[int], foo:int})
  let y = (x:gno)
```

Type alias is not fully abstracted, for now custom types are expected to be matched only to their same type, much like with ground types. However, can now have a better granularity on contraints (format type is no longer orderable!) and other specific type properties.

Future use of these changes:
* Private type aliases!
* Domain-specific type for content/kind