### PR TITLE
Record spread and `never` type

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,8 @@ New:
   - `file.replaygain` to compute the replaygain of a file
 - Added support for ImageLib to decode images.
 - Added support for completion in emacs based on company (#2652).
+- Added syntactic sugar for record spread: `let {foo, gni, ..y} = x`
+  and `y = { foo = 123, gni = "aabb", ...x}` (#2737)
 
 Changed:
 

--- a/doc/content/language.md
+++ b/doc/content/language.md
@@ -879,6 +879,26 @@ the duration with
 print("The duration of the song is #{song.duration} seconds")
 ```
 
+Records can be re-used using _spreads_:
+
+```liquidsoap
+song = { filename = "song.mp3", duration = 257., bpm = 132. }
+
+# This is a fresh value with all the fields from `song` and
+# a new `id` field:
+song_with_id = { id = 1234, ...song }
+```
+
+Alternatively, you can also extend a record using the explicit `v.{...}` syntax:
+
+```liquidsoap
+song = { filename = "song.mp3", duration = 257., bpm = 132. }
+
+# This is a fresh value with all the fields from `song` and
+# a new `id` field:
+song_with_id = song.{id = 1234}
+```
+
 ### Modules
 
 Records are heavily used in Liquidsoap in order to structure the functions of
@@ -1071,6 +1091,10 @@ Here are some examples:
 # Record capture
 let {foo, bar} = {foo = 123, bar = "baz", gni = true}
 # foo = 123, bar = "baz"
+
+# Record capture with spread
+let {foo, bar, ...x} = {foo = 123, bar = "baz", gni = true}
+# foo = 123, bar = "baz", x = {gni = true}
 
 # Module capture
 let v.{foo, bar} = "aabbcc".{foo = 123, bar = "baz", gni = true}

--- a/src/lang/evaluation.ml
+++ b/src/lang/evaluation.ml
@@ -84,6 +84,14 @@ let rec eval_pat pat v =
           @ env
       | PMeth (pat, l), _ ->
           let m, v = Value.split_meths v in
+          let fields = List.map fst l in
+          let v =
+            List.fold_left
+              (fun v (l, m) ->
+                if List.mem l fields then v
+                else { v with Value.value = Meth (l, m, v) })
+              v m
+          in
           let env = match pat with None -> env | Some pat -> aux env pat v in
           List.fold_left
             (fun env (lbl, pat) ->

--- a/src/lang/term.ml
+++ b/src/lang/term.ml
@@ -532,8 +532,6 @@ end
 
 module MkAbstract (Def : AbstractDef) = struct
   module T = Type.Ground.Make (struct
-    type t
-
     let name = Def.name
   end)
 

--- a/src/lang/typechecking.ml
+++ b/src/lang/typechecking.ml
@@ -96,6 +96,14 @@ let rec type_of_pat ~level ~pos = function
           | None -> ([], Type.make ?pos (Type.Tuple []))
           | Some pat -> type_of_pat ~level ~pos pat
       in
+      Typing.(
+        ty
+        <: List.fold_left
+             (fun ty (label, _) ->
+               Type.meth ~optional:true label
+                 ([], Type.make ?pos Ground_type.never)
+                 ty)
+             (Type.var ~level ?pos ()) l);
       let env, ty =
         List.fold_left
           (fun (env, ty) (lbl, p) ->

--- a/src/lang/types/ground_type.ml
+++ b/src/lang/types/ground_type.ml
@@ -21,8 +21,6 @@
  *****************************************************************************)
 
 module type Spec = sig
-  type t
-
   val name : string
 end
 
@@ -69,34 +67,32 @@ module Make (S : Spec) = struct
 end
 
 module Int = Make (struct
-  type t = int
-
   let name = "int"
 end)
 
 let int = Int.descr
 
 module Float = Make (struct
-  type t = float
-
   let name = "float"
 end)
 
 let float = Float.descr
 
 module String = Make (struct
-  type t = string
-
   let name = "string"
 end)
 
 let string = String.descr
 
 module Bool = Make (struct
-  type t = bool
-
   let name = "bool"
 end)
 
 let bool = Bool.descr
+
+module Never = Make (struct
+  let name = "never"
+end)
+
+let never = Bool.descr
 let is_ground v = List.mem v !types

--- a/src/lang/types/ground_type.ml
+++ b/src/lang/types/ground_type.ml
@@ -94,5 +94,5 @@ module Never = Make (struct
   let name = "never"
 end)
 
-let never = Bool.descr
+let never = Never.descr
 let is_ground v = List.mem v !types

--- a/src/lang/types/ground_type.mli
+++ b/src/lang/types/ground_type.mli
@@ -21,8 +21,6 @@
  *****************************************************************************)
 
 module type Spec = sig
-  type t
-
   val name : string
 end
 
@@ -48,4 +46,8 @@ val string : Type_base.descr
 module Bool : Custom
 
 val bool : Type_base.descr
+
+module Never : Custom
+
+val never : Type_base.descr
 val is_ground : Type_base.custom -> bool

--- a/tests/language/record.liq
+++ b/tests/language/record.liq
@@ -173,6 +173,43 @@ def f() =
   test.equals(f({ foo = (fun (_) -> { gni = 2 } ) }), 2)
   test.equals(f(456.{ foo = (fun (_) -> true.{ gni = 2 } ) }), 2)
 
+  # Spread patterns:
+  x = { foo = 123, gni = "aabb" }
+  let { foo, ...y } = x
+  test.equals(foo, 123)
+  test.equals(y.gni, "aabb")
+  test.equals(y, ())
+  test.equals(y?.foo, null())
+
+  x = 1.{ foo = 123, gni = "aabb" }
+  let { foo, ...y } = x
+  test.equals(foo, 123)
+  test.equals(y.gni, "aabb")
+  test.equals(y, 1)
+  test.equals(y?.foo, null())
+
+  x = 1.{ foo = 123, gni = "aabb" }
+  let y.{ foo } = x
+  test.equals(foo, 123)
+  test.equals(y.gni, "aabb")
+  test.equals(y, 1)
+  test.equals(y?.foo, null())
+
+  x = {foo = 3.14}.{ foo = 123, gni = "aabb" }
+  let { foo, ...y } = x
+  test.equals(foo, 123)
+  test.equals(y.gni, "aabb")
+  test.equals(y, ())
+  test.equals(y?.foo, null())
+
+  x = { foo = 123, gni = "aabb" }
+  y = { bla = 3.14, ...x }
+  test.equals(y, { foo = 123, gni = "aabb", bla = 3.14 })
+
+  x = 1.{ foo = 123, gni = "aabb" }
+  y = { bla = 3.14, ...x }
+  test.equals(y, 1.{ foo = 123, gni = "aabb", bla = 3.14 })
+
   test.pass()
 end
 

--- a/tests/language/type_errors.liq
+++ b/tests/language/type_errors.liq
@@ -210,6 +210,14 @@ def f() =
   correct("fun (x) -> x.foo.gni?.bla(1,2,3).blo")
   correct("fun (x) -> x?.foo(123).gni ?? null()")
 
+  section("PATTERNS")
+  incorrect("
+  def f(x) =
+    let y.{foo} = x
+    y.foo + 1
+    end
+  ")
+
   test.pass()
 end
 


### PR DESCRIPTION
This PR does two things:

#### Add an impossible `never` type when removing record methods

Example:
```ruby
def f(x) =
 let y.{foo, gni} = x
 y
end

f : ('c.{foo : 'b, gni : 'a}) -> 'c.{foo? : never, gni? : never} = <fun>
```

This makes sure that the returned `y` value never has any `foo` or `gni` method, which is the runtime behavior. 

Before that, the following was a correct function:
```ruby
def f(x) =
  let y.{foo} = x
  y.foo + 1
end

f : ('b.{foo : 'a}) -> int = <fun>
```

#### Add syntactic sugar for record and record pattern spread

```ruby
# This:
let y.{foo, gni} = x

# Can be written as:
let {foo, gni, ...y} = x

# This:
y = x.{foo = 123, gni = "aabb"}

# Can be written as:
y = {foo = 123, gni = "aabb", ...x}
```

These spread patterns are much more common nowadays and will help programmers being more confident in learning and understanding the language.

Ideally, we would like the spread to only apply to records (unit values with methods) and not other values, for instance:
```ruby
x = 1.{foo = 123}
let { ...y } = x
y : { foo = 123}
```
However, I don't think that this is currently possible with the existing type system because we need to keep the root type universal in case this becomes wrapped into a function:
```ruby
def f(x) =
  let {foo, gni, ...y } = x
   y
end

f : ('c.{foo : 'b, gni : 'a}) -> 'c.{foo? : never, gni? : never} = <fun>
```

There isn't a way currently to both say that `y` should be a record _and_ that it should retain all the other methods from `x`. This might be possible with e.g. a constraint but I didn't want to enter that territory yet as I believe non-unit values with methods are still pretty advanced so why not let the advanced programmer know what they are doing?