### PR TITLE
Error enhancements

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -28,6 +28,9 @@ Changed:
 - Added support for a Javascript build an interpreter.
 - Removed support for `%define` variables, superseded by support for actual
   variables in encoders.
+- Errors now report proper stack trace via their `trace` method, making it
+  possible to programmatically point to file, line and character offsets
+  of each step in the error call trace (#2712)
 - Reimplemented `harbor` http handler API to be more flexible. Added a new
   node/express-like registration and middleware API (#2599).
 - Switched default persistence for cross and fade-related overrides

--- a/src/core/builtins/builtins_ffmpeg_filters.ml
+++ b/src/core/builtins/builtins_ffmpeg_filters.ml
@@ -115,16 +115,9 @@ module Graph = Value.MkAbstract (struct
   let name = "ffmpeg.filter.graph"
   let descr _ = name
 
-  let to_json _ =
-    raise
-      Runtime_error.(
-        Runtime_error
-          {
-            kind = "json";
-            msg =
-              Printf.sprintf "Ffmpeg filter graph cannot be represented as json";
-            pos = [];
-          })
+  let to_json ~pos _ =
+    Lang.raise_error
+      ~message:"Ffmpeg filter graph cannot be represented as json" ~pos "json"
 
   let compare = Stdlib.compare
 end)
@@ -138,15 +131,9 @@ module Audio = Value.MkAbstract (struct
   let name = "ffmpeg.filter.audio"
   let descr _ = name
 
-  let to_json _ =
-    raise
-      Runtime_error.(
-        Runtime_error
-          {
-            kind = "json";
-            msg = "Ffmpeg filter audio input cannot be represented as json";
-            pos = [];
-          })
+  let to_json ~pos _ =
+    Lang.raise_error ~pos
+      ~message:"Ffmpeg filter audio input cannot be represented as json" "json"
 
   let compare = Stdlib.compare
 end)
@@ -160,15 +147,9 @@ module Video = Value.MkAbstract (struct
   let name = "ffmpeg.filter.video"
   let descr _ = name
 
-  let to_json _ =
-    raise
-      Runtime_error.(
-        Runtime_error
-          {
-            kind = "json";
-            msg = "Ffmpeg filter video input cannot be represented as json";
-            pos = [];
-          })
+  let to_json ~pos _ =
+    Lang.raise_error ~pos
+      ~message:"Ffmpeg filter video input cannot be represented as json" "json"
 
   let compare = Stdlib.compare
 end)

--- a/src/core/builtins/builtins_files_extra.ml
+++ b/src/core/builtins/builtins_files_extra.ml
@@ -77,7 +77,7 @@ let () =
       let fname = Lang_string.home_unrelate fname in
       let f = Extralib.List.assoc_nth "" 1 p in
       let f () = ignore (Lang.apply f []) in
-      let unwatch = File_watcher.watch [`Modify] fname f in
+      let unwatch = File_watcher.watch ~pos:(Lang.pos p) [`Modify] fname f in
       Lang.meth Lang.unit
         [
           ( "unwatch",

--- a/src/core/builtins/builtins_harbor.ml
+++ b/src/core/builtins/builtins_harbor.ml
@@ -116,7 +116,8 @@ let () =
       "Low-level harbor handler registration. Overridden in standard library."
     register_args Lang.unit_t (fun p ->
       let uri, port, transport, verb, handler = parse_register_args p in
-      Harbor.add_http_handler ~transport ~port ~verb ~uri handler;
+      Harbor.add_http_handler ~pos:(Lang.pos p) ~transport ~port ~verb ~uri
+        handler;
       Lang.unit)
 
 let () =

--- a/src/core/builtins/builtins_http.ml
+++ b/src/core/builtins/builtins_http.ml
@@ -29,13 +29,6 @@ let () =
     "http.transport.unix" (Lang.http_transport Http.unix_transport).Lang.value
     Lang.http_transport_t
 
-let add_http_error kind =
-  Lang.add_builtin_base ~category:`Internet
-    ~descr:(Printf.sprintf "Base error for %s" kind)
-    (Printf.sprintf "%s.error" kind)
-    (Lang.error { Runtime_error.kind; msg = ""; pos = [] }).Lang.value
-    Lang.error_t
-
 let add_http_request ~stream_body ~descr ~request name =
   let name = Printf.sprintf "http.%s" name in
   let name = if stream_body then Printf.sprintf "%s.stream" name else name in
@@ -158,8 +151,8 @@ let add_http_request ~stream_body ~descr ~request name =
               | Delete -> `Delete
           in
           let ans =
-            Liqcurl.http_request ~follow_redirect:redirect ~timeout ~headers
-              ~url
+            Liqcurl.http_request ~pos:(Lang.pos p) ~follow_redirect:redirect
+              ~timeout ~headers ~url
               ~on_body_data:(fun s -> on_body_data (Some s))
               ~request ?http_version ()
           in
@@ -207,7 +200,6 @@ let add_http_request ~stream_body ~descr ~request name =
         ])
 
 let () =
-  add_http_error "http";
   List.iter
     (fun stream_body ->
       add_http_request ~descr:"Perform a full http GET request." ~request:Get

--- a/src/core/builtins/builtins_socket.ml
+++ b/src/core/builtins/builtins_socket.ml
@@ -26,15 +26,9 @@ module SocketValue = struct
 
     let name = "socket"
 
-    let to_json _ =
-      raise
-        Runtime_error.(
-          Runtime_error
-            {
-              kind = "json";
-              msg = "Socket cannot be represented as json";
-              pos = [];
-            })
+    let to_json ~pos _ =
+      Lang.raise_error ~pos ~message:"Socket cannot be represented as json"
+        "json"
 
     let descr s = Printf.sprintf "<%s socket>" s#typ
     let compare = Stdlib.compare
@@ -75,7 +69,7 @@ module SocketValue = struct
                         if rem <= 0. then failwith "timeout!";
                         socket#wait_for `Write rem
                       with _ ->
-                        Lang.raise_error
+                        Lang.raise_error ~pos:(Lang.pos p)
                           ~message:"Timeout while writing to the socket!"
                           "socket")
               in
@@ -116,7 +110,7 @@ module SocketValue = struct
                         if rem <= 0. then failwith "timeout!";
                         socket#wait_for `Read rem
                       with _ ->
-                        Lang.raise_error
+                        Lang.raise_error ~pos:(Lang.pos p)
                           ~message:"Timeout while reading from the socket!"
                           "socket")
               in

--- a/src/core/builtins/builtins_srt.ml
+++ b/src/core/builtins/builtins_srt.ml
@@ -247,15 +247,9 @@ module SocketValue = struct
 
     let name = "srt_socket"
 
-    let to_json _ =
-      raise
-        Runtime_error.(
-          Runtime_error
-            {
-              kind = "json";
-              msg = "SRT socket cannot be represented as json";
-              pos = [];
-            })
+    let to_json ~pos _ =
+      Runtime_error.raise ~pos
+        ~message:"SRT socket cannot be represented as json" "json"
 
     let descr _ = "<srt_socket>"
     let compare = Stdlib.compare

--- a/src/core/builtins/builtins_string_extra.ml
+++ b/src/core/builtins/builtins_string_extra.ml
@@ -36,13 +36,7 @@ let () =
           (Lang.metadata (Utils.hashtbl_of_list metadata))
           (Lang.string uri)
       with Annotate.Error err ->
-        raise
-          (Runtime_error.Runtime_error
-             {
-               Runtime_error.kind = "string";
-               msg = err;
-               pos = (match v.Value.pos with None -> [] | Some p -> [p]);
-             }))
+        Lang.raise_error ~message:err ~pos:(Lang.pos p) "string")
 
 let () =
   Lang.add_builtin "string.recode" ~category:`String

--- a/src/core/builtins/builtins_sys.ml
+++ b/src/core/builtins/builtins_sys.ml
@@ -373,13 +373,13 @@ let () =
       let f = Lang.to_string (List.assoc "" p) in
       let f = Lang_string.home_unrelate f in
       if not (Sys.file_exists f) then
-        Lang.raise_error
+        Lang.raise_error ~pos:(Lang.pos p)
           ~message:
             (Printf.sprintf "File %s does not exist!"
                (Lang_string.quote_string f))
           "playlist";
       if Sys.is_directory f then
-        Lang.raise_error
+        Lang.raise_error ~pos:(Lang.pos p)
           ~message:
             (Printf.sprintf
                "File %s is a directory! A regular file was expected."

--- a/src/core/builtins/builtins_thread.ml
+++ b/src/core/builtins/builtins_thread.ml
@@ -111,14 +111,14 @@ let () =
       let fn = Lang.assoc "" 2 p in
       let handler ~bt err =
         match (err, on_err) with
-          | Runtime_error.(Runtime_error { kind; msg; _ }), None ->
-              let error = Lang.error { Runtime_error.kind; msg; pos = [] } in
+          | Runtime_error.(Runtime_error error), None ->
+              let error = Lang.error error in
               let bt = Lang.string bt in
               ignore (Lang.apply fn [("backtrace", bt); ("", error)]);
               true
-          | Runtime_error.(Runtime_error { kind; msg; _ }), Some err
-            when kind = err.Runtime_error.kind ->
-              let error = Lang.error { Runtime_error.kind; msg; pos = [] } in
+          | Runtime_error.(Runtime_error error), Some err
+            when error.Runtime_error.kind = err.Runtime_error.kind ->
+              let error = Lang.error error in
               let bt = Lang.string bt in
               ignore (Lang.apply fn [("backtrace", bt); ("", error)]);
               true

--- a/src/core/builtins/builtins_time.ml
+++ b/src/core/builtins/builtins_time.ml
@@ -26,18 +26,17 @@ let () =
     ~descr:
       ("INTERNAL: time_in_mod(a,b,c) checks that the unix time T "
      ^ "satisfies a <= T mod c < b") [t; t; t] Lang.bool_t (fun p ->
-      match List.map (fun (_, x) -> Lang.to_int x) p with
-        | [a; b; c] ->
-            let t = Unix.localtime (Unix.time ()) in
-            let t =
-              t.Unix.tm_sec + (t.Unix.tm_min * 60)
-              + (t.Unix.tm_hour * 60 * 60)
-              + (t.Unix.tm_wday * 24 * 60 * 60)
-            in
-            let t = t mod c in
-            if a <= b then Lang.bool (a <= t && t < b)
-            else Lang.bool (not (b <= t && t < a))
-        | _ -> assert false)
+      let g pos = Lang.to_int (Lang.assoc "" pos p) in
+      let a, b, c = (g 1, g 2, g 3) in
+      let t = Unix.localtime (Unix.time ()) in
+      let t =
+        t.Unix.tm_sec + (t.Unix.tm_min * 60)
+        + (t.Unix.tm_hour * 60 * 60)
+        + (t.Unix.tm_wday * 24 * 60 * 60)
+      in
+      let t = t mod c in
+      if a <= b then Lang.bool (a <= t && t < b)
+      else Lang.bool (not (b <= t && t < a)))
 
 let () =
   Lang.add_builtin ~category:`Time "time"
@@ -162,18 +161,10 @@ let () =
         let predicate = processor tokenizer in
         Lang.val_fun [] (fun _ -> Liquidsoap_lang.Evaluation.eval predicate)
       with _ ->
-        raise
-          Runtime_error.(
-            Runtime_error
-              {
-                kind = "string";
-                msg =
-                  Printf.sprintf "Failed to parse %s as time predicate"
-                    predicate;
-                pos =
-                  Option.value ~default:[]
-                    (Option.map (fun v -> [v]) v.Value.pos);
-              }))
+        Lang.raise_error
+          ~message:
+            (Printf.sprintf "Failed to parse %s as time predicate" predicate)
+          ~pos:(Lang.pos p) "string")
 
 let () =
   let tz_t =

--- a/src/core/file_watcher.inotify.ml
+++ b/src/core/file_watcher.inotify.ml
@@ -27,7 +27,12 @@ type event = [ `Modify ]
 type unwatch = unit -> unit
 
 (** Type for watching function. *)
-type watch = event list -> string -> (unit -> unit) -> unwatch
+type watch =
+  pos:Liquidsoap_lang.Pos.t list ->
+  event list ->
+  string ->
+  (unit -> unit) ->
+  unwatch
 
 let fd = ref (None : Unix.file_descr option)
 let handlers = ref []
@@ -48,8 +53,8 @@ let rec watchdog () =
   { Duppy.Task.priority = `Maybe_blocking; events = [`Read fd]; handler }
 
 let watch : watch =
- fun e file f ->
-  if not (Sys.file_exists file) then Lang.raise_error "not_found";
+ fun ~pos e file f ->
+  if not (Sys.file_exists file) then Lang.raise_error ~pos "not_found";
   Tutils.mutexify m
     (fun () ->
       if !fd = None then (

--- a/src/core/file_watcher.mtime.ml
+++ b/src/core/file_watcher.mtime.ml
@@ -27,7 +27,12 @@ type event = [ `Modify ]
 type unwatch = unit -> unit
 
 (** Type for watching function. *)
-type watch = event list -> string -> (unit -> unit) -> unwatch
+type watch =
+  pos:Liquidsoap_lang.Pos.t list ->
+  event list ->
+  string ->
+  (unit -> unit) ->
+  unwatch
 
 type watched_files = {
   file : string;
@@ -60,8 +65,8 @@ let rec handler _ =
     ()
 
 let watch : watch =
- fun e file callback ->
-  if not (Sys.file_exists file) then Lang.raise_error "not_found";
+ fun ~pos e file callback ->
+  if not (Sys.file_exists file) then Lang.raise_error ~pos "not_found";
   if List.mem `Modify e then
     Tutils.mutexify m
       (fun () ->

--- a/src/core/lang.ml
+++ b/src/core/lang.ml
@@ -25,15 +25,9 @@ module HttpTransport = struct
 
     let name = "http_transport"
 
-    let to_json _ =
-      raise
-        Runtime_error.(
-          Runtime_error
-            {
-              kind = "json";
-              msg = "Http transport cannot be represented as json";
-              pos = [];
-            })
+    let to_json ~pos _ =
+      Runtime_error.raise ~pos
+        ~message:"Http transport cannot be represented as json" "json"
 
     let descr transport = Printf.sprintf "<%s_transport>" transport#name
     let compare = Stdlib.compare

--- a/src/core/lang.mli
+++ b/src/core/lang.mli
@@ -39,7 +39,7 @@ module Ground : sig
 
   type content = Liquidsoap_lang.Term.Ground.content = {
     descr : t -> string;
-    to_json : t -> Json.t;
+    to_json : pos:Liquidsoap_lang.Pos.t list -> t -> Json.t;
     compare : t -> t -> int;
     typ : (module Liquidsoap_lang.Type.Ground.Custom);
   }
@@ -250,14 +250,17 @@ val val_fun : (string * string * value option) list -> (env -> value) -> value
   * when the constant is ground. *)
 val val_cst_fun : (string * value option) list -> value -> value
 
+(** Extract position from the environment. Used inside function execution. *)
+val pos : env -> Liquidsoap_lang.Pos.t list
+
 (** Convert a metadata packet to a list associating strings to strings. *)
 val metadata : Frame.metadata -> value
 
 (** Raise an error. *)
 val raise_error :
   ?bt:Printexc.raw_backtrace ->
-  ?pos:Liquidsoap_lang.Pos.List.t ->
   ?message:string ->
+  pos:Liquidsoap_lang.Pos.List.t ->
   string ->
   'a
 

--- a/src/core/lang_encoders/lang_avi.ml
+++ b/src/core/lang_encoders/lang_avi.ml
@@ -45,7 +45,7 @@ let make params =
             { f with Avi_format.width = Lazy.from_val i }
         | "height", `Value { value = Ground (Int i); _ } ->
             { f with Avi_format.height = Lazy.from_val i }
-        | t -> raise (Lang_encoder.generic_error t))
+        | t -> Lang_encoder.raise_generic_error t)
       defaults params
   in
   Encoder.AVI avi

--- a/src/core/lang_encoders/lang_external_encoder.ml
+++ b/src/core/lang_encoders/lang_external_encoder.ml
@@ -91,7 +91,7 @@ let make params =
             { f with External_encoder_format.process = s }
         | "", `Value { value = Ground (String s); _ } ->
             { f with External_encoder_format.process = s }
-        | t -> raise (Lang_encoder.generic_error t))
+        | t -> Lang_encoder.raise_generic_error t)
       defaults params
   in
   if ext.External_encoder_format.process = "" then

--- a/src/core/lang_encoders/lang_fdkaac.ml
+++ b/src/core/lang_encoders/lang_fdkaac.ml
@@ -50,7 +50,7 @@ let make params =
            Printf.sprintf "invalid samplerate value. Possible values: %s"
              (String.concat ", " (List.map string_of_int valid_samplerates))
          in
-         raise (Lang_encoder.error ~pos err));
+         Lang_encoder.raise_error ~pos err);
        i)
   in
   let defaults =
@@ -78,7 +78,7 @@ let make params =
             let aot =
               try Fdkaac_format.aot_of_string s
               with Not_found ->
-                raise (Lang_encoder.error ~pos "invalid aot value")
+                Lang_encoder.raise_error ~pos "invalid aot value"
             in
             { f with Fdkaac_format.aot }
         | "vbr", `Value { value = Ground (Int i); pos } ->
@@ -87,7 +87,7 @@ let make params =
                 Printf.sprintf "invalid vbr mode. Possible values: %s"
                   (String.concat ", " (List.map string_of_int valid_vbr))
               in
-              raise (Lang_encoder.error ~pos err));
+              Lang_encoder.raise_error ~pos err);
             { f with Fdkaac_format.bitrate_mode = `Variable i }
         | "bandwidth", `Value { value = Ground (Int i); _ } ->
             { f with Fdkaac_format.bandwidth = `Fixed i }
@@ -109,7 +109,7 @@ let make params =
             let transmux =
               try Fdkaac_format.transmux_of_string s
               with Not_found ->
-                raise (Lang_encoder.error ~pos "invalid transmux value")
+                Lang_encoder.raise_error ~pos "invalid transmux value"
             in
             { f with Fdkaac_format.transmux }
         | "", `Value { value = Ground (String s); _ }
@@ -118,7 +118,7 @@ let make params =
         | "", `Value { value = Ground (String s); _ }
           when String.lowercase_ascii s = "stereo" ->
             { f with Fdkaac_format.channels = 2 }
-        | t -> raise (Lang_encoder.generic_error t))
+        | t -> Lang_encoder.raise_generic_error t)
       defaults params
   in
   let aot = fdkaac.Fdkaac_format.aot in

--- a/src/core/lang_encoders/lang_ffmpeg.ml
+++ b/src/core/lang_encoders/lang_ffmpeg.ml
@@ -127,30 +127,29 @@ let ffmpeg_gen params =
       | Ground (Int i) -> i
       | Ground (String s) -> int_of_string s
       | Ground (Float f) -> int_of_float f
-      | _ -> raise (Lang_encoder.error ~pos:t.pos "integer expected")
+      | _ -> Lang_encoder.raise_error ~pos:t.pos "integer expected"
   in
   let to_string t =
     match t.value with
       | Ground (Int i) -> Printf.sprintf "%i" i
       | Ground (String s) -> s
       | Ground (Float f) -> Printf.sprintf "%f" f
-      | _ -> raise (Lang_encoder.error ~pos:t.pos "string expected")
+      | _ -> Lang_encoder.raise_error ~pos:t.pos "string expected"
   in
   let to_float t =
     match t.value with
       | Ground (Int i) -> float i
       | Ground (String s) -> float_of_string s
       | Ground (Float f) -> f
-      | _ -> raise (Lang_encoder.error ~pos:t.pos "float expected")
+      | _ -> Lang_encoder.raise_error ~pos:t.pos "float expected"
   in
   let to_copy_opt t =
     match t.value with
       | Ground (String "wait_for_keyframe") -> `Wait_for_keyframe
       | Ground (String "ignore_keyframe") -> `Ignore_keyframe
       | _ ->
-          raise
-            (Lang_encoder.error ~pos:t.pos
-               ("Invalid value for copy encoder parameter: " ^ Value.to_string t))
+          Lang_encoder.raise_error ~pos:t.pos
+            ("Invalid value for copy encoder parameter: " ^ Value.to_string t)
   in
   let rec parse_args ~format ~mode f = function
     | [] -> f
@@ -256,7 +255,7 @@ let ffmpeg_gen params =
           | `Audio -> Hashtbl.add f.Ffmpeg_format.audio_opts k (`Float fl)
           | `Video -> Hashtbl.add f.Ffmpeg_format.video_opts k (`Float fl));
         parse_args ~format ~mode f l
-    | (_, t) :: _ -> raise (Lang_encoder.error ~pos:t.pos "unexpected option")
+    | (_, t) :: _ -> Lang_encoder.raise_error ~pos:t.pos "unexpected option"
   in
   List.fold_left
     (fun f -> function
@@ -299,14 +298,13 @@ let ffmpeg_gen params =
       | `Option (k, { value = Ground (Float i); _ }) ->
           Hashtbl.add f.Ffmpeg_format.other_opts k (`Float i);
           f
-      | `Option (l, v) -> raise (Lang_encoder.generic_error (l, `Value v)))
+      | `Option (l, v) -> Lang_encoder.raise_generic_error (l, `Value v))
     defaults params
 
 let copy_param = function
   | [] -> None
   | [("", t)] -> Some t
-  | [(l, v)] | _ :: (l, v) :: _ ->
-      raise (Lang_encoder.generic_error (l, `Value v))
+  | [(l, v)] | _ :: (l, v) :: _ -> Lang_encoder.raise_generic_error (l, `Value v)
 
 let make params =
   let params =

--- a/src/core/lang_encoders/lang_flac.ml
+++ b/src/core/lang_encoders/lang_flac.ml
@@ -46,11 +46,11 @@ let flac_gen params =
           { f with Flac_format.samplerate = Lazy.from_val i }
       | "compression", `Value { value = Ground (Int i); pos } ->
           if i < 0 || i > 8 then
-            raise (Lang_encoder.error ~pos "invalid compression value");
+            Lang_encoder.raise_error ~pos "invalid compression value";
           { f with Flac_format.compression = i }
       | "bits_per_sample", `Value { value = Ground (Int i); pos } ->
           if not (List.mem i accepted_bits_per_sample) then
-            raise (Lang_encoder.error ~pos "invalid bits_per_sample value");
+            Lang_encoder.raise_error ~pos "invalid bits_per_sample value";
           { f with Flac_format.bits_per_sample = i }
       | "bytes_per_page", `Value { value = Ground (Int i); _ } ->
           { f with Flac_format.fill = Some i }
@@ -60,7 +60,7 @@ let flac_gen params =
       | "", `Value { value = Ground (String s); _ }
         when String.lowercase_ascii s = "stereo" ->
           { f with Flac_format.channels = 2 }
-      | t -> raise (Lang_encoder.generic_error t))
+      | t -> Lang_encoder.raise_generic_error t)
     defaults params
 
 let make_ogg params = Ogg_format.Flac (flac_gen params)

--- a/src/core/lang_encoders/lang_gstreamer.ml
+++ b/src/core/lang_encoders/lang_gstreamer.ml
@@ -71,7 +71,7 @@ let make ?pos params =
             { f with Gstreamer_format.log = i }
         | "pipeline", `Value { value = Ground (String s); _ } ->
             { f with Gstreamer_format.pipeline = perhaps s }
-        | t -> raise (Lang_encoder.generic_error t))
+        | t -> Lang_encoder.raise_generic_error t)
       defaults params
   in
   if
@@ -79,18 +79,16 @@ let make ?pos params =
     && gstreamer.Gstreamer_format.audio <> None
     && gstreamer.Gstreamer_format.channels = 0
   then
-    raise
-      (Lang_encoder.error ~pos
-         "must have at least one audio channel when passing an audio pipeline");
+    Lang_encoder.raise_error ~pos
+      "must have at least one audio channel when passing an audio pipeline";
   if
     gstreamer.Gstreamer_format.pipeline = None
     && gstreamer.Gstreamer_format.video <> None
     && gstreamer.Gstreamer_format.audio <> None
     && gstreamer.Gstreamer_format.muxer = None
   then
-    raise
-      (Lang_encoder.error ~pos
-         "must have a muxer when passing an audio and a video pipeline");
+    Lang_encoder.raise_error ~pos
+      "must have a muxer when passing an audio and a video pipeline";
   Encoder.GStreamer gstreamer
 
 let () = Lang_encoder.register "gstreamer" type_of_encoder (make ?pos:None)

--- a/src/core/lang_encoders/lang_mp3.ml
+++ b/src/core/lang_encoders/lang_mp3.ml
@@ -37,7 +37,7 @@ let check_samplerate ~pos i =
        [8000; 11025; 12000; 16000; 22050; 24000; 32000; 44100; 48000]
      in
      if not (List.mem i allowed) then
-       raise (Lang_encoder.error ~pos "invalid samplerate value");
+       Lang_encoder.raise_error ~pos "invalid samplerate value";
      i)
 
 let mp3_base_defaults () =
@@ -63,14 +63,13 @@ let mp3_base f = function
           | "default" -> Mp3_format.Default
           | "joint_stereo" -> Mp3_format.Joint_stereo
           | "stereo" -> Mp3_format.Stereo
-          | _ -> raise (Lang_encoder.error ~pos "invalid stereo mode")
+          | _ -> Lang_encoder.raise_error ~pos "invalid stereo mode"
       in
       { f with Mp3_format.stereo_mode = mode }
   | "internal_quality", `Value { value = Ground (Int q); pos } ->
       if q < 0 || q > 9 then
-        raise
-          (Lang_encoder.error ~pos
-             "internal quality must be a value between 0 and 9");
+        Lang_encoder.raise_error ~pos
+          "internal quality must be a value between 0 and 9";
       { f with Mp3_format.internal_quality = q }
   | "msg_interval", `Value { value = Ground (Float i); _ } ->
       { f with Mp3_format.msg_interval = i }
@@ -81,9 +80,8 @@ let mp3_base f = function
   | "id3v2", `Value { value = Ground (Bool true); pos } -> (
       match !Mp3_format.id3v2_export with
         | None ->
-            raise
-              (Lang_encoder.error ~pos
-                 "no id3v2 support available for the mp3 encoder")
+            Lang_encoder.raise_error ~pos
+              "no id3v2 support available for the mp3 encoder"
         | Some g -> { f with Mp3_format.id3v2 = Some g })
   | "id3v2", `Value { value = Ground (Bool false); _ } ->
       { f with Mp3_format.id3v2 = None }
@@ -93,7 +91,7 @@ let mp3_base f = function
   | "", `Value { value = Ground (String s); _ }
     when String.lowercase_ascii s = "stereo" ->
       { f with Mp3_format.stereo = true }
-  | t -> raise (Lang_encoder.generic_error t)
+  | t -> Lang_encoder.raise_generic_error t
 
 let make_cbr params =
   let defaults =
@@ -113,7 +111,7 @@ let make_cbr params =
       (fun f -> function
         | "bitrate", `Value { value = Ground (Int i); pos } ->
             if not (List.mem i allowed_bitrates) then
-              raise (Lang_encoder.error ~pos "invalid bitrate value");
+              Lang_encoder.raise_error ~pos "invalid bitrate value";
             set_bitrate f i
         | x -> mp3_base f x)
       defaults params
@@ -205,21 +203,21 @@ let make_abr_vbr ~default params =
       (fun f -> function
         | "quality", `Value { value = Ground (Int q); pos } when is_vbr f ->
             if q < 0 || q > 9 then
-              raise (Lang_encoder.error ~pos "quality should be in [0..9]");
+              Lang_encoder.raise_error ~pos "quality should be in [0..9]";
             set_quality f (Some q)
         | "hard_min", `Value { value = Ground (Bool b); _ } ->
             set_hard_min f (Some b)
         | "bitrate", `Value { value = Ground (Int i); pos } ->
             if not (List.mem i allowed_bitrates) then
-              raise (Lang_encoder.error ~pos "invalid bitrate value");
+              Lang_encoder.raise_error ~pos "invalid bitrate value";
             set_mean_bitrate f (Some i)
         | "min_bitrate", `Value { value = Ground (Int i); pos } ->
             if not (List.mem i allowed_bitrates) then
-              raise (Lang_encoder.error ~pos "invalid bitrate value");
+              Lang_encoder.raise_error ~pos "invalid bitrate value";
             set_min_bitrate f (Some i)
         | "max_bitrate", `Value { value = Ground (Int i); pos } ->
             if not (List.mem i allowed_bitrates) then
-              raise (Lang_encoder.error ~pos "invalid bitrate value");
+              Lang_encoder.raise_error ~pos "invalid bitrate value";
             set_max_bitrate f (Some i)
         | x -> mp3_base f x)
       default params

--- a/src/core/lang_encoders/lang_opus.ml
+++ b/src/core/lang_encoders/lang_opus.ml
@@ -55,8 +55,7 @@ let make params =
         | "complexity", `Value { value = Ground (Int c); pos } ->
             (* Doc say this should be from 0 to 10. *)
             if c < 0 || c > 10 then
-              raise
-                (Lang_encoder.error ~pos "Opus complexity should be in 0..10");
+              Lang_encoder.raise_error ~pos "Opus complexity should be in 0..10";
             { f with Opus_format.complexity = Some c }
         | "max_bandwidth", `Value { value = Ground (String "narrow_band"); _ }
           ->
@@ -74,24 +73,21 @@ let make params =
         | "frame_size", `Value { value = Ground (Float size); pos } ->
             let frame_sizes = [2.5; 5.; 10.; 20.; 40.; 60.] in
             if not (List.mem size frame_sizes) then
-              raise
-                (Lang_encoder.error ~pos
-                   "Opus frame size should be one of 2.5, 5., 10., 20., 40. or \
-                    60.");
+              Lang_encoder.raise_error ~pos
+                "Opus frame size should be one of 2.5, 5., 10., 20., 40. or 60.";
             { f with Opus_format.frame_size = size }
         | "samplerate", `Value { value = Ground (Int i); pos } ->
             let samplerates = [8000; 12000; 16000; 24000; 48000] in
             if not (List.mem i samplerates) then
-              raise
-                (Lang_encoder.error ~pos
-                   "Opus samplerate should be one of 8000, 12000, 16000, 24000 \
-                    or 48000");
+              Lang_encoder.raise_error ~pos
+                "Opus samplerate should be one of 8000, 12000, 16000, 24000 or \
+                 48000";
             { f with Opus_format.samplerate = i }
         | "bitrate", `Value { value = Ground (Int i); pos } ->
             let i = i * 1000 in
             (* Doc say this should be from 500 to 512000. *)
             if i < 500 || i > 512000 then
-              raise (Lang_encoder.error ~pos "Opus bitrate should be in 5..512");
+              Lang_encoder.raise_error ~pos "Opus bitrate should be in 5..512";
             { f with Opus_format.bitrate = `Bitrate i }
         | "bitrate", `Value { value = Ground (String "auto"); _ } ->
             { f with Opus_format.bitrate = `Auto }
@@ -99,9 +95,8 @@ let make params =
             { f with Opus_format.bitrate = `Bitrate_max }
         | "channels", `Value { value = Ground (Int i); pos } ->
             if i < 1 || i > 2 then
-              raise
-                (Lang_encoder.error ~pos
-                   "only mono and stereo streams are supported for now");
+              Lang_encoder.raise_error ~pos
+                "only mono and stereo streams are supported for now";
             { f with Opus_format.channels = i }
         | "vbr", `Value { value = Ground (String "none"); _ } ->
             { f with Opus_format.mode = Opus_format.CBR }
@@ -125,7 +120,7 @@ let make params =
         | "", `Value { value = Ground (String s); _ }
           when String.lowercase_ascii s = "stereo" ->
             { f with Opus_format.channels = 2 }
-        | t -> raise (Lang_encoder.generic_error t))
+        | t -> Lang_encoder.raise_generic_error t)
       defaults params
   in
   Ogg_format.Opus opus

--- a/src/core/lang_encoders/lang_shine.ml
+++ b/src/core/lang_encoders/lang_shine.ml
@@ -50,7 +50,7 @@ let make params =
         | "", `Value { value = Ground (String s); _ }
           when String.lowercase_ascii s = "stereo" ->
             { f with Shine_format.channels = 2 }
-        | t -> raise (Lang_encoder.generic_error t))
+        | t -> Lang_encoder.raise_generic_error t)
       defaults params
   in
   Encoder.Shine shine

--- a/src/core/lang_encoders/lang_speex.ml
+++ b/src/core/lang_encoders/lang_speex.ml
@@ -53,7 +53,7 @@ let make params =
         | "quality", `Value { value = Ground (Int q); pos } ->
             (* Doc say this should be from 0 to 10. *)
             if q < 0 || q > 10 then
-              raise (Lang_encoder.error ~pos "Speex quality should be in 0..10");
+              Lang_encoder.raise_error ~pos "Speex quality should be in 0..10";
             { f with Speex_format.bitrate_control = Speex_format.Quality q }
         | "vbr", `Value { value = Ground (Int q); _ } ->
             { f with Speex_format.bitrate_control = Speex_format.Vbr q }
@@ -71,8 +71,8 @@ let make params =
         | "complexity", `Value { value = Ground (Int i); pos } ->
             (* Doc says this should be between 1 and 10. *)
             if i < 1 || i > 10 then
-              raise
-                (Lang_encoder.error ~pos "Speex complexity should be in 1..10");
+              Lang_encoder.raise_error ~pos
+                "Speex complexity should be in 1..10";
             { f with Speex_format.complexity = Some i }
         | "bytes_per_page", `Value { value = Ground (Int i); _ } ->
             { f with Speex_format.fill = Some i }
@@ -86,7 +86,7 @@ let make params =
         | "", `Value { value = Ground (String s); _ }
           when String.lowercase_ascii s = "stereo" ->
             { f with Speex_format.stereo = true }
-        | t -> raise (Lang_encoder.generic_error t))
+        | t -> Lang_encoder.raise_generic_error t)
       defaults params
   in
   Ogg_format.Speex speex

--- a/src/core/lang_encoders/lang_theora.ml
+++ b/src/core/lang_encoders/lang_theora.ml
@@ -52,37 +52,33 @@ let make params =
           (* According to the doc, this should be a value between
            * 0 and 63. *)
           if i < 0 || i > 63 then
-            raise (Lang_encoder.error ~pos "Theora quality should be in 0..63");
+            Lang_encoder.raise_error ~pos "Theora quality should be in 0..63";
           { f with Theora_format.bitrate_control = Theora_format.Quality i }
       | "bitrate", `Value { value = Ground (Int i); _ } ->
           { f with Theora_format.bitrate_control = Theora_format.Bitrate i }
       | "width", `Value { value = Ground (Int i); pos } ->
           (* According to the doc: must be a multiple of 16, and less than 1048576. *)
           if i mod 16 <> 0 || i >= 1048576 then
-            raise
-              (Lang_encoder.error ~pos
-                 "invalid frame width value (should be a multiple of 16)");
+            Lang_encoder.raise_error ~pos
+              "invalid frame width value (should be a multiple of 16)";
           { f with Theora_format.width = lazy i; picture_width = lazy i }
       | "height", `Value { value = Ground (Int i); pos } ->
           (* According to the doc: must be a multiple of 16, and less than 1048576. *)
           if i mod 16 <> 0 || i >= 1048576 then
-            raise
-              (Lang_encoder.error ~pos
-                 "invalid frame height value (should be a multiple of 16)");
+            Lang_encoder.raise_error ~pos
+              "invalid frame height value (should be a multiple of 16)";
           { f with Theora_format.height = lazy i; picture_height = lazy i }
       | "picture_width", `Value { value = Ground (Int i); pos } ->
           (* According to the doc: must not be larger than width. *)
           if i > Lazy.force f.Theora_format.width then
-            raise
-              (Lang_encoder.error ~pos
-                 "picture width must not be larger than width");
+            Lang_encoder.raise_error ~pos
+              "picture width must not be larger than width";
           { f with Theora_format.picture_width = lazy i }
       | "picture_height", `Value { value = Ground (Int i); pos } ->
           (* According to the doc: must not be larger than height. *)
           if i > Lazy.force f.Theora_format.height then
-            raise
-              (Lang_encoder.error ~pos
-                 "picture height must not be larger than height");
+            Lang_encoder.raise_error ~pos
+              "picture height must not be larger than height";
           { f with Theora_format.picture_height = lazy i }
       | "picture_x", `Value { value = Ground (Int i); pos } ->
           (* According to the doc: must be no larger than width-picture_width
@@ -94,10 +90,9 @@ let make params =
                 - Lazy.force f.Theora_format.picture_width)
                 255
           then
-            raise
-              (Lang_encoder.error ~pos
-                 "picture x must not be larger than width - picture width or \
-                  255, whichever is smaller");
+            Lang_encoder.raise_error ~pos
+              "picture x must not be larger than width - picture width or 255, \
+               whichever is smaller";
           { f with Theora_format.picture_x = i }
       | "picture_y", `Value { value = Ground (Int i); pos } ->
           (* According to the doc: must be no larger than width-picture_width
@@ -107,13 +102,11 @@ let make params =
             > Lazy.force f.Theora_format.height
               - Lazy.force f.Theora_format.picture_height
           then
-            raise
-              (Lang_encoder.error ~pos
-                 "picture y must not be larger than height - picture height");
+            Lang_encoder.raise_error ~pos
+              "picture y must not be larger than height - picture height";
           if Lazy.force f.Theora_format.picture_height - i > 255 then
-            raise
-              (Lang_encoder.error ~pos
-                 "picture height - picture y must not be larger than 255");
+            Lang_encoder.raise_error ~pos
+              "picture height - picture y must not be larger than 255";
           { f with Theora_format.picture_y = i }
       | "aspect_numerator", `Value { value = Ground (Int i); _ } ->
           { f with Theora_format.aspect_numerator = i }
@@ -131,7 +124,7 @@ let make params =
           { f with Theora_format.speed = Some i }
       | "bytes_per_page", `Value { value = Ground (Int i); _ } ->
           { f with Theora_format.fill = Some i }
-      | t -> raise (Lang_encoder.generic_error t))
+      | t -> Lang_encoder.raise_generic_error t)
     defaults params
 
 let () =

--- a/src/core/lang_encoders/lang_vorbis.ml
+++ b/src/core/lang_encoders/lang_vorbis.ml
@@ -53,7 +53,7 @@ let make_cbr params =
         | "", `Value { value = Ground (String s); _ }
           when String.lowercase_ascii s = "stereo" ->
             { f with Vorbis_format.channels = 2 }
-        | t -> raise (Lang_encoder.generic_error t))
+        | t -> Lang_encoder.raise_generic_error t)
       defaults params
   in
   Ogg_format.Vorbis vorbis
@@ -96,7 +96,7 @@ let make_abr params =
         | "", `Value { value = Ground (String s); _ }
           when String.lowercase_ascii s = "stereo" ->
             { f with Vorbis_format.channels = 2 }
-        | t -> raise (Lang_encoder.generic_error t))
+        | t -> Lang_encoder.raise_generic_error t)
       defaults params
   in
   Ogg_format.Vorbis vorbis
@@ -117,11 +117,11 @@ let make params =
             { f with Vorbis_format.samplerate = Lazy.from_val i }
         | "quality", `Value { value = Ground (Float q); pos } ->
             if q < -0.2 || q > 1. then
-              raise (Lang_encoder.error ~pos "quality should be in [(-0.2)..1]");
+              Lang_encoder.raise_error ~pos "quality should be in [(-0.2)..1]";
             { f with Vorbis_format.mode = Vorbis_format.VBR q }
         | "quality", `Value { value = Ground (Int i); pos } ->
             if i <> 0 && i <> 1 then
-              raise (Lang_encoder.error ~pos "quality should be in [-(0.2)..1]");
+              Lang_encoder.raise_error ~pos "quality should be in [-(0.2)..1]";
             let q = float i in
             { f with Vorbis_format.mode = Vorbis_format.VBR q }
         | "channels", `Value { value = Ground (Int i); _ } ->
@@ -134,7 +134,7 @@ let make params =
         | "", `Value { value = Ground (String s); _ }
           when String.lowercase_ascii s = "stereo" ->
             { f with Vorbis_format.channels = 2 }
-        | t -> raise (Lang_encoder.generic_error t))
+        | t -> Lang_encoder.raise_generic_error t)
       defaults params
   in
   Ogg_format.Vorbis vorbis

--- a/src/core/lang_encoders/lang_wav.ml
+++ b/src/core/lang_encoders/lang_wav.ml
@@ -58,11 +58,11 @@ let make params =
             { f with Wav_format.samplerate = Lazy.from_val i }
         | "samplesize", `Value { value = Ground (Int i); pos } ->
             if i <> 8 && i <> 16 && i <> 24 && i <> 32 then
-              raise (Lang_encoder.error ~pos "invalid sample size");
+              Lang_encoder.raise_error ~pos "invalid sample size";
             { f with Wav_format.samplesize = i }
         | "header", `Value { value = Ground (Bool b); _ } ->
             { f with Wav_format.header = b }
-        | t -> raise (Lang_encoder.generic_error t))
+        | t -> Lang_encoder.raise_generic_error t)
       defaults params
   in
   Encoder.WAV wav

--- a/src/core/lang_source.ml
+++ b/src/core/lang_source.ml
@@ -47,15 +47,10 @@ module V = MkAbstract (struct
   let name = "source"
   let descr s = Printf.sprintf "<source#%s>" s#id
 
-  let to_json _ =
-    raise
-      Runtime_error.(
-        Runtime_error
-          {
-            kind = "json";
-            msg = Printf.sprintf "Sources cannot be represented as json";
-            pos = [];
-          })
+  let to_json ~pos _ =
+    Runtime_error.raise ~pos
+      ~message:(Printf.sprintf "Sources cannot be represented as json")
+      "json"
 
   let compare s1 s2 = Stdlib.compare s1#id s2#id
 end)
@@ -371,7 +366,11 @@ let add_operator =
       (* Negotiate content for all sources and formats in the arguments. *)
       let () =
         let env =
-          List.stable_sort (fun (l, _) (l', _) -> Stdlib.compare l l') env
+          List.stable_sort
+            (fun (l, _) (l', _) -> Stdlib.compare l l')
+            (List.filter
+               (fun (lbl, _) -> lbl <> Liquidsoap_lang.Lang_core.pos_var)
+               env)
         in
         List.iter2
           (fun (name, typ) (name', v) ->

--- a/src/core/outputs/harbor_output.ml
+++ b/src/core/outputs/harbor_output.ml
@@ -296,6 +296,7 @@ let client_task c =
 (** Sending encoded data to a shout-compatible server.
     * It directly takes the Lang param list and extracts stuff from it. *)
 class output p =
+  let pos = Lang.pos p in
   let e f v = f (List.assoc v p) in
   let s v = e Lang.to_string v in
   let on_connect = List.assoc "on_connect" p in
@@ -593,7 +594,7 @@ class output p =
       let handler ~protocol ~meth:_ ~data:_ ~headers ~query ~socket uri =
         self#add_client ~protocol ~headers ~uri ~query socket
       in
-      Harbor.add_http_handler ~transport ~port ~verb:`Get ~uri handler;
+      Harbor.add_http_handler ~pos ~transport ~port ~verb:`Get ~uri handler;
       match dumpfile with Some f -> dump <- Some (open_out_bin f) | None -> ()
 
     method stop =

--- a/src/core/outputs/pipe_output.ml
+++ b/src/core/outputs/pipe_output.ml
@@ -264,9 +264,9 @@ class virtual ['a] chan_output p =
       try
         self#output_substring chan b ofs len;
         if flush then self#flush chan
-      with Sys_error e ->
+      with Sys_error _ as exn ->
         let bt = Printexc.get_raw_backtrace () in
-        Lang.raise_error ~bt ~message:e "system"
+        Lang.raise_as_runtime ~bt ~kind:"system" exn
 
     method close_pipe =
       self#close_chan (Option.get chan);
@@ -308,9 +308,9 @@ class virtual ['a] file_output_base p =
         let fd = self#open_out_gen mode perm filename in
         current_filename <- Some filename;
         fd
-      with Sys_error e ->
+      with Sys_error _ as exn ->
         let bt = Printexc.get_raw_backtrace () in
-        Lang.raise_error ~bt ~message:e "system"
+        Lang.raise_as_runtime ~bt ~kind:"system" exn
 
     method virtual close_out : 'a -> unit
 
@@ -319,9 +319,9 @@ class virtual ['a] file_output_base p =
         self#close_out fd;
         self#on_close (Option.get current_filename);
         current_filename <- None
-      with Sys_error e ->
+      with Sys_error _ as exn ->
         let bt = Printexc.get_raw_backtrace () in
-        Lang.raise_error ~bt ~message:e "system"
+        Lang.raise_as_runtime ~bt ~kind:"system" exn
 
     method private on_close = on_close
   end

--- a/src/core/request.ml
+++ b/src/core/request.ml
@@ -666,8 +666,9 @@ module Value = Value.MkAbstract (struct
 
   let name = "request"
 
-  let to_json _ =
-    Runtime_error.error ~message:"Requests cannot be represented as json" "json"
+  let to_json ~pos _ =
+    Runtime_error.raise ~pos ~message:"Requests cannot be represented as json"
+      "json"
 
   let descr r = Printf.sprintf "<request(id=%d)>" (get_id r)
   let compare = Stdlib.compare

--- a/src/core/sources/debug_sources.ml
+++ b/src/core/sources/debug_sources.ml
@@ -47,13 +47,7 @@ class fail_init =
     inherit fail "source.fail.init"
 
     method wake_up _ =
-      raise
-        (Runtime_error.Runtime_error
-           {
-             Runtime_error.kind = "debug";
-             msg = "Source's initialization failed";
-             pos = [];
-           })
+      Lang.raise_error ~pos:[] ~message:"Source's initialization failed" "debug"
   end
 
 let () =

--- a/src/core/sources/harbor_input.ml
+++ b/src/core/sources/harbor_input.ml
@@ -28,9 +28,9 @@ let address_resolver s =
   Utils.name_of_sockaddr ~rev_dns:Harbor_base.conf_revdns#get
     (Unix.getpeername s)
 
-class http_input_server ~transport ~dumpfile ~logfile ~bufferize ~max ~icy ~port
-  ~meta_charset ~icy_charset ~replay_meta ~mountpoint ~on_connect ~on_disconnect
-  ~login ~debug ~log_overfull ~timeout () =
+class http_input_server ~pos ~transport ~dumpfile ~logfile ~bufferize ~max ~icy
+  ~port ~meta_charset ~icy_charset ~replay_meta ~mountpoint ~on_connect
+  ~on_disconnect ~login ~debug ~log_overfull ~timeout () =
   let max_ticks = Frame.main_of_seconds max in
   (* We need a temporary log until
    * the source has an id *)
@@ -156,7 +156,7 @@ class http_input_server ~transport ~dumpfile ~logfile ~bufferize ~max ~icy ~port
 
     method private wake_up act =
       super#wake_up act;
-      Harbor.add_source ~transport ~port ~mountpoint ~icy
+      Harbor.add_source ~pos ~transport ~port ~mountpoint ~icy
         (self :> Harbor.source);
 
       (* Now we can create the log function *)
@@ -471,7 +471,8 @@ let () =
       let on_disconnect () =
         ignore (Lang.apply (List.assoc "on_disconnect" p) [])
       in
+      let pos = Lang.pos p in
       new http_input_server
-        ~transport ~timeout ~bufferize ~max ~login ~mountpoint ~dumpfile
+        ~pos ~transport ~timeout ~bufferize ~max ~login ~mountpoint ~dumpfile
         ~logfile ~icy ~port ~icy_charset ~meta_charset ~replay_meta ~on_connect
         ~on_disconnect ~debug ~log_overfull ())

--- a/src/core/tools/liqcurl.ml
+++ b/src/core/tools/liqcurl.ml
@@ -115,7 +115,7 @@ let () =
              code msg)
     | _ -> None)
 
-let fail message = Lang.raise_error ~message "http"
+let fail ~pos message = Lang.raise_error ~pos ~message "http"
 let interrupt = Atomic.make false
 let () = Lifecycle.on_core_shutdown (fun () -> Atomic.set interrupt true)
 
@@ -126,11 +126,11 @@ let mk_read =
     if Atomic.get interrupt then Curl.Abort
     else (try Proceed (fn len) with _ -> Curl.Abort)
 
-let parse_http_answer s =
+let parse_http_answer ~pos s =
   let f v c s = (v, c, s) in
   try Scanf.sscanf s "HTTP/%s %i %[^\r^\n]" f with
-    | Scanf.Scan_failure s -> fail s
-    | _ -> fail "Unknown error"
+    | Scanf.Scan_failure s -> fail ~pos s
+    | _ -> fail ~pos "Unknown error"
 
 let should_stop =
   let should_stop = ref false in
@@ -143,7 +143,7 @@ let should_stop =
   fun _ _ _ _ -> should_stop ()
 
 let rec http_request ?headers ?http_version ~follow_redirect ~timeout ~url
-    ~request ~on_body_data () =
+    ~request ~on_body_data ~pos () =
   let connection = new Curl.handle in
   try
     (* Check url correctness, fix fixable mistakes.
@@ -160,7 +160,7 @@ let rec http_request ?headers ?http_version ~follow_redirect ~timeout ~url
         | Some "1.0" -> Curl.HTTP_VERSION_1_0
         | Some "1.1" -> Curl.HTTP_VERSION_1_1
         | Some "2.0" -> Curl.HTTP_VERSION_2
-        | Some v -> fail (Printf.sprintf "Unsupported http version %s" v));
+        | Some v -> fail ~pos (Printf.sprintf "Unsupported http version %s" v));
     ignore (Option.map connection#set_timeoutms timeout);
     (match request with
       | `Get -> connection#set_httpget true
@@ -195,14 +195,14 @@ let rec http_request ?headers ?http_version ~follow_redirect ~timeout ~url
       | url when url <> "" && follow_redirect ->
           connection#cleanup;
           http_request ?headers ?http_version ~follow_redirect ~timeout ~url
-            ~request ~on_body_data ()
+            ~request ~on_body_data ~pos ()
       | _ ->
           let response_headers =
             Pcre.split ~rex:(Pcre.regexp "[\r]?\n")
               (Buffer.contents response_headers)
           in
           let http_version, status_code, status_message =
-            parse_http_answer (List.hd response_headers)
+            parse_http_answer ~pos (List.hd response_headers)
           in
           let response_headers =
             List.fold_left

--- a/src/core/tools/liqfm.ml
+++ b/src/core/tools/liqfm.ml
@@ -56,7 +56,7 @@ module Liq_http = struct
       let url = Printf.sprintf "http://%s:%d%s" host port url in
       let data = Buffer.create 1024 in
       let x, code, y, _ =
-        Liqcurl.http_request ?headers ~follow_redirect:true
+        Liqcurl.http_request ?headers ~pos:[] ~follow_redirect:true
           ~on_body_data:(Buffer.add_string data)
           ~timeout:(Some (int_of_float (timeout *. 1000.)))
           ~url ~request ()

--- a/src/core/tools/start_stop.ml
+++ b/src/core/tools/start_stop.ml
@@ -163,9 +163,9 @@ let meth :
         ([], fun_t [] unit_t),
         "Ask the source or output to stop.",
         fun s ->
-          val_fun [] (fun _ ->
+          val_fun [] (fun p ->
               if s#stype = `Infallible then
-                Lang.raise_error
+                Lang.raise_error ~pos:(Lang.pos p)
                   ~message:"Source is infallible and cannot be stopped" "input";
               s#transition_to `Stopped;
               unit) );

--- a/src/lang/builtins_bool.ml
+++ b/src/lang/builtins_bool.ml
@@ -48,9 +48,9 @@ let () =
     ]
     Lang.bool_t
     (fun p ->
-      match List.map (fun (_, x) -> Lang.to_bool_getter x) p with
-        | [a; b] -> Lang.bool (if a () then b () else false)
-        | _ -> assert false);
+      let a = Lang.to_bool_getter (Lang.assoc "" 1 p) in
+      let b = Lang.to_bool_getter (Lang.assoc "" 2 p) in
+      Lang.bool (if a () then b () else false));
   Lang.add_builtin "or" ~category:`Bool
     ~descr:"Return the disjunction of its arguments"
     [
@@ -59,9 +59,9 @@ let () =
     ]
     Lang.bool_t
     (fun p ->
-      match List.map (fun (_, x) -> Lang.to_bool_getter x) p with
-        | [a; b] -> Lang.bool (if a () then true else b ())
-        | _ -> assert false)
+      let a = Lang.to_bool_getter (Lang.assoc "" 1 p) in
+      let b = Lang.to_bool_getter (Lang.assoc "" 2 p) in
+      Lang.bool (if a () then true else b ()))
 
 let () =
   Lang.add_builtin "not" ~category:`Bool

--- a/src/lang/builtins_files.ml
+++ b/src/lang/builtins_files.ml
@@ -368,4 +368,4 @@ let () =
         Lang.string (Digest.to_hex (Digest.file file))
       else (
         let message = Printf.sprintf "The file %s does not exist." file in
-        Lang.raise_error ~message "file"))
+        Lang.raise_error ~pos:(Lang_core.pos p) ~message "file"))

--- a/src/lang/builtins_lang.ml
+++ b/src/lang/builtins_lang.ml
@@ -47,16 +47,30 @@ let () =
         Lang.bool_t,
         Some (Lang.bool true),
         Some "If true, a newline is added after displaying the value." );
+      ( "position",
+        Lang.bool_t,
+        Some (Lang.bool false),
+        Some
+          "Print the position of the call, mostly useful for debugging \
+           purposes." );
       ("", Lang.univ_t (), None, None);
     ]
     Lang.unit_t
     (fun p ->
       let nl = Lang.to_bool (List.assoc "newline" p) in
+      let position = Lang.to_bool (List.assoc "position" p) in
       let v = List.assoc "" p in
       let v =
         match v.Lang.value with
           | Lang.(Ground (Ground.String s)) -> s
           | _ -> Value.to_string v
+      in
+      let v =
+        if position then
+          Printf.sprintf "%s: %s"
+            (Pos.List.to_string ~prefix:"At " (Lang.pos p))
+            v
+        else v
       in
       let v = if nl then v ^ "\n" else v in
       print_string v;

--- a/src/lang/builtins_lang.ml
+++ b/src/lang/builtins_lang.ml
@@ -47,30 +47,16 @@ let () =
         Lang.bool_t,
         Some (Lang.bool true),
         Some "If true, a newline is added after displaying the value." );
-      ( "position",
-        Lang.bool_t,
-        Some (Lang.bool false),
-        Some
-          "Print the position of the call, mostly useful for debugging \
-           purposes." );
       ("", Lang.univ_t (), None, None);
     ]
     Lang.unit_t
     (fun p ->
       let nl = Lang.to_bool (List.assoc "newline" p) in
-      let position = Lang.to_bool (List.assoc "position" p) in
       let v = List.assoc "" p in
       let v =
         match v.Lang.value with
           | Lang.(Ground (Ground.String s)) -> s
           | _ -> Value.to_string v
-      in
-      let v =
-        if position then
-          Printf.sprintf "%s: %s"
-            (Pos.List.to_string ~prefix:"At " (Lang.pos p))
-            v
-        else v
       in
       let v = if nl then v ^ "\n" else v in
       print_string v;

--- a/src/lang/builtins_lang.ml
+++ b/src/lang/builtins_lang.ml
@@ -7,6 +7,13 @@ let () =
     (fun _ -> Lang.unit)
 
 let () =
+  Lang.add_builtin "position" ~descr:"Return the current position in the script"
+    ~category:`Programming [] Lang_core.Single_position.t (fun p ->
+      match Lang.pos p with
+        | [] -> Lang.raise_error ~pos:[] ~message:"Unknown position" "eval"
+        | (p, _) :: _ -> Lang_core.Single_position.to_value p)
+
+let () =
   let t = Lang.univ_t () in
   Lang.add_builtin "if" ~category:`Programming ~descr:"The basic conditional."
     ~flags:[`Hidden]

--- a/src/lang/builtins_list.ml
+++ b/src/lang/builtins_list.ml
@@ -61,11 +61,7 @@ let () =
     ]
     b
     (fun p ->
-      let l, e, f =
-        match p with
-          | [("", l); ("", e); ("", f)] -> (l, e, f)
-          | _ -> assert false
-      in
+      let l, e, f = (Lang.assoc "" 1 p, Lang.assoc "" 2 p, Lang.assoc "" 3 p) in
       match Lang.to_list l with
         | [] -> e
         | x :: l -> Lang.apply f [("", x); ("", Lang.list l)])
@@ -92,11 +88,7 @@ let () =
     ]
     b
     (fun p ->
-      let l, e, f =
-        match p with
-          | [("", l); ("", e); ("", f)] -> (l, e, f)
-          | _ -> assert false
-      in
+      let l, e, f = (Lang.assoc "" 1 p, Lang.assoc "" 2 p, Lang.assoc "" 3 p) in
       let rec aux k = function
         | [] -> k e
         | x :: l ->
@@ -115,9 +107,7 @@ let () =
         [("", a, None, None); ("", Lang.list_t a, None, None)]
         (Lang.list_t a)
         (fun p ->
-          let x, l =
-            match p with [("", x); ("", l)] -> (x, l) | _ -> assert false
-          in
+          let x, l = (Lang.assoc "" 1 p, Lang.assoc "" 2 p) in
           let l = Lang.to_list l in
           Lang.list (x :: l)))
     ["list.add"; "_::_"]

--- a/src/lang/builtins_regexp.ml
+++ b/src/lang/builtins_regexp.ml
@@ -65,15 +65,9 @@ module RegExp = Value.MkAbstract (struct
   let name = "regexp"
   let descr = string_of_regexp
 
-  let to_json _ =
-    raise
-      Runtime_error.(
-        Runtime_error
-          {
-            kind = "json";
-            msg = "Regexp cannot be represented as json";
-            pos = [];
-          })
+  let to_json ~pos _ =
+    Runtime_error.raise ~pos ~message:"Regexp cannot be represented as json"
+      "json"
 
   let compare r r' =
     Stdlib.compare
@@ -175,7 +169,7 @@ let replace_fun regexp =
       let string =
         try Regexp.substitute regexp ~subst string
         with exn ->
-          Runtime_error.error
+          Runtime_error.raise
             ~message:
               (Printf.sprintf "string.replace error: %s"
                  (Printexc.to_string exn))

--- a/src/lang/builtins_string.ml
+++ b/src/lang/builtins_string.ml
@@ -68,8 +68,8 @@ print(c) # should print 99 which is the ascii code for "c"
         let n = Lang.to_int (Lang.assoc "" 2 p) in
         Lang.int (int_of_char s.[n])
       with _ ->
-        Runtime_error.error ~message:"string.nth: character not found!"
-          "not_found")
+        Runtime_error.raise ~pos:(Lang.pos p)
+          ~message:"string.nth: character not found!" "not_found")
 
 let () =
   Lang.add_builtin "string.char" ~category:`String
@@ -151,7 +151,7 @@ let () =
              s)
       with _ ->
         let bt = Printexc.get_raw_backtrace () in
-        Runtime_error.error ~bt
+        Runtime_error.raise ~bt ~pos:(Lang.pos p)
           ~message:
             (Printf.sprintf "Error while escaping %s string.%s"
                (match encoding with `Utf8 -> "utf8" | `Ascii -> "ascii")
@@ -399,7 +399,8 @@ let () =
         try out_value (func (in_value (List.assoc "" p)))
         with _ -> (
           try Option.get (Lang.to_option (List.assoc "default" p))
-          with _ -> Runtime_error.error ~message:name "failure"))
+          with _ ->
+            Runtime_error.raise ~pos:(Lang.pos p) ~message:name "failure"))
   in
   let register_tts name func out_value out_type =
     register_tt ~needs_default:true ("a string to a " ^ name)
@@ -465,11 +466,13 @@ let () =
     (fun p ->
       let n = Lang.to_int (List.assoc "" p) in
       if n < 0 then
-        Runtime_error.error ~message:"Invalid string length!" "invalid";
+        Runtime_error.raise ~pos:(Lang.pos p) ~message:"Invalid string length!"
+          "invalid";
       let c =
         try Char.chr (Lang.to_int (List.assoc "char_code" p))
         with _ ->
-          Runtime_error.error ~message:"Invalid character code!" "invalid"
+          Runtime_error.raise ~pos:(Lang.pos p)
+            ~message:"Invalid character code!" "invalid"
       in
       Lang.string (String.make n c))
 
@@ -493,7 +496,8 @@ let () =
       let string = Lang.to_string (List.assoc "" p) in
       try Lang.string (Lang_string.decode64 string)
       with _ ->
-        Runtime_error.error ~message:"Invalid base64 string!" "invalid")
+        Runtime_error.raise ~pos:(Lang.pos p) ~message:"Invalid base64 string!"
+          "invalid")
 
 let () =
   Lang.add_builtin "string.base64.encode" ~category:`String

--- a/src/lang/evaluation.ml
+++ b/src/lang/evaluation.ml
@@ -42,13 +42,15 @@ let rec eval_pat pat v =
       | PTuple pl, { Value.value = Value.Tuple l } ->
           List.fold_left2 aux env pl l
       (* The parser parses [x,y,z] as PList ([], None, l) *)
-      | PList (([] as l'), (None as spread), l), { Value.value = Value.List lv }
-      | PList (l, spread, l'), { Value.value = Value.List lv } ->
+      | ( PList (([] as l'), (None as spread), l),
+          { Value.value = Value.List lv; pos } )
+      | PList (l, spread, l'), { Value.value = Value.List lv; pos } ->
           let ln = List.length l in
           let ln' = List.length l' in
           let lvn = List.length lv in
           if lvn < ln + ln' then
-            Runtime_error.error
+            Runtime_error.raise
+              ~pos:(match pos with None -> [] | Some p -> [p])
               ~message:
                 "List value does not have enough elements to fit the \
                  extraction pattern!"
@@ -271,10 +273,9 @@ and apply ?pos f l =
     try f pe with
       | Runtime_error.Runtime_error err ->
           let bt = Printexc.get_raw_backtrace () in
-          Printexc.raise_with_backtrace
-            (Runtime_error.Runtime_error
-               { err with pos = Option.to_list pos @ err.pos })
-            bt
+          Runtime_error.raise ~bt
+            ~pos:(Option.to_list pos @ err.pos)
+            ~message:err.Runtime_error.msg err.Runtime_error.kind
       | Internal_error (poss, e) ->
           let bt = Printexc.get_raw_backtrace () in
           Printexc.raise_with_backtrace
@@ -304,6 +305,15 @@ and apply ?pos f l =
           { v with Value.pos } )
         :: pe)
       pe p
+  in
+  (* Add position *)
+  let pe =
+    pe
+    @ [
+        ( Lang_core.pos_var,
+          Lang_core.Position.to_value
+            (match pos with None -> [] | Some p -> [p]) );
+      ]
   in
   let v = f pe in
   (* Similarly here, the result of an FFI call should have some position

--- a/src/lang/evaluation.ml
+++ b/src/lang/evaluation.ml
@@ -311,7 +311,7 @@ and apply ?pos f l =
     pe
     @ [
         ( Lang_core.pos_var,
-          Lang_core.Position.to_value
+          Lang_core.Stacktrace.to_value
             (match pos with None -> [] | Some p -> [p]) );
       ]
   in

--- a/src/lang/json.ml
+++ b/src/lang/json.ml
@@ -19,10 +19,7 @@ let from_string ?(pos = []) ?(json5 = false) s =
     | Runtime_error.Runtime_error _ as exn ->
         let bt = Printexc.get_raw_backtrace () in
         Printexc.raise_with_backtrace exn bt
-    | _ ->
-        raise
-          Runtime_error.(
-            Runtime_error { kind = "json"; msg = "Parse error"; pos })
+    | _ -> Runtime_error.raise ~message:"Parse error" ~pos "json"
 
 (* Special version of utf8 quoting that uses [Uchar.rep]
    when a character cannot be escaped. *)
@@ -58,17 +55,11 @@ let rec to_string_compact ~json5 = function
         | FP_infinite when json5 -> if f < 0. then "-Infinity" else "Infinity"
         | FP_nan when json5 -> if f < 0. then "-NaN" else "NaN"
         | FP_infinite | FP_nan ->
-            raise
-              Runtime_error.(
-                Runtime_error
-                  {
-                    kind = "json";
-                    msg =
-                      "Infinite or Nan number cannot be represented in JSON. \
-                       You might want to consider using the `json5` \
-                       representation.";
-                    pos = [];
-                  })
+            Runtime_error.raise ~pos:[]
+              ~message:
+                "Infinite or Nan number cannot be represented in JSON. You \
+                 might want to consider using the `json5` representation."
+              "json"
         | _ ->
             let s = string_of_float f in
             let s = Printf.sprintf "%s" s in

--- a/src/lang/json_lexer.ml
+++ b/src/lang/json_lexer.ml
@@ -74,13 +74,9 @@ let rec json_token lexbuf =
              (Buffer.create 17) lexbuf)
     | eof -> EOF
     | _ ->
-        raise
-          (Runtime_error
-             {
-               kind = "json";
-               msg = "Parse error";
-               pos = [Sedlexing.lexing_positions lexbuf];
-             })
+        Runtime_error.raise ~message:"Parse error"
+          ~pos:[Sedlexing.lexing_positions lexbuf]
+          "json"
 
 and read_string pos buf lexbuf =
   (* See: https://en.wikipedia.org/wiki/Escape_sequences_in_C *)
@@ -113,24 +109,14 @@ and read_string pos buf lexbuf =
         read_string pos buf lexbuf
     | '"' -> Buffer.contents buf
     | eof ->
-        raise
-          Runtime_error.(
-            Runtime_error
-              {
-                kind = "json";
-                msg = "String is not terminated";
-                pos = [(pos, snd (Sedlexing.lexing_positions lexbuf))];
-              })
+        Runtime_error.raise ~message:"String is not terminated"
+          ~pos:[(pos, snd (Sedlexing.lexing_positions lexbuf))]
+          "json"
     | _ ->
-        raise
-          Runtime_error.(
-            Runtime_error
-              {
-                kind = "json";
-                msg =
-                  "Illegal string character: " ^ Sedlexing.Utf8.lexeme lexbuf;
-                pos = [(pos, snd (Sedlexing.lexing_positions lexbuf))];
-              })
+        Runtime_error.raise
+          ~message:("Illegal string character: " ^ Sedlexing.Utf8.lexeme lexbuf)
+          ~pos:[(pos, snd (Sedlexing.lexing_positions lexbuf))]
+          "json"
 
 (* Json 5 extension *)
 
@@ -221,48 +207,31 @@ let rec json5_token lexbuf =
              (Buffer.create 17) lexbuf)
     | eof -> EOF
     | _ ->
-        raise
-          (Runtime_error
-             {
-               kind = "json";
-               msg = "Parse error";
-               pos = [Sedlexing.lexing_positions lexbuf];
-             })
+        Runtime_error.raise ~message:"Parse error"
+          ~pos:[Sedlexing.lexing_positions lexbuf]
+          "json"
 
 and read_single_line_comment pos lexbuf =
   match%sedlex lexbuf with
     | eof | line_terminator_sequence -> ()
     | Plus (Compl line_terminator) -> read_single_line_comment pos lexbuf
     | _ ->
-        raise
-          (Runtime_error
-             {
-               kind = "json";
-               msg = "Parse error";
-               pos = [(pos, snd (Sedlexing.lexing_positions lexbuf))];
-             })
+        Runtime_error.raise ~message:"Parse error"
+          ~pos:[(pos, snd (Sedlexing.lexing_positions lexbuf))]
+          "json"
 
 and read_multiline_comment pos lexbuf =
   match%sedlex lexbuf with
     | Plus '*', '/' -> ()
     | '*', Compl '/' | Plus (Compl '*') -> read_multiline_comment pos lexbuf
     | eof ->
-        raise
-          Runtime_error.(
-            Runtime_error
-              {
-                kind = "json";
-                msg = "Comment is not terminated";
-                pos = [(pos, snd (Sedlexing.lexing_positions lexbuf))];
-              })
+        Runtime_error.raise ~message:"Comment is not terminated"
+          ~pos:[(pos, snd (Sedlexing.lexing_positions lexbuf))]
+          "json"
     | _ ->
-        raise
-          (Runtime_error
-             {
-               kind = "json";
-               msg = "Parse error";
-               pos = [(pos, snd (Sedlexing.lexing_positions lexbuf))];
-             })
+        Runtime_error.raise ~message:"Parse error"
+          ~pos:[(pos, snd (Sedlexing.lexing_positions lexbuf))]
+          "json"
 
 and read_json5_string sep pos buf lexbuf =
   (* See: https://en.wikipedia.org/wiki/Escape_sequences_in_C *)
@@ -314,19 +283,10 @@ and read_json5_string sep pos buf lexbuf =
           Buffer.add_string buf m;
           read_json5_string sep pos buf lexbuf)
     | eof ->
-        raise
-          Runtime_error.(
-            Runtime_error
-              {
-                kind = "json";
-                msg = "String is not terminated";
-                pos = [(pos, snd (Sedlexing.lexing_positions lexbuf))];
-              })
+        Runtime_error.raise ~message:"String is not terminated"
+          ~pos:[(pos, snd (Sedlexing.lexing_positions lexbuf))]
+          "json"
     | _ ->
-        raise
-          (Runtime_error
-             {
-               kind = "json";
-               msg = "Parse error";
-               pos = [Sedlexing.lexing_positions lexbuf];
-             })
+        Runtime_error.raise ~message:"Parse error"
+          ~pos:[Sedlexing.lexing_positions lexbuf]
+          "json"

--- a/src/lang/lang.mli
+++ b/src/lang/lang.mli
@@ -37,7 +37,7 @@ module Ground : sig
 
   type content = Term.Ground.content = {
     descr : t -> string;
-    to_json : t -> Json.t;
+    to_json : pos:Pos.t list -> t -> Json.t;
     compare : t -> t -> int;
     typ : (module Type.Ground.Custom);
   }
@@ -186,11 +186,14 @@ val val_fun : (string * string * value option) list -> (env -> value) -> value
   * when the constant is ground. *)
 val val_cst_fun : (string * value option) list -> value -> value
 
+(** Extract position from the environment. Used inside function execution. *)
+val pos : env -> Pos.t list
+
 (** Raise an error. *)
 val raise_error :
   ?bt:Printexc.raw_backtrace ->
-  ?pos:Pos.List.t ->
   ?message:string ->
+  pos:Pos.List.t ->
   string ->
   'a
 

--- a/src/lang/lang_core.ml
+++ b/src/lang/lang_core.ml
@@ -359,22 +359,17 @@ module Single_position = struct
         ("line_number", int pos_lnum);
         ("character_offset", int (pos_cnum - pos_bol));
       ]
+
+  let of_value v =
+    {
+      Lexing.pos_fname = to_string (invoke v "filename");
+      pos_lnum = to_int (invoke v "line_number");
+      pos_bol = 0;
+      pos_cnum = to_int (invoke v "character_offset");
+    }
 end
 
 module Position = struct
-  include Value.MkAbstract (struct
-    type content = Pos.t
-
-    let name = "position"
-    let descr _ = "position"
-
-    let to_json ~pos _ =
-      Runtime_error.raise ~pos
-        ~message:"Positions cannot be represented as json" "json"
-
-    let compare = Stdlib.compare
-  end)
-
   let t =
     method_t unit_t
       [
@@ -386,8 +381,7 @@ module Position = struct
       ]
 
   let to_value (start, _end) =
-    let v = to_value (start, _end) in
-    meth v
+    meth unit
       [
         ("position_start", Single_position.to_value start);
         ("position_end", Single_position.to_value _end);
@@ -400,8 +394,8 @@ module Position = struct
       ]
 
   let of_value v =
-    let v = demeth v in
-    of_value v
+    ( Single_position.of_value (invoke v "position_start"),
+      Single_position.of_value (invoke v "position_end") )
 end
 
 module Stacktrace = struct

--- a/src/lang/lang_error.ml
+++ b/src/lang/lang_error.ml
@@ -24,7 +24,7 @@ include Runtime_error
 
 exception Encoder_error of (Pos.Option.t * string)
 
-type error = Runtime_error.runtime_error = {
+type error = Runtime_error.runtime_error = private {
   kind : string;
   msg : string;
   pos : Pos.List.t;
@@ -48,15 +48,9 @@ module ErrorDef = struct
       (Lang_string.quote_string msg)
       pos
 
-  let to_json _ =
-    raise
-      Runtime_error.(
-        Runtime_error
-          {
-            kind = "json";
-            msg = "Error cannot be represented as json";
-            pos = [];
-          })
+  let to_json ~pos _ =
+    Runtime_error.raise ~pos ~message:"Error cannot be represented as json"
+      "json"
 
   let compare = Stdlib.compare
 end
@@ -102,7 +96,7 @@ let () =
     Error.t
     (fun p ->
       let kind = Lang_core.to_string (List.assoc "" p) in
-      Error.to_value { kind; msg = ""; pos = [] })
+      Error.to_value (Runtime_error.make ~pos:(Lang_core.pos p) kind))
 
 let () =
   Lang_core.add_builtin "error.raise" ~category:`Programming
@@ -118,7 +112,21 @@ let () =
     (fun p ->
       let { kind } = Error.of_value (Lang_core.assoc "" 1 p) in
       let message = Lang_core.to_string (Lang_core.assoc "" 2 p) in
-      Runtime_error.error ~message kind)
+      Runtime_error.raise ~pos:(Lang_core.pos p) ~message kind)
+
+let () =
+  Lang_core.add_builtin "error.on_error" ~category:`Programming
+    ~descr:
+      "Register a callback to monitor errors raised during the execution of \
+       the program. The callback is allow to re-raise a different error if \
+       needed."
+    [("", Lang_core.fun_t [(false, "", Error.t)] Lang_core.unit_t, None, None)]
+    Lang_core.unit_t
+    (fun p ->
+      let fn = List.assoc "" p in
+      let fn err = ignore (Lang_core.apply fn [("", Error.to_value err)]) in
+      Runtime_error.on_error fn;
+      Lang_core.unit)
 
 let error_t = Error.t
 let error = Error.to_value
@@ -151,4 +159,9 @@ let () =
       when errors = None
            || List.exists (fun err -> err.kind = kind) (Option.get errors)
       ->
-        h [("", Error.to_value { kind; msg; pos = [] })])
+        h
+          [
+            ( "",
+              Error.to_value
+                (Runtime_error.make ~pos:(Lang_core.pos p) ~message:msg kind) );
+          ])

--- a/src/lang/lang_error.ml
+++ b/src/lang/lang_error.ml
@@ -68,12 +68,10 @@ module Error = struct
         ([], Lang_core.string_t),
         "Error message.",
         fun { msg } -> Lang_core.string msg );
-      ( "positions",
-        ([], Lang_core.(list_t string_t)),
-        "Error positions.",
-        fun { pos } ->
-          Lang_core.list
-            (List.map (fun pos -> Lang_core.string (Pos.to_string pos)) pos) );
+      ( "trace",
+        ([], Lang_core.Stacktrace.t),
+        "Error stacktrace.",
+        fun { pos } -> Lang_core.Stacktrace.to_value pos );
     ]
 
   let t =
@@ -96,7 +94,7 @@ let () =
     Error.t
     (fun p ->
       let kind = Lang_core.to_string (List.assoc "" p) in
-      Error.to_value (Runtime_error.make ~pos:(Lang_core.pos p) kind))
+      Error.to_value (Runtime_error.make ~pos:[] kind))
 
 let () =
   Lang_core.add_builtin "error.raise" ~category:`Programming

--- a/src/lang/value.ml
+++ b/src/lang/value.ml
@@ -227,15 +227,9 @@ module RuntimeType = MkAbstract (struct
   let name = "type"
   let descr _ = "type"
 
-  let to_json _ =
-    raise
-      Runtime_error.(
-        Runtime_error
-          {
-            kind = "json";
-            msg = "Types cannot be represented as json";
-            pos = [];
-          })
+  let to_json ~pos _ =
+    Runtime_error.raise ~pos ~message:"Types cannot be represented as json"
+      "json"
 
   let compare = Stdlib.compare
 end)

--- a/tests/language/error.liq
+++ b/tests/language/error.liq
@@ -1,12 +1,3 @@
-success = ref(true)
-
-def t(x, y)
-  if x != y then
-    print("Failure: got #{x} instead of #{y}")
-    success := false
-  end
-end
-
 def f() =
   # Works as expected with no errors
   ret = try
@@ -15,7 +6,7 @@ def f() =
     5
   end
 
-  t(ret, 4)
+  test.equals(ret, 4)
 
   e = error.register("foo")
 
@@ -26,7 +17,7 @@ def f() =
     5
   end
 
-  t(ret, 4)
+  test.equals(ret, 4)
 
   # Can report kind
   ret = try
@@ -35,7 +26,7 @@ def f() =
   catch err do
     err.kind
   end
-  t(ret, "foo")
+  test.equals(ret, "foo")
 
   # Can report empty message
   ret = try
@@ -44,7 +35,7 @@ def f() =
   catch err do
     err.message
   end
-  t(ret, "")
+  test.equals(ret, "")
 
   # Can report set message
   ret = try
@@ -53,10 +44,20 @@ def f() =
   catch err do
     err.message ?? "blo"
   end
-  t(ret, "msg")
+  test.equals(ret, "msg")
+
+  # Can report stack trace
+  trace = try
+    error.raise(e, "msg");
+    []
+  catch err do
+    err.trace
+  end
+  pos = string.concat(separator=", ", list.map(fun (pos) -> pos.to_string(), trace))
+  test.equals(pos, "At error.liq, line 50 char 10 - line 55 char 5")
 
   e' = error.register("bla")
-  t(false, (e == e'))
+  test.equals(false, (e == e'))
 
   # Ignores errors when not in list
   ret =
@@ -70,7 +71,7 @@ def f() =
     catch _ : [e] do
       "gni"
     end
-  t(ret, "gni")
+  test.equals(ret, "gni")
 
   # Ignore errors when list is empty
   ret =
@@ -84,7 +85,7 @@ def f() =
     catch _ : [e] do
       "gni"
     end
-  t(ret, "gni")
+  test.equals(ret, "gni")
 
   # Catches error when in list
   ret =
@@ -98,7 +99,7 @@ def f() =
     catch _ : [e] do
       "gni"
     end
-  t(ret, "blo")
+  test.equals(ret, "blo")
 
   on_error = ref(error.register("dummy"))
   error.on_error(fun (e) -> on_error := e)
@@ -118,11 +119,7 @@ def f() =
   end
 
   def on_done() =
-    if !success then
-      test.pass()
-    else
-      test.fail()
-    end
+    test.pass()
   end
 
   # Catches error

--- a/tests/language/error.liq
+++ b/tests/language/error.liq
@@ -18,7 +18,6 @@ def f() =
   t(ret, 4)
 
   e = error.register("foo")
-  t(e, error.register("foo"))
 
   # Works as expected with no errors
   ret = try
@@ -100,6 +99,23 @@ def f() =
       "gni"
     end
   t(ret, "blo")
+
+  on_error = ref(error.register("dummy"))
+  error.on_error(fun (e) -> on_error := e)
+
+  try
+    error.raise(e, "On done callback")
+  catch _ : [e] do
+    ()
+  end
+
+  if (!on_error).kind != e.kind then
+    test.fail()
+  end
+
+  if (!on_error).message != "On done callback" then
+    test.fail()
+  end
 
   def on_done() =
     if !success then


### PR DESCRIPTION
This PR introduces several enhancements to runtime error handling:
* Runtime errors are now marked as `private` so that the dedicated functions have to called to manipulate them
* Raising errors is done solely through `Runtime_error.raise` (for code internal to the language) and `Lang.raise_error` for code using the language
* Building on this, we can now register error listeners that are called whenever an error is raised. These can be used to monitor and report errors, for instance using `Sentry`.
* Error positions are enforced across the board. In particular, a new mechanism is introduced wherein a special `_pos_` environment variable is passed to functions are run-time, allowing them to grab the location of their execution in the code and use it when raising a runtime error.
* Errors full trace is exported in the liquidsoap side:
```ruby
- : error
    .{
      kind : string,
      message : string,
      trace : [
               {
                 position_end :
                 {
                   character_offset : int,
                   filename : string,
                   line_number : int
                 },
                 position_start :
                 {
                   character_offset : int,
                   filename : string,
                   line_number : int
                 },
                 to_string : (?prefix : string) -> string
               }]
```
This means that the user should now be able to grab the file/line/character of each error start/stop position, for reporting and potentially editor's highlight and etc.