### PR TITLE
Various `http.post` fixes

### DIFF
--- a/src/core/builtins/builtins_http.ml
+++ b/src/core/builtins/builtins_http.ml
@@ -57,11 +57,11 @@ let add_http_request ~stream_body ~descr ~request name =
     else
       [
         ( "data",
-          Lang.getter_t (Lang.nullable_t Lang.string_t),
+          Lang.getter_t Lang.string_t,
           Some (Lang.string ""),
           Some
-            "POST data. Use a `string?` getter to stream data and return \
-             `null` when all data has been passed." );
+            "POST data. Use a `string` getter to stream data and return `\"\"` \
+             when all data has been passed." );
       ]
   in
   let params =

--- a/src/core/tools/liqcurl.ml
+++ b/src/core/tools/liqcurl.ml
@@ -156,12 +156,6 @@ let rec http_request ?headers ?http_version ~follow_redirect ~timeout ~url
     connection#set_writefunction (fun s ->
         on_body_data s;
         String.length s);
-    ignore
-      (Option.map
-         (fun headers ->
-           connection#set_httpheader
-             (List.map (fun (k, v) -> Printf.sprintf "%s: %s" k v) headers))
-         headers);
     connection#set_httpversion
       (match http_version with
         | None -> Curl.HTTP_VERSION_NONE
@@ -186,6 +180,12 @@ let rec http_request ?headers ?http_version ~follow_redirect ~timeout ~url
           connection#set_readfunction2 (mk_read get_data)
       | `Head -> connection#set_nobody true
       | `Delete -> connection#set_customrequest "DELETE");
+    ignore
+      (Option.map
+         (fun headers ->
+           connection#set_httpheader
+             (List.map (fun (k, v) -> Printf.sprintf "%s: %s" k v) headers))
+         headers);
     let response_headers = Buffer.create 1024 in
     connection#set_headerfunction (fun s ->
         Buffer.add_string response_headers s;

--- a/src/libs/http.liq
+++ b/src/libs/http.liq
@@ -384,7 +384,7 @@ end
 # @category Interaction
 # @param ~boundary Specify boundary to use for multipart/form-data.
 # @param data data to insert
-def http.post.multipart_form_data(~boundary=null(), data)
+def http.multipart_form_data(~boundary=null(), data)
   def default_boundary()
     range = [...string.char.ascii.alphabet, ...string.char.ascii.number]
     l = list.init(12, fun(_) -> string.char.ascii.random(range))
@@ -425,7 +425,37 @@ def http.post.multipart_form_data(~boundary=null(), data)
   { contents = string.getter.concat(contents), boundary = boundary }
 end
 
+# @flag hidden
 stdlib_file = file
+
+# @flag hidden
+upload_file_fn = fun (~name, ~content_type, ~headers, ~boundary, ~filename, ~file, ~contents, ~timeout, ~redirect, url, fn) -> begin
+  if not null.defined(filename) and not null.defined(file) then
+    error.raise(error.http, "At least one of: `file` or `filename` must be defined!")
+  end
+
+  if null.defined(file) and null.defined(contents) then
+    error.raise(error.http, "Only one of: `contents` or `file` must be defined!")
+  end
+
+  # Massage parameters
+  filename = null.defined(filename) ? null.get(filename) : string(path.basename(null.get(file)))
+  contents = null.defined(contents) ? null.get(contents) : getter(stdlib_file.read(null.get(file)))
+
+  # Create query
+
+  content_type = content_type ?? "application/octet-stream"
+
+  data = http.multipart_form_data(boundary=boundary, [{
+    name=name,
+    attributes=[("filename", filename)],
+    headers=[("Content-Type",content_type)],
+    contents=contents
+  }])
+  headers = ("Content-Type", "multipart/form-data; boundary=#{data.boundary}")::headers
+
+  fn(headers=headers, timeout_ms=timeout, redirect=redirect, data=data.contents, url)
+end
 
 # Send a file via POST request encoded in multipart/form-data. The contents can
 # either be directly specified (with the `contents` argument) or taken from a
@@ -442,36 +472,27 @@ stdlib_file = file
 # @param ~redirect Follow reidrections.
 # @param url URL to post to.
 def http.post.file(~name="file", ~content_type=null(), ~headers=[], ~boundary=null(), ~filename=null(), ~file=null(), ~contents=null(), ~timeout=null(), ~redirect=true, url)
-  if not null.defined(filename) and not null.defined(file) then
-    error.raise(error.http, "At least one of: `file` or `filename` must be defined!")
-  end
+  upload_file_fn(name=name, content_type=content_type, headers=headers, boundary=boundary, filename=filename,
+                 file=file, contents=contents, timeout=timeout, redirect=redirect, url, http.post)
+end
 
-  if null.defined(file) and null.defined(contents) then
-    error.raise(error.http, "Only one of: `contents` or `file` must be defined!")
-  end
-
-  # Massage parameters
-  filename = null.defined(filename) ? null.get(filename) : string(path.basename(null.get(file)))
-  contents = null.defined(contents) ? null.get(contents) : getter(stdlib_file.read(null.get(file)))
-
-  # Create query
-
-  content_type =
-    if null.defined(content_type) then
-      null.get(content_type)
-    else
-      stdlib_file.mime(filename) ?? "application/octet-stream"
-    end
-
-  data = http.post.multipart_form_data(boundary=boundary, [{
-    name=name,
-    attributes=[("filename", filename)],
-    headers=[("Content-Type",content_type)],
-    contents=contents
-  }])
-  headers = ("Content-Type", "multipart/form-data; boundary=#{data.boundary}")::headers
-
-  http.post(headers=headers, timeout_ms=timeout, redirect=redirect, data=data.contents, url)
+# Send a file via PUT request encoded in multipart/form-data. The contents can
+# either be directly specified (with the `contents` argument) or taken from a
+# file (with the `file` argument).
+# @category Interaction
+# @param ~name Name of the field field
+# @param ~content_type Content-type (mime) for the file.
+# @param ~headers Additional headers.
+# @param ~boundary Specify boundary to use for multipart/form-data.
+# @param ~filename File name sent in the request.
+# @param ~file File whose contents is to be sent in the request.
+# @param ~contents Contents of the file sent in the request.
+# @param ~timeout Timeout in ms.
+# @param ~redirect Follow reidrections.
+# @param url URL to put to.
+def http.put.file(~name="file", ~content_type=null(), ~headers=[], ~boundary=null(), ~filename=null(), ~file=null(), ~contents=null(), ~timeout=null(), ~redirect=true, url)
+  upload_file_fn(name=name, content_type=content_type, headers=headers, boundary=boundary, filename=filename,
+                 file=file, contents=contents, timeout=timeout, redirect=redirect, url, http.put)
 end
 
 let harbor.http.request = ()

--- a/tests/harbor/http.liq
+++ b/tests/harbor/http.liq
@@ -10,11 +10,11 @@ def f() =
 
   harbor.http.register("/default", port=3456, handler)
   resp = http.get("http://localhost:3456/default")
- test.equals(resp.status_message, "OK")
- test.equals(resp.status_code, 200)
- test.equals(resp.http_version, "1.1")
- test.equals(resp.headers, [])
- test.equals("#{resp}", "")
+  test.equals(resp.status_message, "OK")
+  test.equals(resp.status_code, 200)
+  test.equals(resp.http_version, "1.1")
+  test.equals(resp.headers, [])
+  test.equals("#{resp}", "")
 
   # Endpoint are executed in the order they are declared
   def handler(_, _) =
@@ -24,11 +24,11 @@ def f() =
   harbor.http.register.regexp(r/default/g, port=3456, handler)
   harbor.http.register("/default", port=3456, handler)
   resp = http.get("http://localhost:3456/default")
- test.equals(resp.status_message, "OK")
- test.equals(resp.status_code, 200)
- test.equals(resp.http_version, "1.1")
- test.equals(resp.headers, [])
- test.equals("#{resp}", "")
+  test.equals(resp.status_message, "OK")
+  test.equals(resp.status_code, 200)
+  test.equals(resp.http_version, "1.1")
+  test.equals(resp.headers, [])
+  test.equals("#{resp}", "")
 
   # String response with matches
   def handler(req, _) =
@@ -41,11 +41,11 @@ def f() =
 
   harbor.http.register("/path/:gni/:bla", port=3456, handler)
   resp = http.get("http://localhost:3456/path/gno/blo")
- test.equals(resp.status_message, "OK")
- test.equals(resp.status_code, 200)
- test.equals(resp.http_version, "1.1")
- test.equals(resp.headers, [])
- test.equals("#{resp}", "")
+  test.equals(resp.status_message, "OK")
+  test.equals(resp.status_code, 200)
+  test.equals(resp.http_version, "1.1")
+  test.equals(resp.headers, [])
+  test.equals("#{resp}", "")
 
   # Full query
   def handler(req, res) =
@@ -85,15 +85,15 @@ def f() =
   harbor.http.register.regexp(r/(?<foo>[^\/]+)\/full\/(?<bla>[^\/]+)/g, method="POST", port=3456, handler)
   resp = http.post(http_version="1.0", data="foobarlol", headers=[("req","header")], "http://localhost:3456/some/path/with/full/in/it?gni=gno&gnu=gno")
 
- test.equals(resp.status_message, "YYR")
- test.equals(resp.status_code, 201)
- test.equals(resp.http_version, "1.0")
- test.equals(resp.headers, [
+  test.equals(resp.status_message, "YYR")
+  test.equals(resp.status_code, 201)
+  test.equals(resp.http_version, "1.0")
+  test.equals(resp.headers, [
     ("some", "value"),
     ("transfer-encoding", "chunked"),
     ("content-type", "liquidsoap/test"),
   ])
- test.equals("#{resp}", "gnignognignognignognigno")
+  test.equals("#{resp}", "gnignognignognignognigno")
 
   # Large non-chunked query
   def handler(req, _) =
@@ -114,11 +114,11 @@ def f() =
   harbor.http.register("/large_non_chunked", method="POST", port=3456, handler)
 
   resp = http.post(data=string.make(10_000), "http://localhost:3456/large_non_chunked")
- test.equals(resp.status_message, "OK")
- test.equals(resp.status_code, 200)
- test.equals(resp.http_version, "1.1")
- test.equals(resp.headers, [])
- test.equals("#{resp}", "")
+  test.equals(resp.status_message, "OK")
+  test.equals(resp.status_code, 200)
+  test.equals(resp.http_version, "1.1")
+  test.equals(resp.headers, [])
+  test.equals("#{resp}", "")
 
   # Chunked query
   def handler(req, res) =
@@ -149,11 +149,11 @@ def f() =
   end
 
   resp = http.post(data=data, "http://localhost:3456/chunked")
- test.equals(resp.status_message, "OK")
- test.equals(resp.status_code, 200)
- test.equals(resp.http_version, "1.1")
- test.equals(resp.headers, [])
- test.equals("#{resp}", "")
+  test.equals(resp.status_message, "OK")
+  test.equals(resp.status_code, 200)
+  test.equals(resp.http_version, "1.1")
+  test.equals(resp.headers, [])
+  test.equals("#{resp}", "")
 
   # Large chunked query
   def handler(req, res) =
@@ -212,23 +212,23 @@ def f() =
   harbor.http.register.simple("/custom", port=3456, handler)
   resp = http.get("http://localhost:3456/custom")
 
- test.equals(resp.status_message, "YYR")
- test.equals(resp.status_code, 201)
- test.equals(resp.http_version, "1.0")
- test.equals(resp.headers, [("foo","bar")])
- test.equals("#{resp}", "")
+  test.equals(resp.status_message, "YYR")
+  test.equals(resp.status_code, 201)
+  test.equals(resp.http_version, "1.0")
+  test.equals(resp.headers, [("foo","bar")])
+  test.equals("#{resp}", "")
 
   # Cors headers
   harbor.http.middleware.register(harbor.http.middleware.cors(origin="foo.com"))
   resp = http.get("http://localhost:3456/default")
- test.equals(resp.status_message, "OK")
- test.equals(resp.http_version, "1.1")
- test.equals(resp.status_code, 200)
- test.equals(resp.headers, [
+  test.equals(resp.status_message, "OK")
+  test.equals(resp.http_version, "1.1")
+  test.equals(resp.status_code, 200)
+  test.equals(resp.headers, [
     ("access-control-allow-origin", "foo.com"),
     ("vary", "Origin")
   ])
- test.equals("#{resp}", "")
+  test.equals("#{resp}", "")
 
   # transport conflict
   transport = http.transport.ssl(certificate="foo", key="bla")
@@ -247,8 +247,8 @@ def f() =
 
   harbor.http.register("/response_ended", port=3456, handler)
   resp = http.get("http://localhost:3456/response_ended")
- test.equals(resp.status_message, "OK")
- test.equals(resp.status_code, 200)
+  test.equals(resp.status_message, "OK")
+  test.equals(resp.status_code, 200)
 
   try
     fn = !read

--- a/tests/harbor/post.liq
+++ b/tests/harbor/post.liq
@@ -1,5 +1,5 @@
 def f() =
-  data = http.post.multipart_form_data(boundary="foobar", [{
+  data = http.multipart_form_data(boundary="foobar", [{
     name = "the name",
     contents = getter("foobarlol"),
     headers = [("some","headers")],
@@ -26,7 +26,7 @@ def f() =
   )
   test.equals(data.boundary, "foobar")
 
-  data = http.post.multipart_form_data(boundary="foobar", [{
+  data = http.multipart_form_data(boundary="foobar", [{
     name = "the name",
     contents = getter("foobarlol"),
     headers = [("some","headers")],
@@ -51,6 +51,44 @@ def f() =
      gnigno\r\n\
      --#{data.boundary}--\r\n"
   )
+
+  fname = "post.liq"
+
+  range = [...string.char.ascii.alphabet, ...string.char.ascii.number]
+  l = list.init(12, fun(_) -> string.char.ascii.random(range))
+  boundary = string.concat(l)
+
+  def handler(req, _) =
+   test.equals(req.http_version, "1.1")
+   test.equals(req.method, "POST")
+   test.equals(req.query, [])
+   test.equals(req.headers, [
+      ("host", "localhost:3456"),
+      ("user-agent", http.user_agent),
+      ("accept", "*/*"),
+      ("transfer-encoding", "chunked"),
+      ("content-type", "multipart/form-data; boundary=#{boundary}"),
+      ("expect", "100-continue")
+    ])
+   test.equals(req.path, "/large_non_chunked")
+   test.equals(
+      harbor.http.request.body(timeout=5.0, req),
+      "--#{boundary}\r\n\
+       Content-Disposition: form-data; name=\"file\"; filename=\"#{fname}\"\r\n\
+       Content-Type: text/plain\r\n\
+       \r\n\
+       #{file.contents(fname)}\r\n\
+       --#{boundary}--\r\n")
+  end
+
+  harbor.http.register("/large_non_chunked", method="POST", port=3456, handler)
+
+  resp = http.post.file(file=fname, content_type="text/plain", boundary=boundary, "http://localhost:3456/large_non_chunked")
+  test.equals(resp.status_message, "OK")
+  test.equals(resp.status_code, 200)
+  test.equals(resp.http_version, "1.1")
+  test.equals(resp.headers, [])
+  test.equals("#{resp}", "")
 
   test.pass()
 end

--- a/tests/test.liq
+++ b/tests/test.liq
@@ -61,7 +61,7 @@ end
 
 def test.equals(v, v') =
   if v != v' then
-    print("expected: #{string.quote(string_of(v'))}, got: #{string.quote(string_of(v))}")
+    print("expected:\r\n#{string.quote(string_of(v'))}\r\ngot:\r\n#{string.quote(string_of(v))}")
     test.fail()
   end
 end


### PR DESCRIPTION
* Fix `http.{post,put}` data type.
* Rename `http.post.multipart_form_data` into `http.multipart_form_data`
* Add `http.put.file`
* Test, fix curl headers logic.