### PR TITLE
Add unix socket API!

### DIFF
--- a/src/core/builtins/builtins_files_extra.ml
+++ b/src/core/builtins/builtins_files_extra.ml
@@ -25,7 +25,7 @@ let () =
         Some "Default file rights if created. Default: `0o644`" );
       ("", Lang.string_t, None, None);
     ]
-    Builtins_socket.SocketValue.t ~descr:"Open a file."
+    Builtins_socket.Socket_value.t ~descr:"Open a file."
     (fun p ->
       let write = Lang.to_bool (List.assoc "write" p) in
       let access_flag = if write then Unix.O_RDWR else Unix.O_RDONLY in
@@ -51,8 +51,8 @@ let () =
       let file_perms = Lang.to_int (List.assoc "perms" p) in
       let path = Lang_string.home_unrelate (Lang.to_string (List.assoc "" p)) in
       try
-        Builtins_socket.SocketValue.(
-          to_value (of_unix_file_descr (Unix.openfile path flags file_perms)))
+        Builtins_socket.Socket_value.(
+          to_value (Http.unix_socket (Unix.openfile path flags file_perms)))
       with exn ->
         let bt = Printexc.get_raw_backtrace () in
         Lang.raise_as_runtime ~bt ~kind:"file" exn)

--- a/src/core/builtins/builtins_harbor.ml
+++ b/src/core/builtins/builtins_harbor.ml
@@ -31,7 +31,7 @@ let request_t =
       ("data", Lang.fun_t [(true, "timeout", Lang.float_t)] Lang.string_t);
       ("headers", Lang.list_t (Lang.product_t Lang.string_t Lang.string_t));
       ("query", Lang.list_t (Lang.product_t Lang.string_t Lang.string_t));
-      ("socket", Builtins_socket.SocketValue.t);
+      ("socket", Builtins_socket.Socket_value.t);
       ("path", Lang.string_t);
     ]
 
@@ -79,8 +79,8 @@ let parse_register_args p =
     in
     let query = Lang.list query in
     let socket =
-      Builtins_socket.SocketValue.to_value
-        (socket :> Builtins_socket.SocketValue.content)
+      Builtins_socket.Socket_value.to_value
+        (socket :> Builtins_socket.Socket_value.content)
     in
     let request =
       Lang.record

--- a/src/core/builtins/builtins_socket.ml
+++ b/src/core/builtins/builtins_socket.ml
@@ -20,7 +20,158 @@
 
  *****************************************************************************)
 
-module SocketValue = struct
+module Socket_domain = struct
+  include Value.MkAbstract (struct
+    type content = Unix.socket_domain
+
+    let name = "socket_domain"
+
+    let to_json ~pos _ =
+      Lang.raise_error ~pos
+        ~message:"Socket domain cannot be represented as json" "json"
+
+    let descr = function
+      | Unix.PF_UNIX -> "socket.domain.unix"
+      | Unix.PF_INET -> "socket.domain.inet"
+      | Unix.PF_INET6 -> "socket.domain.inet6"
+
+    let compare = Stdlib.compare
+  end)
+
+  let unix = to_value Unix.PF_UNIX
+  let inet = to_value Unix.PF_INET
+  let inet6 = to_value Unix.PF_INET6
+end
+
+module Socket_type = struct
+  include Value.MkAbstract (struct
+    type content = Unix.socket_type
+
+    let name = "socket_type"
+
+    let to_json ~pos _ =
+      Lang.raise_error ~pos ~message:"Socket type cannot be represented as json"
+        "json"
+
+    let descr = function
+      | Unix.SOCK_STREAM -> "socket.type.stream"
+      | Unix.SOCK_DGRAM -> "socket.type.dgram"
+      | Unix.SOCK_RAW -> "socket.type.raw"
+      (* From OCaml: SOCK_SEQPACKET is included for completeness,
+         but is rarely supported by the OS, and needs system calls
+         that are not available in this library. *)
+      | Unix.SOCK_SEQPACKET -> assert false
+
+    let compare = Stdlib.compare
+  end)
+
+  let stream = to_value Unix.SOCK_STREAM
+  let dgram = to_value Unix.SOCK_DGRAM
+  let raw = to_value Unix.SOCK_RAW
+end
+
+module Inet_addr = struct
+  let descr s =
+    Printf.sprintf "socket.internet_address(%S)" (Unix.string_of_inet_addr s)
+
+  include Value.MkAbstract (struct
+    type content = Unix.inet_addr
+
+    let name = "internet_address"
+
+    let to_json ~pos _ =
+      Lang.raise_error ~pos
+        ~message:"Internet address type cannot be represented as json" "json"
+
+    let descr = descr
+
+    let compare s s' =
+      Stdlib.compare (Unix.string_of_inet_addr s) (Unix.string_of_inet_addr s')
+  end)
+
+  let base_t = t
+
+  let t =
+    Lang.method_t base_t
+      [
+        ( "to_string",
+          ([], Lang.fun_t [] Lang.string_t),
+          "String representation of the internet address" );
+        ("is_ipv6", ([], Lang.bool_t), "Is the internet address a ipv6 address?");
+      ]
+
+  let to_value v =
+    Lang.meth (to_value v)
+      [
+        ( "to_string",
+          Lang.val_fun [] (fun _ -> Lang.string (Unix.string_of_inet_addr v)) );
+        ("is_ipv6", Lang.bool (Unix.is_inet6_addr v));
+      ]
+
+  let of_value v = of_value (Lang.demeth v)
+  let any = to_value Unix.inet_addr_any
+  let loopback = to_value Unix.inet_addr_loopback
+  let ipv6_any = to_value Unix.inet6_addr_any
+  let ipv6_loopback = to_value Unix.inet6_addr_loopback
+end
+
+module Socket_addr = struct
+  include Value.MkAbstract (struct
+    type content = Unix.sockaddr
+
+    let name = "socket_address"
+
+    let to_json ~pos _ =
+      Lang.raise_error ~pos
+        ~message:"Socket address type cannot be represented as json" "json"
+
+    let descr = function
+      | Unix.ADDR_UNIX s -> Printf.sprintf "socket.address.unix(%S)" s
+      | Unix.ADDR_INET (inet_addr, port) ->
+          Printf.sprintf "socket.address.inet(%s, %i)"
+            (Inet_addr.descr inet_addr)
+            port
+
+    let compare = Stdlib.compare
+  end)
+
+  let base_t = t
+
+  let t =
+    Lang.method_t base_t [("domain", ([], Socket_domain.t), "Socket domain")]
+
+  let to_value v =
+    Lang.meth (to_value v)
+      [("domain", Socket_domain.to_value (Unix.domain_of_sockaddr v))]
+
+  let unix_t =
+    Lang.method_t t [("path", ([], Lang.string_t), "Unix socket path")]
+
+  let inet_t =
+    Lang.method_t t
+      [
+        ("internet_address", ([], Inet_addr.t), "Internet address");
+        ("port", ([], Lang.int_t), "Port");
+      ]
+
+  let to_unix_value = function
+    | Unix.ADDR_UNIX path as v ->
+        Lang.meth (to_value v) [("path", Lang.string path)]
+    | _ -> assert false
+
+  let to_inet_value = function
+    | Unix.ADDR_INET (addr, port) as v ->
+        Lang.meth (to_value v)
+          [
+            ("internet_address", Inet_addr.to_value addr);
+            ("port", Lang.int port);
+          ]
+    | _ -> assert false
+
+  let of_value v = of_value (Lang.demeth v)
+end
+
+module Socket_value = struct
   include Value.MkAbstract (struct
     type content = Http.socket
 
@@ -34,93 +185,163 @@ module SocketValue = struct
     let compare = Stdlib.compare
   end)
 
+  let of_value socket = of_value (Lang.demeth socket)
+
   let meths =
+    let descr_of_mode = function `Read -> "read" | `Write -> "write" in
+    let wait_t ~mode t =
+      Lang.method_t t
+        [
+          ( "wait",
+            ( [],
+              Lang.fun_t
+                [
+                  (true, "timeout", Lang.nullable_t Lang.float_t);
+                  (false, "", Lang.fun_t [] Lang.unit_t);
+                ]
+                Lang.unit_t ),
+            "Execute the given callback when the socket is ready to "
+            ^ descr_of_mode mode ^ " some data" );
+        ]
+    in
+    let wait_meth ~mode socket v =
+      Lang.meth v
+        [
+          ( "wait",
+            Lang.val_fun
+              [("timeout", "timeout", Some (Lang.float 10.)); ("", "", None)]
+              (fun p ->
+                let timeout =
+                  Lang.to_valued_option Lang.to_float (List.assoc "timeout" p)
+                in
+                let event =
+                  match mode with
+                    | `Read -> `Read socket#file_descr
+                    | `Write -> `Write socket#file_descr
+                in
+                let events =
+                  match timeout with
+                    | None -> [event]
+                    | Some t -> [`Delay t; event]
+                in
+                let fn = List.assoc "" p in
+                let fn events =
+                  if not (List.mem event events) then
+                    Lang.raise_error ~pos:(Lang.pos p)
+                      ~message:"Timeout while writing to the socket!" "socket";
+                  ignore (Lang.apply fn []);
+                  []
+                in
+                Duppy.Task.add Tutils.scheduler
+                  {
+                    Duppy.Task.priority = `Maybe_blocking;
+                    events;
+                    handler = fn;
+                  };
+                Lang.unit) );
+        ]
+    in
     [
       ( "type",
         ([], Lang.string_t),
         "Socket type",
         fun (socket : content) -> Lang.string socket#typ );
-      ( "write",
-        ( [],
-          Lang.fun_t
-            [
-              (true, "timeout", Lang.nullable_t Lang.float_t);
-              (false, "", Lang.string_t);
-            ]
-            Lang.unit_t ),
-        "Write data to a socket",
+      ( "non_blocking",
+        ([], Lang.fun_t [(false, "", Lang.bool_t)] Lang.unit_t),
+        "Set the non-blocking flag on the socket",
         fun socket ->
           Lang.val_fun
-            [("timeout", "timeout", Some (Lang.float 10.)); ("", "", None)]
+            [("", "", None)]
             (fun p ->
-              let timeout =
-                Lang.to_valued_option Lang.to_float (List.assoc "timeout" p)
-              in
-              let data = Lang.to_string (List.assoc "" p) in
-              let data = Bytes.of_string data in
-              let len = Bytes.length data in
-              let start_time = Unix.gettimeofday () in
-              let check_timeout () =
-                match timeout with
-                  | None -> ()
-                  | Some t -> (
-                      let rem = start_time +. t -. Unix.gettimeofday () in
-                      try
-                        if rem <= 0. then failwith "timeout!";
-                        socket#wait_for `Write rem
-                      with _ ->
-                        Lang.raise_error ~pos:(Lang.pos p)
-                          ~message:"Timeout while writing to the socket!"
-                          "socket")
-              in
-              try
-                let rec f pos =
-                  check_timeout ();
-                  let n = socket#write data pos (len - pos) in
-                  if n < len then f (pos + n)
-                in
-                f 0;
-                Lang.unit
-              with exn ->
-                let bt = Printexc.get_raw_backtrace () in
-                Lang.raise_as_runtime ~bt ~kind:"socket" exn) );
+              if Lang.to_bool (List.assoc "" p) then
+                Unix.set_nonblock socket#file_descr
+              else Unix.clear_nonblock socket#file_descr;
+              Lang.unit) );
+      ( "write",
+        ( [],
+          wait_t ~mode:`Write
+            (Lang.fun_t
+               [
+                 (true, "timeout", Lang.nullable_t Lang.float_t);
+                 (false, "", Lang.string_t);
+               ]
+               Lang.unit_t) ),
+        "Write data to a socket",
+        fun socket ->
+          wait_meth ~mode:`Write socket
+            (Lang.val_fun
+               [("timeout", "timeout", Some (Lang.float 10.)); ("", "", None)]
+               (fun p ->
+                 let timeout =
+                   Lang.to_valued_option Lang.to_float (List.assoc "timeout" p)
+                 in
+                 let data = Lang.to_string (List.assoc "" p) in
+                 let data = Bytes.of_string data in
+                 let len = Bytes.length data in
+                 let start_time = Unix.gettimeofday () in
+                 let check_timeout () =
+                   match timeout with
+                     | None -> ()
+                     | Some t -> (
+                         let rem = start_time +. t -. Unix.gettimeofday () in
+                         try
+                           if rem <= 0. then failwith "timeout!";
+                           socket#wait_for `Write rem
+                         with _ ->
+                           Lang.raise_error ~pos:(Lang.pos p)
+                             ~message:"Timeout while writing to the socket!"
+                             "socket")
+                 in
+                 try
+                   let rec f pos =
+                     check_timeout ();
+                     let n = socket#write data pos (len - pos) in
+                     if n < len then f (pos + n)
+                   in
+                   f 0;
+                   Lang.unit
+                 with exn ->
+                   let bt = Printexc.get_raw_backtrace () in
+                   Lang.raise_as_runtime ~bt ~kind:"socket" exn)) );
       ( "read",
         ( [],
-          Lang.fun_t
-            [(true, "timeout", Lang.nullable_t Lang.float_t)]
-            Lang.string_t ),
+          wait_t ~mode:`Read
+            (Lang.fun_t
+               [(true, "timeout", Lang.nullable_t Lang.float_t)]
+               Lang.string_t) ),
         "Read data from a socket. Reading is done when the function returns an \
          empty string `\"\"`.",
         fun socket ->
           let buflen = Utils.pagesize in
           let buf = Bytes.create buflen in
-          Lang.val_fun
-            [("timeout", "timeout", Some (Lang.float 10.))]
-            (fun p ->
-              let timeout =
-                Lang.to_valued_option Lang.to_float (List.assoc "timeout" p)
-              in
-              let start_time = Unix.gettimeofday () in
-              let check_timeout () =
-                match timeout with
-                  | None -> ()
-                  | Some t -> (
-                      let rem = start_time +. t -. Unix.gettimeofday () in
-                      try
-                        if rem <= 0. then failwith "timeout!";
-                        socket#wait_for `Read rem
-                      with _ ->
-                        Lang.raise_error ~pos:(Lang.pos p)
-                          ~message:"Timeout while reading from the socket!"
-                          "socket")
-              in
-              try
-                check_timeout ();
-                let n = socket#read buf 0 buflen in
-                Lang.string (Bytes.sub_string buf 0 n)
-              with exn ->
-                let bt = Printexc.get_raw_backtrace () in
-                Lang.raise_as_runtime ~bt ~kind:"socket" exn) );
+          wait_meth ~mode:`Read socket
+            (Lang.val_fun
+               [("timeout", "timeout", Some (Lang.float 10.))]
+               (fun p ->
+                 let timeout =
+                   Lang.to_valued_option Lang.to_float (List.assoc "timeout" p)
+                 in
+                 let start_time = Unix.gettimeofday () in
+                 let check_timeout () =
+                   match timeout with
+                     | None -> ()
+                     | Some t -> (
+                         let rem = start_time +. t -. Unix.gettimeofday () in
+                         try
+                           if rem <= 0. then failwith "timeout!";
+                           socket#wait_for `Read rem
+                         with _ ->
+                           Lang.raise_error ~pos:(Lang.pos p)
+                             ~message:"Timeout while reading from the socket!"
+                             "socket")
+                 in
+                 try
+                   check_timeout ();
+                   let n = socket#read buf 0 buflen in
+                   Lang.string (Bytes.sub_string buf 0 n)
+                 with exn ->
+                   let bt = Printexc.get_raw_backtrace () in
+                   Lang.raise_as_runtime ~bt ~kind:"socket" exn)) );
       ( "close",
         ([], Lang.fun_t [] Lang.unit_t),
         "Close the socket.",
@@ -137,10 +358,213 @@ module SocketValue = struct
   let t =
     Lang.method_t t (List.map (fun (lbl, t, descr, _) -> (lbl, t, descr)) meths)
 
-  let to_value socket =
-    Lang.meth (to_value socket)
-      (List.map (fun (lbl, _, _, m) -> (lbl, m socket)) meths)
+  let to_value v =
+    Lang.meth (to_value v) (List.map (fun (lbl, _, _, m) -> (lbl, m v)) meths)
 
-  let of_unix_file_descr = Http.unix_socket
-  let of_value socket = of_value (Lang.demeth socket)
+  let server_t =
+    Lang.method_t t
+      [
+        ( "bind",
+          ([], Lang.fun_t [(false, "", Socket_addr.base_t)] Lang.unit_t),
+          "Bind a socket to an address." );
+        ( "listen",
+          ([], Lang.fun_t [(false, "", Lang.int_t)] Lang.unit_t),
+          "Set up a socket for receiving connection requests. The integer \
+           argument is the maximal number of pending requests." );
+      ]
+
+  let to_server_value socket =
+    Lang.meth (to_value socket)
+      [
+        ( "bind",
+          Lang.val_fun
+            [("", "", None)]
+            (fun p ->
+              Unix.bind socket#file_descr
+                (Socket_addr.of_value (List.assoc "" p));
+              Lang.unit) );
+        ( "listen",
+          Lang.val_fun
+            [("", "", None)]
+            (fun p ->
+              Unix.listen socket#file_descr (Lang.to_int (List.assoc "" p));
+              Lang.unit) );
+      ]
+
+  let unix_t =
+    Lang.method_t server_t
+      [
+        ( "accept",
+          ([], Lang.fun_t [] (Lang.product_t t Socket_addr.base_t)),
+          "Accept connections on the given socket. The returned socket is a \
+           socket connected to the client; the returned address is the address \
+           of the connecting client." );
+        ( "connect",
+          ([], Lang.fun_t [(false, "", Socket_addr.base_t)] Lang.unit_t),
+          "Connect a socket to an address." );
+      ]
+
+  let to_unix_value v =
+    let socket = Http.unix_socket v in
+    Lang.meth (to_server_value socket)
+      [
+        ( "accept",
+          Lang.val_fun [] (fun _ ->
+              let fd, sockaddr = socket#transport#accept socket#file_descr in
+              Lang.product (to_value fd) (Socket_addr.to_value sockaddr)) );
+        ( "connect",
+          Lang.val_fun
+            [("", "", None)]
+            (fun p ->
+              Unix.connect socket#file_descr
+                (Socket_addr.of_value (List.assoc "" p));
+              Lang.unit) );
+      ]
 end
+
+let () =
+  Lang.add_module "socket";
+  Lang.add_builtin "socket.unix" ~category:`Internet
+    [
+      ("domain", Socket_domain.t, Some Socket_domain.inet, Some "Socket domain.");
+      ("type", Socket_type.t, Some Socket_type.stream, Some "Socket type");
+      ( "protocol",
+        Lang.int_t,
+        Some (Lang.int 0),
+        Some
+          "Protocol type. `0` selects the default protocol for that kind of \
+           sockets." );
+    ]
+    Socket_value.unix_t ~descr:"Create a unix socket."
+    (fun p ->
+      let domain = Socket_domain.of_value (List.assoc "domain" p) in
+      let typ = Socket_type.of_value (List.assoc "type" p) in
+      let protocol = Lang.to_int (List.assoc "protocol" p) in
+      Socket_value.to_unix_value (Unix.socket ~cloexec:true domain typ protocol));
+
+  Lang.add_builtin "socket.pair" ~category:`Internet
+    [
+      ("domain", Socket_domain.t, Some Socket_domain.inet, Some "Socket domain.");
+      ("type", Socket_type.t, Some Socket_type.stream, Some "Socket type");
+      ( "protocol",
+        Lang.int_t,
+        Some (Lang.int 0),
+        Some
+          "Protocol type. `0` selects the default protocol for that kind of \
+           sockets." );
+    ]
+    Socket_value.t ~descr:"Create a pair of sockets connected together."
+    (fun p ->
+      let domain = Socket_domain.of_value (List.assoc "domain" p) in
+      let typ = Socket_type.of_value (List.assoc "type" p) in
+      let protocol = Lang.to_int (List.assoc "protocol" p) in
+      let s, s' = Unix.socketpair ~cloexec:true domain typ protocol in
+      Lang.product
+        (Socket_value.to_unix_value s)
+        (Socket_value.to_unix_value s'));
+
+  Lang.add_module "socket.domain";
+  Lang.add_module "socket.type";
+  let add ~t ~name ~descr value =
+    Lang.add_builtin_base ~category:`Internet ~descr ("socket." ^ name) value t
+  in
+  add ~t:Socket_domain.t ~name:"domain.unix" ~descr:"Unix socket domain"
+    Socket_domain.unix.Value.value;
+  add ~t:Socket_domain.t ~name:"domain.inet" ~descr:"Inet socket domain"
+    Socket_domain.inet.Value.value;
+  add ~t:Socket_domain.t ~name:"domain.inet6" ~descr:"Inet6 socket domain"
+    Socket_domain.inet6.Value.value;
+  add ~t:Socket_type.t ~name:"type.stream" ~descr:"Stream socket type"
+    Socket_type.stream.Value.value;
+  add ~t:Socket_type.t ~name:"type.dgram" ~descr:"Dgram socket type"
+    Socket_type.dgram.Value.value;
+  add ~t:Socket_type.t ~name:"type.raw" ~descr:"Raw socket type"
+    Socket_type.raw.Value.value;
+
+  Lang.add_builtin "socket.internet_address" ~category:`Internet
+    [("", Lang.string_t, None, Some "Socket internet address.")]
+    Inet_addr.t
+    ~descr:"Return an internet address from its string representation."
+    (fun p ->
+      Inet_addr.to_value
+        (Unix.inet_addr_of_string (Lang.to_string (List.assoc "" p))));
+
+  add ~t:Inet_addr.t ~name:"internet_address.any"
+    ~descr:
+      "A special IPv4 address, for use only with `socket.bind`, representing \
+       all the Internet addresses that the host machine possesses."
+    Inet_addr.any.Value.value;
+  add ~t:Inet_addr.t ~name:"internet_address.loopback"
+    ~descr:"A special IPv4 address representing the host machine (`127.0.0.1`)."
+    Inet_addr.loopback.Value.value;
+
+  Lang.add_module "socket.internet_address.ipv6";
+
+  add ~t:Inet_addr.t ~name:"internet_address.ipv6.any"
+    ~descr:
+      "A special IPv6 address, for use only with `socket.bind`, representing \
+       all the Internet addresses that the host machine possesses."
+    Inet_addr.ipv6_any.Value.value;
+  add ~t:Inet_addr.t ~name:"internet_address.ipv6.loopback"
+    ~descr:"A special IPv6 address representing the host machine (`::1`)."
+    Inet_addr.ipv6_loopback.Value.value;
+
+  Lang.add_module "socket.address";
+
+  Lang.add_builtin "socket.address.unix" ~category:`Internet
+    [("", Lang.string_t, None, Some "Unix socket path")]
+    Socket_addr.unix_t ~descr:"Create a socket address for a unix file socket."
+    (fun p ->
+      Socket_addr.to_unix_value
+        (Unix.ADDR_UNIX (Lang.to_string (List.assoc "" p))));
+
+  Lang.add_builtin "socket.address.internet_address" ~category:`Internet
+    [
+      ("", Inet_addr.t, None, Some "Internet address.");
+      ("", Lang.int_t, None, Some "port");
+    ]
+    Socket_addr.inet_t ~descr:"Create a socket address for a internet address."
+    (fun p ->
+      let addr = Inet_addr.of_value (Lang.assoc "" 1 p) in
+      let port = Lang.to_int (Lang.assoc "" 2 p) in
+      Socket_addr.to_inet_value (Unix.ADDR_INET (addr, port)))
+
+let host_t =
+  Lang.record_t
+    [
+      ("name", Lang.string_t);
+      ("aliases", Lang.list_t Lang.string_t);
+      ("domain", Socket_domain.t);
+      ("addresses", Lang.list_t Inet_addr.t);
+    ]
+
+let to_host_value { Unix.h_name; h_aliases; h_addrtype; h_addr_list } =
+  Lang.record
+    [
+      ("name", Lang.string h_name);
+      ("aliases", Lang.list (List.map Lang.string (Array.to_list h_aliases)));
+      ("domain", Socket_domain.to_value h_addrtype);
+      ( "addresses",
+        Lang.list (List.map Inet_addr.to_value (Array.to_list h_addr_list)) );
+    ]
+
+let () =
+  Lang.add_module "host";
+
+  Lang.add_builtin "host.of_name" ~category:`Internet
+    ~descr:"Find a host by name"
+    [("", Lang.string_t, None, Some "hostname")]
+    (Lang.nullable_t host_t)
+    (fun p ->
+      let hostname = Lang.to_string (List.assoc "" p) in
+      try to_host_value (Unix.gethostbyname hostname)
+      with Not_found -> Lang.null);
+
+  Lang.add_builtin "host.of_internet_address" ~category:`Internet
+    ~descr:"Find a host by internet address"
+    [("", Inet_addr.base_t, None, None)]
+    (Lang.nullable_t host_t)
+    (fun p ->
+      let inet_addr = Inet_addr.of_value (List.assoc "" p) in
+      try to_host_value (Unix.gethostbyaddr inet_addr)
+      with Not_found -> Lang.null)

--- a/src/core/builtins/builtins_srt.ml
+++ b/src/core/builtins/builtins_srt.ml
@@ -30,7 +30,7 @@ exception Not_connected
 module G = Generator
 module Generator = Generator.From_audio_video_plus
 
-module SocketValue = struct
+module Socket_value = struct
   let socket_options_specs =
     [
       ("connection_timeout", `Int Srt.conntimeo);

--- a/src/core/io/srt_io.ml
+++ b/src/core/io/srt_io.ml
@@ -51,7 +51,7 @@ let common_options ~mode =
              (false, "hs_version", Lang.int_t);
              (false, "peeraddr", Lang.string_t);
              (false, "streamid", Lang.nullable_t Lang.string_t);
-             (false, "", Builtins_srt.SocketValue.t);
+             (false, "", Builtins_srt.Socket_value.t);
            ]
            Lang.bool_t),
       Some Lang.null,
@@ -142,7 +142,7 @@ let meth () =
       ( [],
         Lang.fun_t []
           (Lang.list_t
-             (Lang.product_t Lang.string_t Builtins_srt.SocketValue.t)) ),
+             (Lang.product_t Lang.string_t Builtins_srt.Socket_value.t)) ),
       "List of `(connected_address, connected_socket)`",
       fun s ->
         Lang.val_fun [] (fun _ ->
@@ -151,7 +151,7 @@ let meth () =
                  (fun (origin, s) ->
                    Lang.product
                      (Lang.string (Utils.name_of_sockaddr origin))
-                     (Builtins_srt.SocketValue.to_value s))
+                     (Builtins_srt.Socket_value.to_value s))
                  s#get_sockets)) );
   ]
 
@@ -208,7 +208,7 @@ let parse_common_options p =
                  match streamid with
                    | None -> Lang.null
                    | Some s -> Lang.string s );
-               ("", Builtins_srt.SocketValue.to_value socket);
+               ("", Builtins_srt.Socket_value.to_value socket);
              ]))
       (Lang.to_option fn)
   in

--- a/src/js/dune.inc
+++ b/src/js/dune.inc
@@ -19,6 +19,7 @@ fades.liq
 profiler.liq
 null.liq
 math.liq
+socket.liq
 error.liq
 request.liq
 string.liq

--- a/src/lang/lang_error.ml
+++ b/src/lang/lang_error.ml
@@ -38,9 +38,8 @@ module ErrorDef = struct
   let descr { kind; msg; pos } =
     let pos =
       if pos <> [] then
-        Lang_string.quote_string
-          (Printf.sprintf ",positions=%s"
-             (Pos.List.to_string ~newlines:false pos))
+        Printf.sprintf ",positions=%s"
+          (Lang_string.quote_string (Pos.List.to_string ~newlines:false pos))
       else ""
     in
     Printf.sprintf "error(kind=%s,message=%s%s)"

--- a/src/libs/dune.inc
+++ b/src/libs/dune.inc
@@ -19,6 +19,7 @@ fades.liq
 profiler.liq
 null.liq
 math.liq
+socket.liq
 error.liq
 request.liq
 string.liq

--- a/src/libs/socket.liq
+++ b/src/libs/socket.liq
@@ -1,0 +1,24 @@
+# Open a named UNIX socket and connect as a client.
+# @param ~non_blocking Open in non-blocking mode.
+# @category File
+def socket.unix.client(~non_blocking=false,path) =
+  s = socket.unix(domain=socket.domain.unix)
+  s.non_blocking(non_blocking)
+  s.connect(socket.address.unix(path))
+  (s:socket).{read = s.read, write=s.write, type = s.type, close = s.close}
+end
+
+# Open a named socket and wait for a client to connect
+def socket.unix.listen(~non_blocking=false,path) =
+  s = socket.unix(domain=socket.domain.unix)
+  s.non_blocking(non_blocking)
+  s.bind(socket.address.unix(path))
+  s.listen(1)
+  let (s', _) = s.accept()
+  close = fun () ->
+   begin
+    s'.close()
+    s.close()
+   end
+  (s':socket).{read = s'.read, write=s'.write, type = s'.type, close = close}
+end

--- a/src/libs/stdlib.liq
+++ b/src/libs/stdlib.liq
@@ -10,6 +10,7 @@
 %include "thread.liq"
 %include "process.liq"
 %include "string.liq"
+%include "socket.liq"
 %include "file.liq"
 %include "switches.liq"
 %include "utils.liq"

--- a/tests/language/dune.inc
+++ b/tests/language/dune.inc
@@ -120,6 +120,19 @@
  (alias runtest)
  (package liquidsoap)
  (deps
+  socket.liq
+  ../media/all_media_files
+  ../../src/bin/liquidsoap.exe
+  (source_tree ../../src/libs)
+  (:stdlib ../../src/libs/stdlib.liq)
+  (:test_liq ../test.liq)
+  (:run_test ../run_test.exe))
+ (action (run %{run_test} socket.liq liquidsoap %{test_liq} socket.liq)))
+
+(rule
+ (alias runtest)
+ (package liquidsoap)
+ (deps
   pp.liq
   ../media/all_media_files
   ../../src/bin/liquidsoap.exe

--- a/tests/language/socket.liq
+++ b/tests/language/socket.liq
@@ -1,0 +1,34 @@
+def f() =
+  test.equals(socket.internet_address.ipv6.any.is_ipv6, true)
+  test.equals(socket.internet_address.ipv6.loopback.to_string(), "::1")
+
+  let [h] = null.get(host.of_name("localhost")).addresses
+  test.equals(socket.address.internet_address(h, 80).port, 80)
+
+  fname = file.temp("unix", "socket")
+  file.remove(fname)
+
+  thread.run(fun () -> begin
+    s = socket.unix.listen(fname)
+    test.equals(s.type, "unix")
+    s.write.wait(fun () -> begin
+      s.write("done!")
+      s.close()
+    end)
+  end)
+
+  thread.run(delay=0.1, fun () -> begin
+    s = socket.unix.client(fname)
+    s.read.wait(fun () ->
+     begin
+      if s.read() == "done!" then
+        s.close()
+        test.pass()
+      else
+        test.fail()
+      end
+     end)
+  end)
+end
+
+test.check(f)


### PR DESCRIPTION
This PR adds the unix socket API to the language:

* `socket.domain` to represent supported socket domains
* `socket.type` to represent supported socket types
* `socket.internet_address` to represent an internet address
* `socket.address` to represent socket addresses (unix, internet address)
* `host.of_name` to resolve a hostname
* `host.of_internet_address` to resolve an internet address back to a host

Specific methods are introduced to handle sockets that can receive or connect to network addresses.

Most the API is directly adapted from the corresponding [OCaml Unix API](https://v2.ocaml.org/api/Unix.html).