### PR TITLE
Parametrize constraints.

### DIFF
--- a/src/lang/builtins_bool.ml
+++ b/src/lang/builtins_bool.ml
@@ -21,7 +21,7 @@
  *****************************************************************************)
 
 let () =
-  let t = Lang.univ_t ~constraints:[Type.Ord] () in
+  let t = Lang.univ_t ~constraints:[Type.ord_constr] () in
   let register_op name op =
     Lang.add_builtin name ~category:`Bool
       ~descr:"Comparison of comparable values."

--- a/src/lang/builtins_getter.ml
+++ b/src/lang/builtins_getter.ml
@@ -80,7 +80,7 @@ let () =
         | _ -> Lang.apply f [("", x)])
 
 let () =
-  let a = Lang.univ_t ~constraints:[Type.Ord] () in
+  let a = Lang.univ_t ~constraints:[Type.ord_constr] () in
   let b = Lang.univ_t () in
   Lang.add_builtin ~category:`Liquidsoap "getter.map.memoize"
     ~descr:

--- a/src/lang/builtins_list.ml
+++ b/src/lang/builtins_list.ml
@@ -23,7 +23,7 @@
 let () = Lang.add_module "list"
 
 let () =
-  let a = Lang.univ_t ~constraints:[Type.Ord] () in
+  let a = Lang.univ_t ~constraints:[Type.ord_constr] () in
   Lang.add_builtin "_[_]" ~category:`List
     ~descr:
       "l[k] returns the first v such that (k,v) is in the list l (or \"\" if \

--- a/src/lang/builtins_math.ml
+++ b/src/lang/builtins_math.ml
@@ -50,7 +50,7 @@ let () =
   add tanh "tanh" "Hyperbolic tangent. Argument is in radians."
 
 let () =
-  let t = Lang.univ_t ~constraints:[Type.Num] () in
+  let t = Lang.univ_t ~constraints:[Type.num_constr] () in
   Lang.add_builtin "~-" ~category:`Math
     ~descr:"Returns the opposite of its argument." [("", t, None, None)] t
     (fun p ->
@@ -59,7 +59,7 @@ let () =
         | `Float i -> Lang.float ~-.i)
 
 let () =
-  let t = Lang.univ_t ~constraints:[Type.Num] () in
+  let t = Lang.univ_t ~constraints:[Type.num_constr] () in
   Lang.add_builtin "abs" ~category:`Math ~descr:"Absolute value."
     [("", t, None, None)] t (fun p ->
       match Lang.to_num (List.assoc "" p) with
@@ -67,7 +67,7 @@ let () =
         | `Float i -> Lang.float (abs_float i))
 
 let () =
-  let t = Lang.univ_t ~constraints:[Type.Num] () in
+  let t = Lang.univ_t ~constraints:[Type.num_constr] () in
   let register_op doc name op_int op_float =
     Lang.add_builtin name ~category:`Math
       ~descr:(Printf.sprintf "%s of numbers." doc)
@@ -90,7 +90,7 @@ let () =
   register_op "Remainder of division" "mod" ( mod ) mod_float
 
 let () =
-  let t = Lang.univ_t ~constraints:[Type.Num] () in
+  let t = Lang.univ_t ~constraints:[Type.num_constr] () in
   Lang.add_builtin "float" ~category:`Math ~descr:"Convert a number to a float."
     [("", t, None, None)] Lang.float_t (fun p ->
       let x = List.assoc "" p |> Lang.to_num in

--- a/src/lang/parser_helper.ml
+++ b/src/lang/parser_helper.ml
@@ -436,7 +436,8 @@ let mk_kind ~pos (kind, params) =
       match params with
         | [] -> Term.kind_t (`Kind k)
         | [("", "any")] -> Type.var ()
-        | [("", "internal")] -> Type.var ~constraints:[Type.InternalMedia] ()
+        | [("", "internal")] ->
+            Type.var ~constraints:[Format_type.internal_media] ()
         | param :: params ->
             let mk_format (label, value) = Content.parse_param k label value in
             let f = mk_format param in

--- a/src/lang/repr.ml
+++ b/src/lang/repr.ml
@@ -356,10 +356,10 @@ let print f t =
         let vars = print ~par:false vars t in
         Format.fprintf f "}";
         vars
-    | `EVar (a, [InternalMedia]) ->
+    | `EVar (a, [c]) when c#t = Format_type.InternalMedia ->
         Format.fprintf f "?internal(%s)" a;
         vars
-    | `UVar (a, [InternalMedia]) ->
+    | `UVar (a, [c]) when c#t = Format_type.InternalMedia ->
         Format.fprintf f "internal(%s)" a;
         vars
     | `EVar (name, c) | `UVar (name, c) ->

--- a/src/lang/term.ml
+++ b/src/lang/term.ml
@@ -94,7 +94,7 @@ let kind_t ?pos kind =
   let mk_format f = Type.make ?pos (Format_type.descr f) in
   match kind with
     | `Any -> evar ()
-    | `Internal -> evar ~constraints:[Type.InternalMedia] ()
+    | `Internal -> evar ~constraints:[Format_type.internal_media] ()
     | `Kind k ->
         Type.make ?pos
           (Type.Constr

--- a/src/lang/type.ml
+++ b/src/lang/type.ml
@@ -22,3 +22,50 @@
 
 include Type_base
 module Ground = Ground_type
+
+let num_constr : constr =
+  object (self)
+    method t = Num
+    method descr = "a number type"
+
+    method satisfied b =
+      let b = demeth b in
+      match b.descr with
+        | Custom { typ = Ground.Int.Type } | Custom { typ = Ground.Float.Type }
+          ->
+            ()
+        | Custom { typ; satisfies_constraint } -> satisfies_constraint typ self
+        | Var { contents = Free v } ->
+            if not (List.exists (fun c -> c#t = Num) v.constraints) then
+              v.constraints <- self :: v.constraints
+        | _ -> raise Unsatisfied_constraint
+  end
+
+let ord_constr : constr =
+  object (self)
+    method t = Ord
+    method descr = "an orderable type"
+
+    method satisfied b =
+      let rec check b =
+        let m, b = split_meths b in
+        match b.descr with
+          | Custom { typ; satisfies_constraint } ->
+              satisfies_constraint typ self
+          | Var { contents = Free v } ->
+              if not (List.exists (fun c -> c#t = Ord) v.constraints) then
+                v.constraints <- self :: v.constraints
+          | Tuple [] ->
+              (* For records, we want to ensure that all fields are ordered. *)
+              List.iter
+                (fun { scheme = v, a } ->
+                  if v <> [] then raise Unsatisfied_constraint;
+                  check a)
+                m
+          | Tuple l -> List.iter (fun b -> check b) l
+          | List { t = b } -> check b
+          | Nullable b -> check b
+          | _ -> raise Unsatisfied_constraint
+      in
+      check b
+  end

--- a/src/lang/type.mli
+++ b/src/lang/type.mli
@@ -24,16 +24,15 @@ val debug : bool ref
 val debug_levels : bool ref
 val debug_variance : bool ref
 
-type constr = Type_base.constr = Num | Ord | Dtools | InternalMedia
-type constraints = constr list
-
-module DS = Type_base.DS
-
-val string_of_constr : constr -> string
-
 type variance = Type_base.variance = Covariant | Contravariant | Invariant
 
 type t = Type_base.t = { pos : Pos.Option.t; descr : descr }
+
+and constr_t = Type_base.constr_t = ..
+
+and constr = < t : constr_t ; descr : string ; satisfied : t -> unit >
+
+and constraints = constr list
 
 and constructed = Type_base.constructed = {
   constructor : string;
@@ -61,6 +60,15 @@ and var = Type_base.var = {
 
 and scheme = var list * t
 
+module DS = Type_base.DS
+
+val string_of_constr : constr -> string
+
+type constr_t += Num | Ord
+
+val num_constr : constr
+val ord_constr : constr
+
 module Subst = Type_base.Subst
 module R = Type_base.R
 
@@ -72,7 +80,7 @@ type custom_handler = Type_base.custom_handler = {
   occur_check : (var -> t -> unit) -> var -> custom -> unit;
   filter_vars : (var list -> t -> var list) -> var list -> custom -> var list;
   repr : (var list -> t -> Repr.t) -> var list -> custom -> Repr.t;
-  satisfies_constraint : (t -> constr -> unit) -> t -> constr -> unit;
+  satisfies_constraint : custom -> constr -> unit;
   subtype : (t -> t -> unit) -> custom -> custom -> unit;
   sup : (t -> t -> t) -> custom -> custom -> custom;
   to_string : custom -> string;
@@ -91,7 +99,7 @@ type descr +=
 
 exception NotImplemented
 exception Exists of Pos.Option.t * string
-exception Unsatisfied_constraint of constr * t
+exception Unsatisfied_constraint
 
 val unit : descr
 

--- a/src/lang/types/format_type.mli
+++ b/src/lang/types/format_type.mli
@@ -21,5 +21,7 @@
  *****************************************************************************)
 
 type Type_base.custom += Type of Content.format
+type Type_base.constr_t += InternalMedia
 
-val descr : Content.format -> Type.descr
+val descr : Content.format -> Type_base.descr
+val internal_media : Type_base.constr

--- a/src/lang/types/ground_type.ml
+++ b/src/lang/types/ground_type.ml
@@ -54,9 +54,10 @@ module Make (S : Spec) = struct
           ignore (get c);
           `Constr (S.name, []));
       satisfies_constraint =
-        (fun _ t -> function
-          | Ord -> ()
-          | c -> raise (Type_base.Unsatisfied_constraint (c, t)));
+        (fun _ constr ->
+          match constr#t with
+            | Type_base.Ord -> ()
+            | _ -> raise Type_base.Unsatisfied_constraint);
       subtype = (fun _ c c' -> assert (get c = get c'));
       sup =
         (fun _ c c' ->

--- a/src/lang/types/type_alias.ml
+++ b/src/lang/types/type_alias.ml
@@ -45,13 +45,8 @@ let handler ~name typ =
                 ] )
         | _ -> assert false);
     satisfies_constraint =
-      (fun check t cons ->
-        let t =
-          match t.Type_base.descr with
-            | Type_base.Custom { Type_base.typ = Type { typ } } -> typ
-            | _ -> assert false
-        in
-        check t cons);
+      (fun t constr ->
+        match t with Type { typ } -> constr#satisfied typ | _ -> assert false);
     subtype = (fun _ _ _ -> assert false);
     sup = (fun _ _ _ -> assert false);
     to_string = (fun c -> Type_base.to_string (get c));


### PR DESCRIPTION
This PR makes the type constraint modular, allowing to define them at separate places.

This allows specific constraints to be defined and/or colocated with specific types and/or use, for instance `InternalMedia` with the format type and `Dtools` with the settings builtin.

There are two main ways to define constraint satisfaction:
* Through the constraint's `satisfied` method itself. This method is required and should account for all structured types, tuples, lists, nullable etc.
* Through the `satisfies_constraint` in custom type handlers. This is intended for leaf types, when the constraint `satisfied` reaches out a custom type.

The reasons for these are:
* There's a mutual dependency between defining custom types and custom constraints. Who comes first? Format type or `InternalMedia`? 🐓 or 🥚? This makes it easier to split.
* Some constraints need specific subset of types, for instance `Num` should be only for `Int` and `Float`. For these, the decision is better left at the constraint level.
* Some constraint satisfaction, however, are better defined at the type level so that the top-level constraint does not have to account for all existing and future custom types. This makes it possible to drop a new custom type without having to change all constraint `satisfied` method. One such example is `Ord`.