### PR TITLE
Optimize typechecking

### DIFF
--- a/src/core/types/format_type.ml
+++ b/src/core/types/format_type.ml
@@ -32,7 +32,7 @@ let format_handler f =
   {
     Type.typ = Format f;
     copy_with = (fun _ f -> Format (Content_base.duplicate (get_format f)));
-    occur_check = (fun _ _ f -> ignore (get_format f));
+    occur_check = (fun _ _ -> ());
     filter_vars =
       (fun _ l f ->
         ignore (get_format f);
@@ -70,9 +70,9 @@ let kind_handler k =
         let k, ty = get_kind k in
         Kind (k, copy_with ty));
     occur_check =
-      (fun occur_check vars k ->
+      (fun occur_check k ->
         let _, ty = get_kind k in
-        occur_check vars ty);
+        occur_check ty);
     filter_vars =
       (fun filter_vars l k ->
         let _, ty = get_kind k in

--- a/src/lang/type.mli
+++ b/src/lang/type.mli
@@ -75,7 +75,7 @@ type custom = Type_base.custom = ..
 type custom_handler = Type_base.custom_handler = {
   typ : custom;
   copy_with : (t -> t) -> custom -> custom;
-  occur_check : (var -> t -> unit) -> var -> custom -> unit;
+  occur_check : (t -> unit) -> custom -> unit;
   filter_vars : (var list -> t -> var list) -> var list -> custom -> var list;
   repr : (var list -> t -> Repr.t) -> var list -> custom -> Repr.t;
   subtype : (t -> t -> unit) -> custom -> custom -> unit;

--- a/src/lang/types/ground_type.ml
+++ b/src/lang/types/ground_type.ml
@@ -44,7 +44,7 @@ module Make (S : Spec) = struct
     {
       Type_base.typ = Type;
       copy_with = (fun _ c -> get c);
-      occur_check = (fun _ _ c -> ignore (get c));
+      occur_check = (fun _ _ -> ());
       filter_vars =
         (fun _ l c ->
           ignore (get c);

--- a/src/lang/types/type_base.ml
+++ b/src/lang/types/type_base.ml
@@ -157,7 +157,7 @@ type custom = ..
 type custom_handler = {
   typ : custom;
   copy_with : (t -> t) -> custom -> custom;
-  occur_check : (var -> t -> unit) -> var -> custom -> unit;
+  occur_check : (t -> unit) -> custom -> unit;
   filter_vars : (var list -> t -> var list) -> var list -> custom -> var list;
   repr : (var list -> t -> R.t) -> var list -> custom -> R.t;
   subtype : (t -> t -> unit) -> custom -> custom -> unit;


### PR DESCRIPTION
At d6c353069abc5636000e6d1c441fcd5c0dd19163:
```
% time ./_build/default/src/bin/liquidsoap.exe ./src/libs/stdlib.liq 'print(1)'
1
No output defined, nothing to do.
zsh: exit 1     ./_build/default/src/bin/liquidsoap.exe ./src/libs/stdlib.liq 'print(1)'
./_build/default/src/bin/liquidsoap.exe ./src/libs/stdlib.liq 'print(1)'  1.81s user 0.06s system 95% cpu 1.959 total
```

At f0ee7d84d68344d35d91b9a1ec644e7110d36a9d:
```
% time ./_build/default/src/bin/liquidsoap.exe ./src/libs/stdlib.liq 'print(1)'
1
No output defined, nothing to do.
zsh: exit 1     ./_build/default/src/bin/liquidsoap.exe ./src/libs/stdlib.liq 'print(1)'
./_build/default/src/bin/liquidsoap.exe ./src/libs/stdlib.liq 'print(1)'  1.42s user 0.03s system 99% cpu 1.454 total
```
About `~20%` increase!

Things I tried:
- [x] Cache types <-> variables mappings. This makes it way worst as neither `WeakHash` or even a specialized `Hashtbl` with type indexes are able to keep up with the sheer amount of stored types and variables.