### PR TITLE
Allow optional methods

### DIFF
--- a/doc/content/language.md
+++ b/doc/content/language.md
@@ -987,7 +987,7 @@ The type of this function is:
 f : (int, 'a.{add? : int}) -> int = <fun>
 ```
 
-Which denotes that the `options` argument can be any value that may or may not have
+which denotes that the `options` argument can be any value that may or may not have
 a `add` field. However, if this field is present, it must be of type `int`.
 
 2. Using the `x?.foo` syntax
@@ -998,7 +998,7 @@ otherwise.
 The `?.` syntax can be chained and works with functions, which make it a very convenient
 way to drill deep inside nested records:
 
-```ruby
+```liquidsoap
 x?.fn(123, "aabb")?.field
 ```
 

--- a/doc/content/language.md
+++ b/doc/content/language.md
@@ -961,6 +961,47 @@ will print
 
 (note that the string is modified but not the fields `duration` and `bpm`).
 
+### Optional fields
+
+During the execution of your script, it can be useful to allow functions
+to receive records that may or may not have a specific field. This can
+be used, for instance, to model optional arguments.
+
+This can be achieved in two ways:
+
+1. Using the `x.foo ?? default` syntax
+
+Here's an example:
+
+```liquidsoap
+# This functions adds 1 to x unless options has a
+# add field in which case it adds this value
+def f(x, options) =
+  x + (options.add ?? 1)
+end
+```
+
+The type of this function is:
+
+```liquidsoap
+f : (int, 'a.{add? : int}) -> int = <fun>
+```
+
+Which denotes that the `options` argument can be any value that may or may not have
+a `add` field. However, if this field is present, it must be of type `int`.
+
+2. Using the `x?.foo` syntax
+
+Given a variable `x`, `x?.foo` returns the field value `foo`, if present, or `null`
+otherwise.
+
+The `?.` syntax can be chained and works with functions, which make it a very convenient
+way to drill deep inside nested records:
+
+```ruby
+x?.fn(123, "aabb")?.field
+```
+
 ## Patterns
 
 As explained earlier, you can use several constructions to extract data from structured values such

--- a/src/core/builtins/builtins_thread.ml
+++ b/src/core/builtins/builtins_thread.ml
@@ -20,6 +20,8 @@
 
  *****************************************************************************)
 
+open Liquidsoap_lang
+
 let () =
   Lang.add_module "thread";
   Lang.add_module "thread.run"

--- a/src/core/builtins/builtins_thread.ml
+++ b/src/core/builtins/builtins_thread.ml
@@ -20,8 +20,6 @@
 
  *****************************************************************************)
 
-open Liquidsoap_lang
-
 let () =
   Lang.add_module "thread";
   Lang.add_module "thread.run"

--- a/src/core/lang_source.ml
+++ b/src/core/lang_source.ml
@@ -431,7 +431,7 @@ let iter_sources ?on_reference ~static_analysis_failed f v =
       | Term.Tuple l -> List.iter (iter_term env) l
       | Term.Null -> ()
       | Term.Cast (a, _) -> iter_term env a
-      | Term.Meth ({ Term.meth_t = a }, b) ->
+      | Term.Meth ({ Term.meth_value = a }, b) ->
           iter_term env a;
           iter_term env b
       | Term.Invoke { Term.invoked = a } -> iter_term env a

--- a/src/core/lang_source.ml
+++ b/src/core/lang_source.ml
@@ -429,7 +429,7 @@ let iter_sources ?on_reference ~static_analysis_failed f v =
       | Term.Ground _ | Term.Encoder _ -> ()
       | Term.List l -> List.iter (iter_term env) l
       | Term.Tuple l -> List.iter (iter_term env) l
-      | Term.Null -> ()
+      | Term.Any | Term.Null -> ()
       | Term.Cast (a, _) -> iter_term env a
       | Term.Meth ({ Term.meth_value = a }, b) ->
           iter_term env a;

--- a/src/core/types/frame_type.ml
+++ b/src/core/types/frame_type.ml
@@ -29,6 +29,7 @@ let make ?pos base_type fields =
       let meth =
         {
           Type.meth = field;
+          optional = false;
           scheme = ([], field_type);
           doc = "Field " ^ field;
           json_name = None;
@@ -45,6 +46,7 @@ let set_field frame_type field field_type =
   let meth =
     {
       Type.meth = field;
+      optional = false;
       scheme = ([], field_type);
       doc = "Field " ^ field;
       json_name = None;

--- a/src/lang/environment.ml
+++ b/src/lang/environment.ml
@@ -72,6 +72,7 @@ let add_builtin ?(override = false) ?(register = true) ?doc name ((g, t), v) =
                     Meth
                       ( {
                           meth = l;
+                          optional = false;
                           scheme = (lvg, lvt);
                           doc = "";
                           json_name = None;

--- a/src/lang/evaluation.ml
+++ b/src/lang/evaluation.ml
@@ -103,8 +103,11 @@ module Env = struct
   let lookup (env : t) var =
     try Lazy.force (List.assoc var env)
     with Not_found ->
-      failwith
-        (Printf.sprintf "Internal error: variable %s not in environment." var)
+      let bt = Printexc.get_raw_backtrace () in
+      Printexc.raise_with_backtrace
+        (Failure
+           (Printf.sprintf "Internal error: variable %s not in environment." var))
+        bt
 
   (** Restrict an environment to a given set of variables. *)
   let restrict (env : t) vars =

--- a/src/lang/evaluation.ml
+++ b/src/lang/evaluation.ml
@@ -152,6 +152,7 @@ let rec prepare_fun fv p env =
 and eval (env : Env.t) tm =
   let mk v = { Value.pos = tm.t.Type.pos; Value.value = v } in
   match tm.term with
+    | Any -> mk Value.Null
     | Ground g -> mk (Value.Ground g)
     | Encoder (e, p) ->
         let pos = tm.t.Type.pos in

--- a/src/lang/evaluation.ml
+++ b/src/lang/evaluation.ml
@@ -169,13 +169,17 @@ and eval (env : Env.t) tm =
     | Cast (e, _) ->
         let e = eval env e in
         mk e.Value.value
-    | Meth ({ name = l; meth_t = u }, v) ->
+    | Meth ({ name = l; meth_value = u }, v) ->
         mk (Value.Meth (l, eval env u, eval env v))
-    | Invoke { invoked = t; meth = l } ->
+    | Invoke { invoked = t; default; meth = l } ->
         let rec aux t =
-          match t.Value.value with
-            | Value.Meth (l', t, _) when l = l' -> t
-            | Value.Meth (_, _, t) -> aux t
+          match (t.Value.value, default) with
+            | Value.Meth (l', t, _), None when l = l' -> t
+            (* A method returning `null` is overridden by the default value *)
+            | Value.Meth (l', t, _), Some tm when l = l' -> (
+                match t.Value.value with Value.Null -> eval env tm | _ -> t)
+            | Value.Meth (_, _, t), _ -> aux t
+            | _, Some tm -> eval env tm
             | _ ->
                 raise
                   (Internal_error

--- a/src/lang/parser_helper.ml
+++ b/src/lang/parser_helper.ml
@@ -269,13 +269,14 @@ let mk_app_invoke_default ~pos ~args body =
   in
   mk_fun ~pos app_args body
 
-let mk_any =
+let () =
   Lang_core.add_builtin ~category:`Programming ~descr:"Internal"
     ~flags:[`Hidden] "_invoke_any_" [] (Lang_core.univ_t ()) (fun _ ->
-      Lang_core.unit);
-  fun ~pos () ->
-    let op = mk ~pos (Var "_invoke_any_") in
-    mk ~pos (App (op, []))
+      Lang_core.unit)
+
+let mk_any ~pos () =
+  let op = mk ~pos (Var "_invoke_any_") in
+  mk ~pos (App (op, []))
 
 let rec mk_invoke_default ~pos ~optional ~name value { invoked; meth; default }
     =

--- a/src/lang/parser_helper.ml
+++ b/src/lang/parser_helper.ml
@@ -269,13 +269,8 @@ let mk_app_invoke_default ~pos ~args body =
   in
   mk_fun ~pos app_args body
 
-let () =
-  Lang_core.add_builtin ~category:`Programming ~descr:"Internal"
-    ~flags:[`Hidden] "_invoke_any_" [] (Lang_core.univ_t ()) (fun _ ->
-      Lang_core.unit)
-
 let mk_any ~pos () =
-  let op = mk ~pos (Var "_invoke_any_") in
+  let op = mk ~pos (Var "💣") in
   mk ~pos (App (op, []))
 
 let rec mk_invoke_default ~pos ~optional ~name value { invoked; meth; default }

--- a/src/lang/parser_helper.ml
+++ b/src/lang/parser_helper.ml
@@ -269,9 +269,7 @@ let mk_app_invoke_default ~pos ~args body =
   in
   mk_fun ~pos app_args body
 
-let mk_any ~pos () =
-  let op = mk ~pos (Var "💣") in
-  mk ~pos (App (op, []))
+let mk_any ~pos () = mk ~pos Any
 
 let rec mk_invoke_default ~pos ~optional ~name value { invoked; meth; default }
     =

--- a/src/lang/parser_helper.ml
+++ b/src/lang/parser_helper.ml
@@ -275,7 +275,7 @@ let mk_any =
       Lang_core.unit);
   fun ~pos () ->
     let op = mk ~pos (Var "_invoke_any_") in
-    mk ~pos (App (op, [("", mk ~pos (Tuple []))]))
+    mk ~pos (App (op, []))
 
 let rec mk_invoke_default ~pos ~optional ~name value { invoked; meth; default }
     =

--- a/src/lang/parser_helper.ml
+++ b/src/lang/parser_helper.ml
@@ -269,10 +269,13 @@ let mk_app_invoke_default ~pos ~args body =
   in
   mk_fun ~pos app_args body
 
-let mk_any ~pos () =
-  (* This is the obj.magic from the standard library. *)
-  let op = mk ~pos (Var "💣") in
-  mk ~pos (App (op, [("", mk ~pos (Tuple []))]))
+let mk_any =
+  Lang_core.add_builtin ~category:`Programming ~descr:"Internal"
+    ~flags:[`Hidden] "_invoke_any_" [] (Lang_core.univ_t ()) (fun _ ->
+      Lang_core.unit);
+  fun ~pos () ->
+    let op = mk ~pos (Var "_invoke_any_") in
+    mk ~pos (App (op, [("", mk ~pos (Tuple []))]))
 
 let rec mk_invoke_default ~pos ~optional ~name value { invoked; meth; default }
     =

--- a/src/lang/term.ml
+++ b/src/lang/term.ml
@@ -204,8 +204,8 @@ and encoder_params = (string * [ `Term of t | `Encoder of encoder ]) list
 (** A formal encoder. *)
 and encoder = string * encoder_params
 
-and invoke = { invoked : t; meth : string }
-and meth = { name : string; meth_t : t }
+and invoke = { invoked : t; default : t option; meth : string }
+and meth = { name : string; meth_value : t }
 
 and in_term =
   | Ground of Ground.t
@@ -291,9 +291,12 @@ let rec to_string v =
     | Tuple l -> "(" ^ String.concat ", " (List.map to_string l) ^ ")"
     | Null -> "null"
     | Cast (e, t) -> "(" ^ to_string e ^ " : " ^ Repr.string_of_type t ^ ")"
-    | Meth ({ name = l; meth_t = v }, e) ->
+    | Meth ({ name = l; meth_value = v }, e) ->
         to_string e ^ ".{" ^ l ^ " = " ^ to_string v ^ "}"
-    | Invoke { invoked = e; meth = l } -> to_string e ^ "." ^ l
+    | Invoke { invoked = e; meth = l; default } -> (
+        match default with
+          | None -> to_string e ^ "." ^ l
+          | Some v -> "(" ^ to_string e ^ "." ^ l ^ " ?? " ^ to_string v ^ ")")
     | Open (m, e) -> "open " ^ to_string m ^ " " ^ to_string e
     | Fun (_, [], v) when is_ground v -> "{" ^ to_string v ^ "}"
     | Fun _ | RFun _ -> "<fun>"
@@ -381,7 +384,7 @@ let rec free_vars tm =
         enc e
     | Cast (e, _) -> free_vars e
     | Seq (a, b) -> Vars.union (free_vars a) (free_vars b)
-    | Meth ({ meth_t = v }, e) -> Vars.union (free_vars v) (free_vars e)
+    | Meth ({ meth_value = v }, e) -> Vars.union (free_vars v) (free_vars e)
     | Invoke { invoked = e } -> free_vars e
     | Open (a, b) -> Vars.union (free_vars a) (free_vars b)
     | List l ->
@@ -436,7 +439,7 @@ let check_unused ~throw ~lib tm =
       | Tuple l -> List.fold_left (fun a -> check a) v l
       | Null -> v
       | Cast (e, _) -> check v e
-      | Meth ({ meth_t = f }, e) -> check (check v e) f
+      | Meth ({ meth_value = f }, e) -> check (check v e) f
       | Invoke { invoked = e } -> check v e
       | Open (a, b) -> check (check v a) b
       | Seq (a, b) -> check ~toplevel (check v a) b

--- a/src/lang/term.ml
+++ b/src/lang/term.ml
@@ -212,6 +212,7 @@ and in_term =
   | Encoder of encoder
   | List of t list
   | Tuple of t list
+  | Any
   | Null
   | Cast of t * Type.t
   | Meth of meth * t
@@ -289,6 +290,7 @@ let rec to_string v =
         aux e
     | List l -> "[" ^ String.concat ", " (List.map to_string l) ^ "]"
     | Tuple l -> "(" ^ String.concat ", " (List.map to_string l) ^ ")"
+    | Any -> "any"
     | Null -> "null"
     | Cast (e, t) -> "(" ^ to_string e ^ " : " ^ Repr.string_of_type t ^ ")"
     | Meth ({ name = l; meth_value = v }, e) ->
@@ -371,7 +373,7 @@ let rec free_vars tm =
     | Var x -> Vars.singleton x
     | Tuple l ->
         List.fold_left (fun v a -> Vars.union v (free_vars a)) Vars.empty l
-    | Null -> Vars.empty
+    | Any | Null -> Vars.empty
     | Encoder e ->
         let rec enc (_, p) =
           List.fold_left
@@ -437,7 +439,7 @@ let check_unused ~throw ~lib tm =
       | Var s -> Vars.remove s v
       | Ground _ -> v
       | Tuple l -> List.fold_left (fun a -> check a) v l
-      | Null -> v
+      | Any | Null -> v
       | Cast (e, _) -> check v e
       | Meth ({ meth_value = f }, e) -> check (check v e) f
       | Invoke { invoked = e } -> check v e

--- a/src/lang/type.mli
+++ b/src/lang/type.mli
@@ -56,6 +56,7 @@ type scheme = var list * t
 
 type meth = Type_base.meth = {
   meth : string;
+  optional : bool;
   scheme : scheme;
   doc : string;
   json_name : string option;
@@ -112,7 +113,14 @@ val has_meth : t -> string -> bool
 val invokes : t -> string list -> var list * t
 
 val meth :
-  ?pos:Pos.t -> ?json_name:string -> string -> scheme -> ?doc:string -> t -> t
+  ?pos:Pos.t ->
+  ?json_name:string ->
+  ?optional:bool ->
+  string ->
+  scheme ->
+  ?doc:string ->
+  t ->
+  t
 
 val meths : ?pos:Pos.t -> string list -> scheme -> t -> t
 val split_meths : t -> meth list * t

--- a/src/lang/typechecking.ml
+++ b/src/lang/typechecking.ml
@@ -158,6 +158,7 @@ let rec check ?(print_toplevel = false) ~throw ~level ~(env : Typing.env) e =
     e.t >: mk (Type.Arrow (proto_t, body.t))
   in
   match e.term with
+    | Any -> ()
     | Ground g -> e.t >: mkg (Ground.to_descr g)
     | Encoder f ->
         (* Ensure that we only use well-formed terms. *)

--- a/src/lang/typechecking.ml
+++ b/src/lang/typechecking.ml
@@ -35,7 +35,7 @@ let rec value_restriction t =
     | RFun _ -> true
     | Null -> true
     | List l | Tuple l -> List.for_all value_restriction l
-    | Meth ({ meth_t = t }, u) -> value_restriction t && value_restriction u
+    | Meth ({ meth_value = v }, u) -> value_restriction v && value_restriction u
     | Ground _ -> true
     | Let l -> value_restriction l.def && value_restriction l.body
     | Cast (t, _) -> value_restriction t
@@ -110,6 +110,7 @@ let rec type_of_pat ~level ~pos = function
                   Meth
                     ( {
                         meth = lbl;
+                        optional = false;
                         scheme = ([], a);
                         doc = "";
                         json_name = None;
@@ -189,7 +190,7 @@ let rec check ?(print_toplevel = false) ~throw ~level ~(env : Typing.env) e =
         check ~level ~env a;
         a.t <: t;
         e.t >: t
-    | Meth ({ name = l; meth_t = a }, b) ->
+    | Meth ({ name = l; meth_value = a }, b) ->
         check ~level ~env a;
         check ~level ~env b;
         e.t
@@ -197,17 +198,19 @@ let rec check ?(print_toplevel = false) ~throw ~level ~(env : Typing.env) e =
              (Type.Meth
                 ( {
                     Type.meth = l;
+                    optional = false;
                     scheme = Typing.generalize ~level a.t;
                     doc = "";
                     json_name = None;
                   },
                   b.t ))
-    | Invoke { invoked = a; meth = l } ->
+    | Invoke { invoked = a; default; meth = l } ->
         check ~level ~env a;
         let rec aux t =
           match (Type.deref t).Type.descr with
-            | Type.(Meth ({ meth = l'; scheme = s }, c)) ->
-                if l = l' then Typing.instantiate ~level s else aux c
+            | Type.(Meth ({ meth = l'; scheme = s }, _)) when l = l' ->
+                (fst s, Typing.instantiate ~level s)
+            | Type.(Meth (_, c)) -> aux c
             | _ ->
                 (* We did not find the method, the type we will infer is not the
                    most general one (no generalization), but this is safe and
@@ -220,14 +223,30 @@ let rec check ?(print_toplevel = false) ~throw ~level ~(env : Typing.env) e =
                        Meth
                          ( {
                              meth = l;
+                             optional = default <> None;
                              scheme = ([], x);
                              doc = "";
                              json_name = None;
                            },
                            y ));
-                x
+                ([], x)
         in
-        e.t >: aux a.t
+        let vars, typ = aux a.t in
+        let typ =
+          match default with
+            | None -> typ
+            | Some v ->
+                check ~level ~env v;
+                (* We want to make sure that: x?.foo types as: { foo?: 'a } *)
+                let typ =
+                  match (Type.deref v.t).descr with
+                    | Type.Nullable _ -> mk Type.(Nullable typ)
+                    | _ -> typ
+                in
+                Typing.instantiate ~level (vars, v.t) <: typ;
+                typ
+        in
+        e.t >: typ
     | Open (a, b) ->
         check ~level ~env a;
         a.t <: mk Type.unit;

--- a/src/lang/types/type_base.ml
+++ b/src/lang/types/type_base.ml
@@ -91,6 +91,7 @@ type scheme = var list * t
 (** A method. *)
 type meth = {
   meth : string;  (** name of the method *)
+  optional : bool;  (** is the method optional? *)
   scheme : scheme;  (** type scheme *)
   doc : string;  (** documentation *)
   json_name : string option;  (** name when represented as JSON *)
@@ -133,6 +134,7 @@ end
 module R = struct
   type meth = {
     name : string;
+    optional : bool;
     scheme : var list * t;
     json_name : string option;
   }
@@ -247,8 +249,8 @@ let rec invokes t = function
   | [] -> ([], t)
 
 (** Add a method to a type. *)
-let meth ?pos ?json_name meth scheme ?(doc = "") t =
-  make ?pos (Meth ({ meth; scheme; doc; json_name }, t))
+let meth ?pos ?json_name ?(optional = false) meth scheme ?(doc = "") t =
+  make ?pos (Meth ({ meth; optional; scheme; doc; json_name }, t))
 
 (** Add a submethod to a type. *)
 let rec meths ?pos l v t =

--- a/src/libs/externals.liq
+++ b/src/libs/externals.liq
@@ -40,7 +40,7 @@ def enable_external_ffmpeg_decoder() =
 
     let json.parse ( parsed : {
       streams : [{
-        channels : int?
+        channels? : int
       }]
     }?) = j
 
@@ -49,8 +49,8 @@ def enable_external_ffmpeg_decoder() =
 
       streams = parsed.streams
       stream = list.find(
-        default={channels = null(0)},
-        (fun (x) -> null.defined(x.channels)),
+        default={},
+        (fun (x) -> null.defined(x?.channels)),
         streams
       )
 

--- a/tests/core/types.ml
+++ b/tests/core/types.ml
@@ -27,7 +27,15 @@ let () =
     (List { t = make Ground.int; json_repr = `Tuple });
 
   let mk_meth meth ty t =
-    Meth ({ meth; scheme = ([], make ty); doc = ""; json_name = None }, make t)
+    Meth
+      ( {
+          meth;
+          optional = false;
+          scheme = ([], make ty);
+          doc = "";
+          json_name = None;
+        },
+        make t )
   in
 
   let m = mk_meth "aa" Ground.int Ground.bool in

--- a/tests/language/json.liq
+++ b/tests/language/json.liq
@@ -1,14 +1,5 @@
 # We test some ground values for json import/export.
 
-success = ref(true)
-
-def t(x,y) =
-  if x != y then
-    print("Failure: #{x} instead of #{y}")
-    success := false
-  end
-end
-
 def test_parse_error(name, f, msg) =
   error_caught = ref(false)
 
@@ -33,16 +24,16 @@ def test_parse_error(name, f, msg) =
 end
 
 def f() =
-  t(json.stringify(()), '[]')
-  t(json.stringify("aa'bb"), "\"aa'bb\"")
-  t(json.stringify("a"), '"a"')
-  t(json.stringify("©"), '"©"')
-  t(json.stringify('"'), '"\\""')
-  t(json.stringify('\\'), '"\\\\"')
+  test.equals(json.stringify(()), '[]')
+  test.equals(json.stringify("aa'bb"), "\"aa'bb\"")
+  test.equals(json.stringify("a"), '"a"')
+  test.equals(json.stringify("©"), '"©"')
+  test.equals(json.stringify('"'), '"\\""')
+  test.equals(json.stringify('\\'), '"\\\\"')
 
-  t(json.stringify(json5=true, infinity), 'Infinity')
-  t(json.stringify(json5=true, (0.-infinity)), '-Infinity')
-  t(json.stringify(json5=true,nan), 'NaN')
+  test.equals(json.stringify(json5=true, infinity), 'Infinity')
+  test.equals(json.stringify(json5=true, (0.-infinity)), '-Infinity')
+  test.equals(json.stringify(json5=true,nan), 'NaN')
 
   let b = json()
   b.add("b", 1)
@@ -50,11 +41,11 @@ def f() =
      a = null({a=1}),
      b = null(b)
   })
-  t(s, "{ \"b\": { \"b\": 1 }, \"a\": { \"a\": 1 } }")
+  test.equals(s, "{ \"b\": { \"b\": 1 }, \"a\": { \"a\": 1 } }")
 
   data = "123"
   let json.parse ( x : int ) = data
-  t(x, 123)
+  test.equals(x, 123)
 
   data = '{
     "foo": 34.24,
@@ -86,7 +77,7 @@ def f() =
     }
   }) = data
 
-  t(x, {
+  test.equals(x, {
     foo = 34.24,
     gni_gno = true,
     nested = {
@@ -107,12 +98,12 @@ def f() =
       nullable_list = [l1, ...tl]
     }
   } = data
-  t(foo, 34.24)
-  t(t1, 123)
-  t(t2, 3.14)
-  t(t3, false)
-  t(l1, null())
-  t(tl, [23, null()])
+  test.equals(foo, 34.24)
+  test.equals(t1, 123)
+  test.equals(t2, 3.14)
+  test.equals(t3, false)
+  test.equals(l1, null())
+  test.equals(tl, [23, null()])
 
   let json.parse x = data
   ignore(x.foo + 1.0)
@@ -208,25 +199,45 @@ def f() =
 
   data = '{"aabbcc": 34, "ddeerr": 54 }'
   let json.parse (x : [(string * int)] as json.object) = data
-  t(list.assoc("aabbcc", x), 34)
-  t(list.assoc("ddeerr", x), 54)
+  test.equals(list.assoc("aabbcc", x), 34)
+  test.equals(list.assoc("ddeerr", x), 54)
 
   data = '{ "foo": 123 }'
   let json.parse ( x : {
     foo : string
   }?) = data
-  t(x, null())
+  test.equals(x, null())
 
   data = '[ "gni", 123 ]'
   let json.parse ( x : [int]? ) = data
-  t(x, null())
+  test.equals(x, null())
 
   let json.parse ( x : (string * int * bool)? ) = data
-  t(x, null())
+  test.equals(x, null())
 
   data = '[ "gni", 123, "gno" ]'
   let json.parse ( x : (string * int) ) = data
-  t(x, ("gni",123))
+  test.equals(x, ("gni",123))
+
+  data = '{
+    "foo": {
+      "gni": {
+        "bla": 123
+      }
+    }
+  }'
+  let json.parse x = data
+  test.equals(x?.foo.gni?.bla, null(123))
+
+  data = '{
+    "foo": {}
+  }'
+  let json.parse x = data
+  test.equals(x?.foo.gni?.bla, null())
+
+  data = '{}'
+  let json.parse x = data
+  test.equals(x?.foo?.gni?.bla, null())
 
   j = json()
   j.add("foo", 1)
@@ -236,7 +247,7 @@ def f() =
   j.add("record", { a = 1, b = "ert"})
   j.remove("foo")
   j = json.stringify(j)
-  t(j, '{
+  test.equals(j, '{
   "record": { "b": "ert", "a": 1 },
   "key_with_methods": "value",
   "bla": "bar",
@@ -254,13 +265,9 @@ def f() =
   end
 
   f(infinity)
-  if not null.defined(!e) then success := false end
+  if not null.defined(!e) then test.fail() end
 
-  if !success then
-    test.pass()
-  else
-    test.fail()
-  end
+  test.pass()
 end
 
 test.check(f)

--- a/tests/language/record.liq
+++ b/tests/language/record.liq
@@ -1,23 +1,15 @@
 #!../../liquidsoap ../test.liq
 
-success = ref(true)
-
-def t(x, y)
-  if x != y then
-    print("Failure: got #{x} instead of #{y}")
-    success := false
-  end
-end
-
 def f() =
   # Basic checks
   n = 2
   r = n.{ a = 8 , b = 12 , f = fun(x) -> 2 * x }
-  t(1+r, 3)
-  t(r.b, 12)
-  t(r.a, 8)
-  t(r.f(5), 10)
+  test.equals(1+r, 3)
+  test.equals(r.b, 12)
+  test.equals(r.a, 8)
+  test.equals(r.f(5), 10)
   r = 2.{a = 5}
+  ignore(r)
 
   # Test overriding with subfields
   r = ()
@@ -47,9 +39,9 @@ def f() =
 
   ignore(counter())
   ignore(counter())
-  t(counter(), 3)
+  test.equals(counter(), 3)
   counter.reset()
-  t(counter(), 1)
+  test.equals(counter(), 1)
 
   # Float / field disambiguation
   r = 3.{s = "a"}
@@ -59,7 +51,7 @@ def f() =
   r = ()
   def r.f(n) = 2*n end
   open r
-  t(f(3), 6)
+  test.equals(f(3), 6)
 
   # Test subtyping in lists
   a = "a"
@@ -72,6 +64,7 @@ def f() =
   l = [b,a]
   ignore(list.hd(l).x)
   def f(c) = [a,c] end
+  ignore(f)
 
   # Subsequent increase of the type
   _ = if true then {a = 4, b = 5} else {a = 4} end
@@ -81,17 +74,106 @@ def f() =
   _ = [{a = 4, b = 5, c = 6}, {a = "a", b = 2, d = "d"}]
 
   # Equality
-  t({a = 5} == {a = 5}, true)
-  t({a = 5} == {a = 6}, false)
-  t({a = 5} == {a = 6, b = 4}, false)
-  t([{a = 5}] == [{a = 5}], true)
-  t(({a = 5}) == ({a = 5}), true)
+  test.equals({a = 5} == {a = 5}, true)
+  test.equals({a = 5} == {a = 6}, false)
+  test.equals({a = 5} == {a = 6, b = 4}, false)
+  test.equals([{a = 5}] == [{a = 5}], true)
+  test.equals(({a = 5}) == ({a = 5}), true)
   # The following is weird but expected
-  t({a = 5} == {a = 5, b = 6}, true)
-  t("bla".{x = 2} == "bla", true)
-  t("bla" == "bla".{x = 2}, true)
+  test.equals({a = 5} == {a = 5, b = 6}, true)
+  test.equals("bla".{x = 2} == "bla", true)
+  test.equals("bla" == "bla".{x = 2}, true)
 
-  if !success then test.pass() else test.fail() end
+  # Test optional fields
+  def f(x) =
+    (x?.foo ?? 2) + 1
+  end
+  test.equals(f(()), 3)
+  test.equals(f({}), 3)
+  test.equals(f({foo=1}), 2)
+  test.equals(f({foo=null()}), 3)
+
+  def f(x) =
+   ret = x?.foo(123)
+   ret ?? 1
+  end
+  test.equals(f(()), 1)
+  test.equals(f({}), 1)
+  test.equals(f({foo=(fun (x) -> x)}), 123)
+  test.equals(f({foo=null()}), 1)
+
+  def f(x) =
+    [x, {foo = 123}]
+  end
+  ignore(f(())?.foo)
+  (f({foo = 345}):{foo?:int})
+
+  x = { }
+  ignore(x.foo ?? 123)
+
+  def f(x) =
+    ignore((x.add ?? 1))
+    if false then x else () end
+    x
+  end
+  x = f(())
+  (x:{add?:int})
+
+  x = (():{foo?:int?})
+  ignore(f(()))
+
+  def f(x) =
+    x.foo.gni.bla(1,2,3).blo
+  end
+
+  test.equals(f({ foo = { gni = { bla = (fun (_,_,_,~foo="gni") -> { blo = 123 })}}}), 123)
+
+  def f(x) =
+    x.foo?.gni.bla(1,2,3)
+  end
+  test.equals(f({ foo = null() }), null())
+
+  # We want to make sure that:
+  def f(x) =
+    x?.foo
+  end
+  # is properly typed as: ('B.{foo? : 'A}) -> 'A?
+  test.equals(f({}), null())
+
+  x = ({foo = null()}:{foo: int?})
+  test.equals(f(x), null())
+
+  x = ({foo = null()}:{foo?:int?})
+  test.equals(f(x), null())
+
+  test.equals(f(true), null())
+  test.equals(f({foo = 1}), null(1))
+
+  # We want to make sure that:
+  def f(x) =
+    x?.foo(1)?.gni
+  end
+  # is properly typed as: ('A.{foo? : (int) -> 'B.{gni? : 'C}}) -> 'C?
+  # i.e. that { foo = (fun (_) -> { } ) } is a valid argument
+  test.equals(f({ foo = (fun (_) -> { } ) }), null())
+  test.equals(f(112.{ foo = (fun (_) -> false ) }), null())
+  test.equals(f({ foo = (fun (_) -> { gni = 2 } ) }), null(2))
+  test.equals(f(345.{ foo = (fun (_) -> "aabb".{ gni = 2 } ) }), null(2))
+
+  # We want to make sure that:
+  def f(x) =
+    x?.foo(1).gni ?? 1
+  end
+  # is properly typed as: ('A.{foo? : (int) -> 'B.{gni? : int}}) -> int
+  # i.e. that { foo = (fun (_) -> { } ) } is a valid argument
+  test.equals(f({}), 1)
+  test.equals(f(2), 1)
+  test.equals(f({ foo = (fun (_) -> { } ) }), 1)
+  test.equals(f("aabb".{ foo = (fun (_) -> 123 ) }), 1)
+  test.equals(f({ foo = (fun (_) -> { gni = 2 } ) }), 2)
+  test.equals(f(456.{ foo = (fun (_) -> true.{ gni = 2 } ) }), 2)
+
+  test.pass()
 end
 
 test.check(f)

--- a/tests/language/type_errors.liq
+++ b/tests/language/type_errors.liq
@@ -202,6 +202,14 @@ def f() =
   incorrect('crossfade(sequence([input.http("http://foo.bar"), input.http(self_sync=true,"http://foo.bar")]))');
   incorrect('crossfade(add([input.http("http://foo.bar"), input.http(self_sync=true,"http://foo.bar")]))');
 
+  section("OPTIONAL METHODS")
+  incorrect("(({}:{foo?:int}):{foo:int?})")
+  incorrect("fun (x) -> x?.foo.gni.gna + 1")
+  correct("(({}:{foo?:int}):{foo?:int?})")
+  correct("fun (x) -> x?.foo.gni.gna ?? 1")
+  correct("fun (x) -> x.foo.gni?.bla(1,2,3).blo")
+  correct("fun (x) -> x?.foo(123).gni ?? null()")
+
   test.pass()
 end
 

--- a/tests/language/typing.liq
+++ b/tests/language/typing.liq
@@ -173,6 +173,15 @@ def f() =
   (():{})
   (():unit.{})
 
+  ({foo = 123}:{foo?:int})
+  ({}:{foo?:int})
+  ({foo = null()}:{foo?:int})
+  ({foo = 123}:{foo?:int})
+  ({foo = null(null())}:{foo?:int?})
+
+  ([({}:{foo?:int}), (), {foo = 123}]:[{foo?:int}])
+  ([(), {foo = 123}]:[{foo?:int}])
+
   test.pass()
 end
 


### PR DESCRIPTION
This PR introduces optional record methods. 

The operational part is:
```ruby
x?.foo
```
This means that the method `foo` will be invoked on `x` but, if `foo` is not found,`null()` will be returned instead.

Optional methods are denoted using a similar `?:` syntax:

```ruby
(x:{foo?:int})
```

Notes:
* We allow `{foo:int?} <: {foo?:int}` and `{foo?:int?} <: {foo?:int}` and prohibit `{foo?:int} <: {foo:int?}` so that if `x.foo` is typed `int?`, this means that `x` does indeed have a `foo` method.
* Both `()` and `{foo:int}` can be unified in lists with `{foo?:int}`
* ~~The idea of adding different values than `null()` for the method's value when it does not exist on the caller has been explored.~~
 
~~It sounds like a great idea b/c it would bridge the gap between function arguments and records. However, it is not clear how to type a method with a default value.  Let's consider this:~~
```
y = x.foo ?? 123
```
~~Or any equivalent syntactic declaration for "let's find method `foo` or else return `123`". It really seems that this shouldn't be reflected in `x`'s type except from the fact that `x` may not have the method `foo`.~~

Well, this has been done. See below for details!

* A great follow-up would be a type annotation for "any type without method `foo`". In this case, it should be possible to define an unreachable type, for instance named `never` and do:
```
'a.{foo?: never}
```
This could be used to define a syntactic sugar to remove a method from a type:
```
f: 'a -> 'a.{foo?: never}
```
