### PR TITLE
Add shfmt (docker) pre-commit hook

### DIFF
--- a/.github/alpine/liquidsoap.pre-install
+++ b/.github/alpine/liquidsoap.pre-install
@@ -1,7 +1,7 @@
 #!/bin/sh
 
-addgroup -S liquidsoap 2>/dev/null
-adduser -S -D -h /var/liquidsoap -s /sbin/nologin -G liquidsoap -g liquidsoap liquidsoap 2>/dev/null
-addgroup liquidsoap audio 2>/dev/null
+addgroup -S liquidsoap 2> /dev/null
+adduser -S -D -h /var/liquidsoap -s /sbin/nologin -G liquidsoap -g liquidsoap liquidsoap 2> /dev/null
+addgroup liquidsoap audio 2> /dev/null
 
 exit 0

--- a/.github/scripts/add-local-opam-packages.sh
+++ b/.github/scripts/add-local-opam-packages.sh
@@ -2,13 +2,13 @@
 
 set -e
 
-PWD=`dirname $0`
-BASE_DIR=`cd "${PWD}/../.." && pwd`
+PWD=$(dirname $0)
+BASE_DIR=$(cd "${PWD}/../.." && pwd)
 RELEASE=$GITHUB_SHA
 
 git config --global user.email "toots@rastageeks.org" && git config --global user.name "Romain Beauxis"
 
-eval `opam config env`
+eval $(opam config env)
 
 opam repository remove windows --all
 cd /home/opam/
@@ -17,11 +17,11 @@ rm -rf opam-cross-windows
 git clone https://github.com/ocaml-cross/opam-cross-windows.git
 
 find ${BASE_DIR}/.github/opam | grep '\.opam$' | while read i; do
-  PACKAGE=`basename $i | sed -e 's#\.opam$##'`;
-  VERSION=`cat $i | grep '^version' | cut -d'"' -f 2`;
-  mkdir -p "/home/opam/opam-cross-windows/packages/$PACKAGE/$PACKAGE.$VERSION";
-  cp "$i" "/home/opam/opam-cross-windows/packages/$PACKAGE/$PACKAGE.$VERSION/opam";
-  sed -e "s#@COMMIT_SHORT@#$RELEASE#g" -i "/home/opam/opam-cross-windows/packages/$PACKAGE/$PACKAGE.$VERSION/opam"; \
+  PACKAGE=$(basename $i | sed -e 's#\.opam$##')
+  VERSION=$(cat $i | grep '^version' | cut -d'"' -f 2)
+  mkdir -p "/home/opam/opam-cross-windows/packages/$PACKAGE/$PACKAGE.$VERSION"
+  cp "$i" "/home/opam/opam-cross-windows/packages/$PACKAGE/$PACKAGE.$VERSION/opam"
+  sed -e "s#@COMMIT_SHORT@#$RELEASE#g" -i "/home/opam/opam-cross-windows/packages/$PACKAGE/$PACKAGE.$VERSION/opam"
 done
 
 cd /home/opam/opam-cross-windows/

--- a/.github/scripts/build-apk.sh
+++ b/.github/scripts/build-apk.sh
@@ -13,15 +13,15 @@ APK_RELEASE=0
 
 cd /tmp/liquidsoap-full/liquidsoap
 
-APK_VERSION=`opam show -f version ./liquidsoap.opam | cut -d'-' -f 1`
-COMMIT_SHORT=`echo "${GITHUB_SHA}" | cut -c-7`
+APK_VERSION=$(opam show -f version ./liquidsoap.opam | cut -d'-' -f 1)
+COMMIT_SHORT=$(echo "${GITHUB_SHA}" | cut -c-7)
 
 if [ -n "${IS_ROLLING_RELEASE}" ]; then
   APK_PACKAGE="liquidsoap-${COMMIT_SHORT}-${ALPINE_ARCH}"
 elif [ -n "${IS_RELEASE}" ]; then
   APK_PACKAGE="liquidsoap-${ALPINE_ARCH}"
 else
-  TAG=`echo "${BRANCH}" | tr '[:upper:]' '[:lower:]' | sed -e 's#[^0-9^a-z^A-Z^.^-]#-#g'`
+  TAG=$(echo "${BRANCH}" | tr '[:upper:]' '[:lower:]' | sed -e 's#[^0-9^a-z^A-Z^.^-]#-#g')
   APK_PACKAGE="liquidsoap-${TAG}-${ALPINE_ARCH}"
 fi
 
@@ -29,11 +29,11 @@ echo "Building ${APK_PACKAGE}.."
 
 cd /tmp/liquidsoap-full
 
-cat liquidsoap/.github/alpine/APKBUILD.in | \
-  sed -e "s#@APK_PACKAGE@#${APK_PACKAGE}#" | \
-  sed -e "s#@APK_VERSION@#${APK_VERSION}#" | \
+cat liquidsoap/.github/alpine/APKBUILD.in |
+  sed -e "s#@APK_PACKAGE@#${APK_PACKAGE}#" |
+  sed -e "s#@APK_VERSION@#${APK_VERSION}#" |
   sed -e "s#@APK_RELEASE@#${APK_RELEASE}#" \
-  > APKBUILD
+    > APKBUILD
 
 cp liquidsoap/.github/alpine/liquidsoap.pre-install ${APK_PACKAGE}.pre-install
 

--- a/.github/scripts/build-deb.sh
+++ b/.github/scripts/build-deb.sh
@@ -1,4 +1,6 @@
-dch --create --distribution unstable --package "${LIQ_PACKAGE}" --newversion "1:${LIQ_VERSION}-${LIQ_TAG}-${DEB_RELEASE}" "Build ${COMMIT_SHORT}" #!/bin/sh
+#!/bin/sh
+
+dch --create --distribution unstable --package "${LIQ_PACKAGE}" --newversion "1:${LIQ_VERSION}-${LIQ_TAG}-${DEB_RELEASE}" "Build ${COMMIT_SHORT}"
 
 set -e
 

--- a/.github/scripts/build-deb.sh
+++ b/.github/scripts/build-deb.sh
@@ -1,4 +1,4 @@
-dch --create --distribution unstable --package "${LIQ_PACKAGE}" --newversion "1:${LIQ_VERSION}-${LIQ_TAG}-${DEB_RELEASE}" "Build ${COMMIT_SHORT}"#!/bin/sh
+dch --create --distribution unstable --package "${LIQ_PACKAGE}" --newversion "1:${LIQ_VERSION}-${LIQ_TAG}-${DEB_RELEASE}" "Build ${COMMIT_SHORT}" #!/bin/sh
 
 set -e
 
@@ -10,9 +10,9 @@ IS_ROLLING_RELEASE=$5
 IS_RELEASE=$6
 DEB_RELEASE=1
 
-ARCH=`dpkg --print-architecture`
+ARCH=$(dpkg --print-architecture)
 
-COMMIT_SHORT=`echo "${GITHUB_SHA}" | cut -c-7`
+COMMIT_SHORT=$(echo "${GITHUB_SHA}" | cut -c-7)
 
 export DEBFULLNAME="The Savonet Team"
 export DEBEMAIL="savonet-users@lists.sourceforge.net"
@@ -20,17 +20,17 @@ export DEBEMAIL="savonet-users@lists.sourceforge.net"
 cd /tmp/liquidsoap-full/liquidsoap
 
 eval $(opam config env)
-export OCAMLPATH=`cat ../.ocamlpath`
+export OCAMLPATH=$(cat ../.ocamlpath)
 
-LIQ_VERSION=`opam show -f version ./liquidsoap.opam | cut -d'-' -f 1`
-LIQ_TAG=`echo ${DOCKER_TAG} | sed -e 's#_#-#g'`
+LIQ_VERSION=$(opam show -f version ./liquidsoap.opam | cut -d'-' -f 1)
+LIQ_TAG=$(echo ${DOCKER_TAG} | sed -e 's#_#-#g')
 
 if [ -n "${IS_ROLLING_RELEASE}" ]; then
   LIQ_PACKAGE="liquidsoap-${COMMIT_SHORT}"
 elif [ -n "${IS_RELEASE}" ]; then
   LIQ_PACKAGE="liquidsoap"
 else
-  TAG=`echo "${BRANCH}" | tr '[:upper:]' '[:lower:]' | sed -e 's#[^0-9^a-z^A-Z^.^-]#-#g'`
+  TAG=$(echo "${BRANCH}" | tr '[:upper:]' '[:lower:]' | sed -e 's#[^0-9^a-z^A-Z^.^-]#-#g')
   LIQ_PACKAGE="liquidsoap-${TAG}"
 fi
 

--- a/.github/scripts/build-details.sh
+++ b/.github/scripts/build-details.sh
@@ -46,7 +46,7 @@ else
   DOCKER_RELEASE=
 fi
 
-SHA=`git rev-parse --short HEAD`
+SHA=$(git rev-parse --short HEAD)
 
 if [[ "${BRANCH}" =~ "rolling-release-" ]]; then
   echo "Branch is rolling release"

--- a/.github/scripts/build-doc.sh
+++ b/.github/scripts/build-doc.sh
@@ -4,6 +4,6 @@ set -e
 
 cd /tmp/liquidsoap-full/liquidsoap
 eval $(opam config env)
-export OCAMLPATH=`cat ../.ocamlpath`
+export OCAMLPATH=$(cat ../.ocamlpath)
 opam install -y odoc
 dune build @doc

--- a/.github/scripts/build-posix.sh
+++ b/.github/scripts/build-posix.sh
@@ -77,7 +77,7 @@ touch liquidsoap/configure
 # Workaround
 rm liquidsoap/configure
 
-export OCAMLPATH=`cat .ocamlpath`
+export OCAMLPATH=$(cat .ocamlpath)
 
 cd /tmp/liquidsoap-full/liquidsoap
 dune build
@@ -85,7 +85,7 @@ dune build
 echo "::endgroup::"
 
 if [ "${PLATFORM}" = "armhf" ]; then
-  exit 0;
+  exit 0
 fi
 
 echo "::group::Print build config"

--- a/.github/scripts/build-website.sh
+++ b/.github/scripts/build-website.sh
@@ -2,8 +2,8 @@
 
 set -e
 
-PWD=`dirname $0`
-BASE_DIR=`cd "${PWD}/../.." && pwd`
+PWD=$(dirname $0)
+BASE_DIR=$(cd "${PWD}/../.." && pwd)
 
 DOCKER_IMAGE=savonet/liquidsoap-github-actions-website
 

--- a/.github/scripts/build-win32.sh
+++ b/.github/scripts/build-win32.sh
@@ -9,11 +9,11 @@ IS_ROLLING_RELEASE=$4
 IS_RELEASE=$5
 GITHUB_SHA=$6
 
-OPAM_PREFIX=`opam var prefix`
-VERSION=`opam show -f version ./liquidsoap.opam | cut -d'-' -f 1`
-PWD=`dirname $0`
-BASE_DIR=`cd "${PWD}/../.." && pwd`
-COMMIT_SHORT=`echo "${GITHUB_SHA}" | cut -c-7`
+OPAM_PREFIX=$(opam var prefix)
+VERSION=$(opam show -f version ./liquidsoap.opam | cut -d'-' -f 1)
+PWD=$(dirname $0)
+BASE_DIR=$(cd "${PWD}/../.." && pwd)
+COMMIT_SHORT=$(echo "${GITHUB_SHA}" | cut -c-7)
 
 if [ -n "${IS_ROLLING_RELEASE}" ]; then
   TAG=${COMMIT_SHORT}-
@@ -39,11 +39,11 @@ export CC=""
 
 echo "::group::Installing deps"
 
-eval `opam config env`
+eval $(opam config env)
 opam repository set-url default https://github.com/ocaml/opam-repository.git
 cd /home/opam/opam-cross-windows/
-opam remove -y ppx_tools_versioned-windows `echo $OPAM_DEPS | sed -e 's#,# #g'`
-opam upgrade -y `echo $OPAM_DEPS | sed -e 's#,# #g'` ffmpeg-windows ffmpeg-avutil-windows
+opam remove -y ppx_tools_versioned-windows $(echo $OPAM_DEPS | sed -e 's#,# #g')
+opam upgrade -y $(echo $OPAM_DEPS | sed -e 's#,# #g') ffmpeg-windows ffmpeg-avutil-windows
 
 echo "::endgroup::"
 
@@ -60,7 +60,7 @@ cp -rf ${BASE_DIR}/.github/win32 liquidsoap-$BUILD
 cd liquidsoap-$BUILD
 cp ${OPAM_PREFIX}/windows-sysroot/bin/liquidsoap ./liquidsoap.exe
 cp ${OPAM_PREFIX}/windows-sysroot/share/liquidsoap-lang/libs/*.liq libs
-cp -rf `ocamlfind -toolchain windows ocamlc -where`/../../share/camomile .
+cp -rf $(ocamlfind -toolchain windows ocamlc -where)/../../share/camomile .
 cd ..
 zip -r liquidsoap-$BUILD.zip liquidsoap-$BUILD
 

--- a/.github/scripts/checkout-deps.sh
+++ b/.github/scripts/checkout-deps.sh
@@ -1,11 +1,11 @@
 #!/bin/sh
 
-CWD=`dirname $0`
-BASEDIR=`cd $CWD/../../.. && pwd`
+CWD=$(dirname $0)
+BASEDIR=$(cd $CWD/../../.. && pwd)
 
-git log --reverse --pretty=format:%B origin/main..HEAD | grep '^DEPS=' | cut -d'=' -f 2  | tr ":" "\n" | while read i; do \
-  MODULE=`echo "$i" | cut -d'#' -f 1`
-  COMMIT=`echo "$i" | cut -d'#' -f 2`
+git log --reverse --pretty=format:%B origin/main..HEAD | grep '^DEPS=' | cut -d'=' -f 2  | tr ":" "\n" | while read i; do
+  MODULE=$(echo "$i" | cut -d'#' -f 1)
+  COMMIT=$(echo "$i" | cut -d'#' -f 2)
   echo "Checking out dep $MODULE on commit $COMMIT"
   cd "${BASEDIR}/${MODULE}" && git fetch origin "$COMMIT" && git reset --hard && git checkout "$COMMIT" && git submodule init && git submodule update
 done

--- a/.github/scripts/test-posix.sh
+++ b/.github/scripts/test-posix.sh
@@ -4,5 +4,5 @@ set -e
 
 cd /tmp/liquidsoap-full/liquidsoap
 eval $(opam config env)
-export OCAMLPATH=`cat ../.ocamlpath`
+export OCAMLPATH=$(cat ../.ocamlpath)
 dune test

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,3 +39,11 @@ repos:
       - id: codespell
         args: [--ignore-words=.codespellignore]
         exclude: ^doc/orig/fosdem2020
+
+  - repo: local
+    hooks:
+      - id: shfmt
+        name: shfmt
+        language: docker_image
+        entry: mvdan/shfmt -i 2 -ci -sr -kp -w
+        types: [shell]

--- a/tests/media/mk_stream_test.sh
+++ b/tests/media/mk_stream_test.sh
@@ -1,11 +1,11 @@
 #!/bin/sh
 
 BASEPATH=$0
-BASEDIR=`dirname $0`
-CWD=`cd $BASEDIR && pwd`
+BASEDIR=$(dirname $0)
+CWD=$(cd $BASEDIR && pwd)
 
 FILE=$1
-FORMAT=`echo $FILE | cut -d '.' -f 1 | sed -e "s#@#%#g"`
+FORMAT=$(echo $FILE | cut -d '.' -f 1 | sed -e "s#@#%#g")
 
 MODE=$2
 


### PR DESCRIPTION
Next iteration on the pre-commit setup: This adds a local shfmt pre-commit hook using the https://hub.docker.com/r/mvdan/shfmt docker image.

This puts a hard dependency on docker for the devs, but on the other hand don't force everyone to install the multiple tools required to make pre-commit work (I will add another one (shellcheck) in a future PR).

This was also the way I intended to setup ocamlformat, as it reduces a lot the setup time (think faster CI) when running pre-commit. (Related to https://togithub.com/ocaml-ppx/ocamlformat/pull/2168)