### PR TITLE
Change harbor request data to be a string getter.

### DIFF
--- a/doc/content/harbor_http.md
+++ b/doc/content/harbor_http.md
@@ -10,13 +10,19 @@ The `harbor.http.register.simple` function provides a simple, easy to use regist
 HTTP response implementation. This function receives a record describing the request and returns 
 the HTTP response.
 
+The request passed to the function contains all expected information from the underlying HTTP
+query. Its `data` method is a _string getter_, that is a function of type: `() -> string` 
+which returns the empty string `""` when all data has been consumed. The convenience function
+`harbor.http.request.body` can be used to read all the data from the request and return it at
+once.
+
 For convenience, a HTTP response builder is provided via `harbor.http.response`. Here's an example:
 
 ```liquidsoap
 def handler(request) =
   log("Got a request on path #{request.path}, protocol version: #{request.http_version}, \
        method: #{request.method}, headers: #{request.headers}, query: #{request.query}, \
-       data: #{request.data}")
+       data: #{harbor.http.request.body((request.data)}")
 
   harbor.http.response(
     content_type="text/html",
@@ -43,7 +49,7 @@ Its API is very similar to the node/express API. Here's an example:
 def handler(request, response) =
   log("Got a request on path #{request.path}, protocol version: #{request.http_version}, \
        method: #{request.method}, headers: #{request.headers}, query: #{request.query}, \
-       data: #{request.data}")
+       data: #{harbor.http.request.body(request.data)}")
 
   # Set response code. Defaults to 200
   response.status_code(201)

--- a/src/core/tools/http.ml
+++ b/src/core/tools/http.ml
@@ -152,6 +152,14 @@ let read_crlf ?(log = fun _ -> ()) ?(max = 4096) ?(count = 2) ~timeout
   done;
   Buffer.contents ans
 
+let read ~timeout (socket : socket) len =
+  if len = 0 then ""
+  else (
+    socket#wait_for `Read timeout;
+    let buf = Bytes.create len in
+    let len = socket#read buf 0 len in
+    Bytes.sub_string buf 0 len)
+
 let really_read ~timeout (socket : socket) len =
   let start_time = Unix.gettimeofday () in
   let buf = Buffer.create len in

--- a/src/core/tools/http.mli
+++ b/src/core/tools/http.mli
@@ -45,5 +45,11 @@ val dirname : string -> string
 (** split arg=value&arg2=value2 into (arg, value) Hashtbl.t *)
 val args_split : string -> (string, string) Hashtbl.t
 
+(** Read with timeout. *)
+val read : timeout:float -> socket -> int -> string
+
+(** Read [len] bytes *)
+val really_read : timeout:float -> socket -> int -> string
+
 (* Read chunked data. *)
 val read_chunked : timeout:float -> socket -> string * int

--- a/src/core/tools/tutils.ml
+++ b/src/core/tools/tutils.ml
@@ -355,8 +355,11 @@ let wait_for ?(log = fun _ -> ()) event timeout =
       | `Both socket -> ([socket], [socket])
   in
   let rec wait t =
-    let l, l', _ = Unix.select r w [] t in
-    if l = [] && l' = [] then (
+    let r, w, _ =
+      try Unix.select r w [] t
+      with Unix.Unix_error (Unix.EINTR, _, _) -> ([], [], [])
+    in
+    if r = [] && w = [] then (
       let current_time = Unix.gettimeofday () in
       if current_time >= max_time then (
         log "Timeout reached!";

--- a/src/libs/error.liq
+++ b/src/libs/error.liq
@@ -6,6 +6,7 @@ let error.file = error.register("file")
 let error.string = error.register("string")
 let error.json = error.register("json")
 let error.http = error.register("http")
+let error.socket = error.register("socket")
 
 # Ensure that a condition is satisfied (raise `error.assertion` exception
 # otherwise).

--- a/src/libs/http.liq
+++ b/src/libs/http.liq
@@ -13,31 +13,53 @@
 # @method status_code Set response status code
 # @method status_message Set response status message
 def http.response(~http_version="1.1",
-                  ~status_code=200,
+                  ~status_code=null(),
                   ~status_message=null(),
                   ~headers=[],
                   ~content_type=null(),
                   ~data=getter("")) = 
+  status_code = status_code ??
+    if http_version == "1.1" and headers["expect"] == "100-continue" and getter.get(data) == "" then
+      100
+    else
+      200
+    end
+
   http_version = ref(http_version)
   status_code = ref(status_code)
   status_message = ref(status_message)
   headers = ref(headers)
   content_type = ref(content_type)
   data = ref(data)
+  status_sent = ref(false)
   headers_sent = ref(false)
+  data_sent = ref(false)
   response_ended = ref(false)
+
+  def mk_status() =
+    status_sent := true
+
+    http_version = !http_version
+    status_code = !status_code
+
+    status_code =
+      if status_code == 100 and getter.get(!data) != "" then
+        200
+      else
+        status_code
+      end
+
+    status_message = !status_message ?? http.codes[status_code]
+
+    "HTTP/#{http_version} #{status_code} #{status_message}\r\n"
+  end
 
   def mk_headers() =
     headers_sent := true
 
-    http_version = !http_version
-    status_code = !status_code
-    status_message = !status_message
     headers = !headers
     content_type = !content_type
     data = !data
-
-    status_message = status_message ?? http.codes[status_code]
 
     headers =
       if getter.is_constant(data) then
@@ -62,11 +84,12 @@ def http.response(~http_version="1.1",
     headers = string.concat(separator="\r\n", headers)
     headers = if headers != "" then "#{headers}\r\n" else "" end 
 
-    "HTTP/#{http_version} #{status_code} #{status_message}\r\n\
-     #{headers}\r\n"
+    "#{headers}\r\n"
   end
 
   def mk_data() =
+    data_sent := true
+
     data = !data
 
     if getter.is_constant(data) then
@@ -82,6 +105,8 @@ def http.response(~http_version="1.1",
   def response() =
     if !response_ended then
       ""
+    elsif not !status_sent then
+      mk_status()
     elsif not !headers_sent then
       mk_headers()
     else
@@ -89,10 +114,10 @@ def http.response(~http_version="1.1",
     end
   end
 
-  def attr_method(attr) =
+  def attr_method(sent, attr) =
     def set(v) =
-      if !headers_sent then
-        error.raise(error.invalid, "HTTP response headers already sent!")
+      if !sent then
+        error.raise(error.invalid, "HTTP response has already been sent for this value!")
       end
       attr := v
     end
@@ -122,17 +147,25 @@ def http.response(~http_version="1.1",
     data := d
   end
 
+  def send_status(socket) =
+    if not !status_sent then
+      socket.write(mk_status())
+    end
+  end
+
   response.{
-    http_version = attr_method(http_version),
-    status_code = attr_method(status_code),
-    status_message = attr_method(status_message),
-    headers = attr_method(headers),
+    http_version = attr_method(status_sent, http_version),
+    status_code = attr_method(status_sent, status_code),
+    status_message = attr_method(status_sent, status_message),
+    headers = attr_method(headers_sent, headers),
     header = header,
     redirect = redirect,
     json = json,
     html = html,
-    content_type = attr_method(content_type),
-    data = attr_method(data)
+    content_type = attr_method(headers_sent, content_type),
+    data = attr_method(data_sent, data),
+    send_status = send_status,
+    status_sent = {!status_sent}
   } 
 end
 
@@ -180,18 +213,37 @@ end
 # @flag hidden
 def harbor.http.register.regexp(%argsof(harbor.http.register), path, handler) =
   def handler(request) =
+    response = http.response(
+      http_version=request.http_version,
+    )
+
+    is_response_done = ref(false)
+
+    def replaces response() =
+      ret = response()
+      is_response_done := ret == ""
+      ret
+    end
+
+    def data(~timeout=10.) =
+      if !is_response_done then
+        error.raise(error.http, "Response ended!")
+      end
+
+      if response.status_code.current() == 100 and not response.status_sent() then
+        response.send_status(request.socket)
+      end
+      request.data(timeout=timeout)
+    end
+
     request = {
-      data = request.data,
+      data = data,
       headers = request.headers,
       http_version = request.http_version,
       method = request.method,
       path = request.path,
       query = request.query
     }
-
-    response = http.response(
-      http_version=request.http_version,
-    )
 
     handler = fun (req, res) -> begin
       middleware = !harbor.http.middleware
@@ -420,4 +472,32 @@ def http.post.file(~name="file", ~content_type=null(), ~headers=[], ~boundary=nu
   headers = ("Content-Type", "multipart/form-data; boundary=#{data.boundary}")::headers
 
   http.post(headers=headers, timeout_ms=timeout, redirect=redirect, data=data.contents, url)
+end
+
+let harbor.http.request = ()
+
+# Read all data from a HTTP request
+# @category Liquidsoap
+# @param ~timeout Read timeout
+# @param req HTTP request
+def harbor.http.request.body(~timeout=10., req) =
+  # This is for typing purposes
+  if false then
+    harbor.http.register("/foo", fun (r, _) -> ignore(if false then r else req end))
+  end
+
+  data = ref("")
+  start_time = time()
+  def rec read() =
+    if start_time+timeout < time() then
+      error.raise(error.http, "Timeout!")
+    end
+
+    r = req.data(timeout=timeout)
+    if r == "" then !data else
+      data := "#{!data}#{r}"
+      read()
+    end
+  end
+  read()
 end

--- a/src/libs/interactive.liq
+++ b/src/libs/interactive.liq
@@ -418,7 +418,7 @@ def interactive.harbor(~transport=http.transport.unix, ~port=8000, ~uri="/intera
   harbor.http.register(transport=transport, port=port, method="GET", uri, webpage)
 
   def setter(request, _)
-    data = url.split_args(request.data)
+    data = url.split_args(harbor.http.request.body(request))
     def update(nv)
       let (name, v) = nv
       try

--- a/src/libs/server.liq
+++ b/src/libs/server.liq
@@ -134,7 +134,7 @@ def server.harbor(~transport=http.transport.unix, ~port=8000, ~uri="/telnet")
 
   def setter(request, response)
     log.info("Executing command: #{request.data}")
-    answer = server.execute(request.data)
+    answer = server.execute(harbor.http.request.body(request))
     answer = string.concat(separator="\n", answer) ^ "\n"
     response.data(answer)
   end

--- a/tests/harbor/http.liq
+++ b/tests/harbor/http.liq
@@ -1,20 +1,20 @@
 def f() =
   # Default response
   def handler(req, _) =
-    test.equals(req.http_version, "1.1")
-    test.equals(req.method, "GET")
-    test.equals(req.data, "")
-    test.equals(req.query, [])
-    test.equals(req.path, "/default")
+   test.equals(req.http_version, "1.1")
+   test.equals(req.method, "GET")
+   test.equals(harbor.http.request.body(timeout=5.0, req), "")
+   test.equals(req.query, [])
+   test.equals(req.path, "/default")
   end
 
   harbor.http.register("/default", port=3456, handler)
   resp = http.get("http://localhost:3456/default")
-  test.equals(resp.headers, [])
-  test.equals(resp.status_message, "OK")
-  test.equals(resp.http_version, "1.1")
-  test.equals(resp.status_code, 200)
-  test.equals("#{resp}", "")
+ test.equals(resp.status_message, "OK")
+ test.equals(resp.status_code, 200)
+ test.equals(resp.http_version, "1.1")
+ test.equals(resp.headers, [])
+ test.equals("#{resp}", "")
 
   # Endpoint are executed in the order they are declared
   def handler(_, _) =
@@ -24,36 +24,35 @@ def f() =
   harbor.http.register.regexp(r/default/g, port=3456, handler)
   harbor.http.register("/default", port=3456, handler)
   resp = http.get("http://localhost:3456/default")
-  test.equals(resp.headers, [])
-  test.equals(resp.status_message, "OK")
-  test.equals(resp.http_version, "1.1")
-  test.equals(resp.status_code, 200)
-  test.equals("#{resp}", "")
+ test.equals(resp.status_message, "OK")
+ test.equals(resp.status_code, 200)
+ test.equals(resp.http_version, "1.1")
+ test.equals(resp.headers, [])
+ test.equals("#{resp}", "")
 
   # String response with matches
   def handler(req, _) =
-    test.equals(req.http_version, "1.1")
-    test.equals(req.method, "GET")
-    test.equals(req.data, "")
-    test.equals(req.query, [("gni", "gno"), ("bla", "blo")])
-    test.equals(req.path, "/path/gno/blo")
+   test.equals(req.http_version, "1.1")
+   test.equals(req.method, "GET")
+   test.equals(harbor.http.request.body(timeout=5.0, req), "")
+   test.equals(req.query, [("gni", "gno"), ("bla", "blo")])
+   test.equals(req.path, "/path/gno/blo")
   end
 
   harbor.http.register("/path/:gni/:bla", port=3456, handler)
   resp = http.get("http://localhost:3456/path/gno/blo")
-  test.equals(resp.headers, [])
-  test.equals(resp.status_message, "OK")
-  test.equals(resp.http_version, "1.1")
-  test.equals(resp.status_code, 200)
-  test.equals("#{resp}", "")
+ test.equals(resp.status_message, "OK")
+ test.equals(resp.status_code, 200)
+ test.equals(resp.http_version, "1.1")
+ test.equals(resp.headers, [])
+ test.equals("#{resp}", "")
 
   # Full query
   def handler(req, res) =
-    test.equals(req.http_version, "1.0")
-    test.equals(req.method, "POST")
-    test.equals(req.data, "foobarlol")
-    test.equals(req.query, [("foo", "with"), ("bla", "in"), ("gnu", "gno"), ("gni", "gno")])
-    test.equals(req.headers, [
+   test.equals(req.http_version, "1.0")
+   test.equals(req.method, "POST")
+   test.equals(req.query, [("foo", "with"), ("bla", "in"), ("gnu", "gno"), ("gni", "gno")])
+   test.equals(req.headers, [
       ("host", "localhost:3456"),
       ("user-agent", http.user_agent),
       ("accept", "*/*"),
@@ -61,7 +60,8 @@ def f() =
       ("content-length", "9"),
       ("content-type", "application/x-www-form-urlencoded")
     ])
-    test.equals(req.path, "/some/path/with/full/in/it")
+   test.equals(req.path, "/some/path/with/full/in/it")
+   test.equals(harbor.http.request.body(timeout=5.0, req), "foobarlol")
 
     res.status_code(201)
     res.status_message("YYR")
@@ -84,23 +84,126 @@ def f() =
 
   harbor.http.register.regexp(r/(?<foo>[^\/]+)\/full\/(?<bla>[^\/]+)/g, method="POST", port=3456, handler)
   resp = http.post(http_version="1.0", data="foobarlol", headers=[("req","header")], "http://localhost:3456/some/path/with/full/in/it?gni=gno&gnu=gno")
-  test.equals(resp.headers, [
+
+ test.equals(resp.status_message, "YYR")
+ test.equals(resp.status_code, 201)
+ test.equals(resp.http_version, "1.0")
+ test.equals(resp.headers, [
     ("some", "value"),
     ("transfer-encoding", "chunked"),
     ("content-type", "liquidsoap/test"),
   ])
-  test.equals(resp.status_message, "YYR")
-  test.equals(resp.http_version, "1.0")
-  test.equals(resp.status_code, 201)
-  test.equals("#{resp}", "gnignognignognignognigno")
+ test.equals("#{resp}", "gnignognignognignognigno")
+
+  # Large non-chunked query
+  def handler(req, _) =
+   test.equals(req.http_version, "1.1")
+   test.equals(req.method, "POST")
+   test.equals(req.query, [])
+   test.equals(req.headers, [
+      ("host", "localhost:3456"),
+      ("user-agent", http.user_agent),
+      ("accept", "*/*"),
+      ("content-length", "10000"),
+      ("content-type", "application/x-www-form-urlencoded"),
+    ])
+   test.equals(req.path, "/large_non_chunked")
+   test.equals(string.length(harbor.http.request.body(timeout=5.0, req)), 10_000)
+  end
+
+  harbor.http.register("/large_non_chunked", method="POST", port=3456, handler)
+
+  resp = http.post(data=string.make(10_000), "http://localhost:3456/large_non_chunked")
+ test.equals(resp.status_message, "OK")
+ test.equals(resp.status_code, 200)
+ test.equals(resp.http_version, "1.1")
+ test.equals(resp.headers, [])
+ test.equals("#{resp}", "")
+
+  # Chunked query
+  def handler(req, res) =
+   test.equals(req.http_version, "1.1")
+   test.equals(req.method, "POST")
+   test.equals(req.query, [])
+   test.equals(req.headers, [
+      ("host", "localhost:3456"),
+      ("user-agent", http.user_agent),
+      ("accept", "*/*"),
+      ("transfer-encoding", "chunked"),
+      ("content-type", "application/x-www-form-urlencoded"),
+      ("expect", "100-continue")
+    ])
+   test.equals(req.path, "/chunked")
+   test.equals(harbor.http.request.body(timeout=5.0, req), "foobarlol")
+  end
+
+  harbor.http.register("/chunked", method="POST", port=3456, handler)
+
+  data = begin
+    is_done = ref(false)
+    fun () ->
+      if !is_done then "" else
+        is_done := true
+        "foobarlol"
+      end
+  end
+
+  resp = http.post(data=data, "http://localhost:3456/chunked")
+ test.equals(resp.status_message, "OK")
+ test.equals(resp.status_code, 200)
+ test.equals(resp.http_version, "1.1")
+ test.equals(resp.headers, [])
+ test.equals("#{resp}", "")
+
+  # Large chunked query
+  def handler(req, res) =
+   test.equals(req.http_version, "1.1")
+   test.equals(req.method, "POST")
+   test.equals(req.query, [])
+   test.equals(req.headers, [
+      ("host", "localhost:3456"),
+      ("user-agent", http.user_agent),
+      ("accept", "*/*"),
+      ("transfer-encoding", "chunked"),
+      ("content-type", "application/x-www-form-urlencoded"),
+      ("expect", "100-continue")
+    ])
+   test.equals(req.path, "/large_chunked")
+
+    def rec f(count) =
+      ret = req.data()
+      
+      if ret != "" then
+        f(count + string.length(ret))
+      else
+        count
+      end
+    end
+
+   test.equals(f(0), 10_000_000)
+  end
+
+  harbor.http.register("/large_chunked", method="POST", port=3456, handler)
+
+  data = begin
+    tmp = string.make(10_000)
+    count = ref(10_000_000 / 10_000)
+    fun () ->
+      if 0 < !count then
+        count := !count - 1
+        tmp
+      else
+        ""
+      end
+  end
 
   # Custom response
   def handler(req) =
-    test.equals(req.http_version, "1.1")
-    test.equals(req.method, "GET")
-    test.equals(req.data, "")
-    test.equals(req.query, [])
-    test.equals(req.path, "/custom")
+   test.equals(req.http_version, "1.1")
+   test.equals(req.method, "GET")
+   test.equals(req.data(), "")
+   test.equals(req.query, [])
+   test.equals(req.path, "/custom")
     req.socket.write("HTTP/1.0 201 YYR\r\nFoo: bar\r\n\r\n")
     req.socket.close()
     null()
@@ -108,23 +211,24 @@ def f() =
 
   harbor.http.register.simple("/custom", port=3456, handler)
   resp = http.get("http://localhost:3456/custom")
-  test.equals(resp.headers, [("foo","bar")])
-  test.equals(resp.status_message, "YYR")
-  test.equals(resp.http_version, "1.0")
-  test.equals(resp.status_code, 201)
-  test.equals("#{resp}", "")
+
+ test.equals(resp.status_message, "YYR")
+ test.equals(resp.status_code, 201)
+ test.equals(resp.http_version, "1.0")
+ test.equals(resp.headers, [("foo","bar")])
+ test.equals("#{resp}", "")
 
   # Cors headers
   harbor.http.middleware.register(harbor.http.middleware.cors(origin="foo.com"))
   resp = http.get("http://localhost:3456/default")
-  test.equals(resp.headers, [
+ test.equals(resp.status_message, "OK")
+ test.equals(resp.http_version, "1.1")
+ test.equals(resp.status_code, 200)
+ test.equals(resp.headers, [
     ("access-control-allow-origin", "foo.com"),
     ("vary", "Origin")
   ])
-  test.equals(resp.status_message, "OK")
-  test.equals(resp.http_version, "1.1")
-  test.equals(resp.status_code, 200)
-  test.equals("#{resp}", "")
+ test.equals("#{resp}", "")
 
   # transport conflict
   transport = http.transport.ssl(certificate="foo", key="bla")
@@ -132,7 +236,26 @@ def f() =
     harbor.http.register("/default", transport=transport, port=3456, fun (_, _) -> ())
     test.fail()
   catch err : [error.http] do
-    test.equals(error.message(err), "Port is already opened with a different transport")
+   test.equals(err.message, "Port is already opened with a different transport")
+  end
+
+  # Response ended
+  read = ref(fun (~timeout=_) -> error.raise(error.assertion))
+  def handler(req, _) =
+    read := req.data
+  end
+
+  harbor.http.register("/response_ended", port=3456, handler)
+  resp = http.get("http://localhost:3456/response_ended")
+ test.equals(resp.status_message, "OK")
+ test.equals(resp.status_code, 200)
+
+  try
+    fn = !read
+    fn(timeout=10.)
+    test.fail()
+  catch err: [error.http] do
+   test.equals(err.message, "Response ended!")
   end
 
   # Register output on the same port


### PR DESCRIPTION
This PR changes harbor `request.data` to be a string getter. It also adds `harbor.http.request.body` to facilitates reading the whole body at once.

If data is read after the response has been sent, an error is raised as the request socket is closed. It could have been an empty string instead but I suspect if situations like this arise, the user would like to know that they are not getting the full data, e.g. if the body is a downloaded file, data would be only partial and corrupted.