### PR TITLE
Add nullable default to conversion functions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -49,6 +49,8 @@ Changed:
 - Added `--list-functions-json` option.
 - Removed built-in use of `strftime` conversions in output filenames, replaced
   by an explicit call to `time.string` (#2593)
+- Added nullable default to `{int,float,bool}_of_string` conversion functions, raise
+  an exception if conversion fails and no default is given.
 
 Fixed:
 

--- a/src/lang/dune
+++ b/src/lang/dune
@@ -42,7 +42,7 @@
  (public_name liquidsoap-lang)
  (library_flags -linkall)
  (preprocess
-  (pps sedlex.ppx))
+  (pps sedlex.ppx ppx_string))
  (libraries dune-site str unix menhirLib)
  (modules
   build_config

--- a/src/libs/audio.liq
+++ b/src/libs/audio.liq
@@ -326,7 +326,7 @@ def mix(~id=null(), ~register_server_commands=true, sources) =
      server.register(namespace=source.id(s), description="Set volume for a given source.",
                      usage="volume <source nb> <vol%>", "volume", fun (v) -> begin
                          try
-                           let [i, v] = string.split(separator=" ", v)
+                           let [i, v] = r/\s/.split(v)
                            input = list.nth(inputs, int_of_string(i))
                            input.set_volume(float_of_string(v))
                            status(input)
@@ -337,7 +337,7 @@ def mix(~id=null(), ~register_server_commands=true, sources) =
      server.register(namespace=source.id(s), description="Enable/disable a source.",
                      usage="select <source nb> <true|false>", "select", fun (arg) -> begin
                          try
-                           let [i, b] = string.split(separator=" ", arg)
+                           let [i, b] = r/\s/.split(arg)
                            input = list.nth(inputs, int_of_string(i))
                            input.set_selected(b == "true")
                            status(input)
@@ -348,7 +348,7 @@ def mix(~id=null(), ~register_server_commands=true, sources) =
      server.register(namespace=source.id(s), description="Enable/disable automatic stop at the end of track.",
                      usage="single <source nb> <true|false>", "single", fun (arg) -> begin
                          try
-                           let [i, b] = string.split(separator=" ", arg)
+                           let [i, b] = r/\s/.split(arg)
                            input = list.nth(inputs, int_of_string(i))
                            input.set_single(b == "true")
                            status(input)

--- a/src/libs/string.liq
+++ b/src/libs/string.liq
@@ -78,7 +78,12 @@ end
 # Test whether a string is a valid integer.
 # @category String
 def string.is_int(s)
-  string.match(pattern="^\\d+$", s)
+  try
+    ignore(int_of_string(s))
+    true
+  catch _ do
+    false
+  end
 end
 
 # Convert a string to a int.

--- a/tests/language/conversions.liq
+++ b/tests/language/conversions.liq
@@ -1,0 +1,19 @@
+
+
+def fn() =
+  test.equals(int_of_string("0xff"), 255)
+  test.raise(fun () -> int_of_string("ff"))
+  test.equals(int_of_string(default=1, "ff"), 1)
+
+  test.equals(float_of_string("0xff"), 255.)
+  test.raise(fun () -> float_of_string("ff"))
+  test.equals(float_of_string(default=1., "ff"), 1.)
+
+  test.equals(bool_of_string("false"), false)
+  test.raise(fun () -> bool_of_string("ff"))
+  test.equals(bool_of_string(default=false, "ff"), false)
+
+  test.pass()
+end
+
+test.check(fn)

--- a/tests/language/dune.inc
+++ b/tests/language/dune.inc
@@ -55,6 +55,19 @@
  (alias runtest)
  (package liquidsoap)
  (deps
+  conversions.liq
+  ../media/all_media_files
+  ../../src/bin/liquidsoap.exe
+  (source_tree ../../src/libs)
+  (:stdlib ../../src/libs/stdlib.liq)
+  (:test_liq ../test.liq)
+  (:run_test ../run_test.exe))
+ (action (run %{run_test} conversions.liq liquidsoap %{test_liq} conversions.liq)))
+
+(rule
+ (alias runtest)
+ (package liquidsoap)
+ (deps
   regexp.liq
   ../media/all_media_files
   ../../src/bin/liquidsoap.exe

--- a/tests/test.liq
+++ b/tests/test.liq
@@ -74,6 +74,10 @@ def test.check(f) =
   output.dummy(blank())
 end
 
+def test.raise(fn) =
+  try ignore(fn()) catch _ do () end
+end
+
 def on_error(~backtrace, error) =
   print("Uncaught error while running test: #{error}\n#{backtrace}")
   test.fail()


### PR DESCRIPTION
This PR adds nullable default to `{int,float,bool}_of_string` conversion functions, raise an exception if conversion fails and no default is given.