### PR TITLE
Allow to pass id to replaygain function

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,7 @@ Changed:
   `"liq_fade_in"`, `"liq_cross_duration"` and `"liq_fade_type"` now all reset on
   new tracks. Use `persist_overrides` to revert to previous behavior
   (`persist_override` for `cross`/`crossfade`) (#2488).
+- Added `id` argument to `replaygain` operator (#2537).
 
 Fixed:
 

--- a/src/libs/audio.liq
+++ b/src/libs/audio.liq
@@ -179,9 +179,10 @@ end
 # compute itself the replaygain: you can use either `enable_replaygain_metadata`
 # or the `replaygain:` protocol for this.
 # @category Source / Sound Processing
+# @param ~id Force the value of the source ID.
 # @param ~ebu_r128 Also amplify according to EBU R128 tags.
 # @param s Source to be amplified.
-def replaygain(~ebu_r128=true, s)
+def replaygain(~id=null(), ~ebu_r128=true, s)
   s = insert_metadata(s)
   # Normalize opus gain
   def f(m)
@@ -199,7 +200,7 @@ def replaygain(~ebu_r128=true, s)
     if ebu_r128 then list.map(f, m) else m end
   end
   s = metadata.map(f, s)
-  amplify(override="replaygain_track_gain", 1., s)
+  amplify(id=id, override="replaygain_track_gain", 1., s)
 end
 
 %ifdef soundtouch


### PR DESCRIPTION
## Summary
Add optional labeled argument id, which defaults to null, to function replaygain.
Pass id argument into amplify function call.
Fixes #2537