### PR TITLE
Cleanup ID3v2 text parsing

### DIFF
--- a/src/metadata/examples/meta.ml
+++ b/src/metadata/examples/meta.ml
@@ -24,6 +24,6 @@ let () =
       List.iter
         (fun (k, v) ->
           let v = if k = "APIC" || k = "PIC" then "<redacted>" else v in
-          Printf.printf "- %s: %s\n%!" k v)
+          Printf.printf "- %s: %S\n%!" k v)
         m)
     !fname

--- a/src/metadata/metadataCharEncoding.ml
+++ b/src/metadata/metadataCharEncoding.ml
@@ -3,5 +3,7 @@ module C = CamomileLibraryDefault.Camomile.CharEncoding
 let iso8859 = C.of_name "ISO-8859-1"
 let utf8 = C.utf8
 let utf16 = C.utf16
+let utf16le = C.utf16le
+let utf16be = C.utf16be
 let auto = C.automatic "auto" [iso8859; utf8; utf16] utf8
 let convert in_enc out_enc s = C.recode_string ~in_enc ~out_enc s

--- a/src/metadata/metadataID3v2.ml
+++ b/src/metadata/metadataID3v2.ml
@@ -19,12 +19,41 @@ let read_size_v2 f =
   let s2 = int_of_char s.[2] in
   (s0 lsl 16) + (s1 lsl 8) + s2
 
-let recode enc =
-  if enc = 0 then CharEncoding.convert CharEncoding.iso8859 CharEncoding.utf8
-  else if enc = 1 || enc = 2 then
-    CharEncoding.convert CharEncoding.utf16 CharEncoding.utf8
-  else if enc = 3 then fun s -> s
-  else fun s -> s
+let rec trim_eos ?(from = 0) enc s =
+  match (enc, String.index_from_opt s from '\000') with
+    | 0, Some n -> String.sub s 0 n
+    | (1, Some n | 2, Some n | 3, Some n)
+      when String.length s > n + 1 && s.[n + 1] = '\000' ->
+        String.sub s 0 n
+    | 1, Some n | 2, Some n | 3, Some n -> trim_eos ~from:(n + 1) enc s
+    (* Probably invalid string *)
+    | _ -> s
+
+let recode = function
+  | 0 -> CharEncoding.convert CharEncoding.iso8859 CharEncoding.utf8
+  | 1 -> (
+      fun s ->
+        match String.length s with
+          (* Probably invalid string *)
+          | n when n < 2 -> s
+          | n -> (
+              match String.sub s 0 2 with
+                | "\255\246" ->
+                    CharEncoding.convert CharEncoding.utf16le CharEncoding.utf8
+                      (String.sub s 2 (n - 2))
+                | "\246\255" ->
+                    CharEncoding.convert CharEncoding.utf16be CharEncoding.utf8
+                      (String.sub s 2 (n - 2))
+                (* Probably invalid string *)
+                | _ ->
+                    CharEncoding.convert CharEncoding.utf16 CharEncoding.utf8 s)
+      )
+  | 2 -> CharEncoding.convert CharEncoding.utf16 CharEncoding.utf8
+  | 3 -> fun s -> s
+  (* Invalid encoding. *)
+  | _ -> fun s -> s
+
+let recode encoding s = recode encoding (trim_eos encoding s)
 
 let normalize_id = function
   | "COMM" -> "comment"
@@ -94,33 +123,12 @@ let parse f : metadata =
             | Some flags -> int_of_char flags.[1] land 0b01000000 <> 0
         in
         if compressed || encrypted then raise Exit;
-        if id.[0] = 'T' then (
+        let len = String.length data in
+        if id.[0] = 'T' && id <> "TXXX" && len >= 1 then (
           let encoding = int_of_char data.[0] in
           let recode = recode encoding in
-          let start, len =
-            match encoding with
-              | 0x00 (* ISO-8859-1 *) | 0x03 (* UTF8 *) ->
-                  if data.[size - 1] = '\000' then (1, size - 2)
-                  else (1, size - 1)
-              | 0x01 (* 16-bit unicode 2.0 *) | 0x02 (* UTF-16BE *) ->
-                  if
-                    size >= 2
-                    && data.[size - 2] = '\000'
-                    && data.[size - 1] = '\000'
-                  then (1, size - 3)
-                  else (1, size - 1)
-              | _ -> (0, size)
-          in
-          let text = String.sub data start len in
-          let text = recode text in
-          let id, text =
-            if id = "TXXX" && String.contains text '\000' then (
-              let n = String.index text '\000' in
-              ( String.sub text 0 n,
-                String.sub text (n + 1) (String.length text - (n + 1)) ))
-            else (id, text)
-          in
-          tags := (normalize_id id, text) :: !tags)
+          tags :=
+            (normalize_id id, recode (String.sub data 1 (len - 1))) :: !tags)
         else tags := (normalize_id id, data) :: !tags)
     with Exit -> ()
   done;

--- a/src/metadata/test/dune
+++ b/src/metadata/test/dune
@@ -1,0 +1,8 @@
+(executable
+ (name test)
+ (libraries metadata))
+
+(rule
+ (alias runtest)
+ (action
+  (run ./test.exe)))

--- a/src/metadata/test/test.ml
+++ b/src/metadata/test/test.ml
@@ -1,0 +1,2 @@
+let () =
+  assert (Metadata.ID3v2.trim_eos 2 "\000ab\000de\000\000" = "\000ab\000de")


### PR DESCRIPTION
Cleanup up internal `ID3v2` test parsing by following the [spec](https://id3.org/id3v2.3.0#Text_information_frames) more closely:
* Encoding type `2` should begin with BOM, we use it to explicitly specify `utf16le` or `utf16be`. Camomile seems to support detecting it already but this makes the code more isomorphic with the spec thus easier to read
* Rewrite end of string detection to match the first termination symbol
* Exclude `TXXX` string from all text frame processing

This should hopefully fix #2453