### PR TITLE
Factor out, balance method resolution.

### DIFF
--- a/tests/core/types.ml
+++ b/tests/core/types.ml
@@ -47,3 +47,23 @@ let () =
   should_fail m n;
 
   ()
+
+let () =
+  (* 'a *)
+  let ty = Lang.univ_t () in
+
+  (* 'b.{foo:int} *)
+  let t1 = Lang.method_t (Lang.univ_t ()) [("foo", ([], Lang.int_t), "foo")] in
+
+  (* 'c.{gni:string} *)
+  let t2 =
+    Lang.method_t (Lang.univ_t ()) [("gni", ([], Lang.string_t), "gni")]
+  in
+
+  (* (ty:t1) *)
+  Typing.(ty <: t1);
+  Typing.(t1 <: ty);
+
+  (* (ty:t2) *)
+  Typing.(ty <: t2);
+  Typing.(t2 <: ty)

--- a/tests/language/type_errors.pl
+++ b/tests/language/type_errors.pl
@@ -44,7 +44,7 @@ incorrect('(1,1)==(1,"1")');
 incorrect('(1,1)==("1",1)');
 incorrect('1==request.create("")');
 incorrect('fun(x)->x(snd(x))');
-incorrect('{a = 5, b = 3} == {a = 6}');
+correct('{a = 5, b = 3} == {a = 6}');
 
 correct('true ? "foo" : "bar"');
 incorrect('false ? true : "bar"');


### PR DESCRIPTION
This PR factors out method type inference to make sure that they are resolved in a predictable order. Test added, I think this is safe to merge.

Added bonus, this is now a valid expression:
```
# {a = 5, b = 3} == {a = 6};;
- : bool = false
```