### PR TITLE
[2.1] Rename playlist.remaining to playlist.remaining_files.

### DIFF
--- a/libs/playlist.liq
+++ b/libs/playlist.liq
@@ -88,7 +88,7 @@ let stdlib_native = native
 # @param ~timeout Timeout (in sec.) for a single download.
 # @param playlist Playlist.
 # @method reload Reload the playlist with given list of songs.
-# @method remaining Songs remaining to be played.
+# @method remaining_files Songs remaining to be played.
 def playlist.list(~id=null(), ~check_next=null(), ~prefetch=1, ~loop=true,
                   ~mode="normal", ~native=false, ~on_loop={()}, ~on_done={()}, ~max_fail=10, ~on_fail=null(), ~timeout=20., playlist)
   id = string.id.default(default="playlist.list", id)
@@ -218,12 +218,12 @@ def playlist.list(~id=null(), ~check_next=null(), ~prefetch=1, ~loop=true,
   next_fun := next
 
   # List of songs remaining to be played
-  def remaining()
+  def remaining_files()
     !playlist
   end
 
   # Return
-  s.{reload = reload, remaining = remaining}
+  s.{reload = reload, remaining_files = remaining_files}
 end
 
 # Read a playlist or a directory and play all files.
@@ -257,6 +257,7 @@ end
 # @param uri Playlist URI.
 # @method reload Reload the playlist.
 # @method length Length of the of the playlist (the number of songs it contains).
+# @method remaining_files Songs remaining to be played.
 def replaces playlist(
   ~id=null(), ~check_next=null(), ~prefetch=1, ~loop=true, 
   ~mime_type=null(), ~mode="randomize", ~native=false, ~on_reload=(fun (_) -> ()),


### PR DESCRIPTION
We don't want to mask the default remaining method. Fixes #2524.

(cherry picked from commit 6148013bea59b7513563e7bdc5014114868db519)