### PR TITLE
Use atomic for ref.

### DIFF
--- a/src/core/lang.mli
+++ b/src/core/lang.mli
@@ -62,7 +62,7 @@ and in_value = Liquidsoap_lang.Value.in_value =
   | Tuple of value list
   | Null
   | Meth of string * value * value
-  | Ref of value ref
+  | Ref of value Atomic.t
   | Fun of
       (string * string * value option) list * lazy_env * Liquidsoap_lang.Term.t
   (* A function with given arguments (argument label, argument variable, default
@@ -184,7 +184,7 @@ val to_valued_option : (value -> 'a) -> value -> 'a option
 val to_default_option : default:'a -> (value -> 'a) -> value -> 'a
 val to_product : value -> value * value
 val to_tuple : value -> value list
-val to_ref : value -> value ref
+val to_ref : value -> value Atomic.t
 val to_metadata_list : value -> (string * string) list
 val to_metadata : value -> Frame.metadata
 val to_string_list : value -> string list
@@ -249,7 +249,7 @@ val product : value -> value -> value
 val tuple : value list -> value
 val meth : value -> (string * value) list -> value
 val record : (string * value) list -> value
-val reference : value ref -> value
+val reference : value Atomic.t -> value
 
 (** Build a function from an OCaml function. Items in the prototype indicate
     the label and optional values. *)

--- a/src/core/lang_source.ml
+++ b/src/core/lang_source.ml
@@ -400,7 +400,7 @@ let iter_sources ?on_reference ~static_analysis_failed f v =
                     | Ground _ | Null -> false
                     | List l -> List.exists aux l
                     | Tuple l -> List.exists aux l
-                    | Ref r -> aux !r
+                    | Ref r -> aux (Atomic.get r)
                     | Fun _ | FFI _ -> true
                     | Meth (_, v, t) -> aux v || aux t
                 in

--- a/src/lang/builtins_ref.ml
+++ b/src/lang/builtins_ref.ml
@@ -26,7 +26,7 @@ let () =
     ~descr:"Create a reference, i.e. a value which can be modified."
     [("", a, None, None)] (Lang.ref_t a) (fun p ->
       let x = List.assoc "" p in
-      Lang.reference (ref x))
+      Lang.reference (Atomic.make x))
 
 let () =
   let a = Lang.univ_t () in
@@ -36,7 +36,7 @@ let () =
     a
     (fun p ->
       let r = Lang.to_ref (List.assoc "" p) in
-      !r)
+      Atomic.get r)
 
 let () =
   let a = Lang.univ_t () in
@@ -47,5 +47,5 @@ let () =
     (fun p ->
       let r = Lang.to_ref (Lang.assoc "" 1 p) in
       let v = Lang.assoc "" 2 p in
-      r := v;
+      Atomic.set r v;
       Lang.unit)

--- a/src/lang/lang.mli
+++ b/src/lang/lang.mli
@@ -57,7 +57,7 @@ and in_value = Value.in_value =
   | Tuple of value list
   | Null
   | Meth of string * value * value
-  | Ref of value ref
+  | Ref of value Atomic.t
   | Fun of (string * string * value option) list * lazy_env * Term.t
   (* A function with given arguments (argument label, argument variable, default
      value), closure and value. *)
@@ -122,7 +122,7 @@ val to_valued_option : (value -> 'a) -> value -> 'a option
 val to_default_option : default:'a -> (value -> 'a) -> value -> 'a
 val to_product : value -> value * value
 val to_tuple : value -> value list
-val to_ref : value -> value ref
+val to_ref : value -> value Atomic.t
 val to_string_list : value -> string list
 val to_int_list : value -> int list
 val to_fun : value -> (string * value) list -> value
@@ -173,7 +173,7 @@ val product : value -> value -> value
 val tuple : value list -> value
 val meth : value -> (string * value) list -> value
 val record : (string * value) list -> value
-val reference : value ref -> value
+val reference : value Atomic.t -> value
 
 (** Build a function from an OCaml function. Items in the prototype indicate
     the label and optional values. *)

--- a/src/lang/value.ml
+++ b/src/lang/value.ml
@@ -41,7 +41,7 @@ and in_value =
      value than a constructor here. However, I am keeping as is for now because
      implementation is safer this way. *)
   | Meth of string * t * t
-  | Ref of t ref
+  | Ref of t Atomic.t
   (* Function with given list of argument name, argument variable and default
      value, the (relevant part of the) closure, and the body. *)
   | Fun of (string * string * t option) list * lazy_env * Term.t
@@ -59,7 +59,7 @@ let rec to_string v =
   match v.value with
     | Ground g -> Ground.to_string g
     | List l -> "[" ^ String.concat ", " (List.map to_string l) ^ "]"
-    | Ref a -> Printf.sprintf "ref(%s)" (to_string !a)
+    | Ref a -> Printf.sprintf "ref(%s)" (to_string (Atomic.get a))
     | Tuple l -> "(" ^ String.concat ", " (List.map to_string l) ^ ")"
     | Null -> "null"
     | Meth (l, v, e) when Lazy.force Term.debug ->

--- a/src/libs/deprecations.liq
+++ b/src/libs/deprecations.liq
@@ -55,13 +55,6 @@ def exec_at(~freq=1., ~pred, f)
   thread.when(every=freq, pred, f)
 end
 
-# Deprecated: this function has been replaced by `thread.mutexify`.
-# @flag deprecated
-def mutexify(f)
-  deprecated("mutexify", "thread.mutexify")
-  thread.mutexify(f)
-end
-
 # Deprecated: this function has been replaced by `file.which`.
 # @flag deprecated
 def which(f)


### PR DESCRIPTION
This PR swaps our implementation of `ref` to use the new `Atomic` API which helps remove concurrency issues when running liquidsoap code inside a duppy task via `thread.run`.

It also removes `thread.mutexify` which becomes almost outdated. Technically, reads might have concurrency issues but this should be rare and will also be fixed with OCaml 5. It is not providing a backward compatible deprecation as this function was pretty arcane and the replacement solution is simple, just remove it 😅