### PR TITLE
Use extract-replaygain path from arguments

### DIFF
--- a/src/libs/protocols.liq
+++ b/src/libs/protocols.liq
@@ -23,7 +23,7 @@ let settings.protocol.replaygain.tag = settings.make(
 def exec_replaygain(~extract_replaygain="#{configure.bindir}/extract-replaygain",
                      ~delay=_,file)
   def log(x) = log.info(label="extract.replaygain",x) end
-  p = process.run(process.quote.command("extract_replaygain", args=[file]))
+  p = process.run(process.quote.command(extract_replaygain, args=[file]))
   stdout = r/\n/.replace(fun (_) -> "", p.stdout)
   if p.status == "exit" and p.status.code == 0 then
     stdout


### PR DESCRIPTION
The extract-replaygain script is hard-coded to be at "extract_replaygain" on $PATH, which isn't the case on all installations. Let's fetch it from the `extract_replaygain` argument instead.

Fixes #2624