### PR TITLE
[2.0] Allow to pass id to replaygain function

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,9 @@ branch for all new liquidsoap work.
 2.0.8 (unreleased)
 =====
 
+Changed:
+- Added `id` argument to `replaygain` operator (#2537).
+
 Fixed:
 - Fixed `list.shuffle` which was used to randomize playlists in `playlist`
   operator (#2507, #2500).

--- a/libs/audio.liq
+++ b/libs/audio.liq
@@ -179,9 +179,10 @@ end
 # compute itself the replaygain: you can use either `enable_replaygain_metadata`
 # or the `replaygain:` protocol for this.
 # @category Source / Sound Processing
+# @param ~id Force the value of the source ID.
 # @param s Source to be amplified.
-def replaygain(s)
-  amplify(override="replaygain_track_gain", 1., s)
+def replaygain(~id=null(), s)
+  amplify(id=id, override="replaygain_track_gain", 1., s)
 end
 
 %ifdef soundtouch


### PR DESCRIPTION
## Summary
Backport of #2539

(cherry picked from commit 2d2e486f8b66e96dd1dc338066c3de468e5a6e36)