### PR TITLE
Set default encoding to UTF8 in icecast/shoutcast operators.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,6 +23,8 @@ Changed:
 
 - Switched to `dune` for building the binary and libraries.
 - Changed `cry` to be a required dependency.
+- Changed default character encoding in `output.harbor`, `output.icecast`
+  `output.shoutcast` to `UTF-8` (#2704)
 - Added support for a Javascript build an interpreter.
 - Removed support for `%define` variables, superseded by support for actual
   variables in encoders.

--- a/src/core/outputs/harbor_output.ml
+++ b/src/core/outputs/harbor_output.ml
@@ -100,9 +100,8 @@ let proto frame_t =
       ( "encoding",
         Lang.string_t,
         Some (Lang.string ""),
-        Some
-          "Encoding used to send metadata. If empty, defaults to \
-           \"ISO-8859-1\" for non-ogg formats and \"UTF-8\" otherwise." );
+        Some "Encoding used to send metadata. If empty, defaults to \"UTF-8\""
+      );
       ("url", Lang.nullable_t Lang.string_t, Some Lang.null, None);
       ( "metaint",
         Lang.int_t,
@@ -317,10 +316,10 @@ class output p =
   let metaint = Lang.to_int (List.assoc "metaint" p) in
   let data = encoder_data p in
   let encoding = Lang.to_string (List.assoc "encoding" p) in
-  let recode ~icy m =
+  let recode m =
     let out_enc =
       match encoding with
-        | "" -> if icy then `ISO_8859_1 else `UTF_8
+        | "" -> `UTF_8
         | s -> Charset.of_string (String.uppercase_ascii s)
     in
     let f = Charset.convert ~target:out_enc in
@@ -429,7 +428,7 @@ class output p =
 
     method insert_metadata m =
       let m = Meta_format.to_metadata m in
-      let m = recode ~icy:true m in
+      let m = recode m in
       Tutils.mutexify metadata.metadata_m
         (fun () -> metadata.metadata <- Some m)
         ();

--- a/src/core/outputs/icecast2.ml
+++ b/src/core/outputs/icecast2.ml
@@ -219,8 +219,7 @@ let proto frame_t =
         Some Lang.null,
         Some
           "Encoding used to send metadata and stream info (name, genre and \
-           description). If null, defaults to \"UTF-8\" for \"http(s)\" \
-           protocol and \"ISO-8859-1\" for \"icy\" protocol." );
+           description). If null, defaults to \"UTF-8\"." );
       ("genre", Lang.nullable_t Lang.string_t, Some Lang.null, None);
       ( "protocol",
         Lang.string_t,
@@ -340,7 +339,7 @@ class output p =
   in
   let out_enc =
     match s_opt "encoding" with
-      | None | Some "" -> if protocol = Cry.Icy then `ISO_8859_1 else `UTF_8
+      | None | Some "" -> `UTF_8
       | Some s -> Charset.of_string (String.uppercase_ascii s)
   in
   let source = Lang.assoc "" 2 p in


### PR DESCRIPTION
This is a follow-up from https://github.com/savonet/liquidsoap/pull/2701. Looking around, it seems that nowadays, most software expect UTF-8 encodings out of the box, including in legacy systems where non-UTF-8 used to be the default such as shoutcast.

In order to follow the most expected best happy path, this PR switches these legacy systems to UTF-8. The option to encode to different encodings should be available for anyone still using a legacy system.