### PR TITLE
Language types cleanup.

### DIFF
--- a/src/core/builtins/builtins_settings.ml
+++ b/src/core/builtins/builtins_settings.ml
@@ -29,26 +29,26 @@ type Type.constr_t += Dtools
 let dtools_constr =
   let open Liquidsoap_lang in
   let open Type in
-  object
-    method t = Dtools
-    method descr = "unit, bool, int, float, string or [string]"
-
-    method satisfied ~subtype ~satisfies:_ b =
-      let b = demeth b in
-      match b.descr with
-        | Custom { typ }
-          when List.mem typ
-                 [
-                   Ground_type.Bool.Type;
-                   Ground_type.Int.Type;
-                   Ground_type.Float.Type;
-                   Ground_type.String.Type;
-                 ] ->
-            ()
-        | Tuple [] -> ()
-        | List { t = b } -> subtype b (make Ground_type.string)
-        | _ -> raise Unsatisfied_constraint
-  end
+  {
+    t = Dtools;
+    constr_descr = "unit, bool, int, float, string or [string]";
+    satisfied =
+      (fun ~subtype ~satisfies:_ b ->
+        let b = demeth b in
+        match b.descr with
+          | Custom { typ }
+            when List.mem typ
+                   [
+                     Ground_type.Bool.Type;
+                     Ground_type.Int.Type;
+                     Ground_type.Float.Type;
+                     Ground_type.String.Type;
+                   ] ->
+              ()
+          | Tuple [] -> ()
+          | List { t = b } -> subtype b (make Ground_type.string)
+          | _ -> raise Unsatisfied_constraint);
+  }
 
 (* Return a lazy variable, to be executed when all dependent
    OCaml modules have been linked. *)

--- a/src/core/lang.ml
+++ b/src/core/lang.ml
@@ -54,7 +54,7 @@ let of_frame_t t =
         let audio = kind_t `Any in
         let video = kind_t `Any in
         let midi = kind_t `Any in
-        var := Type.Link (Type.Invariant, Frame_type.make ~audio ~video ~midi ());
+        var := Type.Link (`Invariant, Frame_type.make ~audio ~video ~midi ());
         Frame.mk_fields ~audio ~video ~midi ()
     | _ -> assert false
 

--- a/src/core/lang.mli
+++ b/src/core/lang.mli
@@ -232,7 +232,7 @@ val of_frame_t : t -> t Frame.Fields.t
   * label) and [t] is the type of the argument. *)
 val fun_t : (bool * string * t) list -> t -> t
 
-val univ_t : ?constraints:Liquidsoap_lang.Type.constraints -> unit -> t
+val univ_t : ?constraints:Liquidsoap_lang.Type.constr list -> unit -> t
 
 (** A shortcut for lists of pairs of strings. *)
 val metadata_t : t

--- a/src/core/lang_encoder.ml
+++ b/src/core/lang_encoder.ml
@@ -47,8 +47,7 @@ module L = struct
   (** Type of audio formats that can encode frame of a given kind. *)
   let format_t ?pos k =
     Type.make ?pos
-      (Type.Constr
-         { Type.constructor = "format"; params = [(Type.Covariant, k)] })
+      (Type.Constr { Type.constructor = "format"; params = [(`Covariant, k)] })
 
   let to_format = V.of_value
   let format = V.to_value

--- a/src/core/lang_source.ml
+++ b/src/core/lang_source.ml
@@ -233,7 +233,7 @@ let source_t ?(methods = false) frame_t =
   let t =
     Type.make
       (Type.Constr
-         { Type.constructor = "source"; params = [(Type.Invariant, frame_t)] })
+         { Type.constructor = "source"; params = [(`Invariant, frame_t)] })
   in
   if methods then
     method_t t

--- a/src/core/types/content_types.ml
+++ b/src/core/types/content_types.ml
@@ -28,11 +28,7 @@ let frame_t ?pos audio video midi =
        {
          Type.constructor = "stream_kind";
          Type.params =
-           [
-             (Type.Covariant, audio);
-             (Type.Covariant, video);
-             (Type.Covariant, midi);
-           ];
+           [(`Covariant, audio); (`Covariant, video); (`Covariant, midi)];
        })
 
 let kind_t ?pos kind =
@@ -46,7 +42,7 @@ let kind_t ?pos kind =
           (Type.Constr
              {
                Type.constructor = Content.string_of_kind k;
-               Type.params = [(Type.Covariant, evar ())];
+               Type.params = [(`Covariant, evar ())];
              })
     | `Format f ->
         let k = Content.kind f in
@@ -54,7 +50,7 @@ let kind_t ?pos kind =
           (Type.Constr
              {
                Type.constructor = Content.string_of_kind k;
-               Type.params = [(Type.Covariant, mk_format f)];
+               Type.params = [(`Covariant, mk_format f)];
              })
 
 let of_frame_t t =
@@ -70,7 +66,7 @@ let of_frame_t t =
         let audio = kind_t `Any in
         let video = kind_t `Any in
         let midi = kind_t `Any in
-        var := Type.Link (Type.Invariant, frame_t audio video midi);
+        var := Type.Link (`Invariant, frame_t audio video midi);
         Frame.mk_fields ~audio ~video ~midi ()
     | _ -> assert false
 
@@ -78,13 +74,13 @@ let of_frame_t t =
 let format_t ?pos k =
   Type.make ?pos
     (Type.Constr
-       { Type.constructor = "format"; Type.params = [(Type.Covariant, k)] })
+       { Type.constructor = "format"; Type.params = [(`Covariant, k)] })
 
 (** Type of sources carrying frames of a given kind. *)
 let source_t ?pos k =
   Type.make ?pos
     (Type.Constr
-       { Type.constructor = "source"; Type.params = [(Type.Invariant, k)] })
+       { Type.constructor = "source"; Type.params = [(`Invariant, k)] })
 
 (* Filled in later to avoid dependency cycles. *)
 let source_methods_t = ref (fun () : Type.t -> assert false)

--- a/src/core/types/format_type.ml
+++ b/src/core/types/format_type.ml
@@ -60,7 +60,7 @@ let repr_of_kind repr l (k, ty) =
   match (Type.deref ty).Type.descr with
     | Type.(Custom { typ = Format f }) ->
         `Constr (Content.string_of_format f, [])
-    | _ -> `Constr (Content_base.string_of_kind k, [(Type.Covariant, repr l ty)])
+    | _ -> `Constr (Content_base.string_of_kind k, [(`Covariant, repr l ty)])
 
 let kind_handler k =
   {
@@ -109,19 +109,19 @@ let rec content_type ~default ty =
     | Type.Var _ -> default ()
     | _ -> assert false
 
-let internal_media : Type.constr =
-  object
-    method t = InternalMedia
-    method descr = "an internal media type (none, pcm, yuva420p or midi)"
-
-    method satisfied ~subtype:_ ~satisfies:_ b =
-      let b = Type.demeth b in
-      match (Type.deref b).Type.descr with
-        | Type.Custom { Type.typ = Kind (k, _) }
-          when Content_base.is_internal_kind k ->
-            ()
-        | Type.Custom { Type.typ = Format f }
-          when Content_base.is_internal_format f ->
-            ()
-        | _ -> raise Type.Unsatisfied_constraint
-  end
+let internal_media =
+  {
+    Type.t = InternalMedia;
+    constr_descr = "an internal media type (none, pcm, yuva420p or midi)";
+    satisfied =
+      (fun ~subtype:_ ~satisfies:_ b ->
+        let b = Type.demeth b in
+        match (Type.deref b).Type.descr with
+          | Type.Custom { Type.typ = Kind (k, _) }
+            when Content_base.is_internal_kind k ->
+              ()
+          | Type.Custom { Type.typ = Format f }
+            when Content_base.is_internal_format f ->
+              ()
+          | _ -> raise Type.Unsatisfied_constraint);
+  }

--- a/src/core/types/frame_type.ml
+++ b/src/core/types/frame_type.ml
@@ -25,12 +25,7 @@ let make ?pos ~audio ~video ~midi () =
     (Type.Constr
        {
          Type.constructor = "stream_kind";
-         params =
-           [
-             (Type.Covariant, audio);
-             (Type.Covariant, video);
-             (Type.Covariant, midi);
-           ];
+         params = [(`Covariant, audio); (`Covariant, video); (`Covariant, midi)];
        })
 
 let univ ?pos () =
@@ -52,12 +47,7 @@ let set_audio t audio =
     | Type.Constr
         {
           Type.constructor = "stream_kind";
-          params =
-            [
-              (Type.Covariant, _);
-              (Type.Covariant, video);
-              (Type.Covariant, midi);
-            ];
+          params = [(`Covariant, _); (`Covariant, video); (`Covariant, midi)];
         } ->
         {
           t with
@@ -66,11 +56,7 @@ let set_audio t audio =
               {
                 Type.constructor = "stream_kind";
                 params =
-                  [
-                    (Type.Covariant, audio);
-                    (Type.Covariant, video);
-                    (Type.Covariant, midi);
-                  ];
+                  [(`Covariant, audio); (`Covariant, video); (`Covariant, midi)];
               };
         }
     | _ -> assert false
@@ -80,12 +66,7 @@ let set_video t video =
     | Type.Constr
         {
           Type.constructor = "stream_kind";
-          params =
-            [
-              (Type.Covariant, audio);
-              (Type.Covariant, _);
-              (Type.Covariant, midi);
-            ];
+          params = [(`Covariant, audio); (`Covariant, _); (`Covariant, midi)];
         } ->
         {
           t with
@@ -94,11 +75,7 @@ let set_video t video =
               {
                 Type.constructor = "stream_kind";
                 params =
-                  [
-                    (Type.Covariant, audio);
-                    (Type.Covariant, video);
-                    (Type.Covariant, midi);
-                  ];
+                  [(`Covariant, audio); (`Covariant, video); (`Covariant, midi)];
               };
         }
     | _ -> assert false
@@ -108,12 +85,7 @@ let set_midi t midi =
     | Type.Constr
         {
           Type.constructor = "stream_kind";
-          params =
-            [
-              (Type.Covariant, audio);
-              (Type.Covariant, video);
-              (Type.Covariant, _);
-            ];
+          params = [(`Covariant, audio); (`Covariant, video); (`Covariant, _)];
         } ->
         {
           t with
@@ -122,11 +94,7 @@ let set_midi t midi =
               {
                 Type.constructor = "stream_kind";
                 params =
-                  [
-                    (Type.Covariant, audio);
-                    (Type.Covariant, video);
-                    (Type.Covariant, midi);
-                  ];
+                  [(`Covariant, audio); (`Covariant, video); (`Covariant, midi)];
               };
         }
     | _ -> assert false
@@ -136,8 +104,7 @@ let get_audio t =
     | Type.Constr
         {
           Type.constructor = "stream_kind";
-          params =
-            [(Type.Covariant, audio); (Type.Covariant, _); (Type.Covariant, _)];
+          params = [(`Covariant, audio); (`Covariant, _); (`Covariant, _)];
         } ->
         audio
     | _ -> assert false
@@ -147,8 +114,7 @@ let get_video t =
     | Type.Constr
         {
           Type.constructor = "stream_kind";
-          params =
-            [(Type.Covariant, _); (Type.Covariant, video); (Type.Covariant, _)];
+          params = [(`Covariant, _); (`Covariant, video); (`Covariant, _)];
         } ->
         video
     | _ -> assert false
@@ -158,8 +124,7 @@ let get_midi t =
     | Type.Constr
         {
           Type.constructor = "stream_kind";
-          params =
-            [(Type.Covariant, _); (Type.Covariant, _); (Type.Covariant, midi)];
+          params = [(`Covariant, _); (`Covariant, _); (`Covariant, midi)];
         } ->
         midi
     | _ -> assert false
@@ -172,11 +137,7 @@ let content_type t =
         {
           Type.constructor = "stream_kind";
           params =
-            [
-              (Type.Covariant, audio);
-              (Type.Covariant, video);
-              (Type.Covariant, midi);
-            ];
+            [(`Covariant, audio); (`Covariant, video); (`Covariant, midi)];
         } ->
         let audio =
           Format_type.content_type ~default:Content_internal.default_audio audio
@@ -196,9 +157,9 @@ let content_type t =
                  Type.constructor = "stream_kind";
                  params =
                    [
-                     (Type.Covariant, mk_format audio);
-                     (Type.Covariant, mk_format video);
-                     (Type.Covariant, mk_format midi);
+                     (`Covariant, mk_format audio);
+                     (`Covariant, mk_format video);
+                     (`Covariant, mk_format midi);
                    ];
                })
         in

--- a/src/lang/lang.mli
+++ b/src/lang/lang.mli
@@ -159,7 +159,7 @@ val error_t : t
   * label) and [t] is the type of the argument. *)
 val fun_t : (bool * string * t) list -> t -> t
 
-val univ_t : ?constraints:Type.constraints -> unit -> t
+val univ_t : ?constraints:Type.constr list -> unit -> t
 
 (** A getter on an arbitrary type. *)
 val getter_t : t -> t

--- a/src/lang/term.ml
+++ b/src/lang/term.ml
@@ -67,7 +67,7 @@ let profile = ref false
 
 let ref_t ?pos t =
   Type.make ?pos
-    (Type.Constr { Type.constructor = "ref"; params = [(Type.Invariant, t)] })
+    (Type.Constr { Type.constructor = "ref"; params = [(`Invariant, t)] })
 
 (** {2 Terms} *)
 

--- a/src/lang/type.ml
+++ b/src/lang/type.ml
@@ -23,38 +23,38 @@
 include Type_base
 module Ground = Ground_type
 
-let num_constr : constr =
-  object
-    method t = Num
-    method descr = "a number type"
+let num_constr =
+  {
+    t = Num;
+    constr_descr = "a number type";
+    satisfied =
+      (fun ~subtype:_ ~satisfies:_ b ->
+        let b = demeth b in
+        match b.descr with
+          | Custom { typ = Ground.Int.Type }
+          | Custom { typ = Ground.Float.Type } ->
+              ()
+          | _ -> raise Unsatisfied_constraint);
+  }
 
-    method satisfied ~subtype:_ ~satisfies:_ b =
-      let b = demeth b in
-      match b.descr with
-        | Custom { typ = Ground.Int.Type } | Custom { typ = Ground.Float.Type }
-          ->
-            ()
-        | _ -> raise Unsatisfied_constraint
-  end
-
-let ord_constr : constr =
-  object
-    method t = Ord
-    method descr = "an orderable type"
-
-    method satisfied ~subtype:_ ~satisfies b =
-      let m, b = split_meths b in
-      match b.descr with
-        | Custom c when Ground_type.is_ground c.Type_base.typ -> ()
-        | Tuple [] ->
-            (* For records, we want to ensure that all fields are ordered. *)
-            List.iter
-              (fun { scheme = v, a } ->
-                if v <> [] then raise Unsatisfied_constraint;
-                satisfies a)
-              m
-        | Tuple l -> List.iter satisfies l
-        | List { t = b } -> satisfies b
-        | Nullable b -> satisfies b
-        | _ -> raise Unsatisfied_constraint
-  end
+let ord_constr =
+  {
+    t = Ord;
+    constr_descr = "an orderable type";
+    satisfied =
+      (fun ~subtype:_ ~satisfies b ->
+        let m, b = split_meths b in
+        match b.descr with
+          | Custom c when Ground_type.is_ground c.Type_base.typ -> ()
+          | Tuple [] ->
+              (* For records, we want to ensure that all fields are ordered. *)
+              List.iter
+                (fun { scheme = v, a } ->
+                  if v <> [] then raise Unsatisfied_constraint;
+                  satisfies a)
+                m
+          | Tuple l -> List.iter satisfies l
+          | List { t = b } -> satisfies b
+          | Nullable b -> satisfies b
+          | _ -> raise Unsatisfied_constraint);
+  }

--- a/tests/core/types.ml
+++ b/tests/core/types.ml
@@ -91,8 +91,7 @@ let () =
   Typing.(a <: b);
 
   assert (
-    List.exists
-      (fun c -> c#t == Type.Ord)
+    Type.Constraints.mem Type.ord_constr
       (match (demeth b).Type.descr with
         | List { Type.t = { Type.descr = Var { contents = Free v }; _ }; _ } ->
             v.Type.constraints
@@ -115,15 +114,13 @@ let () =
   Typing.(b <: c);
 
   assert (
-    List.exists
-      (fun c -> c#t == Type.Ord)
+    Type.Constraints.mem Type.ord_constr
       (match (demeth b).Type.descr with
         | Var { contents = Free v } -> v.Type.constraints
         | _ -> assert false));
 
   assert (
-    List.exists
-      (fun c -> c#t == Type.Ord)
+    Type.Constraints.mem Type.ord_constr
       (match (demeth a).Type.descr with
         | Var { contents = Free v } -> v.Type.constraints
         | _ -> assert false))


### PR DESCRIPTION
This PR de-entangles some of the types used in `type.mli`:
* Use polymorphic variants for variance
* Break type recursive definition
* Use a set for variable constraints
* Use records for constraints