### PR TITLE
Remove let json.stringify.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -30,7 +30,7 @@ Changed:
 - Add `sorted` option to `file.ls`.
 - Add `buffer_length` method to `input.external.rawaudio` and
   `input.external.wav` (#2612).
-- Removed confusing `let json.stringify` in favor of `json.stringify()`
+- Removed confusing `let json.stringify` in favor of `json.stringify()`.
 
 Fixed:
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -30,6 +30,7 @@ Changed:
 - Add `sorted` option to `file.ls`.
 - Add `buffer_length` method to `input.external.rawaudio` and
   `input.external.wav` (#2612).
+- Removed confusing `let json.stringify` in favor of `json.stringify()`
 
 Fixed:
 

--- a/doc/content/json.md
+++ b/doc/content/json.md
@@ -260,19 +260,8 @@ If a `json5` variable is in scope, you can also simply use `let json.parse[json5
 Exporting JSON values
 ---------------------
 
-Exporting JSON values works similarly to importing, using the `json.stringify` let syntax:
-```liquidsoap
-let json.stringify s = x
-```
-You can also use type annotation to explicitely state what kind of JSON value you want to render:
-```liquidsoap
-let json.stringify s = (x : {foo: int})
-```
-
-The `json.stringify` syntax supports the following arguments:
-
-* `json5`: allow `json5` representations, in particular infinite and `NaN` floating point numbers. Default: `false`
-* `compact`: output a compact value instead of a human-readable value. Default: `false`.
+Exporting JSON values can be done using the `json.stringify` function. Please note that not
+all values are exportable as JSON, in which case the function will raise an exception.
 
 Generic JSON objects
 --------------------
@@ -288,6 +277,6 @@ j.add("baz", 3.14)
 j.add("key_with_methods", "value".{method = 123})
 j.add("record", { a = 1, b = "ert"})
 j.remove("foo")
-let json.stringify s = j
+s = json.stringify(j)
 - s: '{ "record": { "b": "ert", "a": 1 }, "key_with_methods": "value", "bla": "bar", "baz": 3.14 }'
 ```

--- a/doc/content/json.md
+++ b/doc/content/json.md
@@ -260,8 +260,14 @@ If a `json5` variable is in scope, you can also simply use `let json.parse[json5
 Exporting JSON values
 ---------------------
 
-Exporting JSON values can be done using the `json.stringify` function. Please note that not
-all values are exportable as JSON, in which case the function will raise an exception.
+Exporting JSON values can be done using the `json.stringify` function:
+
+```liquidsoap
+r = {artist = "Bla", title = "Blo"}
+print(json.stringify(r))
+```
+
+Please note that not all values are exportable as JSON, for instance function. In such cases the function will raise an `error.json` exception.
 
 Generic JSON objects
 --------------------

--- a/doc/content/migrating.md
+++ b/doc/content/migrating.md
@@ -21,6 +21,11 @@ The list of concerned metadata is:
 * `"liq_cross_duration"`
 * `"liq_fade_type"`
 
+### JSON rendering
+
+The confusing `let json.stringify` syntax has been removed as it did not provide any feature not already covered by either
+the `json.stringify()` function or the generic `json()` object mapper. Please use either of those now.
+
 From 2.0.x to 2.1.x
 -------------------
 

--- a/src/js/dune.inc
+++ b/src/js/dune.inc
@@ -47,7 +47,6 @@ lastfm.liq
 playlist.liq
 hls.liq
 runtime.liq
-json.liq
 server.liq
 settings.liq)))
   

--- a/src/lang/builtins_json.ml
+++ b/src/lang/builtins_json.ml
@@ -306,7 +306,9 @@ let () =
 
 let () =
   Lang.add_builtin "json.stringify" ~category:`String
-    ~descr:"Convert a value to JSON when possible."
+    ~descr:
+      "Convert a value to JSON. If the value cannot be represented as JSON \
+       (for instance a function), a `error.json` exception is raised."
     [
       ( "compact",
         Lang.bool_t,

--- a/src/lang/lexer.ml
+++ b/src/lang/lexer.ml
@@ -193,9 +193,6 @@ let rec token lexbuf =
     | "let", Plus skipped, "json.parse", Star skipped, '[' ->
         LETLBRA `Json_parse
     | "let", Plus skipped, "json.parse", Plus skipped -> LET `Json_parse
-    | "let", Plus skipped, "json.stringify", Star skipped, '[' ->
-        LETLBRA `Json_stringify
-    | "let", Plus skipped, "json.stringify", Plus skipped -> LET `Json_stringify
     | "let", Plus skipped, "type", Plus skipped -> TYPEDEF
     | "let" -> LET `None
     | "fun" -> FUN

--- a/src/lang/parser.mly
+++ b/src/lang/parser.mly
@@ -461,7 +461,6 @@ _let:
   | LETLBRA let_opt RBRA {
       match $1 with
         | `Json_parse     -> `Json_parse (Parser_helper.args_of_json_parse ~pos:$loc $2)
-        | `Json_stringify -> `Json_stringify (Parser_helper.args_of_json_stringify ~pos:$loc $2)
         | _ -> raise (Parse_error ($loc, "Invalid let constructor")) }
 
 binding:

--- a/src/lang/parser_helper.ml
+++ b/src/lang/parser_helper.ml
@@ -28,15 +28,14 @@ open Ground
 type arglist = (string * string * Type.t * Term.t option) list
 
 type lexer_let_decoration =
-  [ `None | `Recursive | `Replaces | `Eval | `Json_parse | `Json_stringify ]
+  [ `None | `Recursive | `Replaces | `Eval | `Json_parse ]
 
 type let_decoration =
   [ `None
   | `Recursive
   | `Replaces
   | `Eval
-  | `Json_parse of (string * Term.t) list
-  | `Json_stringify of (string * Term.t) list ]
+  | `Json_parse of (string * Term.t) list ]
 
 type app_list_elem = (string * Term.t) list
 
@@ -65,7 +64,6 @@ type meth_pattern_el = string * Term.pattern option
 
 let let_decoration_of_lexer_let_decoration = function
   | `Json_parse -> `Json_parse []
-  | `Json_stringify -> `Json_stringify []
   | `Eval -> `Eval
   | `Recursive -> `Recursive
   | `None -> `None
@@ -77,7 +75,6 @@ let string_of_let_decoration = function
   | `Replaces -> "replaces"
   | `Eval -> "eval"
   | `Json_parse _ -> "json.parse"
-  | `Json_stringify _ -> "json.stringify"
 
 let args_of_json_parse ~pos = function
   | [] -> []
@@ -86,19 +83,6 @@ let args_of_json_parse ~pos = function
       raise
         (Parse_error
            (pos, "Invalid argument " ^ lbl ^ " for json.parse let constructor"))
-
-let args_of_json_stringify ~pos args =
-  match List.sort (fun (lbl, _) (lbl', _) -> Stdlib.compare lbl lbl') args with
-    | [] -> []
-    | [("compact", c)] -> [("compact", c)]
-    | [("compact", c); ("json5", j)] -> [("compact", c); ("json5", j)]
-    | [("json5", j)] -> [("json5", j)]
-    | (lbl, _) :: _ ->
-        raise
-          (Parse_error
-             ( pos,
-               "Invalid argument " ^ lbl ^ " for json.stringify let constructor"
-             ))
 
 let gen_args_of ~only ~except ~pos get_args name =
   match Environment.get_builtin name with
@@ -251,41 +235,6 @@ let mk_fun ~pos args body =
   let fv = Term.Vars.union fv (Term.free_vars ~bound body) in
   mk ~pos (Fun (fv, args, body))
 
-let mk_let_json_stringify ~pos (args, pat, def, cast) body =
-  (match List.sort Stdlib.compare (List.map (fun (lbl, _) -> lbl) args) with
-    | [] | ["compact"] | ["json5"] | ["compact"; "json5"] -> ()
-    | _ ->
-        raise
-          (Parse_error
-             (pos, "json.stringify only accepts `compact` and `json5` arguments")));
-  let find_arg name =
-    match List.assoc_opt name args with
-      | Some v -> v
-      | None -> Term.(make (Ground (Ground.Bool false)))
-  in
-  let json5 = find_arg "json5" in
-  let compact = find_arg "compact" in
-  let ty = match cast with Some ty -> ty | None -> Type.var ~pos () in
-  let tty = Value.RuntimeType.to_term ty in
-  let def = mk ~pos (Cast (def, ty)) in
-  let parser = mk ~pos (Var "_internal_json_renderer_") in
-  let def =
-    mk ~pos
-      (App
-         ( parser,
-           [("json5", json5); ("compact", compact); ("type", tty); ("", def)] ))
-  in
-  mk ~pos
-    (Let
-       {
-         doc = (Doc.none (), [], []);
-         replace = false;
-         pat;
-         gen = [];
-         def;
-         body;
-       })
-
 let mk_let_json_parse ~pos (args, pat, def, cast) body =
   let ty = match cast with Some ty -> ty | None -> Type.var ~pos () in
   let tty = Value.RuntimeType.to_term ty in
@@ -353,8 +302,6 @@ let mk_let ~pos (doc, decoration, pat, arglist, def, cast) body =
     | None, `Eval -> mk_eval ~pos (doc, pat, def, body, cast)
     | None, `Json_parse args ->
         mk_let_json_parse ~pos (args, pat, def, cast) body
-    | None, `Json_stringify args ->
-        mk_let_json_stringify ~pos (args, pat, def, cast) body
     | Some _, v ->
         raise
           (Parse_error

--- a/src/libs/dune.inc
+++ b/src/libs/dune.inc
@@ -47,7 +47,6 @@ lastfm.liq
 playlist.liq
 hls.liq
 runtime.liq
-json.liq
 server.liq
 settings.liq))
   

--- a/src/libs/file.liq
+++ b/src/libs/file.liq
@@ -276,7 +276,7 @@ def playlog(~duration=infinity, ~persistency=null(), ~hash=fun(m)->m["filename"]
   # Save into persistency file
   def save()
     if null.defined(persistency) then
-      let json.stringify data = !l
+      data = json.stringify(!l)
       file.write(data=data, null.get(persistency))
     end
   end

--- a/src/libs/interactive.liq
+++ b/src/libs/interactive.liq
@@ -248,12 +248,12 @@ server.register(usage="set <name> = <value>", description="Set the value of a va
 # @category Interactive
 # @param fname Name of the file.
 def interactive.save(fname)
-  let json.stringify data = {
+  data = json.stringify({
     float = list.map(fun (nv) -> begin let (name, v) = nv; (name, !v.ref) end, !variables_float),
     int = list.map(fun (nv) -> begin let (name, v) = nv; (name, !v.ref) end, !variables_int),
     bool = list.map(fun (nv) -> begin let (name, v) = nv; (name, !v.ref) end, !variables_bool),
     string = list.map(fun (nv) -> begin let (name, v) = nv; (name, !v.ref) end, !variables_string)
-  }
+  })
 
   file.write(data=data, fname)
 end

--- a/src/libs/json.liq
+++ b/src/libs/json.liq
@@ -1,8 +1,0 @@
-# Convert a value to a JSON string.
-# @category String
-# @param ~compact Output compact text.
-# @param ~json5 Use JSON5 extended spec.
-def json.stringify(~compact=false, ~json5=false, s) =
-  let json.stringify[compact=compact, json5=json5] j = s
-  j
-end

--- a/src/libs/metadata.liq
+++ b/src/libs/metadata.liq
@@ -165,8 +165,9 @@ def metadata.json.stringify(~coverart_mime=null(), ~base64=true, ~compact=false,
       m
     end
 
-  let json.stringify[compact, json5] (data : [(string * string)] as json.object) = m
-  data
+  data = json()
+  list.iter(fun (v) -> data.add(fst(v),snd(v)), m)
+  json.stringify(json5=json5,compact=compact,data)
 end
 
 # Parse metadata from JSON object

--- a/src/libs/stdlib.liq
+++ b/src/libs/stdlib.liq
@@ -10,7 +10,6 @@
 %include "thread.liq"
 %include "process.liq"
 %include "string.liq"
-%include "json.liq"
 %include "file.liq"
 %include "switches.liq"
 %include "utils.liq"

--- a/tests/language/functions.liq
+++ b/tests/language/functions.liq
@@ -40,9 +40,6 @@ def f() =
   let evalf = ()
   x = evalf
 
-  let json.stringifyf = ()
-  x = json.stringifyf
-
   test.pass()
 end
 

--- a/tests/language/json.liq
+++ b/tests/language/json.liq
@@ -33,63 +33,23 @@ def test_parse_error(name, f, msg) =
 end
 
 def f() =
-  let json.stringify s = ()
-  t(s, '[]')
+  t(json.stringify(()), '[]')
+  t(json.stringify("aa'bb"), "\"aa'bb\"")
+  t(json.stringify("a"), '"a"')
+  t(json.stringify("©"), '"©"')
+  t(json.stringify('"'), '"\\""')
+  t(json.stringify('\\'), '"\\\\"')
 
-  let json.stringify s = "aa'bb"
-  t(s, "\"aa'bb\"")
-
-  let json.stringify s = "a"
-  t(s, '"a"')
-
-  let json.stringify s = "©"
-  t(s, '"©"')
-
-  let json.stringify s = '"'
-  t(s, '"\\""')
-
-  let json.stringify s = '\\'
-  t(s, '"\\\\"')
-
-  let json.stringify s = (infinity:float?)
-  t(s, 'null')
-
-  let json.stringify s = (0.-infinity:float?)
-  t(s, 'null')
-
-  let json.stringify s = (nan:float?)
-  t(s, 'null')
-
-  let json.stringify s = null(infinity)
-  t(s, 'null')
-
-  let json.stringify s = null(0.-infinity)
-  t(s, 'null')
-
-  let json.stringify s = null(nan)
-  t(s, 'null')
-
-  let json.stringify[json5=true] s = infinity
-  t(s, 'Infinity')
-
-  let json.stringify[json5=true] s = (0.-infinity)
-  t(s, '-Infinity')
-
-  let json.stringify[json5=true] s = nan
-  t(s, 'NaN')
-
-  let json.stringify s = ([("foo",123), ("bar", 456)]:[(string * int)] as json.object)
-  t(s, "{ \"foo\": 123, \"bar\": 456 }")
-
-  let json.stringify s = ({foo = 123}:{ "✨foo✨" as foo: int})
-  t(s, "{ \"✨foo✨\": 123 }")
+  t(json.stringify(json5=true, infinity), 'Infinity')
+  t(json.stringify(json5=true, (0.-infinity)), '-Infinity')
+  t(json.stringify(json5=true,nan), 'NaN')
 
   let b = json()
   b.add("b", 1)
-  let json.stringify s = {
+  s = json.stringify({
      a = null({a=1}),
      b = null(b)
-  }
+  })
   t(s, "{ \"b\": { \"b\": 1 }, \"a\": { \"a\": 1 } }")
 
   data = "123"
@@ -275,7 +235,7 @@ def f() =
   j.add("key_with_methods", "value".{method = 123})
   j.add("record", { a = 1, b = "ert"})
   j.remove("foo")
-  let json.stringify j = j
+  j = json.stringify(j)
   t(j, '{
   "record": { "b": "ert", "a": 1 },
   "key_with_methods": "value",
@@ -286,7 +246,7 @@ def f() =
   e = ref(null())
   def f(data)
     try
-      let json.stringify d = data
+      d = json.stringify(data)
       ignore(d)
     catch err do
       e := err

--- a/tests/language/string.liq
+++ b/tests/language/string.liq
@@ -4,9 +4,7 @@ success = ref(true)
 
 def t(x, y)
   if x != y then
-    let json.stringify x = x
-    let json.stringify y = y
-    print("Failure: got #{x} instead of #{y}")
+    print("Failure: got #{json.stringify(x)} instead of #{json.stringify(y)}")
     success := false
   end
 end


### PR DESCRIPTION
This PR removes `let string.stringify` from the language. It was not a good solution as the type checker was not able to generalize properly the construct inside a function. The only advanced use of it was to use type annotations to convert e.g. a `[string * string]` to a JSON object but you can do that explicitly via the abstract `json()` object API.