### PR TITLE
Rewrite generators

### DIFF
--- a/src/core/builtins/builtins_ffmpeg_filters.ml
+++ b/src/core/builtins/builtins_ffmpeg_filters.ml
@@ -579,13 +579,13 @@ let () =
   let raw_video_format = `Kind Ffmpeg_raw_content.Video.kind in
   let audio_frame_t =
     Lang.frame_t (Lang.univ_t ())
-      (Frame.mk_fields
+      (Frame.Fields.make
          ~audio:(Type.make (Format_type.descr raw_audio_format))
          ())
   in
   let video_frame_t =
     Lang.frame_t (Lang.univ_t ())
-      (Frame.mk_fields
+      (Frame.Fields.make
          ~video:(Type.make (Format_type.descr raw_video_format))
          ())
   in
@@ -612,7 +612,7 @@ let () =
 
       let frame_t =
         Lang.frame_t Lang.unit_t
-          (Frame.mk_fields
+          (Frame.Fields.make
            (* We need to make sure that we are using a format here to
               ensure that its params are properly unified with the underlying source. *)
              ~audio:
@@ -661,7 +661,7 @@ let () =
 
   let return_t =
     Lang.frame_t (Lang.univ_t ())
-      (Frame.mk_fields
+      (Frame.Fields.make
          ~audio:(Type.make (Format_type.descr raw_audio_format))
          ())
   in
@@ -683,7 +683,7 @@ let () =
 
       let frame_t =
         Lang.frame_t Lang.unit_t
-          (Frame.mk_fields
+          (Frame.Fields.make
            (* We need to make sure that we are using a format here to
               ensure that its params are properly unified with the underlying source. *)
              ~audio:
@@ -736,7 +736,7 @@ let () =
 
       let frame_t =
         Lang.frame_t Lang.unit_t
-          (Frame.mk_fields
+          (Frame.Fields.make
            (* We need to make sure that we are using a format here to
               ensure that its params are properly unified with the underlying source. *)
              ~video:
@@ -784,7 +784,7 @@ let () =
 
   let return_t =
     Lang.frame_t (Lang.univ_t ())
-      (Frame.mk_fields
+      (Frame.Fields.make
          ~video:(Type.make (Format_type.descr raw_video_format))
          ())
   in
@@ -814,7 +814,7 @@ let () =
 
       let frame_t =
         Lang.frame_t Lang.unit_t
-          (Frame.mk_fields
+          (Frame.Fields.make
              ~video:
                (Type.make
                   (Format_type.descr (`Kind Ffmpeg_raw_content.Video.kind)))

--- a/src/core/builtins/builtins_srt.ml
+++ b/src/core/builtins/builtins_srt.ml
@@ -27,9 +27,6 @@ open Unsigned
 exception Done
 exception Not_connected
 
-module G = Generator
-module Generator = Generator.From_audio_video_plus
-
 module Socket_value = struct
   let socket_options_specs =
     [

--- a/src/core/conversions/audio_to_stereo.ml
+++ b/src/core/conversions/audio_to_stereo.ml
@@ -57,10 +57,10 @@ class basic source =
 let () =
   let input_type =
     Lang.frame_t (Lang.univ_t ())
-      (Frame.mk_fields ~audio:(Format_type.audio ()) ())
+      (Frame.Fields.make ~audio:(Format_type.audio ()) ())
   in
   let output_type =
-    Frame_type.set_field input_type Frame.audio_field
+    Frame_type.set_field input_type Frame.Fields.audio
       (Format_type.audio_stereo ())
   in
   Lang.add_operator "audio_to_stereo" ~category:`Conversion

--- a/src/core/conversions/conversion.ml
+++ b/src/core/conversions/conversion.ml
@@ -48,17 +48,14 @@ class base ?(audio = false) ?(video = false) ?(midi = false) ~converter
             frame
 
     method private copy_frame src dst =
-      Frame.set_pts dst (Frame.pts src);
       Frame.set_breaks dst (Frame.breaks src);
       Frame.set_all_metadata dst (Frame.get_all_metadata src);
-      if not audio then
-        ignore
-          (Option.map (fun src -> Frame.set_audio dst src) (Frame.audio src));
-      if not video then
-        ignore
-          (Option.map (fun src -> Frame.set_video dst src) (Frame.video src));
-      if not midi then
-        ignore (Option.map (fun src -> Frame.set_midi dst src) (Frame.midi src))
+      if not audio then (
+        try Frame.set_audio dst (Frame.audio src) with Not_found -> ());
+      if not video then (
+        try Frame.set_video dst (Frame.video src) with Not_found -> ());
+      if not midi then (
+        try Frame.set_video dst (Frame.midi src) with Not_found -> ())
 
     method private get_frame frame =
       let tmp_frame = self#tmp_frame in

--- a/src/core/conversions/drop.ml
+++ b/src/core/conversions/drop.ml
@@ -40,21 +40,21 @@ let () =
           | `Audio ->
               ( "drop_audio",
                 "Drop all audio content of a stream.",
-                Frame_type.set_field output Frame.audio_field (Lang.univ_t ()),
+                Frame_type.set_field output Frame.Fields.audio (Lang.univ_t ()),
                 fun p ->
                   let source = Lang.to_source (List.assoc "" p) in
                   new drop ~audio:true ~name:"drop_audio" source )
           | `Video ->
               ( "drop_video",
                 "Drop all video content of a stream.",
-                Frame_type.set_field output Frame.video_field (Lang.univ_t ()),
+                Frame_type.set_field output Frame.Fields.video (Lang.univ_t ()),
                 fun p ->
                   let source = Lang.to_source (List.assoc "" p) in
                   new drop ~video:true ~name:"drop_video" source )
           | `Midi ->
               ( "drop_midi",
                 "Drop all midi content of a stream.",
-                Frame_type.set_field output Frame.midi_field (Lang.univ_t ()),
+                Frame_type.set_field output Frame.Fields.midi (Lang.univ_t ()),
                 fun p ->
                   let source = Lang.to_source (List.assoc "" p) in
                   new drop ~midi:true ~name:"drop_midi" source )

--- a/src/core/conversions/mean.ml
+++ b/src/core/conversions/mean.ml
@@ -49,10 +49,10 @@ class mean ~normalize source =
 let () =
   let in_t =
     Lang.frame_t (Lang.univ_t ())
-      (Frame.mk_fields ~audio:(Format_type.audio ()) ())
+      (Frame.Fields.make ~audio:(Format_type.audio ()) ())
   in
   let out_t =
-    Frame_type.set_field in_t Frame.audio_field (Format_type.audio_mono ())
+    Frame_type.set_field in_t Frame.Fields.audio (Format_type.audio_mono ())
   in
   Lang.add_operator "mean"
     [

--- a/src/core/conversions/swap.ml
+++ b/src/core/conversions/swap.ml
@@ -53,7 +53,7 @@ class swap (source : source) =
 let () =
   let frame_t =
     Lang.frame_t (Lang.univ_t ())
-      (Frame.mk_fields ~audio:(Format_type.audio_stereo ()) ())
+      (Frame.Fields.make ~audio:(Format_type.audio_stereo ()) ())
   in
   Lang.add_operator "swap"
     [("", Lang.source_t frame_t, None, None)]

--- a/src/core/decoder/aac_decoder.ml
+++ b/src/core/decoder/aac_decoder.ml
@@ -160,7 +160,9 @@ let file_type ~ctype:_ filename =
         (Lang_string.quote_string filename)
         rate channels;
       Some
-        (Frame.mk_fields ~audio:(Content.Audio.format_of_channels channels) ()))
+        (Frame.Fields.make
+           ~audio:(Content.Audio.format_of_channels channels)
+           ()))
 
 let file_decoder ~metadata:_ ~ctype filename =
   Decoder.opaque_file_decoder ~filename ~ctype create_decoder
@@ -234,7 +236,9 @@ let file_type ~ctype:_ filename =
         (Lang_string.quote_string filename)
         rate channels;
       Some
-        (Frame.mk_fields ~audio:(Content.Audio.format_of_channels channels) ()))
+        (Frame.Fields.make
+           ~audio:(Content.Audio.format_of_channels channels)
+           ()))
 
 let mp4_mime_types =
   Dtools.Conf.list

--- a/src/core/decoder/decoder.ml
+++ b/src/core/decoder/decoder.ml
@@ -50,8 +50,6 @@ type file = string
 (** A stream is identified by a MIME type. *)
 type stream = string
 
-module G = Generator.From_audio_video_plus
-
 type fps = Decoder_utils.fps = { num : int; den : int }
 
 (* Buffer passed to decoder. This wraps around
@@ -62,9 +60,9 @@ type fps = Decoder_utils.fps = { num : int; den : int }
     - Implicit fps conversion
     - Implicit content drop *)
 type buffer = {
-  generator : G.t;
-  put_pcm : ?pts:Int64.t -> samplerate:int -> Content.Audio.data -> unit;
-  put_yuva420p : ?pts:Int64.t -> fps:fps -> Content.Video.data -> unit;
+  generator : Generator.t;
+  put_pcm : samplerate:int -> Content.Audio.data -> unit;
+  put_yuva420p : fps:fps -> Content.Video.data -> unit;
 }
 
 type decoder = {
@@ -249,7 +247,7 @@ let channel_layout audio =
 
 let can_decode_type decoded_type target_type =
   let map_convertible cur (field, target_field) =
-    let decoded_field = Frame.find_field_opt decoded_type field in
+    let decoded_field = Frame.Fields.find_opt field decoded_type in
     match decoded_field with
       | None -> cur
       | Some decoded_field when Content.Audio.is_format decoded_field -> (
@@ -259,9 +257,9 @@ let can_decode_type decoded_type target_type =
                 (create
                    (channel_layout decoded_field)
                    (channel_layout target_field));
-              Frame.set_field cur field target_field
+              Frame.Fields.add field target_field cur
             with _ -> cur))
-      | Some decoded_field -> Frame.set_field cur field decoded_field
+      | Some decoded_field -> Frame.Fields.add field decoded_field cur
   in
   (* Map content that can be converted and drop content that isn't used *)
   let decoded_type =
@@ -273,7 +271,7 @@ let can_decode_type decoded_type target_type =
 let decoder_modes ctype =
   let has field = Frame.Fields.exists (fun k _ -> k = field) ctype in
   match
-    (has Frame.audio_field, has Frame.video_field, has Frame.midi_field)
+    (has Frame.Fields.audio, has Frame.Fields.video, has Frame.Fields.midi)
   with
     | true, true, false -> [`Audio_video]
     | true, false, false -> [`Audio; `Audio_video]
@@ -421,19 +419,11 @@ let get_stream_decoder ~ctype mime =
 (** {1 Helpers for defining decoders} *)
 
 let mk_buffer ~ctype generator =
-  let has field = Frame.Fields.exists (fun k _ -> k = field) ctype in
-  let mode =
-    match (has Frame.audio_field, has Frame.video_field) with
-      | true, true -> `Both
-      | true, false -> `Audio
-      | false, true -> `Video
-      | _ -> failwith "Invalid type for buffer!"
-  in
-
-  G.set_mode generator mode;
+  let has_audio = Frame.Fields.mem Frame.Fields.audio ctype in
+  let has_video = Frame.Fields.mem Frame.Fields.video ctype in
 
   let put_pcm =
-    if mode <> `Video then (
+    if has_audio then (
       let resampler = Decoder_utils.samplerate_converter () in
       let current_channel_converter = ref None in
       let current_dst = ref None in
@@ -446,29 +436,28 @@ let mk_buffer ~ctype generator =
       in
 
       let get_channel_converter () =
-        let dst = channel_layout (Option.get (Frame.find_audio ctype)) in
+        let dst = channel_layout (Frame.Fields.find Frame.Fields.audio ctype) in
         match !current_channel_converter with
           | None -> mk_channel_converter dst
           | Some _ when !current_dst <> Some dst -> mk_channel_converter dst
           | Some c -> c
       in
-      fun ?pts ~samplerate data ->
+      fun ~samplerate data ->
         let data, _, _ = resampler ~samplerate data 0 (Audio.length data) in
         let data = (get_channel_converter ()) data in
-        let len = Audio.length data in
         let data = Content.Audio.lift_data data in
-        G.put_audio ?pts generator data 0 (Frame.main_of_audio len))
-    else fun ?pts:_ ~samplerate:_ _ -> ()
+        Generator.put generator Frame.Fields.audio data)
+    else fun ~samplerate:_ _ -> ()
   in
 
   let put_yuva420p =
-    if mode <> `Audio then (
+    if has_video then (
       let video_resample = Decoder_utils.video_resample () in
       let video_scale =
         let width, height =
           try
             Content.Video.dimensions_of_format
-              (Option.get (Frame.find_video ctype))
+              (Option.get (Frame.Fields.find_opt Frame.Fields.video ctype))
           with Content.Invalid ->
             (* We might have encoded contents *)
             (Lazy.force Frame.video_width, Lazy.force Frame.video_height)
@@ -478,7 +467,7 @@ let mk_buffer ~ctype generator =
       let out_freq =
         Decoder_utils.{ num = Lazy.force Frame.video_rate; den = 1 }
       in
-      fun ?pts ~fps (data : Content.Video.data) ->
+      fun ~fps (data : Content.Video.data) ->
         let data = Array.map video_scale data in
         let data = video_resample ~in_freq:fps ~out_freq data in
         let len = Video.Canvas.length data in
@@ -487,8 +476,8 @@ let mk_buffer ~ctype generator =
             ~length:(Frame_settings.main_of_video len)
             data
         in
-        G.put_video ?pts generator data 0 (Frame.main_of_video len))
-    else fun ?pts:_ ~fps:_ _ -> ()
+        Generator.put generator Frame.Fields.video data)
+    else fun ~fps:_ _ -> ()
   in
 
   { generator; put_pcm; put_yuva420p }
@@ -498,13 +487,15 @@ let mk_decoder ~filename ~close ~remaining ~buffer decoder =
   let decoding_done = ref false in
 
   let remaining frame offset =
-    remaining () + G.length buffer.generator + Frame.position frame - offset
+    remaining ()
+    + Generator.length buffer.generator
+    + Frame.position frame - offset
   in
 
   let fill frame =
     if not !decoding_done then (
       try
-        while G.length buffer.generator < prebuf do
+        while Generator.length buffer.generator < prebuf do
           decoder.decode buffer
         done
       with e ->
@@ -517,7 +508,7 @@ let mk_decoder ~filename ~close ~remaining ~buffer decoder =
         if conf_debug#get then raise e);
 
     let offset = Frame.position frame in
-    G.fill buffer.generator frame;
+    Generator.fill buffer.generator frame;
 
     try remaining frame offset
     with e ->
@@ -528,21 +519,19 @@ let mk_decoder ~filename ~close ~remaining ~buffer decoder =
   in
 
   let fseek len =
-    let gen_len = G.length buffer.generator in
+    let gen_len = Generator.length buffer.generator in
     if len < 0 || len > gen_len then (
-      G.clear buffer.generator;
+      Generator.clear buffer.generator;
       gen_len + decoder.seek (len - gen_len))
     else (
       (* Seek within the pre-buffered data if possible *)
-      G.remove buffer.generator len;
+      Generator.truncate buffer.generator len;
       len)
   in
   { fill; fseek; close }
 
 let file_decoder ~filename ~close ~remaining ~ctype decoder =
-  let generator =
-    G.create ~log_overfull:false ~log:(log#info "%s") `Undefined
-  in
+  let generator = Generator.create ~log:(log#info "%s") ctype in
   let buffer = mk_buffer ~ctype generator in
   mk_decoder ~filename ~close ~remaining ~buffer decoder
 
@@ -567,17 +556,15 @@ let opaque_file_decoder ~filename ~ctype create_decoder =
     { read; tell = Some tell; length = Some length; lseek = Some lseek }
   in
 
-  let generator =
-    G.create ~log:(log#info "%s") ~log_overfull:false `Undefined
-  in
+  let generator = Generator.create ~log:(log#info "%s") ctype in
   let buffer = mk_buffer ~ctype generator in
   let decoder = create_decoder input in
 
   let out_ticks = ref 0 in
   let decode buffer =
-    let start = G.length buffer.generator in
+    let start = Generator.length buffer.generator in
     decoder.decode buffer;
-    let stop = G.length buffer.generator in
+    let stop = Generator.length buffer.generator in
     out_ticks := !out_ticks + stop - start
   in
 

--- a/src/core/decoder/decoder.mli
+++ b/src/core/decoder/decoder.mli
@@ -38,8 +38,6 @@ type input = {
   length : (unit -> int) option;
 }
 
-module G = Generator.From_audio_video_plus
-
 type fps = { num : int; den : int }
 
 (* Buffer passed to decoder. This wraps around
@@ -50,9 +48,9 @@ type fps = { num : int; den : int }
     - Implicit fps conversion
     - Implicit content drop *)
 type buffer = {
-  generator : G.t;
-  put_pcm : ?pts:Int64.t -> samplerate:int -> Content.Audio.data -> unit;
-  put_yuva420p : ?pts:Int64.t -> fps:fps -> Content.Video.data -> unit;
+  generator : Generator.t;
+  put_pcm : samplerate:int -> Content.Audio.data -> unit;
+  put_yuva420p : fps:fps -> Content.Video.data -> unit;
 }
 
 type decoder = {
@@ -123,7 +121,7 @@ val image_file_decoders : (file -> Video.Image.t option) Plug.t
 val get_image_file_decoder : file -> Video.Image.t option
 
 (* Initialize a decoding buffer *)
-val mk_buffer : ctype:Frame.content_type -> G.t -> buffer
+val mk_buffer : ctype:Frame.content_type -> Generator.t -> buffer
 
 (* Create a file decoder when remaining time is known. *)
 val file_decoder :

--- a/src/core/decoder/external_decoder.ml
+++ b/src/core/decoder/external_decoder.ml
@@ -107,7 +107,7 @@ let test_ctype f filename =
   if ret = 0 then None
   else
     Some
-      (Frame.mk_fields
+      (Frame.Fields.make
          ~audio:
            (if ret < 0 then audio_n (Lazy.force Frame.audio_channels)
            else audio_n ret)
@@ -143,8 +143,6 @@ let register_stdin ~name ~doc ~priority ~mimes ~file_extensions ~test process =
 
 let log = Log.make ["decoder"; "external"; "oblivious"]
 
-module Generator = Decoder.G
-
 let external_input_oblivious process filename prebuf =
   let command = process filename in
   let process =
@@ -160,9 +158,9 @@ let external_input_oblivious process filename prebuf =
   let input = { Decoder.read; tell = None; length = None; lseek = None } in
   (* TODO: is this really what we want for audio channels? *)
   let ctype =
-    Frame.mk_fields ~audio:(audio_n (Lazy.force Frame.audio_channels)) ()
+    Frame.Fields.make ~audio:(audio_n (Lazy.force Frame.audio_channels)) ()
   in
-  let gen = Generator.create ~log_overfull:false ~log:(log#info "%s") `Audio in
+  let gen = Generator.create ~log:(log#info "%s") ctype in
   let buffer = Decoder.mk_buffer ~ctype gen in
   let prebuf = Frame.main_of_seconds prebuf in
   let decoder = Wav_aiff_decoder.create input in

--- a/src/core/decoder/ffmpeg_internal_decoder.ml
+++ b/src/core/decoder/ffmpeg_internal_decoder.ml
@@ -24,8 +24,6 @@ open Mm
 
 (** Decode media using ffmpeg. *)
 
-module Generator = Decoder.G
-
 let log = Log.make ["decoder"; "ffmpeg"; "internal"]
 
 module ConverterInput = Swresample.Make (Swresample.Frame)
@@ -65,7 +63,7 @@ let mk_audio_decoder ~channels container =
         in_sample_format := frame_in_sample_format;
         converter := mk_converter ());
       let content = Converter.convert !converter frame in
-      buffer.Decoder.put_pcm ?pts:None ~samplerate:target_sample_rate content;
+      buffer.Decoder.put_pcm ~samplerate:target_sample_rate content;
       let metadata = Avutil.Frame.metadata frame in
       if metadata <> [] then (
         let m = Hashtbl.create (List.length metadata) in
@@ -113,7 +111,7 @@ let mk_video_decoder ~width ~height container =
   let cb ~buffer frame =
     let img = scale frame in
     let content = Video.Canvas.single img in
-    buffer.Decoder.put_yuva420p ?pts:None
+    buffer.Decoder.put_yuva420p
       ~fps:{ Decoder.num = target_fps; den = 1 }
       content;
     let metadata = Avutil.Frame.metadata frame in

--- a/src/core/decoder/ffmpeg_raw_decoder.ml
+++ b/src/core/decoder/ffmpeg_raw_decoder.ml
@@ -22,8 +22,6 @@
 
 (** Decode raw ffmpeg frames. *)
 
-module G = Decoder.G
-
 let mk_decoder ~stream_idx ~stream_time_base ~mk_params ~lift_data ~put_data
     params =
   let duration_converter =
@@ -48,7 +46,7 @@ let mk_decoder ~stream_idx ~stream_time_base ~mk_params ~lift_data ~put_data
             { Ffmpeg_content_base.params = mk_params params; data; length }
           in
           let data = lift_data data in
-          put_data ?pts:None buffer.Decoder.generator data 0 length
+          put_data buffer.Decoder.generator data
       | None -> ()
 
 let mk_audio_decoder ~stream_idx ~format container =
@@ -63,7 +61,8 @@ let mk_audio_decoder ~stream_idx ~format container =
   ( idx,
     stream,
     mk_decoder ~stream_idx ~lift_data ~mk_params ~stream_time_base
-      ~put_data:G.put_audio params )
+      ~put_data:(fun g c -> Generator.put g Frame.Fields.audio c)
+      params )
 
 let mk_video_decoder ~stream_idx ~format container =
   let idx, stream, params = Av.find_best_video_stream container in
@@ -77,4 +76,5 @@ let mk_video_decoder ~stream_idx ~format container =
   ( idx,
     stream,
     mk_decoder ~stream_idx ~mk_params ~lift_data ~stream_time_base
-      ~put_data:G.put_video params )
+      ~put_data:(fun g c -> Generator.put g Frame.Fields.video c)
+      params )

--- a/src/core/decoder/image_decoder.ml
+++ b/src/core/decoder/image_decoder.ml
@@ -137,12 +137,12 @@ let create_decoder ~audio ~width ~height ~metadata img =
   { Decoder.fill; fseek = (fun _ -> 0); close }
 
 let is_audio_compatible ctype =
-  match Frame.find_field_opt ctype Frame.audio_field with
+  match Frame.Fields.find_opt Frame.Fields.audio ctype with
     | None -> true
     | Some f -> Content.Audio.is_format f
 
 let is_video_compatible ctype =
-  match Frame.find_field_opt ctype Frame.video_field with
+  match Frame.Fields.find_opt Frame.Fields.video ctype with
     | None -> false
     | Some f -> Content.Video.is_format f
 
@@ -160,8 +160,8 @@ let () =
             && is_audio_compatible ctype && is_video_compatible ctype
           then
             Some
-              (Frame.mk_fields
-                 ?audio:(Frame.find_field_opt ctype Frame.audio_field)
+              (Frame.Fields.make
+                 ?audio:(Frame.Fields.find_opt Frame.Fields.audio ctype)
                  ~video:Content.(default_format Video.kind)
                  ())
           else None);
@@ -171,10 +171,10 @@ let () =
             let img = Option.get (Decoder.get_image_file_decoder filename) in
             let width, height =
               Content.Video.dimensions_of_format
-                (Option.get (Frame.find_video ctype))
+                (Option.get (Frame.Fields.find_opt Frame.Fields.video ctype))
             in
             create_decoder
-              ~audio:(Frame.has_field ctype Frame.audio_field)
+              ~audio:(Frame.Fields.mem Frame.Fields.audio ctype)
               ~width ~height ~metadata img);
       stream_decoder = None;
     }

--- a/src/core/decoder/liq_flac_decoder.ml
+++ b/src/core/decoder/liq_flac_decoder.ml
@@ -125,7 +125,9 @@ let file_type filename =
         (Lang_string.quote_string filename)
         rate channels;
       Some
-        (Frame.mk_fields ~audio:(Content.Audio.format_of_channels channels) ()))
+        (Frame.Fields.make
+           ~audio:(Content.Audio.format_of_channels channels)
+           ()))
 
 let file_decoder ~metadata:_ ~ctype filename =
   Decoder.opaque_file_decoder ~filename ~ctype create_decoder

--- a/src/core/decoder/mad_decoder.ml
+++ b/src/core/decoder/mad_decoder.ml
@@ -158,7 +158,7 @@ let file_type filename =
          channels)."
         filename layer (f.Mad.bitrate / 1000) f.Mad.samplerate f.Mad.channels;
       Some
-        (Frame.mk_fields
+        (Frame.Fields.make
            ~audio:(Content.Audio.format_of_channels f.Mad.channels)
            ()))
 

--- a/src/core/decoder/midi_decoder.ml
+++ b/src/core/decoder/midi_decoder.ml
@@ -69,7 +69,7 @@ let () =
       file_type =
         (fun ~ctype:_ _ ->
           Some
-            (Frame.mk_fields
+            (Frame.Fields.make
                ~midi:Content.(Midi.lift_params { Content.channels = 16 })
                ()));
       file_decoder =

--- a/src/core/decoder/srt_decoder.ml
+++ b/src/core/decoder/srt_decoder.ml
@@ -50,8 +50,10 @@ let () =
         (fun ~ctype fname ->
           if Srt_parser.check_file fname then
             Some
-              (Frame.mk_fields ?audio:(Frame.find_audio ctype)
-                 ?video:(Frame.find_video ctype) ())
+              (Frame.Fields.make
+                 ?audio:(Frame.Fields.find_opt Frame.Fields.audio ctype)
+                 ?video:(Frame.Fields.find_opt Frame.Fields.video ctype)
+                 ())
           else None);
       file_decoder =
         Some

--- a/src/core/decoder/wav_aiff_decoder.ml
+++ b/src/core/decoder/wav_aiff_decoder.ml
@@ -149,7 +149,7 @@ let file_type ~ctype:_ filename =
               0
       in
       Some
-        (Frame.mk_fields
+        (Frame.Fields.make
            ~audio:
              Content.(
                Audio.lift_params

--- a/src/core/encoder.ml
+++ b/src/core/encoder.ml
@@ -35,7 +35,7 @@ type format =
   | GStreamer of Gstreamer_format.t
 
 let audio_type n =
-  Frame.mk_fields
+  Frame.Fields.make
     ~audio:
       (Type.make
          (Format_type.descr
@@ -49,9 +49,10 @@ let audio_type n =
     ()
 
 let audio_video_type n =
-  Frame.set_field (audio_type n) Frame.video_field
+  Frame.Fields.add Frame.Fields.video
     (Type.make
        (Format_type.descr (`Format Content.(default_format Video.kind))))
+    (audio_type n)
 
 let type_of_format = function
   | WAV w -> audio_type w.Wav_format.channels
@@ -97,7 +98,7 @@ let type_of_format = function
           m.Ffmpeg_format.video_codec
       in
       let video = Option.map (fun f -> Type.make (Format_type.descr f)) video in
-      Frame.mk_fields ?audio ?video ()
+      Frame.Fields.make ?audio ?video ()
   | FdkAacEnc m -> audio_type m.Fdkaac_format.channels
   | Ogg { Ogg_format.audio; video } ->
       let channels =

--- a/src/core/encoder/fdkaac_encoder.ml
+++ b/src/core/encoder/fdkaac_encoder.ml
@@ -24,8 +24,6 @@ open Mm
 
 (** FDK-AAC encoder *)
 
-module G = Generator.Generator
-
 let create_encoder params =
   let encoder = Fdkaac.Encoder.create params.Fdkaac_format.channels in
   let bandwidth =

--- a/src/core/encoder/ffmpeg_encoder.ml
+++ b/src/core/encoder/ffmpeg_encoder.ml
@@ -47,8 +47,7 @@ let () =
                         ~video_size:(fun _ -> None)
                         ~get_stream ~remove_stream ~keyframe_opt
                         ~get_data:(fun frame ->
-                          Ffmpeg_copy_content.Audio.get_data
-                            (Option.get (Frame.audio frame)))
+                          Ffmpeg_copy_content.Audio.get_data (Frame.audio frame))
                 | None | Some (`Internal (Some _)) | Some (`Raw (Some _)) ->
                     Ffmpeg_internal_encoder.mk_audio
                 | Some (`Internal None) ->
@@ -61,8 +60,7 @@ let () =
                 | Some (`Copy keyframe_opt) ->
                     fun ~ffmpeg:_ ~options:_ ->
                       let get_data frame =
-                        Ffmpeg_copy_content.Video.get_data
-                          (Option.get (Frame.video frame))
+                        Ffmpeg_copy_content.Video.get_data (Frame.video frame)
                       in
                       let video_size frame =
                         let { Ffmpeg_content_base.params } = get_data frame in

--- a/src/core/encoder/ffmpeg_encoder_common.ml
+++ b/src/core/encoder/ffmpeg_encoder_common.ml
@@ -191,11 +191,11 @@ let encoder ~mk_audio ~mk_video ffmpeg meta =
       | Some "mp4" ->
           encode ~encoder frame start len;
           if encoder.video_stream <> None then (
-            let d = Content.sub (Option.get (Frame.video frame)) start len in
+            let d = Content.sub (Frame.video frame) start len in
             video_sent := !video_sent || not (Content.is_empty d))
           else video_sent := true;
           if encoder.audio_stream <> None then (
-            let d = Content.sub (Option.get (Frame.audio frame)) start len in
+            let d = Content.sub (Frame.audio frame) start len in
             audio_sent := !audio_sent || not (Content.is_empty d))
           else audio_sent := true;
           if not (!audio_sent && !video_sent) then raise Encoder.Not_enough_data;

--- a/src/core/encoder/ffmpeg_internal_encoder.ml
+++ b/src/core/encoder/ffmpeg_internal_encoder.ml
@@ -181,7 +181,7 @@ let mk_audio ~ffmpeg ~options output =
     in
     fun frame start len ->
       let frames =
-        Ffmpeg_raw_content.Audio.(get_data (Option.get (Frame.audio frame)))
+        Ffmpeg_raw_content.Audio.(get_data (Frame.audio frame))
           .Ffmpeg_content_base.data
       in
       let frames =
@@ -442,7 +442,7 @@ let mk_video ~ffmpeg ~options output =
     fun frame start len ->
       let stop = start + len in
       let { Ffmpeg_raw_content.VideoSpecs.data } =
-        Ffmpeg_raw_content.Video.get_data (Option.get (Frame.video frame))
+        Ffmpeg_raw_content.Video.get_data (Frame.video frame)
       in
       List.iter
         (fun (pos, { Ffmpeg_raw_content.time_base; frame; stream_idx }) ->

--- a/src/core/hooks_implementations.ml
+++ b/src/core/hooks_implementations.ml
@@ -111,7 +111,7 @@ let mk_source_ty ~pos name args =
           List.fold_left
             (fun fields (lbl, k) ->
               Frame.Fields.add
-                (Frame.field_of_string lbl)
+                (Frame.Fields.field_of_string lbl)
                 (mk_field_t ~pos k) fields)
             Frame.Fields.empty args
         in

--- a/src/core/io/alsa_io.ml
+++ b/src/core/io/alsa_io.ml
@@ -272,7 +272,7 @@ class input ~clock_safe ~start ~on_stop ~on_start ~fallible dev =
 let () =
   let frame_t =
     Lang.frame_t (Lang.univ_t ())
-      (Frame.mk_fields ~audio:(Format_type.audio ()) ())
+      (Frame.Fields.make ~audio:(Format_type.audio ()) ())
   in
   Lang.add_operator "output.alsa"
     (Output.proto
@@ -320,7 +320,8 @@ let () =
 
 let () =
   let return_t =
-    Lang.frame_t Lang.unit_t (Frame.mk_fields ~audio:(Format_type.audio ()) ())
+    Lang.frame_t Lang.unit_t
+      (Frame.Fields.make ~audio:(Format_type.audio ()) ())
   in
   Lang.add_operator "input.alsa"
     (Start_stop.active_source_proto ~clock_safe:true ~fallible_opt:(`Yep false)

--- a/src/core/io/oss_io.ml
+++ b/src/core/io/oss_io.ml
@@ -129,7 +129,7 @@ class input ~clock_safe ~start ~on_stop ~on_start ~fallible dev =
 let () =
   let frame_t =
     Lang.frame_t (Lang.univ_t ())
-      (Frame.mk_fields ~audio:(Format_type.audio ()) ())
+      (Frame.Fields.make ~audio:(Format_type.audio ()) ())
   in
   Lang.add_operator "output.oss"
     (Output.proto
@@ -166,7 +166,8 @@ let () =
         :> Output.output));
 
   let return_t =
-    Lang.frame_t Lang.unit_t (Frame.mk_fields ~audio:(Format_type.audio ()) ())
+    Lang.frame_t Lang.unit_t
+      (Frame.Fields.make ~audio:(Format_type.audio ()) ())
   in
   Lang.add_operator "input.oss"
     (Start_stop.active_source_proto ~clock_safe:true ~fallible_opt:(`Yep false)

--- a/src/core/io/portaudio_io.ml
+++ b/src/core/io/portaudio_io.ml
@@ -240,7 +240,7 @@ class input ~clock_safe ~start ~on_start ~on_stop ~fallible ~device_id ~latency
 let () =
   let frame_t =
     Lang.frame_t (Lang.univ_t ())
-      (Frame.mk_fields ~audio:(Format_type.audio ()) ())
+      (Frame.Fields.make ~audio:(Format_type.audio ()) ())
   in
   Lang.add_operator "output.portaudio"
     (Output.proto
@@ -293,7 +293,8 @@ let () =
 
 let () =
   let return_t =
-    Lang.frame_t Lang.unit_t (Frame.mk_fields ~audio:(Format_type.audio ()) ())
+    Lang.frame_t Lang.unit_t
+      (Frame.Fields.make ~audio:(Format_type.audio ()) ())
   in
   Lang.add_operator "input.portaudio"
     (Start_stop.active_source_proto ~clock_safe:true ~fallible_opt:(`Yep false)

--- a/src/core/io/pulseaudio_io.ml
+++ b/src/core/io/pulseaudio_io.ml
@@ -173,7 +173,7 @@ let proto =
 let () =
   let frame_t =
     Lang.frame_t (Lang.univ_t ())
-      (Frame.mk_fields ~audio:(Format_type.audio ()) ())
+      (Frame.Fields.make ~audio:(Format_type.audio ()) ())
   in
   Lang.add_operator "output.pulseaudio"
     (Output.proto @ proto @ [("", Lang.source_t frame_t, None, None)])
@@ -194,7 +194,8 @@ let () =
 
 let () =
   let return_t =
-    Lang.frame_t Lang.unit_t (Frame.mk_fields ~audio:(Format_type.audio ()) ())
+    Lang.frame_t Lang.unit_t
+      (Frame.Fields.make ~audio:(Format_type.audio ()) ())
   in
   Lang.add_operator "input.pulseaudio"
     (Start_stop.active_source_proto ~clock_safe:true ~fallible_opt:(`Yep false)

--- a/src/core/io/udp_io.ml
+++ b/src/core/io/udp_io.ml
@@ -104,28 +104,17 @@ class output ~on_start ~on_stop ~infallible ~autostart ~hostname ~port
       Strings.iter (fun s o l -> ignore (socket_send s o l)) data
   end
 
-module Generator = Generator.From_audio_video_plus
-module Generated = Generated.Make (Generator)
-
-class input ~hostname ~port ~get_stream_decoder ~bufferize ~log_overfull =
-  let max_ticks = 2 * Frame.main_of_seconds bufferize in
-  (* A log function for our generator: start with a stub, and replace it
-   * when we have a proper logger with our ID on it. *)
-  let log_ref = ref (fun _ -> ()) in
-  let log x = !log_ref x in
+class input ~hostname ~port ~get_stream_decoder ~bufferize =
+  let max_length = Some (2 * Frame.main_of_seconds bufferize) in
   object (self)
-    inherit
-      Generated.source
-        (Generator.create ~log ~log_overfull ~overfull:(`Drop_old max_ticks)
-           `Undefined)
-        ~empty_on_abort:false ~bufferize
+    inherit Generated.source ~empty_on_abort:false ~bufferize ()
 
     inherit
       Start_stop.active_source
         ~name:"input.udp" ~clock_safe:false ~fallible:true ~on_start:ignore
           ~on_stop:ignore ~autostart:true ()
 
-    initializer log_ref := fun s -> self#log#important "%s" s
+    initializer Generator.set_max_length self#buffer max_length
     val mutable kill_feeding = None
     val mutable wait_feeding = None
     val mutable decoder_factory = None
@@ -134,7 +123,7 @@ class input ~hostname ~port ~get_stream_decoder ~bufferize ~log_overfull =
     method private start =
       begin
         let decoder args =
-          let buffer = Decoder.mk_buffer ~ctype:self#content_type generator in
+          let buffer = Decoder.mk_buffer ~ctype:self#content_type self#buffer in
           (get_stream_decoder self#content_type args, buffer)
         in
         decoder_factory <- Some decoder;
@@ -183,7 +172,7 @@ class input ~hostname ~port ~get_stream_decoder ~bufferize ~log_overfull =
           decoder.Decoder.decode buffer
         done
       with e ->
-        Generator.add_break ~sync:true generator;
+        Generator.add_track_mark self#buffer;
 
         (* Closing the socket is slightly overkill but
          * we need to recreate the decoder anyway, which
@@ -254,10 +243,6 @@ let () =
         Lang.float_t,
         Some (Lang.float 1.),
         Some "Duration of buffered data before starting playout." );
-      ( "log_overfull",
-        Lang.bool_t,
-        Some (Lang.bool true),
-        Some "Log when the source's buffer is overfull." );
       ("", Lang.string_t, None, Some "Mime type.");
     ]
     ~return_t:frame_t
@@ -266,7 +251,6 @@ let () =
       let port = Lang.to_int (List.assoc "port" p) in
       let hostname = Lang.to_string (List.assoc "host" p) in
       let bufferize = Lang.to_float (List.assoc "buffer" p) in
-      let log_overfull = Lang.to_bool (List.assoc "log_overfull" p) in
       let mime = Lang.to_string (Lang.assoc "" 1 p) in
       let get_stream_decoder ctype =
         match Decoder.get_stream_decoder ~ctype mime with
@@ -277,5 +261,5 @@ let () =
                      "Cannot get a stream decoder for this MIME" ))
           | Some decoder_factory -> decoder_factory
       in
-      (new input ~hostname ~port ~bufferize ~log_overfull ~get_stream_decoder
+      (new input ~hostname ~port ~bufferize ~get_stream_decoder
         :> Source.source))

--- a/src/core/lang_encoders/lang_ffmpeg.ml
+++ b/src/core/lang_encoders/lang_ffmpeg.ml
@@ -82,7 +82,7 @@ let type_of_encoder p =
       None p
   in
   let video = Option.map (fun f -> Type.make (Format_type.descr f)) video in
-  Frame.mk_fields ?audio ?video ()
+  Frame.Fields.make ?audio ?video ()
 
 let flag_qscale = ref 0
 let qp2lambda = ref 0

--- a/src/core/lang_source.ml
+++ b/src/core/lang_source.ml
@@ -67,6 +67,22 @@ let source_methods =
        source is currently streaming, just that its resources are all properly \
        initialized.",
       fun s -> val_fun [] (fun _ -> bool s#is_ready) );
+    ( "buffered",
+      ([], fun_t [] (list_t (product_t string_t float_t))),
+      "Length of buffered data.",
+      fun s ->
+        val_fun [] (fun _ ->
+            let l =
+              Frame.Fields.fold
+                (fun field _ l ->
+                  ( Frame.Fields.string_of_field field,
+                    Frame.seconds_of_main
+                      (Generator.field_length s#buffer field) )
+                  :: l)
+                s#content_type []
+            in
+            list (List.map (fun (lbl, v) -> product (string lbl) (float v)) l))
+    );
     ( "last_metadata",
       ([], fun_t [] (nullable_t metadata_t)),
       "Return the last metadata from the source.",

--- a/src/core/operators/accelerate.ml
+++ b/src/core/operators/accelerate.ml
@@ -21,7 +21,6 @@
  *****************************************************************************)
 
 open Source
-module Generator = Generator.From_frames
 
 class accelerate ~ratio ~randomize source_val =
   let source = Lang.to_source source_val in
@@ -42,7 +41,7 @@ class accelerate ~ratio ~randomize source_val =
     method abort_track = source#abort_track
 
     (** Frame used for dropping samples. *)
-    val mutable null = Frame.dummy
+    val mutable null = Frame.dummy ()
 
     method private wake_up x =
       super#wake_up x;

--- a/src/core/operators/add.ml
+++ b/src/core/operators/add.ml
@@ -81,7 +81,7 @@ class add ~renorm ~power (sources : ((unit -> float) * source) list) video_init
      * wanted, even if they end a track -- this is quite needed. There is an
      * exception when there is only one active source, then the end of tracks
      * are not hidden anymore, which is useful for transitions, for example. *)
-    val mutable tmp = Frame.dummy
+    val mutable tmp = Frame.dummy ()
 
     method wake_up a =
       super#wake_up a;
@@ -241,7 +241,7 @@ let tile_pos n =
 let () =
   let frame_t =
     Lang.frame_t (Lang.univ_t ())
-      (Frame.mk_fields ~video:(Format_type.video ()) ())
+      (Frame.Fields.make ~video:(Format_type.video ()) ())
   in
   Lang.add_operator "video.tile" ~category:`Video
     ~descr:"Tile sources (same as add but produces tiles of videos)."

--- a/src/core/operators/amplify.ml
+++ b/src/core/operators/amplify.ml
@@ -66,7 +66,7 @@ class amplify (source : source) override_field coeff =
 let () =
   let frame_t =
     Lang.frame_t (Lang.univ_t ())
-      (Frame.mk_fields ~audio:(Format_type.audio ()) ())
+      (Frame.Fields.make ~audio:(Format_type.audio ()) ())
   in
   Lang.add_operator "amplify"
     [

--- a/src/core/operators/chord.ml
+++ b/src/core/operators/chord.ml
@@ -118,7 +118,7 @@ let () =
   let in_t = Lang.frame_t (Lang.univ_t ()) Frame.Fields.empty in
   let out_t =
     Lang.frame_t (Lang.univ_t ())
-      (Frame.mk_fields ~midi:(Format_type.midi_n 1) ())
+      (Frame.Fields.make ~midi:(Format_type.midi_n 1) ())
   in
   Lang.add_operator "midi.chord"
     [

--- a/src/core/operators/clip.ml
+++ b/src/core/operators/clip.ml
@@ -44,7 +44,7 @@ class clip (source : source) =
 let () =
   let frame_t =
     Lang.frame_t (Lang.univ_t ())
-      (Frame.mk_fields ~audio:(Format_type.audio ()) ())
+      (Frame.Fields.make ~audio:(Format_type.audio ()) ())
   in
   Lang.add_operator "clip"
     [("", Lang.source_t frame_t, None, None)]

--- a/src/core/operators/comb.ml
+++ b/src/core/operators/comb.ml
@@ -62,7 +62,7 @@ class comb (source : source) delay feedback =
 let () =
   let frame_t =
     Lang.frame_t (Lang.univ_t ())
-      (Frame.mk_fields ~audio:(Format_type.audio ()) ())
+      (Frame.Fields.make ~audio:(Format_type.audio ()) ())
   in
   Lang.add_operator "comb"
     [

--- a/src/core/operators/compand.ml
+++ b/src/core/operators/compand.ml
@@ -50,7 +50,7 @@ class compand (source : source) mu =
 let () =
   let frame_t =
     Lang.frame_t (Lang.univ_t ())
-      (Frame.mk_fields ~audio:(Format_type.audio ()) ())
+      (Frame.Fields.make ~audio:(Format_type.audio ()) ())
   in
   Lang.add_operator "compand"
     [

--- a/src/core/operators/compress.ml
+++ b/src/core/operators/compress.ml
@@ -169,7 +169,7 @@ class compress ~attack ~release ~threshold ~ratio ~knee ~track_sensitive
 let () =
   let return_t =
     Lang.frame_t (Lang.univ_t ())
-      (Frame.mk_fields ~audio:(Format_type.audio ()) ())
+      (Frame.Fields.make ~audio:(Format_type.audio ()) ())
   in
   Lang.add_operator "compress"
     [

--- a/src/core/operators/compress_exp.ml
+++ b/src/core/operators/compress_exp.ml
@@ -49,7 +49,7 @@ class compress (source : source) mu =
 let () =
   let return_t =
     Lang.frame_t (Lang.univ_t ())
-      (Frame.mk_fields ~audio:(Format_type.audio ()) ())
+      (Frame.Fields.make ~audio:(Format_type.audio ()) ())
   in
   Lang.add_operator "compress.exponential" ~category:`Audio
     ~descr:"Exponential compressor."

--- a/src/core/operators/compress_old.ml
+++ b/src/core/operators/compress_old.ml
@@ -119,7 +119,7 @@ let compress p =
 let () =
   let frame_t =
     Lang.frame_t (Lang.univ_t ())
-      (Frame.mk_fields ~audio:(Format_type.audio ()) ())
+      (Frame.Fields.make ~audio:(Format_type.audio ()) ())
   in
   Lang.add_operator "compress.old"
     (( "ratio",
@@ -130,7 +130,7 @@ let () =
     ~return_t:frame_t ~category:`Audio ~descr:"Compress the signal." compress;
   let frame_t =
     Lang.frame_t (Lang.univ_t ())
-      (Frame.mk_fields ~audio:(Format_type.audio ()) ())
+      (Frame.Fields.make ~audio:(Format_type.audio ()) ())
   in
   Lang.add_operator "limit"
     (( "ratio",

--- a/src/core/operators/delay_line.ml
+++ b/src/core/operators/delay_line.ml
@@ -75,7 +75,7 @@ class delay (source : source) duration =
 let () =
   let frame_t =
     Lang.frame_t (Lang.univ_t ())
-      (Frame.mk_fields ~audio:(Format_type.audio ()) ())
+      (Frame.Fields.make ~audio:(Format_type.audio ()) ())
   in
   Lang.add_operator "delay_line"
     [

--- a/src/core/operators/dtmf.ml
+++ b/src/core/operators/dtmf.ml
@@ -236,7 +236,7 @@ let () = Lang.add_module "dtmf"
 let () =
   let frame_t =
     Lang.frame_t (Lang.univ_t ())
-      (Frame.mk_fields ~audio:(Format_type.audio ()) ())
+      (Frame.Fields.make ~audio:(Format_type.audio ()) ())
   in
   Lang.add_operator "dtmf.detect"
     [
@@ -361,7 +361,7 @@ class detect ~duration ~bands ~threshold ~smoothing ~debug ~frequencies callback
 let () =
   let frame_t =
     Lang.frame_t (Lang.univ_t ())
-      (Frame.mk_fields ~audio:(Format_type.audio ()) ())
+      (Frame.Fields.make ~audio:(Format_type.audio ()) ())
   in
   Lang.add_operator "sine.detect"
     [

--- a/src/core/operators/echo.ml
+++ b/src/core/operators/echo.ml
@@ -58,7 +58,7 @@ class echo (source : source) delay feedback ping_pong =
 let () =
   let frame_t =
     Lang.frame_t (Lang.univ_t ())
-      (Frame.mk_fields ~audio:(Format_type.audio ()) ())
+      (Frame.Fields.make ~audio:(Format_type.audio ()) ())
   in
   Lang.add_operator "echo"
     [

--- a/src/core/operators/filter.ml
+++ b/src/core/operators/filter.ml
@@ -88,7 +88,7 @@ class filter (source : source) freq q wet mode =
 let () =
   let frame_t =
     Lang.frame_t (Lang.univ_t ())
-      (Frame.mk_fields ~audio:(Format_type.audio ()) ())
+      (Frame.Fields.make ~audio:(Format_type.audio ()) ())
   in
   Lang.add_operator "filter"
     [

--- a/src/core/operators/filter_rc.ml
+++ b/src/core/operators/filter_rc.ml
@@ -82,7 +82,7 @@ class filter (source : source) freq wet mode =
 let () =
   let frame_t =
     Lang.frame_t (Lang.univ_t ())
-      (Frame.mk_fields ~audio:(Format_type.audio ()) ())
+      (Frame.Fields.make ~audio:(Format_type.audio ()) ())
   in
   Lang.add_operator "filter.rc"
     [

--- a/src/core/operators/fir_filter.ml
+++ b/src/core/operators/fir_filter.ml
@@ -154,7 +154,7 @@ class fir (source : source) freq beta numcoeffs =
 let () =
   let frame_t =
     Lang.frame_t (Lang.univ_t ())
-      (Frame.mk_fields ~audio:(Format_type.audio ()) ())
+      (Frame.Fields.make ~audio:(Format_type.audio ()) ())
   in
   Lang.add_operator "filter.fir"
     [

--- a/src/core/operators/flanger.ml
+++ b/src/core/operators/flanger.ml
@@ -74,7 +74,7 @@ class flanger (source : source) delay freq feedback phase =
 let () =
   let frame_t =
     Lang.frame_t (Lang.univ_t ())
-      (Frame.mk_fields ~audio:(Format_type.audio ()) ())
+      (Frame.Fields.make ~audio:(Format_type.audio ()) ())
   in
   Lang.add_operator "flanger"
     [

--- a/src/core/operators/frei0r_op.ml
+++ b/src/core/operators/frei0r_op.ml
@@ -105,7 +105,7 @@ class frei0r_mixer ~name bgra instance params (source : source) source2 =
       source2#abort_track
 
     val mutable t = 0.
-    val mutable tmp = Frame.dummy
+    val mutable tmp = Frame.dummy ()
 
     method private wake_up a =
       super#wake_up a;
@@ -290,7 +290,7 @@ let register_plugin fname =
   if inputs > 2 then raise Unhandled_number_of_inputs;
   let return_t =
     Lang.frame_t (Lang.univ_t ())
-      (Frame.mk_fields ~video:(Format_type.video ()) ())
+      (Frame.Fields.make ~video:(Format_type.video ()) ())
   in
   let liq_params, params = params plugin info in
   let liq_params =

--- a/src/core/operators/gate.ml
+++ b/src/core/operators/gate.ml
@@ -101,7 +101,7 @@ class gate ~threshold ~attack ~release ~hold ~range ~window (source : source) =
 let () =
   let frame_t =
     Lang.frame_t (Lang.univ_t ())
-      (Frame.mk_fields ~audio:(Format_type.audio ()) ())
+      (Frame.Fields.make ~audio:(Format_type.audio ()) ())
   in
   Lang.add_operator "gate"
     [

--- a/src/core/operators/iir_filter.ml
+++ b/src/core/operators/iir_filter.ml
@@ -451,7 +451,7 @@ let () =
 let () =
   let frame_t =
     Lang.frame_t (Lang.univ_t ())
-      (Frame.mk_fields ~audio:(Format_type.audio ()) ())
+      (Frame.Fields.make ~audio:(Format_type.audio ()) ())
   in
   Lang.add_operator "filter.iir.butterworth.high"
     [
@@ -472,7 +472,7 @@ let () =
 let () =
   let frame_t =
     Lang.frame_t (Lang.univ_t ())
-      (Frame.mk_fields ~audio:(Format_type.audio ()) ())
+      (Frame.Fields.make ~audio:(Format_type.audio ()) ())
   in
   Lang.add_operator "filter.iir.butterworth.low"
     [
@@ -493,7 +493,7 @@ let () =
 let () =
   let frame_t =
     Lang.frame_t (Lang.univ_t ())
-      (Frame.mk_fields ~audio:(Format_type.audio ()) ())
+      (Frame.Fields.make ~audio:(Format_type.audio ()) ())
   in
   Lang.add_operator "filter.iir.butterworth.bandpass"
     [
@@ -516,7 +516,7 @@ let () =
 let () =
   let frame_t =
     Lang.frame_t (Lang.univ_t ())
-      (Frame.mk_fields ~audio:(Format_type.audio ()) ())
+      (Frame.Fields.make ~audio:(Format_type.audio ()) ())
   in
   Lang.add_operator "filter.iir.butterworth.bandstop"
     [
@@ -539,7 +539,7 @@ let () =
 let () =
   let frame_t =
     Lang.frame_t (Lang.univ_t ())
-      (Frame.mk_fields ~audio:(Format_type.audio ()) ())
+      (Frame.Fields.make ~audio:(Format_type.audio ()) ())
   in
   Lang.add_operator "filter.iir.resonator.bandpass"
     [
@@ -560,7 +560,7 @@ let () =
 let () =
   let frame_t =
     Lang.frame_t (Lang.univ_t ())
-      (Frame.mk_fields ~audio:(Format_type.audio ()) ())
+      (Frame.Fields.make ~audio:(Format_type.audio ()) ())
   in
   Lang.add_operator "filter.iir.resonator.bandstop"
     [
@@ -581,7 +581,7 @@ let () =
 let () =
   let frame_t =
     Lang.frame_t (Lang.univ_t ())
-      (Frame.mk_fields ~audio:(Format_type.audio ()) ())
+      (Frame.Fields.make ~audio:(Format_type.audio ()) ())
   in
   Lang.add_operator "filter.iir.resonator.allpass"
     [

--- a/src/core/operators/ladspa_op.ml
+++ b/src/core/operators/ladspa_op.ml
@@ -105,7 +105,8 @@ class ladspa_mono (source : source) plugin descr input output params =
       let i =
         Array.init
           (Content.Audio.channels_of_format
-             (Option.get (Frame.find_audio self#content_type)))
+             (Option.get
+                (Frame.Fields.find_opt Frame.Fields.audio self#content_type)))
           (fun _ -> instantiate d (Lazy.force Frame.audio_rate))
       in
       Array.iter Descriptor.activate i;
@@ -314,7 +315,7 @@ let register_descr plugin_name descr_n d inputs outputs =
   let liq_params, params = params_of_descr d in
   let input_t =
     Lang.frame_t (Lang.univ_t ())
-      (Frame.mk_fields ~audio:(Format_type.audio ()) ())
+      (Frame.Fields.make ~audio:(Format_type.audio ()) ())
   in
   let liq_params =
     liq_params
@@ -325,7 +326,8 @@ let register_descr plugin_name descr_n d inputs outputs =
   let descr = Printf.sprintf "%s by %s." (Descriptor.name d) maker in
   let return_t =
     if mono then input_t
-    else Frame_type.set_field input_t Frame.audio_field (Format_type.audio_n no)
+    else
+      Frame_type.set_field input_t Frame.Fields.audio (Format_type.audio_n no)
   in
   let label = Descriptor.label d |> Utils.normalize_parameter_string in
   let label =

--- a/src/core/operators/lilv_op.ml
+++ b/src/core/operators/lilv_op.ml
@@ -73,7 +73,8 @@ class lilv_mono (source : source) plugin input output params =
       let i =
         Array.init
           (Content.Audio.channels_of_format
-             (Option.get (Frame.find_audio self#content_type)))
+             (Option.get
+                (Frame.Fields.find_opt Frame.Fields.audio self#content_type)))
           (fun _ ->
             Plugin.instantiate plugin
               (float_of_int (Lazy.force Frame.audio_rate)))
@@ -324,7 +325,7 @@ let register_plugin plugin =
   let return_t =
     let input_kind = Lang.of_frame_t input_t in
     Lang.frame_t
-      (Frame.set_audio_field input_kind (Lang.kind_t (Frame.audio_n no)))
+      (Frame.set_Fields.audio input_kind (Lang.kind_t (Frame.audio_n no)))
   in
   Lang.add_operator
     ("lv2." ^ Utils.normalize_parameter_string (Plugin.name plugin))

--- a/src/core/operators/lufs.ml
+++ b/src/core/operators/lufs.ml
@@ -187,7 +187,7 @@ class lufs window source =
 let () =
   let return_t =
     Lang.frame_t (Lang.univ_t ())
-      (Frame.mk_fields ~audio:(Format_type.audio ()) ())
+      (Frame.Fields.make ~audio:(Format_type.audio ()) ())
   in
   Lang.add_operator "lufs" ~category:`Visualization
     ~meth:

--- a/src/core/operators/midi_routing.ml
+++ b/src/core/operators/midi_routing.ml
@@ -60,7 +60,7 @@ class remove (source : source) t =
 let () =
   let frame_t =
     Lang.frame_t (Lang.univ_t ())
-      (Frame.mk_fields ~midi:(Format_type.midi ()) ())
+      (Frame.Fields.make ~midi:(Format_type.midi ()) ())
   in
   Lang.add_operator "midi.merge_all"
     [
@@ -77,7 +77,7 @@ let () =
 let () =
   let frame_t =
     Lang.frame_t (Lang.univ_t ())
-      (Frame.mk_fields ~midi:(Format_type.midi ()) ())
+      (Frame.Fields.make ~midi:(Format_type.midi ()) ())
   in
   Lang.add_operator "midi.remove"
     [

--- a/src/core/operators/ms_stereo.ml
+++ b/src/core/operators/ms_stereo.ml
@@ -61,7 +61,7 @@ let () =
   Lang.add_module "stereo.ms";
   let return_t =
     Lang.frame_t (Lang.univ_t ())
-      (Frame.mk_fields ~audio:(Format_type.audio_stereo ()) ())
+      (Frame.Fields.make ~audio:(Format_type.audio_stereo ()) ())
   in
   Lang.add_operator "stereo.ms.encode"
     [("", Lang.source_t return_t, None, None)]
@@ -72,7 +72,7 @@ let () =
       new msstereo s Encode 0.);
   let return_t =
     Lang.frame_t (Lang.univ_t ())
-      (Frame.mk_fields ~audio:(Format_type.audio_stereo ()) ())
+      (Frame.Fields.make ~audio:(Format_type.audio_stereo ()) ())
   in
   Lang.add_operator "stereo.ms.decode"
     [
@@ -124,7 +124,7 @@ class spatializer ~width (source : source) =
 let () =
   let return_t =
     Lang.frame_t (Lang.univ_t ())
-      (Frame.mk_fields ~audio:(Format_type.audio_stereo ()) ())
+      (Frame.Fields.make ~audio:(Format_type.audio_stereo ()) ())
   in
   Lang.add_operator "stereo.width"
     [

--- a/src/core/operators/noblank.ml
+++ b/src/core/operators/noblank.ml
@@ -246,7 +246,7 @@ let extract p =
 let () =
   let frame_t =
     Lang.frame_t (Lang.univ_t ())
-      (Frame.mk_fields ~audio:(Format_type.audio ()) ())
+      (Frame.Fields.make ~audio:(Format_type.audio ()) ())
   in
   Lang.add_operator "blank.detect" ~return_t:frame_t ~category:`Track
     ~meth:
@@ -280,7 +280,7 @@ let () =
 let () =
   let frame_t =
     Lang.frame_t (Lang.univ_t ())
-      (Frame.mk_fields ~audio:(Format_type.audio ()) ())
+      (Frame.Fields.make ~audio:(Format_type.audio ()) ())
   in
   Lang.add_operator "blank.strip" ~return_t:frame_t
     ~meth:
@@ -302,7 +302,7 @@ let () =
 let () =
   let frame_t =
     Lang.frame_t (Lang.univ_t ())
-      (Frame.mk_fields ~audio:(Format_type.audio ()) ())
+      (Frame.Fields.make ~audio:(Format_type.audio ()) ())
   in
   Lang.add_operator "blank.eat" ~return_t:frame_t ~category:`Track
     ~meth:

--- a/src/core/operators/normalize.ml
+++ b/src/core/operators/normalize.ml
@@ -110,7 +110,7 @@ let () = Lang.add_module "normalize"
 let () =
   let frame_t =
     Lang.frame_t (Lang.univ_t ())
-      (Frame.mk_fields ~audio:(Format_type.audio ()) ())
+      (Frame.Fields.make ~audio:(Format_type.audio ()) ())
   in
   Lang.add_operator "normalize.old"
     [

--- a/src/core/operators/pan.ml
+++ b/src/core/operators/pan.ml
@@ -51,7 +51,7 @@ class pan (source : source) phi phi_0 =
 let () =
   let frame_t =
     Lang.frame_t (Lang.univ_t ())
-      (Frame.mk_fields ~audio:(Format_type.audio_stereo ()) ())
+      (Frame.Fields.make ~audio:(Format_type.audio_stereo ()) ())
   in
   Lang.add_operator "stereo.pan"
     [

--- a/src/core/operators/replaygain_op.ml
+++ b/src/core/operators/replaygain_op.ml
@@ -60,7 +60,7 @@ let () = Lang.add_module "source.replaygain"
 let () =
   let frame_t =
     Lang.frame_t (Lang.univ_t ())
-      (Frame.mk_fields ~audio:(Format_type.audio ()) ())
+      (Frame.Fields.make ~audio:(Format_type.audio ()) ())
   in
   Lang.add_operator "source.replaygain.compute"
     ~meth:

--- a/src/core/operators/resample.ml
+++ b/src/core/operators/resample.ml
@@ -22,21 +22,19 @@
 
 open Mm
 open Source
-module Generator = Generator.From_frames
 
 class resample ~ratio source_val =
   let source = Lang.to_source source_val in
   let write_frame_ref = ref (fun _ -> ()) in
   let consumer =
     new Producer_consumer.consumer
-      ~write_frame:(fun frame -> !write_frame_ref frame)
+      ~write_frame:(fun _ frame -> !write_frame_ref frame)
       ~name:"stretch.consumer" ~source:source_val ()
   in
   let () =
     Typing.(consumer#frame_type <: source#frame_type);
     Typing.(source#frame_type <: consumer#frame_type)
   in
-  let generator = Generator.create () in
   object (self)
     inherit operator ~name:"stretch" [(consumer :> Source.source)] as super
 
@@ -47,14 +45,14 @@ class resample ~ratio source_val =
     method stype = source#stype
 
     method seek len =
-      let glen = min (Generator.length generator) len in
-      Generator.remove generator glen;
+      let glen = min (Generator.length self#buffer) len in
+      Generator.truncate self#buffer glen;
       (if glen < len then source#seek (len - glen) else 0) + glen
 
     method remaining =
       let rem = source#remaining in
       if rem = -1 then rem
-      else int_of_float (float (rem + Generator.length generator) *. ratio ())
+      else int_of_float (float (rem + Generator.length self#buffer) *. ratio ())
 
     method abort_track = source#abort_track
     method is_ready = source#is_ready
@@ -78,40 +76,38 @@ class resample ~ratio source_val =
 
     method private process_frame frame =
       let ratio = ratio () in
-      let content, len =
-        let content = AFrame.pcm frame in
-        let converter = Option.get converter in
-        let pcm, offset, length =
-          Audio_converter.Samplerate.resample converter ratio content 0
-            (Audio.length content)
-        in
-        let offset = Frame_settings.main_of_audio offset in
-        let length = Frame_settings.main_of_audio length in
-        ( Frame.mk_fields ~audio:(Content.Audio.lift_data ~offset ~length pcm) (),
-          length )
+      let content = AFrame.pcm frame in
+      let converter = Option.get converter in
+      let pcm, offset, length =
+        Audio_converter.Samplerate.resample converter ratio content 0
+          (Audio.length content)
       in
+      let offset = Frame_settings.main_of_audio offset in
+      let length = Frame_settings.main_of_audio length in
+      Generator.put self#buffer Frame.Fields.audio
+        (Content.Audio.lift_data ~offset ~length pcm);
       let convert x = int_of_float (float x *. ratio) in
-      let metadata =
-        List.map (fun (i, m) -> (convert i, m)) (Frame.get_all_metadata frame)
-      in
-      Generator.feed generator ~metadata ~copy:`None content 0 len;
-      if Frame.is_partial frame then Generator.add_break generator
+      List.iter
+        (fun (pos, m) ->
+          Generator.add_metadata ~pos:(convert pos) self#buffer m)
+        (Frame.get_all_metadata frame);
+      if Frame.is_partial frame then Generator.add_track_mark self#buffer
 
     method private get_frame frame =
       consumer#set_output_enabled true;
       while
-        Generator.length generator < Lazy.force Frame.size && source#is_ready
+        Generator.length self#buffer < Lazy.force Frame.size && source#is_ready
       do
         self#child_tick
       done;
       consumer#set_output_enabled false;
-      Generator.fill generator frame
+      Generator.fill self#buffer frame
   end
 
 let () =
   let return_t =
     Lang.frame_t (Lang.univ_t ())
-      (Frame.mk_fields ~audio:(Format_type.audio ()) ())
+      (Frame.Fields.make ~audio:(Format_type.audio ()) ())
   in
   Lang.add_operator "stretch" (* TODO better name *)
     [

--- a/src/core/operators/rms_smooth.ml
+++ b/src/core/operators/rms_smooth.ml
@@ -57,7 +57,7 @@ class rms ~tau source =
 let () =
   let return_t =
     Lang.frame_t (Lang.univ_t ())
-      (Frame.mk_fields ~audio:(Format_type.audio ()) ())
+      (Frame.Fields.make ~audio:(Format_type.audio ()) ())
   in
   Lang.add_operator "rms.smooth" ~category:`Visualization
     ~meth:

--- a/src/core/operators/st_bpm.ml
+++ b/src/core/operators/st_bpm.ml
@@ -39,7 +39,8 @@ class bpm (source : source) =
         Some
           (Soundtouch.BPM.make
              (Content.Audio.channels_of_format
-                (Option.get (Frame.find_audio self#content_type)))
+                (Option.get
+                   (Frame.Fields.find_opt Frame.Fields.audio self#content_type)))
              (Lazy.force Frame.audio_rate))
 
     method private get_frame buf =
@@ -57,7 +58,7 @@ class bpm (source : source) =
 let () =
   let frame_t =
     Lang.frame_t (Lang.univ_t ())
-      (Frame.mk_fields ~audio:(Format_type.audio ()) ())
+      (Frame.Fields.make ~audio:(Format_type.audio ()) ())
   in
   Lang.add_operator "bpm"
     [("", Lang.source_t frame_t, None, None)]

--- a/src/core/operators/still_frame.ml
+++ b/src/core/operators/still_frame.ml
@@ -67,7 +67,7 @@ class still_frame ~name (source : source) =
 let () =
   let return_t =
     Lang.frame_t (Lang.univ_t ())
-      (Frame.mk_fields ~video:(Format_type.video ()) ())
+      (Frame.Fields.make ~video:(Format_type.video ()) ())
   in
   let name = "video.still_frame" in
   Lang.add_operator name

--- a/src/core/operators/time_warp.ml
+++ b/src/core/operators/time_warp.ml
@@ -22,6 +22,78 @@
 
 open Mm
 
+module MG = struct
+  type t = {
+    mutable metadata : (int * Frame.metadata) list;
+    mutable breaks : int list;
+    mutable length : int;
+  }
+
+  let create () = { metadata = []; breaks = []; length = 0 }
+
+  let clear g =
+    g.metadata <- [];
+    g.breaks <- [];
+    g.length <- 0
+
+  let advance g len =
+    g.metadata <- List.map (fun (t, m) -> (t - len, m)) g.metadata;
+    g.metadata <- List.filter (fun (t, _) -> t >= 0) g.metadata;
+    g.breaks <- List.map (fun t -> t - len) g.breaks;
+    g.breaks <- List.filter (fun t -> t >= 0) g.breaks;
+    g.length <- g.length - len;
+    assert (g.length >= 0)
+
+  let length g = g.length
+  let remaining g = match g.breaks with a :: _ -> a | _ -> -1
+  let metadata g len = List.filter (fun (t, _) -> t < len) g.metadata
+
+  let feed_from_frame g frame =
+    let size = Lazy.force Frame.size in
+    let length = length g in
+    g.metadata <-
+      g.metadata
+      @ List.map (fun (t, m) -> (length + t, m)) (Frame.get_all_metadata frame);
+    g.breaks <-
+      g.breaks
+      @ List.map
+          (fun t -> length + t)
+          (* Filter out the last break, which only marks the end of frame, not a
+           * track limit (doesn't mean is_partial). *)
+          (List.filter (fun x -> x < size) (Frame.breaks frame));
+    let frame_length =
+      let rec aux = function [t] -> t | _ :: tl -> aux tl | [] -> size in
+      aux (Frame.breaks frame)
+    in
+    g.length <- g.length + frame_length
+
+  let drop_initial_break g =
+    match g.breaks with
+      | 0 :: tl -> g.breaks <- tl
+      | [] -> () (* end of stream / underrun... *)
+      | _ -> assert false
+
+  let fill g frame =
+    let offset = Frame.position frame in
+    let needed =
+      let size = Lazy.force Frame.size in
+      let remaining = remaining g in
+      let remaining = if remaining = -1 then length g else remaining in
+      min (size - offset) remaining
+    in
+    List.iter
+      (fun (p, m) -> if p < needed then Frame.set_metadata frame (offset + p) m)
+      g.metadata;
+    advance g needed;
+
+    (* Mark the end of this filling. If the frame is partial it must be because
+     * of a break in the generator, or because the generator is emptying.
+     * Conversely, each break in the generator must cause a partial frame, so
+     * don't remove any if it isn't partial. *)
+    Frame.add_break frame (offset + needed);
+    if Frame.is_partial frame then drop_initial_break g
+end
+
 (** Create a buffer between two clocks.
   *
   * This creates an active operator in the inner clock (the action consists
@@ -35,8 +107,6 @@ open Mm
   * in which the buffer-consumer will still behave OK (except obviously
   * that the buffer will empty). *)
 module Buffer = struct
-  module Generator = Generator.From_frames
-
   (* The kind of value shared by a producer and a consumer. *)
   type control = {
     lock : Mutex.t;
@@ -58,7 +128,7 @@ module Buffer = struct
 
       method seek len =
         let len = min (Generator.length c.generator) len in
-        Generator.remove c.generator len;
+        Generator.truncate c.generator len;
         len
 
       method private get_frame frame =
@@ -91,11 +161,11 @@ module Buffer = struct
             if c.abort then (
               c.abort <- false;
               source#abort_track);
-            Generator.feed_from_frame c.generator frame;
+            Generator.feed c.generator frame;
             if Generator.length c.generator > prebuf then (
               c.buffering <- false;
               if Generator.length c.generator > maxbuf then
-                Generator.remove c.generator
+                Generator.truncate c.generator
                   (Generator.length c.generator - maxbuf)))
     end
 
@@ -103,7 +173,7 @@ module Buffer = struct
       ~max_buffer source_val =
     let control =
       {
-        generator = Generator.create ();
+        generator = Generator.create (Lang.to_source source_val)#content_type;
         lock = Mutex.create ();
         buffering = true;
         abort = false;
@@ -181,8 +251,6 @@ module AdaptativeBuffer = struct
             r.rb <- Some (RB.create (Audio.channels buf) r.size);
             write r buf
   end
-
-  module MG = Generator.Metadata
 
   (* The kind of value shared by a producer and a consumer. *)
   (* TODO: also have breaks and metadata as in generators. *)
@@ -351,7 +419,7 @@ end
 let () =
   let frame_t =
     Lang.frame_t (Lang.univ_t ())
-      (Frame.mk_fields ~audio:(Format_type.audio ()) ())
+      (Frame.Fields.make ~audio:(Format_type.audio ()) ())
   in
   Lang.add_operator "buffer.adaptative"
     (Output.proto

--- a/src/core/operators/video_effects.ml
+++ b/src/core/operators/video_effects.ml
@@ -57,7 +57,7 @@ class effect_map ~name (source : source) effect =
 
 let return_t () =
   Lang.frame_t (Lang.univ_t ())
-    (Frame.mk_fields ~video:(Format_type.video ()) ())
+    (Frame.Fields.make ~video:(Format_type.video ()) ())
 
 let () = Lang.add_module "video.alpha"
 

--- a/src/core/operators/video_fade.ml
+++ b/src/core/operators/video_fade.ml
@@ -275,7 +275,7 @@ let override_doc =
 let () =
   let frame_t =
     Lang.frame_t (Lang.univ_t ())
-      (Frame.mk_fields ~video:(Format_type.video ()) ())
+      (Frame.Fields.make ~video:(Format_type.video ()) ())
   in
   Lang.add_operator "video.fade.in"
     (( "override",
@@ -295,7 +295,7 @@ let () =
 let () =
   let frame_t =
     Lang.frame_t (Lang.univ_t ())
-      (Frame.mk_fields ~video:(Format_type.video ()) ())
+      (Frame.Fields.make ~video:(Format_type.video ()) ())
   in
   Lang.add_operator "video.fade.out"
     (( "override",

--- a/src/core/operators/window_op.ml
+++ b/src/core/operators/window_op.ml
@@ -133,11 +133,11 @@ let () =
   in
   let pcm_t () =
     Lang.frame_t (Lang.univ_t ())
-      (Frame.mk_fields ~audio:(Format_type.audio ()) ())
+      (Frame.Fields.make ~audio:(Format_type.audio ()) ())
   in
   let stereo_t () =
     Lang.frame_t (Lang.univ_t ())
-      (Frame.mk_fields ~audio:(Format_type.audio_stereo ()) ())
+      (Frame.Fields.make ~audio:(Format_type.audio_stereo ()) ())
   in
   declare RMS "" pcm_t Lang.float_t mean;
   declare RMS ".stereo" stereo_t

--- a/src/core/outputs/ao_out.ml
+++ b/src/core/outputs/ao_out.ml
@@ -106,7 +106,7 @@ class output ~clock_safe ~nb_blocks ~driver ~infallible ~on_start ~on_stop
 let () =
   let return_t =
     Lang.frame_t (Lang.univ_t ())
-      (Frame.mk_fields ~audio:(Format_type.audio ()) ())
+      (Frame.Fields.make ~audio:(Format_type.audio ()) ())
   in
   Lang.add_operator "output.ao"
     (Output.proto

--- a/src/core/outputs/bjack_out.ml
+++ b/src/core/outputs/bjack_out.ml
@@ -111,7 +111,7 @@ class output ~clock_safe ~infallible ~on_stop ~on_start ~nb_blocks ~server
 let () =
   let frame_t =
     Lang.frame_t (Lang.univ_t ())
-      (Frame.mk_fields ~audio:(Format_type.audio ()) ())
+      (Frame.Fields.make ~audio:(Format_type.audio ()) ())
   in
   Lang.add_operator "output.jack"
     (Output.proto

--- a/src/core/outputs/graphics_out.ml
+++ b/src/core/outputs/graphics_out.ml
@@ -54,7 +54,7 @@ class output ~infallible ~autostart ~on_start ~on_stop source =
 let () =
   let frame_t =
     Lang.frame_t (Lang.univ_t ())
-      (Frame.mk_fields ~video:(Format_type.video ()) ())
+      (Frame.Fields.make ~video:(Format_type.video ()) ())
   in
   Lang.add_operator "output.graphics"
     (Output.proto @ [("", Lang.source_t frame_t, None, None)])

--- a/src/core/outputs/sdl_out.ml
+++ b/src/core/outputs/sdl_out.ml
@@ -101,7 +101,7 @@ class output ~infallible ~on_start ~on_stop ~autostart source =
 let () =
   let frame_t =
     Lang.frame_t (Lang.univ_t ())
-      (Frame.mk_fields ~video:(Format_type.video ()) ())
+      (Frame.Fields.make ~video:(Format_type.video ()) ())
   in
   Lang.add_operator "output.sdl"
     (Output.proto @ [("", Lang.source_t frame_t, None, None)])

--- a/src/core/source.ml
+++ b/src/core/source.ml
@@ -358,11 +358,13 @@ class virtual operator ?(name = "src") sources =
 
     method private audio_channels =
       Content.Audio.channels_of_format
-        (Option.get (Frame.find_audio self#content_type))
+        (Option.get
+           (Frame.Fields.find_opt Frame.Fields.audio self#content_type))
 
     method private video_dimensions =
       Content.Video.dimensions_of_format
-        (Option.get (Frame.find_video self#content_type))
+        (Option.get
+           (Frame.Fields.find_opt Frame.Fields.video self#content_type))
 
     (** Startup/shutdown.
 
@@ -555,6 +557,18 @@ class virtual operator ?(name = "src") sources =
             let m = Frame.create self#content_type in
             memo <- Some m;
             m
+
+    val mutable buffer = None
+
+    method buffer =
+      match buffer with
+        | Some buffer -> buffer
+        | None ->
+            let buf =
+              Generator.create ~log:(self#log#info "%s") self#content_type
+            in
+            buffer <- Some buf;
+            buf
 
     val mutable last_metadata = None
     method last_metadata = self#mutexify (fun () -> last_metadata) ()

--- a/src/core/source.mli
+++ b/src/core/source.mli
@@ -155,6 +155,9 @@ class virtual source :
        (** Retrieve the frame currently being filled. *)
        method memo : Frame.t
 
+       (** A buffer that can be used by the source. *)
+       method buffer : Generator.t
+
        (** Number of frames left in the current track. Defaults to -1=infinity. *)
        method virtual remaining : int
 

--- a/src/core/sources/audio_gen.ml
+++ b/src/core/sources/audio_gen.ml
@@ -42,7 +42,8 @@ class gen ~seek name g freq duration ampl =
 
 let add name g =
   let return_t =
-    Lang.frame_t Lang.unit_t (Frame.mk_fields ~audio:(Format_type.audio ()) ())
+    Lang.frame_t Lang.unit_t
+      (Frame.Fields.make ~audio:(Format_type.audio ()) ())
   in
   Lang.add_operator name ~category:`Input
     ~descr:("Generate a " ^ name ^ " wave.")

--- a/src/core/sources/bjack_in.ml
+++ b/src/core/sources/bjack_in.ml
@@ -116,7 +116,8 @@ class jack_in ~clock_safe ~on_start ~on_stop ~fallible ~autostart ~nb_blocks
 
 let () =
   let return_t =
-    Lang.frame_t Lang.unit_t (Frame.mk_fields ~audio:(Format_type.audio ()) ())
+    Lang.frame_t Lang.unit_t
+      (Frame.Fields.make ~audio:(Format_type.audio ()) ())
   in
   Lang.add_operator "input.jack"
     (Start_stop.active_source_proto ~clock_safe:true ~fallible_opt:(`Yep false)

--- a/src/core/sources/blank.ml
+++ b/src/core/sources/blank.ml
@@ -46,13 +46,13 @@ class blank duration =
       in
       let video_pos = Frame.video_of_main position in
       (* Audio *)
-      if Frame.has_field self#content_type Frame.audio_field then
+      if Frame.Fields.mem Frame.Fields.audio self#content_type then
         Audio.clear (AFrame.pcm ab)
           (Frame.audio_of_main position)
           (Frame.audio_of_main length);
 
       (* Video *)
-      if Frame.has_field self#content_type Frame.video_field then
+      if Frame.Fields.mem Frame.Fields.video self#content_type then
         Video.Canvas.blank (VFrame.data ab) video_pos
           (Frame.video_of_main length);
 

--- a/src/core/sources/generated.ml
+++ b/src/core/sources/generated.ml
@@ -20,130 +20,117 @@
 
  *****************************************************************************)
 
-module Make (Generator : Generator.S) = struct
-  (* Reads data from an audio buffer generator.
-   * A thread safe generator should be used if it has to be fed concurrently.
-   * Store [bufferize] seconds before declaring itself as ready. *)
-  class virtual source ?(seek = false) ?(replay_meta = false) ~bufferize
-    ~empty_on_abort gen =
-    let bufferize = Frame.main_of_seconds bufferize in
-    object (self)
-      (* We keep the generator in an instance variable so that derived
-       * classes can access it. There are concurrency issues, though:
-       *  - In classes such as http_source, the generator is fed concurrently
-       *    with its consumption. But in that case a thread-safe implementation
-       *    of Generator is used.
-       *  - In any case there is always concurrency in this class, with #get
-       *    on one hand and #is_ready, #abort_track and #seek that can be
-       *    called from other threads. We use the generator_lock to avoid
-       *    the only bad interference, ie. #get_frame vs #seek. *)
-      val generator = gen
-      val generator_lock = Mutex.create ()
-      val mutable buffering = true
-      val mutable should_fail = false
-      val mutable cur_meta : Request.metadata option = None
-      method virtual private log : Log.t
-      method self_sync : Source.self_sync = (`Static, false)
+(* Reads data from an audio buffer generator.
+ * A thread safe generator should be used if it has to be fed concurrently.
+ * Store [bufferize] seconds before declaring itself as ready. *)
+class virtual source ?(seek = false) ?(replay_meta = false) ~bufferize
+  ~empty_on_abort () =
+  let bufferize = Frame.main_of_seconds bufferize in
+  object (self)
+    val mutable buffering = true
+    val mutable should_fail = false
+    val mutable cur_meta : Request.metadata option = None
+    method virtual private log : Log.t
+    method virtual private mutexify : 'a 'b. ('a -> 'b) -> 'a -> 'b
+    method virtual buffer : Generator.t
+    method self_sync : Source.self_sync = (`Static, false)
 
-      method seek len =
-        if (not seek) || len <= 0 then 0
-        else
-          Tutils.mutexify generator_lock
-            (fun () ->
-              let len = min len (Generator.remaining generator) in
-              Generator.remove generator len;
-              len)
-            ()
-
-      method abort_track = should_fail <- true
-      method private length = Generator.length generator
-      val mutable last_buffering_warning = -1
-
-      method is_ready =
-        let r = self#length in
-        if buffering then (
-          (* We have some data, but not enough for safely starting to play it. *)
-          if bufferize > 0 && r <= bufferize && r <> last_buffering_warning then (
-            last_buffering_warning <- r;
-            self#log#debug "Not ready: need more buffering (%i/%i)." r bufferize);
-          r > bufferize)
-        else (
-          (* This only happens if the end of track has not been played yet,
-           * after which the buffering phase will start again. Does not mean
-           * that we're not accumulating data, but it means that we don't know
-           * yet that we'll stop playing it until the buffer is full enough. *)
-          if r = 0 then self#log#info "Not ready for a new track: empty buffer.";
-          r > 0)
-
-      method remaining =
-        if should_fail then 0
-        else if buffering && self#length <= bufferize then 0
-        else Generator.remaining generator
-
-      (* Returns true if metadata should be replayed. *)
-      method private save_metadata frame =
-        let new_meta =
-          match
-            List.fold_left
-              (function
-                | None -> fun (p, m) -> Some (p, m)
-                | Some (curp, curm) ->
-                    fun (p, m) ->
-                      Some (if p >= curp then (p, m) else (curp, curm)))
-              (match cur_meta with None -> None | Some m -> Some (-1, m))
-              (Frame.get_all_metadata frame)
-          with
-            | None -> None
-            | Some (_, m) -> Some m
-        in
-        if cur_meta = new_meta then true
-        else (
-          cur_meta <- new_meta;
-          false)
-
-      method private replay_metadata pos frame =
-        match cur_meta with
-          | None -> ()
-          | Some m -> Frame.set_metadata frame pos m
-
-      method private get_frame ab =
-        Tutils.mutexify generator_lock
+    method seek len =
+      if (not seek) || len <= 0 then 0
+      else
+        self#mutexify
           (fun () ->
-            let was_buffering = buffering in
-            let pos = Frame.position ab in
-            buffering <- false;
-            if should_fail then (
-              self#log#info "Performing skip.";
-              should_fail <- false;
-              if empty_on_abort then Generator.clear generator;
-              Frame.add_break ab (Frame.position ab))
-            else (
-              Generator.fill generator ab;
-
-              (* Currently, we don't enter the buffering phase between tracks
-               * even when there's not enough data in the buffer. This is mostly
-               * historical because there was initially no breaks in generators.
-               * This may sometimes be better to do it (to avoid a lag breaking
-               * the new track) but not always (a total disconnection should cause
-               * the start of a new track anyway, since the content after it
-               * has nothing to do with the content before the connection). *)
-              if Frame.is_partial ab then self#log#info "End of track.";
-              if Generator.length generator = 0 then (
-                self#log#info "Buffer emptied, buffering needed.";
-                buffering <- true);
-              if self#save_metadata ab && was_buffering && replay_meta then
-                self#replay_metadata pos ab))
+            let len = min len (Generator.remaining self#buffer) in
+            Generator.truncate self#buffer len;
+            len)
           ()
-    end
 
-  (* Reads data from a fixed audio buffer generator, of a certain kind.
-   * The generator shouldn't be fed anymore. *)
-  class consumer generator =
-    object
-      inherit Source.source ~name:"buffer" ()
-      inherit source generator ~bufferize:0. ~empty_on_abort:true
-      method stype = `Fallible
-    end
-end
+    method abort_track = should_fail <- true
+    method private length = Generator.length self#buffer
+    val mutable last_buffering_warning = -1
 
-module From_audio_video_plus = Make (Generator.From_audio_video_plus)
+    method is_ready =
+      let r = self#length in
+      if buffering then (
+        (* We have some data, but not enough for safely starting to play it. *)
+        if bufferize > 0 && r <= bufferize && r <> last_buffering_warning then (
+          last_buffering_warning <- r;
+          self#log#debug "Not ready: need more buffering (%i/%i)." r bufferize);
+        r > bufferize)
+      else (
+        (* This only happens if the end of track has not been played yet,
+         * after which the buffering phase will start again. Does not mean
+         * that we're not accumulating data, but it means that we don't know
+         * yet that we'll stop playing it until the buffer is full enough. *)
+        if r = 0 then self#log#info "Not ready for a new track: empty buffer.";
+        r > 0)
+
+    method remaining =
+      if should_fail then 0
+      else if buffering && self#length <= bufferize then 0
+      else Generator.remaining self#buffer
+
+    (* Returns true if metadata should be replayed. *)
+    method private save_metadata frame =
+      let new_meta =
+        match
+          List.fold_left
+            (function
+              | None -> fun (p, m) -> Some (p, m)
+              | Some (curp, curm) ->
+                  fun (p, m) ->
+                    Some (if p >= curp then (p, m) else (curp, curm)))
+            (match cur_meta with None -> None | Some m -> Some (-1, m))
+            (Frame.get_all_metadata frame)
+        with
+          | None -> None
+          | Some (_, m) -> Some m
+      in
+      if cur_meta = new_meta then true
+      else (
+        cur_meta <- new_meta;
+        false)
+
+    method private replay_metadata pos frame =
+      match cur_meta with
+        | None -> ()
+        | Some m -> Frame.set_metadata frame pos m
+
+    method private get_frame ab =
+      self#mutexify
+        (fun () ->
+          let was_buffering = buffering in
+          let pos = Frame.position ab in
+          buffering <- false;
+          if should_fail then (
+            self#log#info "Performing skip.";
+            should_fail <- false;
+            if empty_on_abort then Generator.clear self#buffer;
+            Frame.add_break ab (Frame.position ab))
+          else (
+            Generator.fill self#buffer ab;
+
+            (* Currently, we don't enter the buffering phase between tracks
+             * even when there's not enough data in the buffer. This is mostly
+             * historical because there was initially no breaks in generators.
+             * This may sometimes be better to do it (to avoid a lag breaking
+             * the new track) but not always (a total disconnection should cause
+             * the start of a new track anyway, since the content after it
+             * has nothing to do with the content before the connection). *)
+            if Frame.is_partial ab then self#log#info "End of track.";
+            if Generator.length self#buffer = 0 then (
+              self#log#info "Buffer emptied, buffering needed.";
+              buffering <- true);
+            if self#save_metadata ab && was_buffering && replay_meta then
+              self#replay_metadata pos ab))
+        ()
+  end
+
+(* Reads data from a fixed buffer generator. The generator shouldn't be fed anymore. *)
+class consumer buffer =
+  object
+    inherit Source.source ~name:"buffer" ()
+    inherit source ~bufferize:0. ~empty_on_abort:true ()
+    method stype = `Fallible
+    method buffer = buffer
+  end

--- a/src/core/sources/video_text.ml
+++ b/src/core/sources/video_text.ml
@@ -87,7 +87,7 @@ let register name init render_text =
   let add_operator op =
     let return_t =
       Lang.frame_t (Lang.univ_t ())
-        (Frame.mk_fields ~video:(Format_type.video ()) ())
+        (Frame.Fields.make ~video:(Format_type.video ()) ())
     in
     Lang.add_operator op
       [

--- a/src/core/stream/aFrame.ml
+++ b/src/core/stream/aFrame.ml
@@ -28,10 +28,7 @@ type t = Frame.t
 (* Samples of ticks, and vice versa. *)
 let sot = audio_of_main
 let tos = main_of_audio
-
-let content b =
-  match Frame.audio b with Some c -> c | None -> raise Content.Invalid
-
+let content b = try Frame.audio b with Not_found -> raise Content.Invalid
 let pcm b = Content.Audio.get_data (content b)
 
 let to_s16le b =

--- a/src/core/stream/content.mli
+++ b/src/core/stream/content.mli
@@ -27,7 +27,7 @@ open Mm
 type 'a chunk = 'a Content_base.chunk = {
   data : 'a;
   offset : int;
-  length : int;
+  length : int option;
 }
 
 type ('a, 'b) chunks = ('a, 'b) Content_base.chunks = {
@@ -62,7 +62,7 @@ module type ContentSpecs = sig
   (** Data *)
 
   (* Length is in main ticks. *)
-  val make : length:int -> params -> data
+  val make : ?length:int -> params -> data
   val length : data -> int
 
   (* TODO: This will be removed when reworking
@@ -127,10 +127,11 @@ type data = Contents.data
 
 (** Data *)
 
-val make : length:int -> format -> data
+val make : ?length:int -> format -> data
 val blit : data -> int -> data -> int -> int -> unit
 val fill : data -> int -> data -> int -> int -> unit
 val sub : data -> int -> int -> data
+val truncate : data -> int -> data
 val copy : data -> data
 val clear : data -> unit
 val length : data -> int
@@ -198,8 +199,8 @@ module Metadata : sig
   val set_data : Contents.data -> (int * Frame_base.metadata) list -> unit
 end
 
-module TrackMark : sig
-  include Content with type kind = [ `TrackMark ] and type params = unit
+module Track_marks : sig
+  include Content with type kind = [ `Track_marks ] and type params = unit
 
   val format : format
   val get_data : Contents.data -> int list

--- a/src/core/stream/content_audio.ml
+++ b/src/core/stream/content_audio.ml
@@ -80,7 +80,7 @@ module Specs = struct
 
   let clear _ = ()
 
-  let make ~length { channel_layout } =
+  let make ?(length = 0) { channel_layout } =
     let channels =
       match !!channel_layout with
         | `Mono -> 1

--- a/src/core/stream/content_midi.ml
+++ b/src/core/stream/content_midi.ml
@@ -50,7 +50,7 @@ module Specs = struct
   let default_params _ = { channels = Lazy.force Frame_settings.midi_channels }
   let clear _ = ()
 
-  let make ~length { channels } =
+  let make ?(length = 0) { channels } =
     MIDI.Multitrack.create channels (midi_of_main length)
 
   let length d = main_of_midi (MIDI.Multitrack.duration d)

--- a/src/core/stream/content_video.ml
+++ b/src/core/stream/content_video.ml
@@ -33,7 +33,7 @@ module Specs = struct
   let internal_content_type = Some `Video
   let string_of_kind = function `Canvas -> "canvas"
 
-  let make ~length (p : params) : data =
+  let make ?(length = 0) (p : params) : data =
     let width = !!(Option.value ~default:video_width p.width) in
     let height = !!(Option.value ~default:video_height p.height) in
     Video.Canvas.make (video_of_main length) (width, height)

--- a/src/core/stream/ffmpeg_content_base.ml
+++ b/src/core/stream/ffmpeg_content_base.ml
@@ -31,7 +31,7 @@ let conf_ffmpeg_content =
     ~p:(Ffmpeg_utils.conf_ffmpeg#plug "content")
     "FFmpeg content configuration"
 
-let make ~length params = { length; params; data = [] }
+let make ?(length = 0) params = { length; params; data = [] }
 let length { length } = length
 let clear d = d.data <- []
 let stream_idx = ref 0L

--- a/src/core/stream/frame.ml
+++ b/src/core/stream/frame.ml
@@ -28,8 +28,6 @@ open Content
   * [sub a b] if [a] is more permissive than [b]..
   * TODO this is the other way around... it's correct in Lang, phew! *)
 
-let map_fields fn = Fields.map fn
-let mapi_fields fn = Fields.mapi fn
 let string_of_format = string_of_format
 
 let string_of_fields fn fields =
@@ -37,7 +35,7 @@ let string_of_fields fn fields =
     (String.concat ","
        (Fields.fold
           (fun f v cur ->
-            Printf.sprintf "%s=%s" (string_of_field f) (fn v) :: cur)
+            Printf.sprintf "%s=%s" (Fields.string_of_field f) (fn v) :: cur)
           fields []))
 
 let string_of_content_type = string_of_fields string_of_format
@@ -61,95 +59,61 @@ let metadata_of_list l =
   List.iter (fun (k, v) -> Hashtbl.add m k v) l;
   m
 
-type content = Content.data Fields.t
+let list_of_metadata h = Hashtbl.fold (fun k v l -> (k, v) :: l) h []
 
-type t = {
-  (* Presentation time, in multiple of frame size. *)
-  mutable pts : int64 option;
-  (* End of track markers.
-   * A break at the end of the buffer is not an end of track.
-   * So maybe we should rather call that an end-of-fill marker,
-   * and notice that end-of-fills in the middle of a buffer are
-   * end-of-tracks.
-   * If needed, the end-of-track needs to be put at the beginning of
-   * the next frame. *)
-  mutable breaks : int list;
-  (* Metadata can be put anywhere in the stream. *)
-  mutable metadata : (int * metadata) list;
-  mutable content : content;
-}
+type t = Generator.t
 
-(** Create a content chunk. All chunks have the same size. *)
-let create_content ctype = map_fields (make ~length:!!size) ctype
-
-let create ctype =
-  { pts = None; breaks = []; metadata = []; content = create_content ctype }
-
-let dummy = { pts = None; breaks = []; metadata = []; content = mk_fields () }
-let content_type { content } = map_fields format content
-let audio { content; _ } = Fields.find_opt audio_field content
-
-let set_audio frame audio =
-  frame.content <- Fields.add audio_field audio frame.content
-
-let video { content; _ } = Fields.find_opt video_field content
-
-let set_video frame video =
-  frame.content <- Fields.add video_field video frame.content
-
-let midi { content; _ } = Fields.find_opt midi_field content
-
-let set_midi frame midi =
-  frame.content <- Fields.add midi_field midi frame.content
+let create content_type = Generator.create ~length:!!size content_type
+let dummy () = create Fields.empty
+let content_type = Generator.content_type
+let get frame field = Generator.get_field frame field
+let set = Generator.set_field
+let audio frame = get frame Fields.audio
+let set_audio frame content = set frame Fields.audio content
+let video frame = get frame Fields.video
+let set_video frame content = set frame Fields.video content
+let midi frame = get frame Fields.midi
+let set_midi frame content = set frame Fields.midi content
 
 (** Content independent *)
 
-let position b = match b.breaks with [] -> 0 | a :: _ -> a
-let is_partial b = position b < !!size
-let breaks b = b.breaks
-let set_breaks b breaks = b.breaks <- breaks
-let add_break b br = b.breaks <- br :: b.breaks
+let breaks frame = Content.Track_marks.get_data (get frame Fields.track_marks)
 
-let clear (b : t) =
-  Fields.iter (fun _ c -> Content.clear c) b.content;
-  b.breaks <- [];
-  b.metadata <- []
+let set_breaks frame =
+  Content.Track_marks.set_data (get frame Fields.track_marks)
 
-let clear_from (b : t) pos =
-  b.breaks <- List.filter (fun p -> p <= pos) b.breaks;
-  b.metadata <- List.filter (fun (p, _) -> p <= pos) b.metadata
-
-(** Presentation time stuff. *)
-
-let pts { pts } = pts
-let set_pts frame pts = frame.pts <- pts
+let add_break b br = set_breaks b (br :: breaks b)
+let position frame = match List.rev (breaks frame) with [] -> 0 | a :: _ -> a
+let remaining b = !!size - position b
+let is_partial b = 0 < remaining b
+let clear b = Fields.iter (fun _ c -> Content.clear c) (Generator.peek b)
 
 (** Metadata stuff *)
 
 exception No_metadata
 
-let set_metadata b t m = b.metadata <- (t, m) :: b.metadata
+let get_all_metadata frame =
+  Content.Metadata.get_data (get frame Fields.metadata)
+
+let set_all_metadata frame data =
+  Content.Metadata.set_data (get frame Fields.metadata) data
+
+let set_metadata b t m = set_all_metadata b ((t, m) :: get_all_metadata b)
 
 let get_metadata b t =
-  try Some (List.assoc t b.metadata) with Not_found -> None
+  try Some (List.assoc t (get_all_metadata b)) with Not_found -> None
 
 let free_metadata b t =
-  b.metadata <- List.filter (fun (tt, _) -> t <> tt) b.metadata
+  set_all_metadata b (List.filter (fun (tt, _) -> t <> tt) (get_all_metadata b))
 
-let free_all_metadata b = b.metadata <- []
-let get_all_metadata b = List.sort (fun (x, _) (y, _) -> compare x y) b.metadata
-let set_all_metadata b l = b.metadata <- l
+let free_all_metadata b = set_all_metadata b []
 
 let blit_content src src_pos dst dst_pos len =
   let blit src dst = blit src src_pos dst dst_pos len in
   Fields.iter (fun field src -> blit src (Fields.find field dst)) src
 
-(** Copy data from [src] to [dst].
-  * This triggers changes of contents layout if needed. *)
 let blit src src_pos dst dst_pos len =
-  (* Assuming that the tracks have the same track layout,
-   * copy a chunk of data from [src] to [dst]. *)
-  blit_content src.content src_pos dst.content dst_pos len
+  blit_content (Generator.peek src) src_pos (Generator.peek dst) dst_pos len
 
 (** Raised by [get_chunk] when no chunk is available. *)
 exception No_chunk
@@ -198,7 +162,9 @@ let get_chunk ab from =
           | [] -> None
           | x :: _ -> Some (snd x)
       in
-      match (before_p from.metadata, before_p ab.metadata) with
+      match
+        (before_p (get_all_metadata from), before_p (get_all_metadata ab))
+      with
         | Some b, None -> set_metadata ab p b
         | Some b, Some a when not (is_meta_equal a b) -> set_metadata ab p b
         | _ -> ()
@@ -209,7 +175,7 @@ let get_chunk ab from =
      * during the next get_chunk. *)
     List.iter
       (fun (mp, m) -> if p <= mp && mp < i then set_metadata ab mp m)
-      from.metadata
+      (get_all_metadata from)
   in
   let rec aux foffset f =
     (* We always have p >= foffset *)
@@ -218,7 +184,7 @@ let get_chunk ab from =
       | i :: tl ->
           (* Breaks are between ticks, they do range from 0 to size. *)
           assert (0 <= i && i <= !!size);
-          if i = 0 && ab.breaks = [] then
+          if i = 0 && breaks ab = [] then
             (* The only empty track that we copy,
              * trying to copy empty tracks in the middle could be useful
              * for packets like those forged by add, with a fake first break,
@@ -227,4 +193,4 @@ let get_chunk ab from =
           else if foffset <= p && i > p then copy_chunk i
           else aux i tl
   in
-  aux 0 (List.rev from.breaks)
+  aux 0 (breaks from)

--- a/src/core/stream/frame_base.ml
+++ b/src/core/stream/frame_base.ml
@@ -24,8 +24,6 @@
 
 (** {2 Frame definitions} *)
 
-type field = int
-
 let field_idx = Atomic.make 0
 
 module FieldNames = Hashtbl.Make (struct
@@ -35,58 +33,59 @@ module FieldNames = Hashtbl.Make (struct
   let hash (x : int) = x [@@inline always]
 end)
 
-module Fields = Map.Make (struct
-  type t = field
+module Fields = struct
+  include Map.Make (struct
+    type t = int
 
-  let compare (x : int) (y : int) = x - y [@@inline always]
-end)
+    let compare (x : int) (y : int) = x - y [@@inline always]
+  end)
 
-let field_names = FieldNames.create 0
-let name_fields = Hashtbl.create 0
-let string_of_field = FieldNames.find field_names
-let field_of_string = Hashtbl.find name_fields
+  type field = key
 
-let register_field name =
-  try field_of_string name
-  with Not_found ->
-    let field = Atomic.fetch_and_add field_idx 1 in
-    FieldNames.replace field_names field name;
-    Hashtbl.replace name_fields name field;
-    field
+  let field_names = FieldNames.create 0
+  let name_fields = Hashtbl.create 0
+  let string_of_field = FieldNames.find field_names
+  let field_of_string = Hashtbl.find name_fields
+
+  let register name =
+    try field_of_string name
+    with Not_found ->
+      let field = Atomic.fetch_and_add field_idx 1 in
+      FieldNames.replace field_names field name;
+      Hashtbl.replace name_fields name field;
+      field
+
+  let metadata = register "metadata"
+  let track_marks = register "track_marks"
+  let audio = register "audio"
+  let video = register "video"
+  let midi = register "midi"
+
+  let audio_n = function
+    | 0 -> audio
+    | n -> register (Printf.sprintf "audio_%d" n)
+
+  let video_n = function
+    | 0 -> video
+    | n -> register (Printf.sprintf "video_%d" n)
+
+  let make =
+    let audio_f = audio in
+    let video_f = video in
+    let midi_f = midi in
+    fun ?audio ?video ?midi () ->
+      List.fold_left
+        (fun fields -> function
+          | _, None -> fields
+          | field, Some v -> add field v fields)
+        empty
+        [(audio_f, audio); (video_f, video); (midi_f, midi)]
+end
+
+type field = Fields.field
 
 (** Precise description of the channel types for the current track. *)
 type content_type = Content_base.format Fields.t
 
 (** Metadata of a frame. *)
 type metadata = (string, string) Hashtbl.t
-
-let audio_field = register_field "audio"
-let video_field = register_field "video"
-let midi_field = register_field "midi"
-
-let audio_field_n = function
-  | 0 -> audio_field
-  | n -> register_field (Printf.sprintf "audio_%d" n)
-
-let video_field_n = function
-  | 0 -> video_field
-  | n -> register_field (Printf.sprintf "video_%d" n)
-
-let find_field c field = Fields.find field c
-let find_field_opt c field = Fields.find_opt field c
-let find_audio c = find_field_opt c audio_field
-let find_video c = find_field_opt c video_field
-let find_midi c = find_field_opt c midi_field
-let set_field fields field value = Fields.add field value fields
-let set_audio_field fields = set_field fields audio_field
-let set_video_field fields = set_field fields video_field
-let set_midi_field fields = set_field fields midi_field
-let has_field fields field = Fields.mem field fields
-
-let mk_fields ?audio ?video ?midi () =
-  List.fold_left
-    (fun fields -> function
-      | _, None -> fields
-      | field, Some v -> Fields.add field v fields)
-    Fields.empty
-    [(audio_field, audio); (video_field, video); (midi_field, midi)]

--- a/src/core/stream/generator.ml
+++ b/src/core/stream/generator.ml
@@ -20,932 +20,273 @@
 
  *****************************************************************************)
 
-exception Incorrect_stream_type
+let log = Log.make ["generator"]
 
-type content = Content.data Frame.Fields.t
+type t = {
+  lock : Mutex.t;
+  log : string -> unit;
+  content_type : Frame_base.content_type;
+  mutable max_length : int option;
+  mutable content : Content.data Frame_base.Fields.t;
+}
 
-let type_of_content = Frame.map_fields Content.format
+let add_timed_content content =
+  Frame_base.Fields.add Frame_base.Fields.track_marks
+    (Content.make Content.Track_marks.format)
+    (Frame_base.Fields.add Frame_base.Fields.metadata
+       (Content.make Content.Metadata.format)
+       content)
 
-module NoneContentSpecs = struct
-  type kind = unit
-  type params = unit
-  type data = int
+let create ?(log = fun s -> log#info "%s" s) ?max_length ?length content_type =
+  {
+    lock = Mutex.create ();
+    max_length;
+    log;
+    content_type;
+    content =
+      add_timed_content
+        (Frame_base.Fields.map (Content.make ?length) content_type);
+  }
 
-  let make ~length () = length
-  let length l = l
-  let clear _ = ()
-  let blit _ _ _ _ _ = ()
-  let copy l = l
-  let params _ = ()
-  let merge _ _ = ()
-  let compatible _ _ = true
-  let string_of_params _ = ""
-  let parse_param _ _ = None
-  let kind = ()
-  let default_params () = ()
-  let string_of_kind () = "none"
-  let kind_of_string = function "none" -> Some () | _ -> None
-end
+let get_field gen =
+  Tutils.mutexify gen.lock (fun field ->
+      Frame_base.Fields.find field gen.content)
 
-module NoneContent = struct
-  include Content.MkContent (NoneContentSpecs)
+let set_field gen field =
+  Tutils.mutexify gen.lock (fun content ->
+      gen.content <- Frame_base.Fields.add field content gen.content)
 
-  let lift_data ~length () = lift_data (make ~length ())
-end
+let max_length gen = Tutils.mutexify gen.lock (fun () -> gen.max_length) ()
+let content_type gen = Tutils.mutexify gen.lock (fun () -> gen.content_type) ()
 
-let copy_audio =
-  Frame.mapi_fields (fun field c ->
-      if field = Frame.audio_field then Content.copy c else c)
+let set_max_length gen =
+  Tutils.mutexify gen.lock (fun max_length -> gen.max_length <- max_length)
 
-let copy_video =
-  Frame.mapi_fields (fun field c ->
-      if field = Frame.video_field then Content.copy c else c)
+let field_length { lock; content } =
+  Tutils.mutexify lock (fun field ->
+      Content.length (Frame_base.Fields.find field content))
 
-let copy_content = Frame.map_fields Content.copy
+let _media_content { content } =
+  Frame_base.Fields.filter
+    (fun f _ ->
+      f <> Frame_base.Fields.metadata && f <> Frame_base.Fields.track_marks)
+    content
 
-let content frame =
-  Frame.mk_fields ?audio:(Frame.audio frame) ?video:(Frame.video frame)
-    ?midi:(Frame.midi frame) ()
+let _length gen =
+  Option.value ~default:0
+    (Frame_base.Fields.fold
+       (fun _ c -> function
+         | None -> Some (Content.length c)
+         | Some l' -> Some (min (Content.length c) l'))
+       (_media_content gen) None)
 
-let fill_content src src_pos dst dst_pos len =
-  let fill src dst =
-    match dst with
-      | Some dst -> Content.fill (Option.get src) src_pos dst dst_pos len
-      | _ -> ()
+let _buffered_length gen =
+  Option.value ~default:0
+    (Frame_base.Fields.fold
+       (fun _ c -> function
+         | None -> Some (Content.length c)
+         | Some l' -> Some (max (Content.length c) l'))
+       (_media_content gen) None)
+
+let buffered_length gen =
+  Tutils.mutexify gen.lock (fun () -> _buffered_length gen) ()
+
+let length gen = Tutils.mutexify gen.lock (fun () -> _length gen) ()
+
+let _remaining gen =
+  match
+    Content.Track_marks.get_data
+      (Frame_base.Fields.find Frame_base.Fields.track_marks gen.content)
+  with
+    | p :: _ when p <= _length gen -> p
+    | _ -> -1
+
+let remaining gen = Tutils.mutexify gen.lock (fun () -> _remaining gen) ()
+
+let _truncate gen len =
+  gen.content <-
+    Frame_base.Fields.map
+      (fun content -> Content.truncate content len)
+      gen.content
+
+let truncate gen = Tutils.mutexify gen.lock (_truncate gen)
+
+let clear gen =
+  Tutils.mutexify gen.lock
+    (fun () ->
+      gen.content <-
+        Frame_base.Fields.map
+          (fun c -> Content.make ~length:0 (Content.format c))
+          gen.content)
+    ()
+
+let _set_metadata gen =
+  Content.Metadata.set_data
+    (Frame_base.Fields.find Frame_base.Fields.metadata gen.content)
+
+let _get_metadata gen =
+  Content.Metadata.get_data
+    (Frame_base.Fields.find Frame_base.Fields.metadata gen.content)
+
+let _default_pos gen = function Some pos -> pos | None -> _length gen
+
+let _add_metadata ?pos gen m =
+  let pos = _default_pos gen pos in
+  _set_metadata gen ((pos, m) :: _get_metadata gen)
+
+let add_metadata ?pos gen = Tutils.mutexify gen.lock (_add_metadata ?pos gen)
+
+let _set_track_marks gen =
+  Content.Track_marks.set_data
+    (Frame_base.Fields.find Frame_base.Fields.track_marks gen.content)
+
+let _get_track_marks gen =
+  Content.Track_marks.get_data
+    (Frame_base.Fields.find Frame_base.Fields.track_marks gen.content)
+
+let _add_track_mark ?pos gen =
+  let pos = _default_pos gen pos in
+  _set_track_marks gen (pos :: _get_track_marks gen)
+
+let add_track_mark ?pos gen =
+  Tutils.mutexify gen.lock (fun () -> _add_track_mark ?pos gen) ()
+
+let _put gen field content =
+  (match field with
+    | f when f = Frame_base.Fields.track_marks ->
+        List.iter
+          (fun pos -> _add_track_mark ~pos gen)
+          (Content.Track_marks.get_data content)
+    | f when f = Frame_base.Fields.metadata ->
+        List.iter
+          (fun (pos, m) -> _add_metadata ~pos gen m)
+          (Content.Metadata.get_data content)
+    | _ ->
+        gen.content <-
+          Frame_base.Fields.add field
+            (Content.append
+               (Frame_base.Fields.find field gen.content)
+               (Content.copy content))
+            gen.content);
+
+  let l = _buffered_length gen in
+  match gen.max_length with
+    | Some l' when l' < l ->
+        let drop = l - l' in
+        gen.log
+          (Printf.sprintf
+             "generator max length exeeded! Dropping %d ticks of data.." drop);
+        _truncate gen drop
+    | _ -> ()
+
+let put gen field =
+  Tutils.mutexify gen.lock (fun content -> _put gen field content)
+
+let _get ?length gen =
+  let length = Option.value ~default:(_length gen) length in
+  if _length gen < length then
+    failwith "Requested length is greater than buffer length!";
+  let content =
+    Frame_base.Fields.map (fun c -> Content.sub c 0 length) gen.content
   in
-  fill (Frame.find_audio src) (Frame.find_audio dst);
-  fill (Frame.find_video src) (Frame.find_video dst);
-  fill (Frame.find_midi src) (Frame.find_midi dst)
-
-module type S = sig
-  type t
-
-  val length : t -> int (* ticks *)
-  val remaining : t -> int (* ticks *)
-  val clear : t -> unit
-  val fill : t -> Frame.t -> unit
-  val remove : t -> int -> unit
-  val add_metadata : ?pos:int -> t -> Frame.metadata -> unit
-end
-
-module type S_Asio = sig
-  type t
-
-  val length : t -> int (* ticks *)
-  val audio_length : t -> int
-  val video_length : t -> int
-  val remaining : t -> int (* ticks *)
-  val clear : t -> unit
-  val fill : t -> Frame.t -> unit
-  val add_metadata : ?pos:int -> t -> Frame.metadata -> unit
-  val add_break : ?sync:bool -> ?pos:int -> t -> unit
-  val put_audio : ?pts:int64 -> t -> Content.data -> int -> int -> unit
-  val put_video : ?pts:int64 -> t -> Content.data -> int -> int -> unit
-  val set_mode : t -> [ `Audio | `Video | `Both | `Undefined ] -> unit
-end
-
-(** The base module doesn't even know what kind of data it is buffering. *)
-module Generator = struct
-  (** A chunk with given offset and length. *)
-  type 'a chunk = 'a * int * int
-
-  (** A buffer is a queue of chunks. *)
-  type 'a buffer = 'a chunk Queue.t
-
-  (** All positions and lengths are in ticks. *)
-  type 'a t = {
-    mutable length : int;
-    mutable offset : int;
-    mutable buffers : 'a buffer;
-  }
-
-  let create () = { length = 0; offset = 0; buffers = Queue.create () }
-
-  let clear g =
-    g.length <- 0;
-    g.offset <- 0;
-    g.buffers <- Queue.create ()
-
-  let length b = b.length
-
-  (** Remove [len] ticks of data. *)
-  let rec remove g len =
-    assert (g.length >= len);
-    if len > 0 then (
-      let _, _, b_len = Queue.peek g.buffers in
-      (* Is it enough to advance in the first buffer?
-       * Or do we need to consume it completely and go farther in the queue? *)
-      if g.offset + len < b_len then (
-        g.length <- g.length - len;
-        g.offset <- g.offset + len)
-      else (
-        let removed = b_len - g.offset in
-        ignore (Queue.take g.buffers);
-        g.length <- g.length - removed;
-        g.offset <- 0;
-        remove g (len - removed)))
-
-  (* Feed an item into a generator.
-     The item is put as such, not copied. *)
-  let put g content ofs len =
-    g.length <- g.length + len;
-    Queue.add (content, ofs, len) g.buffers
-
-  (* Get [size] amount of data from [g].
-     Returns a list where each element will typically be passed to a blit:
-     its elements are of the form [b,o,o',l] where [o] is the offset of data
-     in the block [b], [o'] is the position at which it should be written
-     (the first position [o'] will always be [0]), and [l] is the length
-     of data to be taken from that block. *)
-  let get g size =
-    (* The main loop takes the current offset in the output buffer,
-     * and iterates on input buffer chunks. *)
-    let rec aux chunks offset =
-      (* How much (more) data should be output? *)
-      let needed = size - offset in
-      assert (needed > 0);
-      let block, block_ofs, block_len = Queue.peek g.buffers in
-      let block_len = block_len - g.offset in
-      let copied = min needed block_len in
-      let chunks = (block, block_ofs + g.offset, offset, copied) :: chunks in
-      (* Update buffer data -- did we consume a full block? *)
-      if copied = block_len then (
-        ignore (Queue.take g.buffers);
-        g.length <- g.length - block_len;
-        g.offset <- 0)
-      else (
-        g.length <- g.length - copied;
-        g.offset <- g.offset + copied);
-
-      (* Add more data by recursing on the next block, or finish. *)
-      if block_len < needed then aux chunks (offset + block_len)
-      else List.rev chunks
-    in
-    if size = 0 then [] else aux [] 0
-end
-
-(* TODO: use this in the following modules instead of copying the code... *)
-module Metadata = struct
-  type t = {
-    mutable metadata : (int * Frame.metadata) list;
-    mutable breaks : int list;
-    mutable length : int;
-  }
-
-  let create () = { metadata = []; breaks = []; length = 0 }
-
-  let clear g =
-    g.metadata <- [];
-    g.breaks <- [];
-    g.length <- 0
-
-  let advance g len =
-    g.metadata <- List.map (fun (t, m) -> (t - len, m)) g.metadata;
-    g.metadata <- List.filter (fun (t, _) -> t >= 0) g.metadata;
-    g.breaks <- List.map (fun t -> t - len) g.breaks;
-    g.breaks <- List.filter (fun t -> t >= 0) g.breaks;
-    g.length <- g.length - len;
-    assert (g.length >= 0)
-
-  let length g = g.length
-  let remaining g = match g.breaks with a :: _ -> a | _ -> -1
-  let metadata g len = List.filter (fun (t, _) -> t < len) g.metadata
-
-  let feed_from_frame g frame =
-    let size = Lazy.force Frame.size in
-    let length = length g in
-    g.metadata <-
-      g.metadata
-      @ List.map (fun (t, m) -> (length + t, m)) (Frame.get_all_metadata frame);
-    g.breaks <-
-      g.breaks
-      @ List.map
-          (fun t -> length + t)
-          (* Filter out the last break, which only marks the end of frame, not a
-           * track limit (doesn't mean is_partial). *)
-          (List.filter (fun x -> x < size) (Frame.breaks frame));
-    let frame_length =
-      let rec aux = function [t] -> t | _ :: tl -> aux tl | [] -> size in
-      aux (Frame.breaks frame)
-    in
-    g.length <- g.length + frame_length
-
-  let drop_initial_break g =
-    match g.breaks with
-      | 0 :: tl -> g.breaks <- tl
-      | [] -> () (* end of stream / underrun... *)
-      | _ -> assert false
-
-  let fill g frame =
-    let offset = Frame.position frame in
-    let needed =
-      let size = Lazy.force Frame.size in
-      let remaining = remaining g in
-      let remaining = if remaining = -1 then length g else remaining in
-      min (size - offset) remaining
-    in
-    List.iter
-      (fun (p, m) -> if p < needed then Frame.set_metadata frame (offset + p) m)
-      g.metadata;
-    advance g needed;
-
-    (* Mark the end of this filling. If the frame is partial it must be because
-     * of a break in the generator, or because the generator is emptying.
-     * Conversely, each break in the generator must cause a partial frame, so
-     * don't remove any if it isn't partial. *)
-    Frame.add_break frame (offset + needed);
-    if Frame.is_partial frame then drop_initial_break g
-end
-
-(** Generate a stream, including metadata and breaks.
-  * The API is based on feeding from frames, and filling frames. *)
-module From_frames = struct
-  type t = {
-    mutable metadata : (int * Frame.metadata) list;
-    mutable breaks : int list;
-    generator : content Generator.t;
-  }
-
-  let create () =
-    { metadata = []; breaks = []; generator = Generator.create () }
-
-  let clear fg =
-    fg.metadata <- [];
-    fg.breaks <- [];
-    Generator.clear fg.generator
-
-  (** Total length. *)
-  let length fg = Generator.length fg.generator
-
-  (** Duration of data (in ticks) before the next break, -1 if there's none. *)
-  let remaining fg = match fg.breaks with a :: _ -> a | _ -> -1
-
-  let add_metadata ?(pos = 0) fg m =
-    fg.metadata <- fg.metadata @ [(length fg + pos, m)]
-
-  let add_break ?(pos = 0) fg = fg.breaks <- fg.breaks @ [length fg + pos]
-
-  (* Advance metadata and breaks by [len] ticks. *)
-  let advance fg len =
-    let meta = List.map (fun (x, y) -> (x - len, y)) fg.metadata in
-    let breaks = List.map (fun x -> x - len) fg.breaks in
-    fg.metadata <- List.filter (fun x -> fst x >= 0) meta;
-    fg.breaks <- List.filter (fun x -> x >= 0) breaks
-
-  let remove fg len =
-    Generator.remove fg.generator len;
-    advance fg len
-
-  (** Only the breaks and metadata in the considered portion of the
-    * content will be taken into account. This includes position
-    * ofs but excludes ofs+len for metadata and the opposite for breaks. *)
-  let feed fg ?(copy : [ `None | `Audio | `Video | `Both ] = `Both)
-      ?(breaks = []) ?(metadata = []) content ofs len =
-    let breaks = List.filter (fun p -> ofs < p && p <= ofs + len) breaks in
-    let metadata =
-      List.filter (fun (p, _) -> ofs <= p && p < ofs + len) metadata
-    in
-    let content =
-      match copy with
-        | `None -> content
-        | `Audio -> copy_audio content
-        | `Video -> copy_video content
-        | `Both -> copy_content content
-    in
-    fg.breaks <- fg.breaks @ List.map (fun p -> length fg + p - ofs) breaks;
-    fg.metadata <-
-      fg.metadata @ List.map (fun (p, m) -> (length fg + p - ofs, m)) metadata;
-    Generator.put fg.generator content ofs len
-
-  (** Take all data from a frame: breaks, metadata and available content. *)
-  let feed_from_frame ?(copy : [ `None | `Audio | `Video | `Both ] = `Both) fg
-      frame =
-    let position = Frame.position frame in
-    fg.metadata <-
-      fg.metadata
-      @ List.map
-          (fun (p, m) -> (length fg + p, m))
-          (Frame.get_all_metadata frame);
-    fg.breaks <-
-      fg.breaks
-      @ List.map
-          (fun p -> length fg + p)
-          (* Filter out the last break, which only marks the end
-           * of frame, not a track limit (doesn't mean is_partial). *)
-          (List.filter (fun x -> x < position) (Frame.breaks frame));
-
-    (* Feed all content layers into the generator. *)
-    let content = content frame in
-    let content =
-      match copy with
-        | `None -> content
-        | `Audio -> copy_audio content
-        | `Video -> copy_video content
-        | `Both -> copy_content content
-    in
-    Generator.put fg.generator content 0 position
-
-  (* Fill a frame from the generator's data. *)
-  let fill fg frame =
-    let offset = Frame.position frame in
-    let buffer_size = Lazy.force Frame.size in
-    let remaining =
-      let l = remaining fg in
-      if l = -1 then length fg else l
-    in
-    let needed = min (buffer_size - offset) remaining in
-    let blocks = Generator.get fg.generator needed in
-    List.iter
-      (fun (block, o, o', size) ->
-        let dst = content frame in
-        fill_content block o dst (offset + o') size)
-      blocks;
-    List.iter
-      (fun (p, m) -> if p < needed then Frame.set_metadata frame (offset + p) m)
-      fg.metadata;
-    advance fg needed;
-
-    (* Mark the end of this filling.
-     * If the frame is partial it must be because of a break in the
-     * generator, or because the generator is emptying.
-     * Conversely, each break in the generator must cause a partial frame,
-     * so don't remove any if it isn't partial. *)
-    Frame.add_break frame (offset + needed);
-    if Frame.is_partial frame then (
-      match fg.breaks with
-        | 0 :: tl -> fg.breaks <- tl
-        | [] -> () (* end of stream / underrun ... *)
-        | _ -> assert false)
-end
-
-(** In [`Both] mode, the buffer is always kept in sync as follows:
-    - PTS in audio and video is expected to be tracked when submitting
-      data. User with no knowledge of PTS (typically all decoders except
-      ffmpeg) should be able to submit without having to deal with PTS.
-    - The buffer is always in sync except for potentially one type of
-      data and always at the end of the buffer. Typically:
-         0----1----2--> audio
-         0----1----2----3----4----> video
-    - When a new chunk is added, any gap in data from the other type
-      is removed. So, for instance, when adding an audio chunk of type
-      4--(5)----(6)- one gets:
-         0----1----4----5----6-> audio
-         0----1----4----> video
-      Note: video frame being usually one frame long, we unfortunately cannot
-      keep partially filled frames.
-    - Current chunk length and PTS are tracked so that new chunk are split
-      by increment of frame size. Typically, if we have:
-         0----1----2--> audio
-         0----1----2----3----4----5> video
-      Adding a chunk of audio of type: 2--(3)----(4)- should
-      result in  adding a first chunk of 4-- then a chunk of 3----
-      and, finally, a chunk of 4-. *)
-module From_audio_video = struct
-  type mode = [ `Audio | `Video | `Both | `Undefined ]
-  type 'a content = { pts : int64 option; data : 'a }
-
-  type t = {
-    mutable mode : mode;
-    mutable current_pts : int64 option;
-    mutable current_audio_pts : int64 option;
-    current_audio : Content.data content Generator.t;
-    audio : Content.data content Generator.t;
-    mutable current_video_pts : int64 option;
-    current_video : Content.data content Generator.t;
-    video : Content.data content Generator.t;
-    mutable metadata : (int * Frame.metadata) list;
-    mutable breaks : int list;
-  }
-
-  let create m =
-    {
-      mode = m;
-      current_pts = None;
-      current_audio_pts = None;
-      current_audio = Generator.create ();
-      audio = Generator.create ();
-      current_video_pts = None;
-      current_video = Generator.create ();
-      video = Generator.create ();
-      metadata = [];
-      breaks = [];
-    }
-
-  (** Audio length, in ticks. *)
-  let audio_length t =
-    Generator.length t.audio + Generator.length t.current_audio
-
-  (** Video length, in ticks. *)
-  let video_length t =
-    Generator.length t.video + Generator.length t.current_video
-
-  (** Total length. *)
-  let length t = min (Generator.length t.audio) (Generator.length t.video)
-
-  (** Total buffered length. *)
-  let buffered_length t = max (audio_length t) (video_length t)
-
-  (** Duration of data (in ticks) before the next break, -1 if there's none. *)
-  let remaining t = match t.breaks with a :: _ -> a | _ -> -1
-
-  (** Add metadata at the minimum position of audio and video.
-    * You probably want to call this when there is as much
-    * audio as video. *)
-  let add_metadata ?(pos = 0) t m =
-    t.metadata <- t.metadata @ [(length t + pos, m)]
-
-  (** Add a track limit. Audio and video length should be equal. *)
-  let add_break ?(sync = false) ?(pos = 0) t =
-    if sync then (
-      Generator.clear t.current_audio;
-      Generator.clear t.current_video);
-    t.breaks <- t.breaks @ [length t + pos]
-
-  let clear t =
-    t.metadata <- [];
-    t.breaks <- [];
-    Generator.clear t.audio;
-    Generator.clear t.video
-
-  (** Current mode:
-    * in Audio mode (resp. Video), only audio (resp. Audio) can be fed,
-    * otherwise both have to be fed. *)
-  let mode t = t.mode
-
-  (** Change the generator mode. Only allowed when there is as much audio as video.  *)
-  let set_mode t m =
-    if t.mode <> m then (
-      assert (audio_length t = video_length t);
-      t.mode <- m)
-
-  (** Check for pending synced A/V content *)
-  let sync_content t =
-    let s = Lazy.force Frame.size in
-
-    let audio = Queue.copy t.current_audio.Generator.buffers in
-    let initial_audio_offset = t.current_audio.Generator.offset in
-
-    let video = Queue.copy t.current_video.Generator.buffers in
-    let initial_video_offset = t.current_video.Generator.offset in
-
-    (* First buffer offset comes from the generator! *)
-    let rec pick ~offset ~picked ~pos ~chunks pts =
-      match (pts, Queue.peek_opt chunks) with
-        | Some p, Some ({ pts = Some p' }, _, l) when p = p' ->
-            Queue.add (Queue.take chunks) picked;
-            pick ~offset:0 ~picked ~pos:(pos + l - offset) ~chunks pts
-        | Some p, Some ({ pts = Some p' }, _, _) when p < p' -> (pos, true)
-        (* Prevent user from submitting non-monotonic PTS. *)
-        | Some p, Some ({ pts = Some p' }, _, _) when p' < p ->
-            pick ~offset:0 ~picked ~pos ~chunks pts
-        | Some _, Some ({ pts = Some _ }, _, l) ->
-            Queue.add (Queue.take chunks) picked;
-            pick ~offset:0 ~picked ~pos:(pos + l - offset) ~chunks pts
-        | None, Some ({ pts = None }, _, l) when pos + l - offset <= s ->
-            Queue.add (Queue.take chunks) picked;
-            pick ~offset:0 ~picked ~pos:(pos + l - offset) ~chunks pts
-        | None, Some ({ pts = None }, _, _) -> (pos, true)
-        | _, None -> (pos, false)
-        | _ -> assert false
-    in
-
-    let add_audio ~picked ~pos () =
-      Queue.iter (fun (chunk, o, l) -> Generator.put t.audio chunk o l) picked;
-      Generator.remove t.current_audio pos
-    in
-
-    let add_video ~picked ~pos () =
-      Queue.iter (fun (chunk, o, l) -> Generator.put t.video chunk o l) picked;
-      Generator.remove t.current_video pos
-    in
-
-    let rec f () =
-      match (Queue.peek_opt audio, Queue.peek_opt video) with
-        | ( Some ({ pts = Some audio_pts }, _, _),
-            Some ({ pts = Some video_pts }, _, _) )
-          when audio_pts < video_pts ->
-            let picked_audio = Queue.create () in
-            let audio_len, _ =
-              pick ~offset:initial_audio_offset ~picked:picked_audio ~pos:0
-                ~chunks:audio (Some audio_pts)
-            in
-            Generator.remove t.current_audio audio_len;
-            f ()
-        | ( Some ({ pts = Some audio_pts }, _, _),
-            Some ({ pts = Some video_pts }, _, _) )
-          when video_pts < audio_pts ->
-            let picked_video = Queue.create () in
-            let video_len, _ =
-              pick ~offset:initial_video_offset ~picked:picked_video ~pos:0
-                ~chunks:video (Some video_pts)
-            in
-            Generator.remove t.current_video video_len;
-            f ()
-        | Some ({ pts = audio_pts }, _, _), Some ({ pts = video_pts }, _, _) ->
-            let picked_audio = Queue.create () in
-            let picked_video = Queue.create () in
-            let audio_len, more_audio =
-              pick ~offset:initial_audio_offset ~picked:picked_audio ~pos:0
-                ~chunks:audio audio_pts
-            in
-            let video_len, more_video =
-              pick ~offset:initial_audio_offset ~picked:picked_video ~pos:0
-                ~chunks:video video_pts
-            in
-            let pts =
-              match (audio_pts, video_pts) with
-                | Some pts, Some _ -> Some pts
-                | _ -> None
-            in
-            (match (audio_len, video_len) with
-              (* Full frame sync. Take it! *)
-              | _ when audio_len = video_len && video_len = s ->
-                  t.current_pts <- pts;
-                  add_audio ~picked:picked_audio ~pos:audio_len ();
-                  add_video ~picked:picked_video ~pos:video_len ()
-              (* Partial audio or video frame. Can it! *)
-              | _
-                when (audio_len < s && more_audio)
-                     || (video_len < s && more_video) ->
-                  Generator.remove t.current_audio audio_len;
-                  Generator.remove t.current_video video_len
-              | _ -> ());
-            f ()
-        | _ -> ()
-    in
-
-    if s <= audio_length t && s <= video_length t then f ()
-
-  let put_frames ~pts ~current_pts gen data o l =
-    let s = Lazy.force Frame.size in
-
-    let current_chunk = Generator.length gen mod s in
-
-    let put ~pts o l =
-      if 0 < l then (
-        match (pts, current_pts) with
-          | Some p, Some p' when p < p' -> ()
-          | _ -> Generator.put gen { pts; data } o l)
-    in
-
-    (* First complete the previous chunk if we're on the same PTS. *)
-    let r, pts =
-      if pts = current_pts then (
-        let r = min l (s - current_chunk) in
-        put ~pts o r;
-        ( r,
-          Option.map
-            (fun pts -> if r + current_chunk = s then Int64.succ pts else pts)
-            pts ))
-      else (0, pts)
-    in
-
-    let l = l - r in
-    let o = o + r in
-
-    (* Now fill out the rest of the frames in [l] *)
-    let frames = l / s in
-    let rem = l mod s in
-
-    (* Add data by increment one one pts/frame.size *)
-    for i = 0 to frames - 1 do
-      let pts = Option.map (fun pts -> Int64.add pts (Int64.of_int i)) pts in
-      put ~pts (o + (i * s)) s
-    done;
-
-    let pts = Option.map (fun pts -> Int64.add pts (Int64.of_int frames)) pts in
-
-    put ~pts (o + (frames * s)) rem;
-
-    pts
-
-  (** Add some audio content. Offset and length are given in main ticks. *)
-  let put_audio ?pts t data o l =
-    let pts =
-      match pts with Some pts -> Some pts | None -> t.current_audio_pts
-    in
-    t.current_audio_pts <-
-      put_frames ~pts ~current_pts:t.current_audio_pts t.current_audio data o l;
-    begin
-      match t.mode with
-        (* The buffer's logic is all synchronous so we keep
-           constant empty content for the other type when using
-           the buffer with one single type. *)
-        | `Audio ->
-            t.current_video_pts <-
-              put_frames ~pts ~current_pts:t.current_video_pts t.current_video
-                (NoneContent.lift_data ~length:l ())
-                0 l
-        | `Both -> ()
-        | _ -> assert false
-    end;
-    sync_content t
-
-  (** Add some video content. Offset and length are given in main ticks. *)
-  let put_video ?pts t data o l =
-    let pts =
-      match pts with Some pts -> Some pts | None -> t.current_video_pts
-    in
-    t.current_video_pts <-
-      put_frames ~pts ~current_pts:t.current_video_pts t.current_video data o l;
-    begin
-      match t.mode with
-        (* The buffer's logic is all synchronous so we keep
-           constant empty content for the other type when using
-           the buffer with one single type. *)
-        | `Video ->
-            t.current_audio_pts <-
-              put_frames ~pts ~current_pts:t.current_audio_pts t.current_audio
-                (NoneContent.lift_data ~length:l ())
-                0 l
-        | _ -> ()
-    end;
-    sync_content t
-
-  (** Take all data from a frame: breaks, metadata and available content. *)
-  let feed_from_frame ?(copy : [ `None | `Audio | `Video | `Both ] = `Both)
-      ?mode t frame =
-    let size = Lazy.force Frame.size in
-    t.metadata <-
-      t.metadata
-      @ List.map
-          (fun (p, m) -> (length t + p, m))
-          (Frame.get_all_metadata frame);
-    t.breaks <-
-      t.breaks
-      @ List.map
-          (fun p -> length t + p)
-          (* Filter out the last break, which only marks the end
-           * of frame, not a track limit (doesn't mean is_partial). *)
-          (List.filter (fun x -> x < size) (Frame.breaks frame));
-
-    (* Feed all content layers into the generator. *)
-    let pts = Frame.pts frame in
-    let mode = match mode with Some mode -> mode | None -> t.mode in
-    let pos = Frame.position frame in
-    let content = content frame in
-
-    match mode with
-      | `Audio ->
-          let content =
-            match copy with
-              | `Audio | `Both -> copy_audio content
-              | _ -> content
+  gen.content <-
+    Frame_base.Fields.map (fun c -> Content.truncate c length) gen.content;
+  content
+
+let get ?length gen = Tutils.mutexify gen.lock (fun () -> _get ?length gen) ()
+let peek gen = Tutils.mutexify gen.lock (fun () -> gen.content) ()
+
+(* The following is frame-specific and should hopefully go away when
+   we switch to immutable content. *)
+
+let _frame_position frame = match _remaining frame with -1 -> 0 | r -> r
+
+let _frame_remaining frame =
+  Lazy.force Frame_settings.size - _frame_position frame
+
+let feed ?offset ?length ?fields gen =
+  Tutils.mutexify gen.lock (fun frame ->
+      Tutils.mutexify frame.lock
+        (fun () ->
+          let offset = Option.value ~default:0 offset in
+          let length = Option.value ~default:(_frame_position frame) length in
+          let fields =
+            Option.value
+              ~default:(List.map fst (Frame_base.Fields.bindings gen.content))
+              fields
           in
-          put_audio ?pts t (Option.get (Frame.find_audio content)) 0 pos
-      | `Video ->
-          let content =
-            match copy with
-              | `Video | `Both -> copy_video content
-              | _ -> content
+
+          gen.content <-
+            List.fold_left
+              (fun content field ->
+                match field with
+                  (* The current use of generators is to explicitly add track marks via `Generator.add_track_mark`.
+                     This will be changed when we switch to immutable content. *)
+                  | f when f = Frame_base.Fields.track_marks -> content
+                  | f when f = Frame_base.Fields.metadata ->
+                      let gen_content =
+                        Frame_base.Fields.find field gen.content
+                      in
+                      let frame_content =
+                        Frame_base.Fields.find field frame.content
+                      in
+                      Content.Metadata.set_data gen_content
+                        (Content.Metadata.get_data gen_content
+                        @ Content.Metadata.get_data frame_content);
+                      content
+                  | _ ->
+                      Frame_base.Fields.add field
+                        (Content.append
+                           (Frame_base.Fields.find field gen.content)
+                           (Content.copy
+                              (Content.sub
+                                 (Frame_base.Fields.find field frame.content)
+                                 offset length)))
+                        content)
+              gen.content fields)
+        ())
+
+let fill gen =
+  Tutils.mutexify gen.lock (fun frame ->
+      Tutils.mutexify frame.lock
+        (fun () ->
+          let available =
+            match _remaining gen with -1 -> _length gen | l -> l
           in
-          put_video ?pts t (Option.get (Frame.find_video content)) 0 pos
-      | `Both ->
-          let content =
-            match copy with
-              | `None -> content
-              | `Audio -> copy_audio content
-              | `Video -> copy_video content
-              | `Both -> copy_content content
-          in
-          put_audio ?pts t (Option.get (Frame.find_audio content)) 0 pos;
-          put_video ?pts t (Option.get (Frame.find_video content)) 0 pos
-      | `Undefined -> ()
-
-  (* Advance metadata and breaks by [len] ticks. *)
-  let advance t len =
-    let meta = List.map (fun (x, y) -> (x - len, y)) t.metadata in
-    let breaks = List.map (fun x -> x - len) t.breaks in
-    t.metadata <- List.filter (fun x -> fst x >= 0) meta;
-    t.breaks <- List.filter (fun x -> x >= 0) breaks
-
-  let remove t len =
-    Generator.remove t.audio len;
-    Generator.clear t.current_audio;
-    Generator.remove t.video len;
-    Generator.clear t.current_video;
-    advance t len
-
-  let remove_buffered t len =
-    let audio_length = Generator.length t.current_audio in
-    let video_length = Generator.length t.current_video in
-    let top_generator, bottom_generator, top_length, diff_len =
-      if audio_length > video_length then
-        ( t.current_audio,
-          t.current_video,
-          audio_length,
-          audio_length - video_length )
-      else
-        ( t.current_video,
-          t.current_audio,
-          audio_length,
-          video_length - audio_length )
-    in
-    let remaining =
-      if len <= diff_len then (
-        Generator.remove top_generator len;
-        0)
-      else if len <= top_length then (
-        Generator.remove top_generator len;
-        Generator.remove bottom_generator (len - diff_len);
-        0)
-      else (
-        Generator.clear top_generator;
-        Generator.clear bottom_generator;
-        len - top_length)
-    in
-    if remaining > 0 then (
-      Generator.remove t.audio remaining;
-      Generator.remove t.video remaining;
-      advance t remaining)
-
-  let fill t frame =
-    let mode = mode t in
-    let fpos = Frame.position frame in
-    let size = Lazy.force Frame.size in
-
-    let remaining =
-      let l = remaining t in
-      if l = -1 then length t else l
-    in
-
-    let l = min (size - fpos) remaining in
-
-    let audio = Generator.get t.audio l in
-    let video = Generator.get t.video l in
-
-    if mode = `Both || mode = `Audio then
-      List.iter
-        (fun ({ data }, apos, apos', al) ->
-          Content.blit data apos (AFrame.content frame) (fpos + apos') al)
-        audio;
-
-    if mode = `Both || mode = `Video then
-      List.iter
-        (fun ({ data }, vpos, vpos', vl) ->
-          Content.blit data vpos (VFrame.content frame) (fpos + vpos') vl)
-        video;
-
-    Frame.set_pts frame t.current_pts;
-    Frame.add_break frame (fpos + l);
-
-    List.iter
-      (fun (p, m) -> if p < l then Frame.set_metadata frame (fpos + p) m)
-      t.metadata;
-
-    advance t l;
-
-    (* If the frame is partial it must be because of a break in the
-     * generator, or because the generator is emptying.
-     * Conversely, each break in the generator must cause a partial frame,
-     * so don't remove any if it isn't partial. *)
-    if Frame.is_partial frame then (
-      match t.breaks with
-        | 0 :: tl -> t.breaks <- tl
-        | [] -> () (* end of stream / underrun ... *)
-        | _ -> assert false)
-end
-
-module From_audio_video_plus = struct
-  module Super = From_audio_video
-
-  type mode = [ `Audio | `Video | `Both | `Undefined ]
-
-  (** There are different ways of handling an overful generator:
-    * (1) when streaming, one should just stop the decoder for a while;
-    * (2) when not streaming, one should throw some data.
-    * Doing 1 instead of 2 can lead to deconnections.
-    * Doing 2 instead of 1 leads to ugly sound.
-    * Currently the only possibility is to drop data, since we want to remain
-    * connected to the client. This behaves well in most cases, since clients
-    * generally don't not go faster than stream-time. *)
-  type overfull = [ `Drop_old of int ]
-
-  type t = {
-    lock : Mutex.t;
-    (* The type of fed data must always be the same. This is fixed by the first
-       filled frame. *)
-    mutable ctype : Frame.content_type option;
-    mutable error : bool;
-    overfull : overfull option;
-    gen : Super.t;
-    log : string -> unit;
-    log_overfull : bool;
-    (* Metadata rewriting, in place modification allowed *)
-    mutable map_meta : Frame.metadata -> Frame.metadata;
-  }
-
-  let create ?(lock = Mutex.create ()) ?overfull ~log ~log_overfull mode =
-    {
-      lock;
-      ctype = None;
-      error = false;
-      overfull;
-      log;
-      log_overfull;
-      gen = Super.create mode;
-      map_meta = (fun x -> x);
-    }
-
-  let content_type t = Tutils.mutexify t.lock (fun () -> Option.get t.ctype) ()
-
-  let set_content_type t =
-    Tutils.mutexify t.lock (fun ctype ->
-        assert (t.ctype = None);
-        t.ctype <- Some ctype)
-
-  let mode t = Tutils.mutexify t.lock Super.mode t.gen
-  let set_mode t mode = Tutils.mutexify t.lock (Super.set_mode t.gen) mode
-  let audio_length t = Tutils.mutexify t.lock Super.audio_length t.gen
-  let video_length t = Tutils.mutexify t.lock Super.video_length t.gen
-  let length t = Tutils.mutexify t.lock Super.length t.gen
-  let remaining t = Tutils.mutexify t.lock Super.remaining t.gen
-  let set_rewrite_metadata t f = t.map_meta <- f
-
-  let add_metadata ?pos t m =
-    Tutils.mutexify t.lock
-      (fun m -> Super.add_metadata ?pos t.gen (t.map_meta m))
-      m
-
-  let add_break ?sync ?pos t =
-    Tutils.mutexify t.lock (Super.add_break ?sync ?pos) t.gen
-
-  let clear t = Tutils.mutexify t.lock Super.clear t.gen
-
-  let fill t frame =
-    Tutils.mutexify t.lock
-      (fun () ->
-        let p = Frame.position frame in
-        let breaks = Frame.breaks frame in
-        Super.fill t.gen frame;
-        let c = content frame in
-        match t.ctype with
-          | None -> t.ctype <- Some (type_of_content c)
-          | Some ctype ->
-              if not (Frame.compatible (type_of_content c) ctype) then (
-                t.log "Incorrect stream type!";
-                t.error <- true;
-                Super.clear t.gen;
-                Frame.clear_from frame p;
-                Frame.set_breaks frame (p :: breaks)))
-      ()
-
-  let remove t len = Tutils.mutexify t.lock (Super.remove t.gen) len
-
-  let check_overfull t extra =
-    assert (Tutils.seems_locked t.lock);
-    match t.overfull with
-      | Some (`Drop_old len) when Super.buffered_length t.gen + extra > len ->
-          let len = Super.buffered_length t.gen + extra - len in
-          let len_time = Frame.seconds_of_main len in
-          if t.log_overfull then
-            t.log
-              (Printf.sprintf
-                 "Buffer overrun: Dropping %.2fs. Consider increasing the max \
-                  buffer size!"
-                 len_time);
-          Super.remove_buffered t.gen len
-      | _ -> ()
-
-  let put_audio ?pts t buf off len =
-    Tutils.mutexify t.lock
-      (fun () ->
-        if t.error then (
-          Super.clear t.gen;
-          t.error <- false;
-          raise Incorrect_stream_type)
-        else (
-          check_overfull t len;
-          Super.put_audio ?pts t.gen buf off len))
-      ()
-
-  let put_video ?pts t buf off len =
-    Tutils.mutexify t.lock
-      (fun () ->
-        if t.error then (
-          Super.clear t.gen;
-          t.error <- false;
-          raise Incorrect_stream_type)
-        else (
-          check_overfull t len;
-          Super.put_video ?pts t.gen buf off len))
-      ()
-
-  let feed_from_frame ?mode t frame =
-    Tutils.mutexify t.lock
-      (fun () ->
-        (match t.ctype with
-          | None -> t.ctype <- Some (Frame.content_type frame)
-          | Some ctype ->
-              if Frame.content_type frame <> ctype then (
-                t.log "Incorrect stream type!";
-                t.error <- true));
-        if t.error then (
-          Super.clear t.gen;
-          t.error <- false;
-          raise Incorrect_stream_type)
-        else (
-          check_overfull t (Lazy.force Frame.size);
-          Super.feed_from_frame ?mode t.gen frame))
-      ()
-end
+          let len = min (_frame_remaining frame) available in
+          let pos = _frame_position frame in
+          gen.content <-
+            Frame_base.Fields.mapi
+              (fun field content ->
+                let rem =
+                  Content.sub content len (Content.length content - len)
+                in
+                (* TODO: make this append after after switch to immutable content. *)
+                (match field with
+                  (* Remove the first break in rem *)
+                  | f when f = Frame_base.Fields.track_marks -> (
+                      match Content.Track_marks.get_data rem with
+                        | _ :: d -> Content.Track_marks.set_data rem d
+                        | _ -> ())
+                  | f when f = Frame_base.Fields.metadata ->
+                      (* For metadata, it is expected that we only add new metadata and do not replace
+                         exiting ones. *)
+                      let frame_content =
+                        Frame_base.Fields.find field frame.content
+                      in
+                      let content =
+                        Content.Metadata.get_data (Content.sub content 0 len)
+                      in
+                      let content =
+                        List.map (fun (p, m) -> (pos + p, m)) content
+                      in
+                      Content.Metadata.set_data frame_content
+                        (Content.Metadata.get_data frame_content @ content)
+                  | f ->
+                      Content.blit content 0
+                        (Frame_base.Fields.find f frame.content)
+                        pos len);
+                rem)
+              gen.content;
+          _add_track_mark ~pos:(pos + len) frame)
+        ())

--- a/src/core/stream/generator.mli
+++ b/src/core/stream/generator.mli
@@ -20,305 +20,84 @@
 
  *****************************************************************************)
 
-(** Operations on generators, which are like FIFO for multimedia data. They are
-    efficiently handling small chunks of data (as found in frames) with minimal copy,
-    and also metadata.
-
-    Data coming from frames is copied when added to the buffer because frame content
-    are reused during each streaming loop. However, data is only assigned exiting the
-    buffer. This means that we expect the buffer to feed a single source on the way
-    out. *)
-
-(** Raised when trying to feed a generator with data of incorrect type (wrong
-    number of audio channels, etc.). *)
-exception Incorrect_stream_type
-
-type content = Content.data Frame.Fields.t
-
-val content : Frame.t -> content
-
-module NoneContent : sig
-  include Content.Content
-
-  val lift_data : length:int -> unit -> Content.data
-end
-
-(** Signature for a generator. *)
-module type S = sig
-  type t
-
-  (** Length of the generator in ticks. *)
-  val length : t -> int
-
-  (** Duration of data (in ticks) before the next break, -1 if there's none. *)
-  val remaining : t -> int
-
-  (** Clear the generator. *)
-  val clear : t -> unit
-
-  (** Fill a frame from the generator. *)
-  val fill : t -> Frame.t -> unit
-
-  (** Forget a given duration (in ticks) of the generator. *)
-  val remove : t -> int -> unit
-
-  (** Add metadata. *)
-  val add_metadata : ?pos:int -> t -> Frame.metadata -> unit
-end
-
-(** Content-agnostic generator. *)
-module Generator : sig
-  (** A generator. *)
-  type 'a t
-
-  (** Create a generator. *)
-  val create : unit -> 'a t
-
-  (** Empty a generator. *)
-  val clear : 'a t -> unit
-
-  (** Length of data contained in a generator (in ticks). *)
-  val length : 'a t -> int
-
-  (** Remove given amount (in ticks) of data. *)
-  val remove : 'a t -> int -> unit
-
-  (** [put data ofs len] adds [len] of data [data] starting from [ofs]. Data is
-      not copied. *)
-  val put : 'a t -> 'a -> int -> int -> unit
-
-  (** Get given amount of data from a generator. Returns a list where each
-      element will typically be passed to a blit: its elements are of the form
-      [b,o,o',l] where [o] is the offset of data in the block [b], [o'] is the
-      position at which it should be written (the first position [o'] will
-      always be [0]), and [l] is the length of data to be taken from that
-      block. *)
-  val get : 'a t -> int -> ('a * int * int * int) list
-end
-
-(** A generator for metadata. *)
-module Metadata : sig
-  (** A metadata generator. *)
-  type t
-
-  (** Create a generator. *)
-  val create : unit -> t
-
-  (** Clear generator. *)
-  val clear : t -> unit
-
-  (** Length in ticks. *)
-  val length : t -> int
-
-  (** Time until next break, or -1 if there is none. *)
-  val remaining : t -> int
-
-  (** Drop a portion at the beginning. *)
-  val advance : t -> int -> unit
-
-  (** Drop break at the beginning. This should be called after filling a partial
-      frame manually (i.e. not using [fill]). *)
-  val drop_initial_break : t -> unit
-
-  (** Retrieve all metadata between now and given time. *)
-  val metadata : t -> int -> (int * Frame.metadata) list
-
-  (** Feed all breaks and metadata from a frame. *)
-  val feed_from_frame : t -> Frame.t -> unit
-
-  (** Fill a frame (until the next break) with metadata and add a break at the
-      end. *)
-  val fill : t -> Frame.t -> unit
-end
-
-(** A generator that consumes frames (or frame content) and produces frames. *)
-module From_frames : sig
-  (** A generator. *)
-  type t
-
-  (** Create a generator. *)
-  val create : unit -> t
-
-  (** Remove all data from a generator. *)
-  val clear : t -> unit
-
-  (** Length of data in the generator. *)
-  val length : t -> int
-
-  (** Remaining data before next break (-1) if there is none. *)
-  val remaining : t -> int
-
-  (** Add metadata at the current position. *)
-  val add_metadata : ?pos:int -> t -> Frame.metadata -> unit
-
-  (** Add a break at the current position. *)
-  val add_break : ?pos:int -> t -> unit
-
-  (** Remove data. *)
-  val remove : t -> int -> unit
-
-  (** Feed the generator with data. *)
-  val feed :
-    t ->
-    ?copy:[ `None | `Audio | `Video | `Both ] ->
-    ?breaks:int list ->
-    ?metadata:(int * Frame.metadata) list ->
-    content ->
-    int ->
-    int ->
-    unit
-
-  (** Feed the generator with the contents of a frame (the contents is
-      copied). *)
-  val feed_from_frame :
-    ?copy:[ `None | `Audio | `Video | `Both ] -> t -> Frame.t -> unit
-
-  (** Fill a frame from the generator. *)
-  val fill : t -> Frame.t -> unit
-end
-
-(** Generator not only with output but also with asynchronous input. *)
-module type S_Asio = sig
-  type t
-
-  val length : t -> int (* ticks *)
-  val audio_length : t -> int
-  val video_length : t -> int
-  val remaining : t -> int (* ticks *)
-  val clear : t -> unit
-  val fill : t -> Frame.t -> unit
-  val add_metadata : ?pos:int -> t -> Frame.metadata -> unit
-  val add_break : ?sync:bool -> ?pos:int -> t -> unit
-  val put_audio : ?pts:int64 -> t -> Content.data -> int -> int -> unit
-  val put_video : ?pts:int64 -> t -> Content.data -> int -> int -> unit
-  val set_mode : t -> [ `Audio | `Video | `Both | `Undefined ] -> unit
-end
-
-(** Generator that consumes audio and video asynchronously, and produces
-    frames. *)
-module From_audio_video : sig
-  type t
-
-  (** In [`Audio] mode, only audio can be put in the buffer, and similarly for
-      the [`Video] mode.
-
-      In [`Both] mode, both types of content can be fed into the generator,
-      asynchronously, and they exit the buffer synchronously. PTS are only
-      used in this mode and are used to make sure that all audio and video
-      content is synchronized when exported. Typically, during muxing, the
-      audio source may not be ready for a while while the video source keeps
-      filling up the buffer. In this case, when the audio source starts
-      filling up the buffer as well, we can filter out all the video content
-      that has no corresponding audio.
-
-      [`Undefined] forbids any feeding, it's useful to make sure a meaningful
-      mode is assigned before any use. *)
-  type mode = [ `Audio | `Video | `Both | `Undefined ]
-
-  (** Create a generator with given mode. *)
-  val create : mode -> t
-
-  (** Current mode: in Audio mode (resp. Video), only audio (resp. Audio) can be
-      fed, otherwise both have to be fed. *)
-  val mode : t -> mode
-
-  (** Change the generator mode. Only allowed when there is as much audio as
-      video. *)
-  val set_mode : t -> mode -> unit
-
-  (** Length of available audio data. *)
-  val audio_length : t -> int
-
-  (** Length of available video data. *)
-  val video_length : t -> int
-
-  (** Length of data available in both audio and video. *)
-  val length : t -> int
-
-  (** Length of buffered data, taking into account buffered
-      unsynced data. *)
-  val buffered_length : t -> int
-
-  (** Duration of data (in ticks) before the next break, -1 if there's none. *)
-  val remaining : t -> int
-
-  (** Add metadata at the minimum position of audio and video. [pos] is an
-      offset from the current buffer's length and defaults to [0]. *)
-  val add_metadata : ?pos:int -> t -> Frame.metadata -> unit
-
-  (** Add a track limit. [pos] is an offset from the current buffer's length and
-      defaults to [0]. *)
-  val add_break : ?sync:bool -> ?pos:int -> t -> unit
-
-  (* [put_audio ?pts buffer data offset length]: offset and length
-   * are in main ticks ! *)
-  val put_audio : ?pts:int64 -> t -> Content.data -> int -> int -> unit
-
-  (* [put_video ?pts buffer data offset length]: offset and length
-   * are in main ticks ! *)
-  val put_video : ?pts:int64 -> t -> Content.data -> int -> int -> unit
-
-  (** Feed from a frame, only copying data according to the mode.
-      Defaults to the generator's mode. *)
-  val feed_from_frame :
-    ?copy:[ `None | `Audio | `Video | `Both ] ->
-    ?mode:mode ->
-    t ->
-    Frame.t ->
-    unit
-
-  (** Fill a frame from the generator. *)
-  val fill : t -> Frame.t -> unit
-
-  (* Remove from synced content, clear unsynced content. *)
-  val remove : t -> int -> unit
-
-  (* Remove from buffered content (synced & unsynced), starting with top buffer. *)
-  val remove_buffered : t -> int -> unit
-  val clear : t -> unit
-end
-
-(** Same as [From_audio_video] but with two extra features useful for streaming
-    decoders: it is thread safe and supports overfull buffer management. *)
-module From_audio_video_plus : sig
-  type t
-
-  (** Same as [From_audio_video]. *)
-  type mode = [ `Audio | `Video | `Both | `Undefined ]
-
-  (** How to handle overfull buffers:
-    * drop old data, keeping at most [len] ticks. *)
-  type overfull = [ `Drop_old of int ]
-
-  val create :
-    ?lock:Mutex.t ->
-    ?overfull:overfull ->
-    log:(string -> unit) ->
-    log_overfull:bool ->
-    mode ->
-    t
-
-  val content_type : t -> Frame.content_type
-  val set_content_type : t -> Frame.content_type -> unit
-  val mode : t -> From_audio_video.mode
-  val set_mode : t -> From_audio_video.mode -> unit
-  val audio_length : t -> int
-  val video_length : t -> int
-  val length : t -> int
-  val remaining : t -> int
-  val set_rewrite_metadata : t -> (Frame.metadata -> Frame.metadata) -> unit
-  val add_metadata : ?pos:int -> t -> Frame.metadata -> unit
-  val add_break : ?sync:bool -> ?pos:int -> t -> unit
-
-  (* [put_audio ?pts buffer data offset length]:
-   * offset and length are in main ticks! *)
-  val put_audio : ?pts:int64 -> t -> Content.data -> int -> int -> unit
-
-  (* [put_video buffer data offset length]:
-   * offset and length are in main ticks! *)
-  val put_video : ?pts:int64 -> t -> Content.data -> int -> int -> unit
-  val feed_from_frame : ?mode:mode -> t -> Frame.t -> unit
-  val fill : t -> Frame.t -> unit
-  val remove : t -> int -> unit
-  val clear : t -> unit
-end
+(** A generator is a collection of content with different
+    length. The set of content contained by a generator is
+    given by its [content_type] to which metadata and track
+    marks are always added.
+
+    For now, metadata and track breaks content have infinite
+    length. All other content have finite length.
+
+    A generator buffered length is the largest content length,
+    excluding metadata and track breaks. If that length exceeds
+    [max_length], the generator is truncated to keep it under
+    that value.
+
+    A generator length is the smallest content length,
+    again excluding metadata and track breaks. This is the
+    maximum content length that can be taken out of the
+    generator. *)
+
+type t
+
+val create :
+  ?log:(string -> unit) ->
+  ?max_length:int ->
+  ?length:int ->
+  Frame_base.content_type ->
+  t
+
+val max_length : t -> int option
+val set_max_length : t -> int option -> unit
+val content_type : t -> Frame_base.content_type
+
+(* Return the content associated with a given [field]. *)
+val get_field : t -> Frame_base.field -> Content.data
+
+(* Set the content associated with a given [field]. *)
+val set_field : t -> Frame_base.field -> Content.data -> unit
+
+(* Length of content for the given field. *)
+val field_length : t -> Frame_base.field -> int
+val length : t -> int
+val buffered_length : t -> int
+
+(* Remaining time before the next track mark or -1 if no
+   track marks are present. *)
+val remaining : t -> int
+
+(* Drop given length of content at the beginning of the generator. *)
+val truncate : t -> int -> unit
+
+(* Empty the generator. *)
+val clear : t -> unit
+
+(* Add content to one of the generator's field. Do not use
+   with metadata or track marks, use the corresponding add method
+   for these type of content. *)
+val put : t -> Frame_base.field -> Content.data -> unit
+
+(* Remove the given length of content from the beginning of the generator
+   and return it. Defaults to the whole available length. *)
+val get : ?length:int -> t -> Content.data Frame_base.Fields.t
+
+(* Return the generator's content without removing it. *)
+val peek : t -> Content.data Frame_base.Fields.t
+
+(* Insert a metadata at the given position. To be used over [put]
+   for metadata. Default position is generator's length. *)
+val add_metadata : ?pos:int -> t -> Frame_base.metadata -> unit
+
+(* Insert a track mark at the given position. To be used over [put]
+   for track mark. Default position is generator's length. *)
+val add_track_mark : ?pos:int -> t -> unit
+
+(* [feed ?offset ?length ?fields generator frame] is the old call
+   to feed a frame's content to a generator. *)
+val feed :
+  ?offset:int -> ?length:int -> ?fields:Frame_base.field list -> t -> t -> unit
+
+(* [fill generator frame] fills the frame with as much content as possible,
+   from the generator either until the frame is full or the generator's
+   remaining length (if applicable) or length. *)
+val fill : t -> t -> unit

--- a/src/core/stream/mFrame.ml
+++ b/src/core/stream/mFrame.ml
@@ -28,10 +28,7 @@ let mot = midi_of_main
 let tom = main_of_midi
 let size () = mot (Lazy.force Frame.size)
 let position t = mot (position t)
-
-let content b =
-  match Frame.midi b with Some c -> c | None -> raise Content.Invalid
-
+let content b = try Frame.midi b with Not_found -> raise Content.Invalid
 let midi b = Content.Midi.get_data (content b)
 let add_break t i = add_break t (tom i)
 let is_partial = is_partial

--- a/src/core/stream/vFrame.ml
+++ b/src/core/stream/vFrame.ml
@@ -31,9 +31,7 @@ let vot ?round x =
     | None | Some `Down -> Frame.video_of_main x
     | Some `Up -> Frame.video_of_main (x + Lazy.force Frame.video_rate - 1)
 
-let content b =
-  match Frame.video b with Some c -> c | None -> raise Content.Invalid
-
+let content b = try Frame.video b with Not_found -> raise Content.Invalid
 let data b = Content.Video.get_data (content b)
 let size _ = vot (Lazy.force size)
 let next_sample_position t = vot ~round:`Up (Frame.position t)

--- a/src/core/synth/dssi_op.ml
+++ b/src/core/synth/dssi_op.ml
@@ -133,7 +133,7 @@ let register_descr plugin_name descr_n descr outputs =
   let chans = Array.length outputs in
   let frame_t =
     Lang.frame_t (Lang.univ_t ())
-      (Frame.mk_fields
+      (Frame.Fields.make
          ~audio:(Format_type.audio_n chans)
          ~midi:(Format_type.midi_n 1) ())
   in
@@ -157,7 +157,7 @@ let register_descr plugin_name descr_n descr outputs =
 
   let frame_t =
     Lang.frame_t (Lang.univ_t ())
-      (Frame.mk_fields
+      (Frame.Fields.make
          ~audio:(Format_type.audio_n chans)
          ~midi:(Format_type.midi_n all_chans)
          ())

--- a/src/core/synth/keyboard.ml
+++ b/src/core/synth/keyboard.ml
@@ -133,7 +133,7 @@ class keyboard =
 
 let () =
   let return_t =
-    Lang.frame_t Lang.unit_t (Frame.mk_fields ~midi:(Format_type.midi_n 1) ())
+    Lang.frame_t Lang.unit_t (Frame.Fields.make ~midi:(Format_type.midi_n 1) ())
   in
   Lang.add_operator "input.keyboard" [] ~return_t ~category:`Input
     ~flags:[`Hidden; `Experimental] ~descr:"Play notes from the keyboard."

--- a/src/core/synth/keyboard_sdl.ml
+++ b/src/core/synth/keyboard_sdl.ml
@@ -155,7 +155,7 @@ class keyboard velocity =
 
 let () =
   let return_t =
-    Lang.frame_t Lang.unit_t (Frame.mk_fields ~midi:(Format_type.midi ()) ())
+    Lang.frame_t Lang.unit_t (Frame.Fields.make ~midi:(Format_type.midi ()) ())
   in
   Lang.add_operator "input.keyboard.sdl"
     [

--- a/src/core/synth/synth_op.ml
+++ b/src/core/synth/synth_op.ml
@@ -54,7 +54,7 @@ class synth (synth : Synth.synth) (source : source) chan volume =
 let register obj name descr =
   let frame_t =
     Lang.frame_t (Lang.univ_t ())
-      (Frame.mk_fields ~midi:(Format_type.midi_n 1) ())
+      (Frame.Fields.make ~midi:(Format_type.midi_n 1) ())
   in
   Lang.add_operator ("synth." ^ name)
     [
@@ -100,7 +100,7 @@ let register obj name descr =
 
   let frame_t =
     Lang.frame_t (Lang.univ_t ())
-      (Frame.mk_fields ~midi:(Format_type.midi_n 16) ())
+      (Frame.Fields.make ~midi:(Format_type.midi_n 16) ())
   in
   Lang.add_operator ("synth.all." ^ name)
     [

--- a/src/core/tools/external_input.ml
+++ b/src/core/tools/external_input.ml
@@ -47,7 +47,7 @@ class virtual base ~name ~restart ~restart_on_error ~on_data ?read_header
           self#log#info "Header read!";
           header_read <- true;
           ret)
-        else on_data reader
+        else on_data ~buffer:self#buffer reader
       in
       let on_stderr =
         let buf = Bytes.create Utils.pagesize in

--- a/src/core/tools/producer_consumer.ml
+++ b/src/core/tools/producer_consumer.ml
@@ -20,16 +20,14 @@
 
  *****************************************************************************)
 
-module Generator = Generator.From_audio_video
-
 type write_payload = [ `Frame of Frame.t | `Flush ]
 type write_frame = write_payload -> unit
 
-let write_to_buffer ~content g = function
+let write_to_buffer ~fields g = function
   | `Frame frame ->
-      Generator.feed_from_frame ~mode:content g frame;
+      Generator.feed ~fields g frame;
       let excess = Generator.length g - Lazy.force Frame.size in
-      if 0 < excess then Generator.remove g excess
+      if 0 < excess then Generator.truncate g excess
   | `Flush -> ()
 
 (* This here is tricky:
@@ -49,18 +47,20 @@ class consumer ~write_frame ~name ~source () =
         ~output_kind:name ~infallible ~on_start:noop ~on_stop:noop source true as super
 
     val mutable output_enabled = false
+    val mutable producer_buffer = Generator.create Frame.Fields.empty
+    method set_producer_buffer b = producer_buffer <- b
     method set_output_enabled v = output_enabled <- v
     method reset = ()
     method start = ()
-    method stop = write_frame `Flush
+    method stop = write_frame producer_buffer `Flush
     method output = if output_enabled then super#output
-    method private send_frame frame = write_frame (`Frame frame)
+    method private send_frame frame = write_frame producer_buffer (`Frame frame)
   end
 
 (** The source which produces data by reading the buffer.
     We do NOT want to use [operator] here b/c the [consumers]
     may have different content-kind when this is used in the muxers. *)
-class producer ~check_self_sync ~consumers ~name g =
+class producer ~check_self_sync ~consumers ~name () =
   let infallible = List.for_all (fun s -> s#stype = `Infallible) consumers in
   let self_sync_type = Utils.self_sync_type consumers in
   object (self)
@@ -78,21 +78,23 @@ class producer ~check_self_sync ~consumers ~name g =
     method stype = if infallible then `Infallible else `Fallible
 
     method seek len =
-      let len = min (Generator.length g) len in
-      Generator.remove g len;
+      let len = min (Generator.length self#buffer) len in
+      Generator.truncate self#buffer len;
       len
 
     method remaining =
       match List.fold_left (fun r p -> min r p#remaining) (-1) consumers with
         | -1 -> -1
-        | r -> Generator.remaining g + r
+        | r -> Generator.remaining self#buffer + r
 
     method is_ready = List.for_all (fun c -> c#is_ready) consumers
 
     method wake_up a =
       super#wake_up a;
       List.iter
-        (fun c -> c#get_ready ?dynamic:None [(self :> Source.source)])
+        (fun c ->
+          c#set_producer_buffer self#buffer;
+          c#get_ready ?dynamic:None [(self :> Source.source)])
         consumers
 
     method sleep =
@@ -105,12 +107,14 @@ class producer ~check_self_sync ~consumers ~name g =
     method private get_frame buf =
       let b = Frame.breaks buf in
       List.iter (fun c -> c#set_output_enabled true) consumers;
-      while Generator.length g < Lazy.force Frame.size && self#is_ready do
+      while
+        Generator.length self#buffer < Lazy.force Frame.size && self#is_ready
+      do
         self#child_tick
       done;
       needs_tick <- false;
       List.iter (fun c -> c#set_output_enabled false) consumers;
-      Generator.fill g buf;
+      Generator.fill self#buffer buf;
       if List.length b + 1 <> List.length (Frame.breaks buf) then (
         let cur_pos = Frame.position buf in
         Frame.set_breaks buf (b @ [cur_pos]))
@@ -124,6 +128,6 @@ class producer ~check_self_sync ~consumers ~name g =
       child_support#after_output
 
     method abort_track =
-      Generator.add_break g;
+      Generator.add_track_mark self#buffer;
       List.iter (fun c -> c#abort_track) consumers
   end

--- a/src/core/types/content_types.ml
+++ b/src/core/types/content_types.ml
@@ -61,13 +61,13 @@ let of_frame_t t =
           Type.constructor = "stream_kind";
           Type.params = [(_, audio); (_, video); (_, midi)];
         } ->
-        Frame.mk_fields ~audio ~video ~midi ()
+        Frame.Fields.make ~audio ~video ~midi ()
     | Type.Var ({ contents = Type.Free _ } as var) ->
         let audio = kind_t `Any in
         let video = kind_t `Any in
         let midi = kind_t `Any in
         var := Type.Link (`Invariant, frame_t audio video midi);
-        Frame.mk_fields ~audio ~video ~midi ()
+        Frame.Fields.make ~audio ~video ~midi ()
     | _ -> assert false
 
 (** Type of audio formats that can encode frame of a given kind. *)

--- a/src/core/types/frame_type.ml
+++ b/src/core/types/frame_type.ml
@@ -25,7 +25,7 @@ module Type = Liquidsoap_lang.Type
 let make ?pos base_type fields =
   Frame.Fields.fold
     (fun field field_type typ ->
-      let field = Frame.string_of_field field in
+      let field = Frame.Fields.string_of_field field in
       let meth =
         {
           Type.meth = field;
@@ -42,7 +42,7 @@ let internal ?pos () =
   Type.var ?pos ~constraints:[Format_type.internal_media] ()
 
 let set_field frame_type field field_type =
-  let field = Frame.string_of_field field in
+  let field = Frame.Fields.string_of_field field in
   let meth =
     {
       Type.meth = field;
@@ -55,7 +55,7 @@ let set_field frame_type field field_type =
   Type.make (Type.Meth (meth, frame_type))
 
 let get_field frame_type field =
-  let field = Frame.string_of_field field in
+  let field = Frame.Fields.string_of_field field in
   let fields, _ = Type.split_meths frame_type in
   match
     List.find_map
@@ -82,7 +82,7 @@ let content_type frame_type =
             else None
           in
           let default_t =
-            make (Type.var ()) (Frame.mk_fields ?audio ?video ())
+            make (Type.var ()) (Frame.Fields.make ?audio ?video ())
           in
           Typing.(frame_type <: default_t);
           default_t
@@ -95,7 +95,9 @@ let content_type frame_type =
            ({ Type.meth = field; scheme = _, ty } as meth) ->
         let format = Format_type.content_type ty in
         let format_type = Type.make (Format_type.descr (`Format format)) in
-        ( Frame.set_field content_type (Frame.field_of_string field) format,
+        ( Frame.Fields.add
+            (Frame.Fields.field_of_string field)
+            format content_type,
           Type.make
             (Type.Meth
                ( { meth with Type.scheme = ([], format_type) },

--- a/src/core/visualization/video_volume.ml
+++ b/src/core/visualization/video_volume.ml
@@ -79,7 +79,7 @@ class visu source =
         let vFrame =
           Frame.(
             create
-              (Frame.mk_fields ~video:Content.(default_format Video.kind) ()))
+              (Frame.Fields.make ~video:Content.(default_format Video.kind) ()))
         in
         Frame.set_video frame (VFrame.content vFrame);
 
@@ -141,7 +141,7 @@ class visu source =
 let () =
   let frame_t =
     Lang.frame_t (Lang.univ_t ())
-      (Frame.mk_fields ~audio:(Format_type.audio ()) ())
+      (Frame.Fields.make ~audio:(Format_type.audio ()) ())
   in
   Lang.add_operator "video.volume"
     [("", Lang.source_t frame_t, None, None)]

--- a/src/core/visualization/vis_volume.ml
+++ b/src/core/visualization/vis_volume.ml
@@ -118,7 +118,7 @@ class vumeter ~kind source =
 let () =
   let frame_t =
     Lang.frame_t (Lang.univ_t ())
-      (Frame.mk_fields ~audio:(Format_type.audio ()) ())
+      (Frame.Fields.make ~audio:(Format_type.audio ()) ())
   in
   Lang.add_operator "visu.volume"
     [("", Lang.source_t frame_t, None, None)]

--- a/src/libs/ffmpeg.liq
+++ b/src/libs/ffmpeg.liq
@@ -28,7 +28,7 @@ end
 # @param ~listen Act as a RTMP server and wait for incoming connection
 # @param url URL to read RTMP from, in the form `rtmp://IP:PORT/ENDPOINT`
 def input.rtmp(~id=null(), ~max_buffer=5., ~listen=true, url)
-  input.ffmpeg(id=id, max_buffer=max_buffer, log_overfull=false, format="live_flv",
+  input.ffmpeg(id=id, max_buffer=max_buffer, format="live_flv",
                int_args=[("listen", listen ? 1 : 0)], url)
 end
 %endif

--- a/src/libs/telnet.liq
+++ b/src/libs/telnet.liq
@@ -89,7 +89,10 @@ def replaces input.external.avi(%argsof(input.external.avi), s) =
   s.on_get_ready(memoize({
     server.register(namespace=source.id(s), description="Show internal buffer length (in seconds).",
                     "buffer_length", fun (_) -> begin
-                      let (audio, video, total) = s.buffer_length()
+                      buffered = s.buffered()
+                      audio = list.assoc(default=0., "audio", buffered)
+                      video = list.assoc(default=0., "video", buffered)
+                      total = min(audio, video)
                       "audio buffer length: #{audio}\nvideo buffer length: #{video}\ntotal buffer length: #{total}"
                     end)
   }))

--- a/tests/core/content_test.ml
+++ b/tests/core/content_test.ml
@@ -2,13 +2,13 @@ open Content
 
 let () =
   let marks ?(offset = 0) len = List.init len (fun x -> x + offset) in
-  let c = TrackMark.(lift_data (make ~length:1000 ())) in
-  let c' = TrackMark.(lift_data (make ~length:10 ())) in
-  TrackMark.set_data c (marks 1000);
+  let c = Track_marks.(lift_data (make ~length:1000 ())) in
+  let c' = Track_marks.(lift_data (make ~length:10 ())) in
+  Track_marks.set_data c (marks 1000);
   (* Track marks outside of the declared length should be ignored. *)
-  TrackMark.set_data c' (marks 10);
-  assert (TrackMark.get_data c' = marks 10);
-  assert (TrackMark.get_data (Content.sub c 5 10) = List.init 10 (fun x -> x));
-  TrackMark.set_data c' [];
+  Track_marks.set_data c' (marks 10);
+  assert (Track_marks.get_data c' = marks 10);
+  assert (Track_marks.get_data (Content.sub c 5 10) = List.init 10 (fun x -> x));
+  Track_marks.set_data c' [];
   Content.blit c' 0 c 5 10;
-  assert (TrackMark.get_data c = marks 5 @ marks ~offset:15 (1000 - 15))
+  assert (Track_marks.get_data c = marks 5 @ marks ~offset:15 (1000 - 15))

--- a/tests/core/decoder_test.ml
+++ b/tests/core/decoder_test.ml
@@ -17,39 +17,39 @@ let () =
   let midi = Content.(Midi.lift_params { Content.channels = 1 }) in
   assert (
     Decoder.can_decode_type
-      (Frame.mk_fields ~audio:stereo ())
-      (Frame.mk_fields ~audio:stereo ()));
+      (Frame.Fields.make ~audio:stereo ())
+      (Frame.Fields.make ~audio:stereo ()));
   assert (
     Decoder.can_decode_type
-      (Frame.mk_fields ~audio:mono ())
-      (Frame.mk_fields ~audio:stereo ()));
+      (Frame.Fields.make ~audio:mono ())
+      (Frame.Fields.make ~audio:stereo ()));
   assert (
     Decoder.can_decode_type
-      (Frame.mk_fields ~audio:five_point_one ())
-      (Frame.mk_fields ~audio:stereo ()));
+      (Frame.Fields.make ~audio:five_point_one ())
+      (Frame.Fields.make ~audio:stereo ()));
   assert (
     not
       (Decoder.can_decode_type
-         (Frame.mk_fields ~audio:mono ())
-         (Frame.mk_fields ~audio:stereo ~video:canvas ())));
+         (Frame.Fields.make ~audio:mono ())
+         (Frame.Fields.make ~audio:stereo ~video:canvas ())));
   assert (
     Decoder.can_decode_type
-      (Frame.mk_fields ~audio:mono ~video:canvas ())
-      (Frame.mk_fields ~audio:stereo ~video:canvas ()));
+      (Frame.Fields.make ~audio:mono ~video:canvas ())
+      (Frame.Fields.make ~audio:stereo ~video:canvas ()));
   assert (
     not
       (Decoder.can_decode_type
-         (Frame.mk_fields ~audio:mono ())
-         (Frame.mk_fields ~audio:stereo ~midi ())));
+         (Frame.Fields.make ~audio:mono ())
+         (Frame.Fields.make ~audio:stereo ~midi ())));
   assert (
     Decoder.can_decode_type
-      (Frame.mk_fields ~audio:stereo ~video:canvas ~midi ())
-      (Frame.mk_fields ~audio:stereo ~midi ()));
+      (Frame.Fields.make ~audio:stereo ~video:canvas ~midi ())
+      (Frame.Fields.make ~audio:stereo ~midi ()));
   assert (
     Decoder.can_decode_type
-      (Frame.mk_fields ~audio:stereo ~video:canvas ~midi ())
-      (Frame.mk_fields ~audio:stereo ~video:canvas ~midi ()));
+      (Frame.Fields.make ~audio:stereo ~video:canvas ~midi ())
+      (Frame.Fields.make ~audio:stereo ~video:canvas ~midi ()));
   assert (
     Decoder.can_decode_type
-      (Frame.mk_fields ~audio:stereo ~video:canvas ~midi ())
-      (Frame.mk_fields ~video:canvas ~midi ()))
+      (Frame.Fields.make ~audio:stereo ~video:canvas ~midi ())
+      (Frame.Fields.make ~video:canvas ~midi ()))

--- a/tests/core/frame_test.ml
+++ b/tests/core/frame_test.ml
@@ -3,7 +3,7 @@ open Frame
 let () =
   Frame_settings.lazy_config_eval := true;
 
-  let src = create (Frame.mk_fields ()) in
+  let src = create (Frame.Fields.make ()) in
   add_break src (Lazy.force size);
   let m = Hashtbl.create 1 in
   Hashtbl.add m "foo" "bar";
@@ -11,14 +11,14 @@ let () =
 
   (* First check that last meta from src is
      set when dst does not have one. *)
-  let dst = create (Frame.mk_fields ()) in
+  let dst = create (Frame.Fields.make ()) in
   add_break dst 1;
   get_chunk dst src;
   assert (get_all_metadata dst = [(1, m)]);
 
   (* Then check that is not set when it has
      one that is the same. *)
-  let dst = create (Frame.mk_fields ()) in
+  let dst = create (Frame.Fields.make ()) in
   add_break dst 1;
   let m' = Hashtbl.create 1 in
   Hashtbl.add m' "foo" "bar";
@@ -28,7 +28,7 @@ let () =
 
   (* Then check that it is set when it has one
      but it is different. *)
-  let dst = create (Frame.mk_fields ()) in
+  let dst = create (Frame.Fields.make ()) in
   add_break dst 1;
   let m' = Hashtbl.create 1 in
   Hashtbl.add m' "gni" "gno";
@@ -39,6 +39,6 @@ let () =
 let () =
   let pcm_t =
     Lang.frame_t (Lang.univ_t ())
-      (Frame.mk_fields ~audio:(Format_type.audio ()) ())
+      (Frame.Fields.make ~audio:(Format_type.audio ()) ())
   in
   Typing.(pcm_t <: Lang.univ_t ())

--- a/tests/core/output_encoded_test.ml
+++ b/tests/core/output_encoded_test.ml
@@ -34,7 +34,7 @@ class encoded_test =
 let () =
   Frame_settings.lazy_config_eval := true;
   let encoded_test = new encoded_test in
-  let frame = Frame.dummy in
+  let frame = Frame.dummy () in
   Frame.add_break frame (Lazy.force Frame.size);
   let m = Hashtbl.create 1 in
   Hashtbl.add m "foo" "bla";

--- a/tests/core/output_test.ml
+++ b/tests/core/output_test.ml
@@ -19,6 +19,7 @@ class failed =
 
     method! get frame =
       Frame.add_break frame (Lazy.force Frame.size);
+      Printf.printf "Frame pos: %d\n%!" (Frame.position frame);
       assert (not (Frame.is_partial frame))
   end
 

--- a/tests/media/dune.inc
+++ b/tests/media/dune.inc
@@ -2,6 +2,46 @@
 (rule
   (alias runtest)
   (package liquidsoap)
+  (target @fdkaac[aot='mpeg4_aac_lc',channels=1]_encoder.liq)
+  (deps
+    (:mk_encoder_test ./mk_encoder_test.sh)
+    (:test_encoder_in ./test_encoder.liq.in))
+  (action
+    (with-stdout-to %{target}
+      (run %{mk_encoder_test} "%fdkaac(aot=\"mpeg4_aac_lc\",channels=1)" sine "@fdkaac[aot='mpeg4_aac_lc',channels=1].aac"))))
+(rule
+  (alias runtest)
+  (package liquidsoap)
+  (target @fdkaac[channels=2]_encoder.liq)
+  (deps
+    (:mk_encoder_test ./mk_encoder_test.sh)
+    (:test_encoder_in ./test_encoder.liq.in))
+  (action
+    (with-stdout-to %{target}
+      (run %{mk_encoder_test} "%fdkaac(channels=2)" sine "@fdkaac[channels=2].aac"))))
+(rule
+  (alias runtest)
+  (package liquidsoap)
+  (target @shine[channels=1]_encoder.liq)
+  (deps
+    (:mk_encoder_test ./mk_encoder_test.sh)
+    (:test_encoder_in ./test_encoder.liq.in))
+  (action
+    (with-stdout-to %{target}
+      (run %{mk_encoder_test} "%shine(channels=1)" sine "@shine[channels=1].mp3"))))
+(rule
+  (alias runtest)
+  (package liquidsoap)
+  (target @shine[channels=2]_encoder.liq)
+  (deps
+    (:mk_encoder_test ./mk_encoder_test.sh)
+    (:test_encoder_in ./test_encoder.liq.in))
+  (action
+    (with-stdout-to %{target}
+      (run %{mk_encoder_test} "%shine(channels=2)" sine "@shine[channels=2].mp3"))))
+(rule
+  (alias runtest)
+  (package liquidsoap)
   (target @flac[stereo]_encoder.liq)
   (deps
     (:mk_encoder_test ./mk_encoder_test.sh)
@@ -159,6 +199,58 @@
   (action
     (with-stdout-to %{target}
       (run %{mk_encoder_test} "%ffmpeg(format=\"mp4\",%audio.none,%video(codec=\"libx264\"))" noise "@ffmpeg[format='mp4',@audio.none,@video[codec='libx264']].mp4"))))
+(rule
+ (alias runtest)
+ (package liquidsoap)
+ (target @fdkaac[aot='mpeg4_aac_lc',channels=1].aac)
+ (deps
+  (:encoder @fdkaac[aot='mpeg4_aac_lc',channels=1]_encoder.liq)
+  (source_tree ../../src/libs)
+  ../../src/bin/liquidsoap.exe
+  (:stdlib ../../src/libs/stdlib.liq)
+  (:test_liq ../test.liq)
+  (:run_test ../run_test.exe))
+ (action
+   (run %{run_test} %{encoder} liquidsoap %{test_liq} %{encoder} -- "%fdkaac(aot=\"mpeg4_aac_lc\",channels=1)")))
+(rule
+ (alias runtest)
+ (package liquidsoap)
+ (target @fdkaac[channels=2].aac)
+ (deps
+  (:encoder @fdkaac[channels=2]_encoder.liq)
+  (source_tree ../../src/libs)
+  ../../src/bin/liquidsoap.exe
+  (:stdlib ../../src/libs/stdlib.liq)
+  (:test_liq ../test.liq)
+  (:run_test ../run_test.exe))
+ (action
+   (run %{run_test} %{encoder} liquidsoap %{test_liq} %{encoder} -- "%fdkaac(channels=2)")))
+(rule
+ (alias runtest)
+ (package liquidsoap)
+ (target @shine[channels=1].mp3)
+ (deps
+  (:encoder @shine[channels=1]_encoder.liq)
+  (source_tree ../../src/libs)
+  ../../src/bin/liquidsoap.exe
+  (:stdlib ../../src/libs/stdlib.liq)
+  (:test_liq ../test.liq)
+  (:run_test ../run_test.exe))
+ (action
+   (run %{run_test} %{encoder} liquidsoap %{test_liq} %{encoder} -- "%shine(channels=1)")))
+(rule
+ (alias runtest)
+ (package liquidsoap)
+ (target @shine[channels=2].mp3)
+ (deps
+  (:encoder @shine[channels=2]_encoder.liq)
+  (source_tree ../../src/libs)
+  ../../src/bin/liquidsoap.exe
+  (:stdlib ../../src/libs/stdlib.liq)
+  (:test_liq ../test.liq)
+  (:run_test ../run_test.exe))
+ (action
+   (run %{run_test} %{encoder} liquidsoap %{test_liq} %{encoder} -- "%shine(channels=2)")))
 (rule
  (alias runtest)
  (package liquidsoap)
@@ -372,7 +464,11 @@
   (package liquidsoap)
   (target all_media_files)
   (deps
-    @flac[stereo].flac
+    @fdkaac[aot='mpeg4_aac_lc',channels=1].aac
+@fdkaac[channels=2].aac
+@shine[channels=1].mp3
+@shine[channels=2].mp3
+@flac[stereo].flac
 @flac[mono].flac
 @wav[stereo].wav
 @wav[mono].wav
@@ -389,6 +485,162 @@
 @ffmpeg[format='mp4',@audio[codec='aac',channels=2],@video[codec='libx264']].mp4
 @ffmpeg[format='mp4',@audio.none,@video[codec='libx264']].mp4)
   (action (run touch %{target})))
+(rule
+ (alias runtest)
+ (package liquidsoap)
+ (deps
+  all_media_files
+  test_mono.liq
+  ../../src/bin/liquidsoap.exe
+  (source_tree ../../src/libs)
+  (:stdlib ../../src/libs/stdlib.liq)
+  (:test_liq ../test.liq)
+  (:run_test ../run_test.exe))
+ (action
+  (run %{run_test} "Mono decoding test for @fdkaac[aot='mpeg4_aac_lc',channels=1].aac" liquidsoap %{test_liq} test_mono.liq -- "@fdkaac[aot='mpeg4_aac_lc',channels=1].aac")))
+(rule
+ (alias runtest)
+ (package liquidsoap)
+ (deps
+  all_media_files
+  test_stereo.liq
+  ../../src/bin/liquidsoap.exe
+  (source_tree ../../src/libs)
+  (:stdlib ../../src/libs/stdlib.liq)
+  (:test_liq ../test.liq)
+  (:run_test ../run_test.exe))
+ (action
+  (run %{run_test} "Stereo decoding test for @fdkaac[aot='mpeg4_aac_lc',channels=1].aac" liquidsoap %{test_liq} test_stereo.liq -- "@fdkaac[aot='mpeg4_aac_lc',channels=1].aac")))
+(rule
+ (alias runtest)
+ (package liquidsoap)
+ (deps
+  all_media_files
+  test_ffmpeg_audio_decoder.liq
+  ../../src/bin/liquidsoap.exe
+  (source_tree ../../src/libs)
+  (:stdlib ../../src/libs/stdlib.liq)
+  (:test_liq ../test.liq)
+  (:run_test ../run_test.exe))
+ (action
+  (run %{run_test} "FFmpeg audio decoder test for @fdkaac[aot='mpeg4_aac_lc',channels=1].aac" liquidsoap %{test_liq} test_ffmpeg_audio_decoder.liq -- "@fdkaac[aot='mpeg4_aac_lc',channels=1].aac")))
+(rule
+ (alias runtest)
+ (package liquidsoap)
+ (deps
+  all_media_files
+  test_mono.liq
+  ../../src/bin/liquidsoap.exe
+  (source_tree ../../src/libs)
+  (:stdlib ../../src/libs/stdlib.liq)
+  (:test_liq ../test.liq)
+  (:run_test ../run_test.exe))
+ (action
+  (run %{run_test} "Mono decoding test for @fdkaac[channels=2].aac" liquidsoap %{test_liq} test_mono.liq -- "@fdkaac[channels=2].aac")))
+(rule
+ (alias runtest)
+ (package liquidsoap)
+ (deps
+  all_media_files
+  test_stereo.liq
+  ../../src/bin/liquidsoap.exe
+  (source_tree ../../src/libs)
+  (:stdlib ../../src/libs/stdlib.liq)
+  (:test_liq ../test.liq)
+  (:run_test ../run_test.exe))
+ (action
+  (run %{run_test} "Stereo decoding test for @fdkaac[channels=2].aac" liquidsoap %{test_liq} test_stereo.liq -- "@fdkaac[channels=2].aac")))
+(rule
+ (alias runtest)
+ (package liquidsoap)
+ (deps
+  all_media_files
+  test_ffmpeg_audio_decoder.liq
+  ../../src/bin/liquidsoap.exe
+  (source_tree ../../src/libs)
+  (:stdlib ../../src/libs/stdlib.liq)
+  (:test_liq ../test.liq)
+  (:run_test ../run_test.exe))
+ (action
+  (run %{run_test} "FFmpeg audio decoder test for @fdkaac[channels=2].aac" liquidsoap %{test_liq} test_ffmpeg_audio_decoder.liq -- "@fdkaac[channels=2].aac")))
+(rule
+ (alias runtest)
+ (package liquidsoap)
+ (deps
+  all_media_files
+  test_mono.liq
+  ../../src/bin/liquidsoap.exe
+  (source_tree ../../src/libs)
+  (:stdlib ../../src/libs/stdlib.liq)
+  (:test_liq ../test.liq)
+  (:run_test ../run_test.exe))
+ (action
+  (run %{run_test} "Mono decoding test for @shine[channels=1].mp3" liquidsoap %{test_liq} test_mono.liq -- "@shine[channels=1].mp3")))
+(rule
+ (alias runtest)
+ (package liquidsoap)
+ (deps
+  all_media_files
+  test_stereo.liq
+  ../../src/bin/liquidsoap.exe
+  (source_tree ../../src/libs)
+  (:stdlib ../../src/libs/stdlib.liq)
+  (:test_liq ../test.liq)
+  (:run_test ../run_test.exe))
+ (action
+  (run %{run_test} "Stereo decoding test for @shine[channels=1].mp3" liquidsoap %{test_liq} test_stereo.liq -- "@shine[channels=1].mp3")))
+(rule
+ (alias runtest)
+ (package liquidsoap)
+ (deps
+  all_media_files
+  test_ffmpeg_audio_decoder.liq
+  ../../src/bin/liquidsoap.exe
+  (source_tree ../../src/libs)
+  (:stdlib ../../src/libs/stdlib.liq)
+  (:test_liq ../test.liq)
+  (:run_test ../run_test.exe))
+ (action
+  (run %{run_test} "FFmpeg audio decoder test for @shine[channels=1].mp3" liquidsoap %{test_liq} test_ffmpeg_audio_decoder.liq -- "@shine[channels=1].mp3")))
+(rule
+ (alias runtest)
+ (package liquidsoap)
+ (deps
+  all_media_files
+  test_mono.liq
+  ../../src/bin/liquidsoap.exe
+  (source_tree ../../src/libs)
+  (:stdlib ../../src/libs/stdlib.liq)
+  (:test_liq ../test.liq)
+  (:run_test ../run_test.exe))
+ (action
+  (run %{run_test} "Mono decoding test for @shine[channels=2].mp3" liquidsoap %{test_liq} test_mono.liq -- "@shine[channels=2].mp3")))
+(rule
+ (alias runtest)
+ (package liquidsoap)
+ (deps
+  all_media_files
+  test_stereo.liq
+  ../../src/bin/liquidsoap.exe
+  (source_tree ../../src/libs)
+  (:stdlib ../../src/libs/stdlib.liq)
+  (:test_liq ../test.liq)
+  (:run_test ../run_test.exe))
+ (action
+  (run %{run_test} "Stereo decoding test for @shine[channels=2].mp3" liquidsoap %{test_liq} test_stereo.liq -- "@shine[channels=2].mp3")))
+(rule
+ (alias runtest)
+ (package liquidsoap)
+ (deps
+  all_media_files
+  test_ffmpeg_audio_decoder.liq
+  ../../src/bin/liquidsoap.exe
+  (source_tree ../../src/libs)
+  (:stdlib ../../src/libs/stdlib.liq)
+  (:test_liq ../test.liq)
+  (:run_test ../run_test.exe))
+ (action
+  (run %{run_test} "FFmpeg audio decoder test for @shine[channels=2].mp3" liquidsoap %{test_liq} test_ffmpeg_audio_decoder.liq -- "@shine[channels=2].mp3")))
 (rule
  (alias runtest)
  (package liquidsoap)

--- a/tests/media/gen_dune.ml
+++ b/tests/media/gen_dune.ml
@@ -34,6 +34,10 @@ let standalone_tests =
 
 let audio_formats =
   [
+    {|%fdkaac(aot="mpeg4_aac_lc",channels=1).aac|};
+    "%fdkaac(channels=2).aac";
+    "%shine(channels=1).mp3";
+    "%shine(channels=2).mp3";
     "%flac(stereo).flac";
     "%flac(mono).flac";
     "%wav(stereo).wav";


### PR DESCRIPTION
The PR rewrites the generators to be ready to support multiple channels in sources.

**Naming note:** OCaml has a `Buffer` module so, in Liquidsoap, we call buffer `Generators`. When clear, the two words may be interchangeable.

**Some context:** "switch to immutable" content is a plan that's been in the work for a while. The old content framework was using frames of fixed content length that was copied/overwritten on each streaming cycle with break marks marking how much had been filled. This has proven complicated for many reasons, in particular a semantic confusion between partial fill and end of tracks and also very specific requirements on breaks.

Instead, we would like to switch to a model where:
* Content are immutable chunks of data with `offset` and `length`
* Getting a smaller slice of a piece of content just means adjusting `offset` and `length`
* Filling up a frame means concatenating immutable content chunks.

Key takeways:

#### The full switch to immutable content should happen with OCaml 5

We are planning a deep rewrite of the streaming model and loop using OCaml 5 effects. This will require a lot of internal changes. With what was learned here, it seems that we should just do both at the same time. Changing to immutable content  already requires touching all these parts and, with all the quirks we have accumulated over the years b/c of the break/track mark situation, we would have to work around that a lot just to remove it when changing the streaming model.

#### Breaks as both track marks and filling marks is definitely a first-class footgun.

I cannot count the number of times I tripped on this doing those changes. Fortunately, we have a lof of tests and internal assertions to catch it.

#### The whole concept of `PTS` (Presentation TimeStamp) is totally removed from our internals

This concept was introduced early in the `2.0.x` cycle with the hope of mimicking what `ffmpeg` does but there are striking differences from our point of view:
* We do not do any consistent muxing/demuxing
* We allow source switch dynamically

Therefore, it should be possible to:
* Take a `audio/video` source
* Split `audio` and `video`
* Initialize another `audio2` source
* Delay and add a flanger effect to the `audio` source, creating a new `audio3` source
* Create a source with the one `video` track, alternating between the 3 audio sources

In a situation like this, there is no way to add a consistent notion of `PTS` that will support what the user is trying to do.

`FPS` as a concept still exist for everything `ffmpeg`. In particular, we do have a mechanism that took us a long time to perfect to keep consistent `PTS` accros streams when outputting to `ffmpeg`. This mechanism will indeed guarantee that audio and video keep in sync when demuxing and remuxing encoded tracks, which is what most people would expect.

#### Generators use the new immutable content

With no PTS, generators become really much more simpler. All they do is queue up chunks of immutable content. The buffered length is the smallest of all queued content. This becomes a little more hairy with discrete content, more on this later.

With the changes, generators are now initialized with a `content_type`, to which metadata and track marks (the future replacement to breaks) are added.

Frame are now also generators, initialized with content of the frame's size. This creates a little bit of a conundrum but allow for one single implementation for everything holding content. Eventually, with the switch to immutable content, frame as a concept will disappear and sources will just be holding a buffer of the content that they have produced during the current streaming cycle.

To this purpose, sources now hold a default `buffer`, initialized with the source's `content_type`, making it simpler to store and retrieve data for a given source.

#### Timed content is still imperfect

The general idea for immutable content is that content would be _appended_ to the buffer and then, when enough content has been added for each type of content, we slice off one chunk to output.

This makes it a little tricky for timed content, though. Imagine a situation where bot `audio` and `video` content have been produced but no metadata was generated. 

In this case, we may have some audio and video queued but no metadata:
```
----------
| audio  |
----------
---------------
| video       |
---------------
-
| metadata
-
```

In such a situation, we may not be able to output a content chunk both `audio`/`video` and `metadata` because the metadata content is still empty.

In the future, we will want to make sure that each streaming cycle does generate a metadata content chunk, possibly with no metadata in it. However, this was too much of a change for this PR.

Therefore, timed content have been changed to allow _infinite_ content chunks. These content chunks have infinite length. One can add metadata/track marks at any point in the future and it's possible to either get a finite slice of them or truncate then when advancing the buffer:

```
----------
| audio  |
----------
---------------
| video       |
---------------
-----------------------------------------------------
| metadata                                          ...................
-----------------------------------------------------
```

While this is neat, this is also a foot gun which should be removed once we switch to immutable content.

With all being said, let's review, comment, merge and move on to the fun part: adding support for generic track muxing, demuxing and multi track support!