### PR TITLE
Merge format and kind custom types.

### DIFF
--- a/src/core/types/format_type.ml
+++ b/src/core/types/format_type.ml
@@ -20,29 +20,96 @@
 
  *****************************************************************************)
 
-type Type.custom += Type of Content_base.format
+type Type.custom += Kind of (Content_base.kind * Type.t)
+type Type.custom += Format of Content_base.format
 type Type.constr_t += InternalMedia
+type descr = [ `Format of Content_base.format | `Kind of Content_base.kind ]
 
-let get = function Type c -> c | _ -> assert false
+let get_format = function Format f -> f | _ -> assert false
+let get_kind = function Kind k -> k | _ -> assert false
 
-let handler f =
+let format_handler f =
   {
-    Type.typ = Type f;
-    copy_with = (fun _ c -> Type (Content_base.duplicate (get c)));
-    occur_check = (fun _ _ c -> ignore (get c));
+    Type.typ = Format f;
+    copy_with = (fun _ f -> Format (Content_base.duplicate (get_format f)));
+    occur_check = (fun _ _ f -> ignore (get_format f));
     filter_vars =
-      (fun _ l c ->
-        ignore (get c);
+      (fun _ l f ->
+        ignore (get_format f);
         l);
-    repr = (fun _ _ c -> `Constr (Content_base.string_of_format (get c), []));
+    repr = (fun _ _ _ -> assert false);
     satisfies_constraint = (fun _ _ -> raise Type.Unsatisfied_constraint);
-    subtype = (fun _ c c' -> Content_base.merge (get c) (get c'));
+    subtype = (fun _ f f' -> Content_base.merge (get_format f) (get_format f'));
     sup =
-      (fun _ c c' ->
-        Content_base.merge (get c) (get c');
-        c);
-    to_string = (fun c -> Content_base.string_of_format (get c));
+      (fun _ f f' ->
+        Content_base.merge (get_format f) (get_format f');
+        f);
+    to_string = (fun f -> Content_base.string_of_format (get_format f));
   }
+
+let format_descr f = Type.Custom (format_handler f)
+
+let string_of_kind (k, ty) =
+  match (Type.deref ty).Type.descr with
+    | Type.(Custom { typ = Format f }) -> Content.string_of_format f
+    | _ ->
+        Printf.sprintf "%s(%s)"
+          (Content_base.string_of_kind k)
+          (Type.to_string ty)
+
+let repr_of_kind repr l (k, ty) =
+  match (Type.deref ty).Type.descr with
+    | Type.(Custom { typ = Format f }) ->
+        `Constr (Content.string_of_format f, [])
+    | _ -> `Constr (Content_base.string_of_kind k, [(Type.Covariant, repr l ty)])
+
+let kind_handler k =
+  {
+    Type.typ = Kind k;
+    copy_with =
+      (fun copy_with k ->
+        let k, ty = get_kind k in
+        Kind (k, copy_with ty));
+    occur_check =
+      (fun occur_check vars k ->
+        let _, ty = get_kind k in
+        occur_check vars ty);
+    filter_vars =
+      (fun filter_vars l k ->
+        let _, ty = get_kind k in
+        filter_vars l ty);
+    repr = (fun repr l k -> repr_of_kind repr l (get_kind k));
+    satisfies_constraint = (fun _ _ -> raise Type.Unsatisfied_constraint);
+    subtype =
+      (fun subtype k k' ->
+        let k, t = get_kind k in
+        let k', t' = get_kind k' in
+        assert (k = k');
+        subtype t t');
+    sup =
+      (fun sup k k' ->
+        let k, t = get_kind k in
+        let k', t' = get_kind k' in
+        assert (k = k');
+        Kind (k, sup t t'));
+    to_string = (fun k -> string_of_kind (get_kind k));
+  }
+
+let descr descr =
+  let k =
+    match descr with
+      | `Format f -> (Content.kind f, Type.make (format_descr f))
+      | `Kind k -> (k, Liquidsoap_lang.Lang.univ_t ())
+  in
+  Type.Custom (kind_handler k)
+
+let rec content_type ~default ty =
+  match (Type.deref ty).Type.descr with
+    | Type.Custom { Type.typ = Kind (k, ty) } ->
+        content_type ~default:(fun () -> Content_base.default_format k) ty
+    | Type.Custom { Type.typ = Format f } -> f
+    | Type.Var _ -> default ()
+    | _ -> assert false
 
 let internal_media : Type.constr =
   object (self)
@@ -50,15 +117,14 @@ let internal_media : Type.constr =
     method descr = "an internal media type (none, pcm, yuva420p or midi)"
 
     method satisfied b =
-      let is_internal name =
-        try
-          let kind = Content_base.kind_of_string name in
-          Content_base.is_internal_kind kind
-        with Content_base.Invalid -> false
-      in
       let b = Type.demeth b in
       match (Type.deref b).Type.descr with
-        | Type.Constr { constructor } when is_internal constructor -> ()
+        | Type.Custom { Type.typ = Kind (k, _) }
+          when Content_base.is_internal_kind k ->
+            ()
+        | Type.Custom { Type.typ = Format f }
+          when Content_base.is_internal_format f ->
+            ()
         | Type.Custom { Type.typ; satisfies_constraint } ->
             satisfies_constraint typ self
         | Type.Var { contents = Type.Free v } ->
@@ -68,5 +134,3 @@ let internal_media : Type.constr =
             then v.Type.constraints <- self :: v.Type.constraints
         | _ -> raise Type.Unsatisfied_constraint
   end
-
-let descr f = Type.Custom (handler f)

--- a/src/core/types/format_type.mli
+++ b/src/core/types/format_type.mli
@@ -20,8 +20,8 @@
 
  *****************************************************************************)
 
-type Type.custom += Type of Content.format
-type Type.constr_t += InternalMedia
+type descr = [ `Format of Content_base.format | `Kind of Content_base.kind ]
 
-val descr : Content.format -> Type.descr
+val descr : descr -> Type.descr
 val internal_media : Type.constr
+val content_type : default:(unit -> Content.format) -> Type.t -> Content.format


### PR DESCRIPTION
This PR merges the support for kind types as frame type into the format custom type.

Previously, kind types was handled through the `Type.Constr` type construction with this has some drawbacks, in particular when printing types and when trying to create abstract type APIs for frame type.

With this PR, format type becomes a sub-type of kind types, with kind types being:
```
Content.kind, 'a
```
Where `'a` is either a universal or a `Content.format`