### PR TITLE
Decode any number of audio and video track with ffmpeg.

### DIFF
--- a/doc/content/ffmpeg.md
+++ b/doc/content/ffmpeg.md
@@ -96,8 +96,8 @@ our [extra API reference](reference-extras.html). Here's one such filter:
 FFmpeg h264_mp4toannexb bitstream filter. See ffmpeg documentation for more
 details.
 
-Type: (?id : string?, source(video=ffmpeg.video.copy('a), 'b)) ->
-source(video=ffmpeg.video.copy('a), 'b)
+Type: (?id : string?, source(video=ffmpeg.copy('a), 'b)) ->
+source(video=ffmpeg.copy('a), 'b)
 
 Category: Source / FFmpeg filter
 
@@ -106,7 +106,7 @@ Arguments:
  * id : string?
      Force the value of the source ID.
 
- * (unlabeled) : source(video=ffmpeg.video.copy('a), 'b)
+ * (unlabeled) : source(video=ffmpeg.copy('a), 'b)
 
 Methods:
 ...

--- a/src/core/builtins/builtins_callbacks.ml
+++ b/src/core/builtins/builtins_callbacks.ml
@@ -27,7 +27,7 @@ let _ =
     ~descr:"Register a function to be called when Liquidsoap shuts down."
     (fun p ->
       let f = List.assoc "" p in
-      Lifecycle.before_core_shutdown (fun () -> ignore (Lang.apply f []));
+      Lifecycle.after_core_shutdown (fun () -> ignore (Lang.apply f []));
       Lang.unit)
 
 let _ =

--- a/src/core/decoder/decoder.mli
+++ b/src/core/decoder/decoder.mli
@@ -49,8 +49,8 @@ type fps = { num : int; den : int }
     - Implicit content drop *)
 type buffer = {
   generator : Generator.t;
-  put_pcm : samplerate:int -> Content.Audio.data -> unit;
-  put_yuva420p : fps:fps -> Content.Video.data -> unit;
+  put_pcm : ?field:Frame.field -> samplerate:int -> Content.Audio.data -> unit;
+  put_yuva420p : ?field:Frame.field -> fps:fps -> Content.Video.data -> unit;
 }
 
 type decoder = {

--- a/src/core/decoder/ffmpeg_copy_decoder.mli
+++ b/src/core/decoder/ffmpeg_copy_decoder.mli
@@ -1,0 +1,41 @@
+(*****************************************************************************
+
+   Liquidsoap, a programmable audio stream generator.
+   Copyright 2003-2022 Savonet team
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 2 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details, fully stated in the COPYING
+   file at the root of the liquidsoap distribution.
+
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA
+
+  *****************************************************************************)
+
+val mk_audio_decoder :
+  stream_idx:int64 ->
+  format:Content_base.Contents.format ->
+  field:int ->
+  stream:(Avutil.input, Avutil.audio, [ `Packet ]) Av.stream ->
+  Avutil.audio Avcodec.params ->
+  buffer:Decoder.buffer ->
+  Avutil.audio Avcodec.Packet.t ->
+  unit
+
+val mk_video_decoder :
+  stream_idx:int64 ->
+  format:Content_base.Contents.format ->
+  stream:(Avutil.input, Avutil.video, [ `Packet ]) Av.stream ->
+  field:int ->
+  Avutil.video Avcodec.params ->
+  buffer:Decoder.buffer ->
+  Avutil.video Avcodec.Packet.t ->
+  unit

--- a/src/core/decoder/ffmpeg_internal_decoder.mli
+++ b/src/core/decoder/ffmpeg_internal_decoder.mli
@@ -1,0 +1,40 @@
+(*****************************************************************************
+
+   Liquidsoap, a programmable audio stream generator.
+   Copyright 2003-2022 Savonet team
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 2 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details, fully stated in the COPYING
+   file at the root of the liquidsoap distribution.
+
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA
+
+  *****************************************************************************)
+
+val mk_audio_decoder :
+  channels:int ->
+  stream:(Avutil.input, Avutil.audio, [ `Frame ]) Av.stream ->
+  field:Frame.field ->
+  Avutil.audio Avcodec.params ->
+  buffer:Decoder.buffer ->
+  Avutil.audio Avutil.Frame.t ->
+  unit
+
+val mk_video_decoder :
+  width:int ->
+  height:int ->
+  stream:(Avutil.input, Avutil.video, [ `Frame ]) Av.stream ->
+  field:Frame.field ->
+  Avutil.video Avcodec.params ->
+  buffer:Decoder.buffer ->
+  [ `Video ] Avutil.Frame.t ->
+  unit

--- a/src/core/decoder/ffmpeg_raw_decoder.ml
+++ b/src/core/decoder/ffmpeg_raw_decoder.ml
@@ -49,8 +49,7 @@ let mk_decoder ~stream_idx ~stream_time_base ~mk_params ~lift_data ~put_data
           put_data buffer.Decoder.generator data
       | None -> ()
 
-let mk_audio_decoder ~stream_idx ~format container =
-  let idx, stream, params = Av.find_best_audio_stream container in
+let mk_audio_decoder ~stream_idx ~format ~stream ~field params =
   Ffmpeg_decoder_common.set_audio_stream_decoder stream;
   ignore
     (Content.merge format
@@ -58,14 +57,11 @@ let mk_audio_decoder ~stream_idx ~format container =
   let stream_time_base = Av.get_time_base stream in
   let lift_data data = Ffmpeg_raw_content.Audio.lift_data data in
   let mk_params = Ffmpeg_raw_content.AudioSpecs.mk_params in
-  ( idx,
-    stream,
-    mk_decoder ~stream_idx ~lift_data ~mk_params ~stream_time_base
-      ~put_data:(fun g c -> Generator.put g Frame.Fields.audio c)
-      params )
+  mk_decoder ~stream_idx ~lift_data ~mk_params ~stream_time_base
+    ~put_data:(fun g c -> Generator.put g field c)
+    params
 
-let mk_video_decoder ~stream_idx ~format container =
-  let idx, stream, params = Av.find_best_video_stream container in
+let mk_video_decoder ~stream_idx ~format ~stream ~field params =
   Ffmpeg_decoder_common.set_video_stream_decoder stream;
   ignore
     (Content.merge format
@@ -73,8 +69,6 @@ let mk_video_decoder ~stream_idx ~format container =
   let stream_time_base = Av.get_time_base stream in
   let lift_data data = Ffmpeg_raw_content.Video.lift_data data in
   let mk_params = Ffmpeg_raw_content.VideoSpecs.mk_params in
-  ( idx,
-    stream,
-    mk_decoder ~stream_idx ~mk_params ~lift_data ~stream_time_base
-      ~put_data:(fun g c -> Generator.put g Frame.Fields.video c)
-      params )
+  mk_decoder ~stream_idx ~mk_params ~lift_data ~stream_time_base
+    ~put_data:(fun g c -> Generator.put g field c)
+    params

--- a/src/core/decoder/ffmpeg_raw_decoder.mli
+++ b/src/core/decoder/ffmpeg_raw_decoder.mli
@@ -1,0 +1,41 @@
+(*****************************************************************************
+
+   Liquidsoap, a programmable audio stream generator.
+   Copyright 2003-2022 Savonet team
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 2 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details, fully stated in the COPYING
+   file at the root of the liquidsoap distribution.
+
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA
+
+  *****************************************************************************)
+
+val mk_audio_decoder :
+  stream_idx:int64 ->
+  format:Content_base.Contents.format ->
+  stream:(Avutil.input, Avutil.audio, [ `Frame ]) Av.stream ->
+  field:Frame.field ->
+  Avutil.audio Avcodec.params ->
+  buffer:Decoder.buffer ->
+  Avutil.audio Avutil.Frame.t ->
+  unit
+
+val mk_video_decoder :
+  stream_idx:int64 ->
+  format:Content_base.Contents.format ->
+  stream:(Avutil.input, Avutil.video, [ `Frame ]) Av.stream ->
+  field:Frame.field ->
+  Avutil.video Avcodec.params ->
+  buffer:Decoder.buffer ->
+  Avutil.video Avutil.Frame.t ->
+  unit

--- a/src/core/dune
+++ b/src/core/dune
@@ -142,7 +142,6 @@
   lang_encoder
   lang_external_encoder
   lang_fdkaac
-  lang_ffmpeg
   lang_flac
   lang_gstreamer
   lang_mp3
@@ -396,7 +395,8 @@
   ffmpeg_raw_content
   ffmpeg_raw_decoder
   ffmpeg_utils
-  ffmpeg_video_converter))
+  ffmpeg_video_converter
+  lang_ffmpeg))
 
 (library
  (name liquidsoap_flac)

--- a/src/core/encoder_formats/ffmpeg_format.ml
+++ b/src/core/encoder_formats/ffmpeg_format.ml
@@ -26,29 +26,39 @@ type opt_val =
 type copy_opt = [ `Wait_for_keyframe | `Ignore_keyframe ]
 type output = [ `Stream | `Url of string ]
 type opts = (string, opt_val) Hashtbl.t
-
-type codec =
-  [ `Copy of copy_opt | `Raw of string option | `Internal of string option ]
-
 type hwaccel = [ `None | `Auto ]
 
-type t = {
-  format : string option;
-  output : output;
+type audio_options = {
   channels : int;
   samplerate : int Lazy.t;
+  sample_format : string option;
+}
+
+type video_options = {
   framerate : int Lazy.t;
   width : int Lazy.t;
   height : int Lazy.t;
   pixel_format : string option;
   hwaccel : hwaccel;
   hwaccel_device : string option;
-  audio_codec : codec option;
-  sample_format : string option;
-  audio_opts : opts;
-  video_codec : codec option;
-  video_opts : opts;
-  other_opts : opts;
+}
+
+type options = [ `Audio of audio_options | `Video of video_options ]
+
+type encoded_stream = {
+  mode : [ `Raw | `Internal ];
+  codec : string option;
+  options : options;
+  opts : opts;
+}
+
+type stream = [ `Copy of copy_opt | `Encode of encoded_stream ]
+
+type t = {
+  format : string option;
+  output : output;
+  streams : stream Frame.Fields.t;
+  opts : opts;
 }
 
 let string_of_options
@@ -74,60 +84,67 @@ let string_of_copy_opt = function
 let to_string m =
   let opts = [] in
   let opts =
-    if Hashtbl.length m.other_opts > 0 then
-      string_of_options m.other_opts :: opts
-    else opts
+    if Hashtbl.length m.opts > 0 then string_of_options m.opts :: opts else opts
   in
   let opts =
-    match m.video_codec with
-      | None -> opts
-      | Some (`Copy opt) ->
-          Printf.sprintf "%%video.copy(%s)" (string_of_copy_opt opt) :: opts
-      | Some (`Raw (Some c)) | Some (`Internal (Some c)) ->
-          let video_opts =
-            Hashtbl.fold
-              (fun lbl v h ->
-                Hashtbl.add h lbl (v :> [ `Var of string | opt_val ]);
-                h)
-              m.video_opts (Hashtbl.create 10)
-          in
-          Hashtbl.add video_opts "codec" (`String c);
-          Hashtbl.add video_opts "framerate" (`Int (Lazy.force m.framerate));
-          Hashtbl.add video_opts "width" (`Int (Lazy.force m.width));
-          Hashtbl.add video_opts "height" (`Int (Lazy.force m.height));
-          Hashtbl.add video_opts "hwaccel"
-            (`Var (match m.hwaccel with `None -> "none" | `Auto -> "auto"));
-          Hashtbl.add video_opts "hwaccel_device"
-            (match m.hwaccel_device with
-              | None -> `Var "none"
-              | Some d -> `String d);
-          let name =
-            match m.video_codec with
-              | Some (`Raw _) -> "video.raw"
-              | _ -> "video"
-          in
-          Printf.sprintf "%%%s(%s)" name (string_of_options video_opts) :: opts
-      | Some (`Raw None) -> "%video.raw" :: opts
-      | Some (`Internal None) -> "%video" :: opts
-  in
-  let opts =
-    match m.audio_codec with
-      | None -> opts
-      | Some (`Copy opt) ->
-          Printf.sprintf "%%audio.copy(%s)" (string_of_copy_opt opt) :: opts
-      | Some (`Raw (Some c)) | Some (`Internal (Some c)) ->
-          let audio_opts = Hashtbl.copy m.audio_opts in
-          Hashtbl.add audio_opts "codec" (`String c);
-          Hashtbl.add audio_opts "channels" (`Int m.channels);
-          Hashtbl.add audio_opts "samplerate" (`Int (Lazy.force m.samplerate));
-          let name =
-            match m.audio_codec with
-              | Some (`Raw _) -> "audio.raw"
-              | _ -> "audio"
-          in
-          Printf.sprintf "%%%s(%s)" name (string_of_options audio_opts) :: opts
-      | Some (`Raw None) -> "%audio.raw" :: opts
-      | Some (`Internal None) -> "%audio" :: opts
+    Frame.Fields.fold
+      (fun field stream opts ->
+        let name = Frame.Fields.string_of_field field in
+        let name =
+          match stream with
+            | `Copy _ -> "%" ^ name ^ ".copy"
+            | `Encode { mode = `Raw } -> "%" ^ name ^ ".raw"
+            | _ -> "%" ^ name
+        in
+        match stream with
+          | `Copy opt ->
+              Printf.sprintf "%s(%s)" name (string_of_copy_opt opt) :: opts
+          | `Encode { codec; options = `Video options; opts = stream_opts } ->
+              let stream_opts =
+                Hashtbl.fold
+                  (fun lbl v h ->
+                    Hashtbl.add h lbl (v :> [ `Var of string | opt_val ]);
+                    h)
+                  stream_opts (Hashtbl.create 10)
+              in
+              ignore
+                (Option.map
+                   (fun codec ->
+                     Hashtbl.add stream_opts "codec" (`String codec))
+                   codec);
+              Hashtbl.add stream_opts "framerate"
+                (`Int (Lazy.force options.framerate));
+              Hashtbl.add stream_opts "width" (`Int (Lazy.force options.width));
+              Hashtbl.add stream_opts "height"
+                (`Int (Lazy.force options.height));
+              Hashtbl.add stream_opts "hwaccel"
+                (`Var
+                  (match options.hwaccel with
+                    | `None -> "none"
+                    | `Auto -> "auto"));
+              Hashtbl.add stream_opts "hwaccel_device"
+                (match options.hwaccel_device with
+                  | None -> `Var "none"
+                  | Some d -> `String d);
+              Printf.sprintf "%%%s(%s%s)" name
+                (if Pcre.pmatch ~pat:"video" name then "" else "video_content,")
+                (string_of_options stream_opts)
+              :: opts
+          | `Encode { codec; options = `Audio options; opts = stream_opts } ->
+              let stream_opts = Hashtbl.copy stream_opts in
+              ignore
+                (Option.map
+                   (fun codec ->
+                     Hashtbl.add stream_opts "codec" (`String codec))
+                   codec);
+              Hashtbl.add stream_opts "channels" (`Int options.channels);
+              Hashtbl.add stream_opts "samplerate"
+                (`Int (Lazy.force options.samplerate));
+              Printf.sprintf "%s(%s%s)" name
+                (if Pcre.pmatch ~pat:"audio" name then "" else "audio_content,")
+                (string_of_options stream_opts)
+              :: opts)
+      m.streams opts
   in
   let opts =
     match m.format with

--- a/src/core/lang_encoders/lang_ffmpeg.ml
+++ b/src/core/lang_encoders/lang_ffmpeg.ml
@@ -23,309 +23,393 @@
 open Value
 open Ground
 
-let type_of_encoder p =
-  let audio =
-    List.fold_left
-      (fun audio p ->
-        match p with
-          | "", `Encoder ("audio.copy", _) ->
-              Some
-                (`Format
-                  Content.(default_format (kind_of_string "ffmpeg.audio.copy")))
-          | "", `Encoder ("audio.raw", _) ->
-              Some
-                (`Format
-                  Content.(default_format (kind_of_string "ffmpeg.audio.raw")))
-          | "", `Encoder ("audio", p) ->
-              let channels =
+type decode_type = [ `Raw | `Internal ]
+type content_type = [ `Audio | `Video ]
+
+type encoder_params =
+  decode_type * content_type * (string * Liquidsoap_lang.Value.t) list
+
+type mode =
+  [ `Copy of Liquidsoap_lang.Value.t option | `Encode of encoder_params ]
+
+type parsed_encoder = Frame.field * mode
+
+let to_int t =
+  match t.value with
+    | Ground (Int i) -> i
+    | Ground (String s) -> int_of_string s
+    | Ground (Float f) -> int_of_float f
+    | _ -> Lang_encoder.raise_error ~pos:t.pos "integer expected"
+
+let to_string t =
+  match t.value with
+    | Ground (Int i) -> Printf.sprintf "%i" i
+    | Ground (String s) -> s
+    | Ground (Float f) -> Printf.sprintf "%f" f
+    | _ -> Lang_encoder.raise_error ~pos:t.pos "string expected"
+
+let to_float t =
+  match t.value with
+    | Ground (Int i) -> float i
+    | Ground (String s) -> float_of_string s
+    | Ground (Float f) -> f
+    | _ -> Lang_encoder.raise_error ~pos:t.pos "float expected"
+
+let to_copy_opt t =
+  match t.value with
+    | Ground (String "wait_for_keyframe") -> `Wait_for_keyframe
+    | Ground (String "ignore_keyframe") -> `Ignore_keyframe
+    | _ ->
+        Lang_encoder.raise_error ~pos:t.pos
+          ("Invalid value for copy encoder parameter: " ^ Value.to_string t)
+
+let has_content ~to_string name p =
+  List.exists (fun (lbl, v) -> lbl = "" && to_string v = name) p
+
+(* The following conventions are used to
+   infer media type from an encoder:
+   - encoder has "audio" or "video" in its name,
+     e.g. dolby_audio, video_1 etc.
+   - encoder has "audio_content" or "video_content" in its arguments:
+     %track(audio_content, ...) or %track(video_content, ...)
+   - encoder has a static codec string, e.g.
+     %track(codec="libmp3lame") *)
+let stream_media_type ~to_pos ~to_string name args =
+  let raise pos =
+    Lang_encoder.raise_error ~pos
+      {|Unable to find a track media content type. Please use one of the available convention:
+- Use `"audio"` or `"video"` in the track name, e.g. `%dolby_audio`
+- Add `audio_content` or `video_content` to the track parameters, e.g. `%track(audio_content)`
+- Use a static codec string, e.g. `%track(codec="libmp3lame")`|}
+  in
+  match (name, args) with
+    | _ when has_content ~to_string "\"audio_content\"" args -> `Audio
+    | _ when has_content ~to_string "\"video_content\"" args -> `Video
+    | _ when Pcre.pmatch ~pat:"audio" name -> `Audio
+    | _ when Pcre.pmatch ~pat:"video" name -> `Video
+    | _ -> (
+        match List.assoc_opt "codec" args with
+          | Some t -> (
+              let codec = to_string t in
+              try
+                ignore (Avcodec.Audio.find_encoder_by_name codec);
+                `Audio
+              with _ -> (
                 try
-                  let channels =
-                    try List.assoc "channels" p
-                    with Not_found -> List.assoc "ac" p
-                  in
-                  match channels with
-                    | `Term { Term.term = Term.Ground (Int n) } -> n
-                    | _ -> raise Exit
-                with
-                  | Not_found -> 2
-                  | Exit -> raise Not_found
-              in
-              Some
-                (`Format
-                  Content.(
-                    Audio.lift_params
-                      {
-                        Content.channel_layout =
-                          lazy
-                            (Audio_converter.Channel_layout.layout_of_channels
-                               channels);
-                      }))
-          | _ -> audio)
-      None p
-  in
-  let audio = Option.map (fun f -> Type.make (Format_type.descr f)) audio in
-  let video =
-    List.fold_left
-      (fun video p ->
-        match p with
-          | "", `Encoder ("video.copy", _) ->
-              Some
-                (`Format
-                  Content.(default_format (kind_of_string "ffmpeg.video.copy")))
-          | "", `Encoder ("video.raw", _) ->
-              Some
-                (`Format
-                  Content.(default_format (kind_of_string "ffmpeg.video.raw")))
-          | "", `Encoder ("video", _) ->
-              Some (`Format Content.(default_format Video.kind))
-          | _ -> video)
-      None p
-  in
-  let video = Option.map (fun f -> Type.make (Format_type.descr f)) video in
-  Frame.Fields.make ?audio ?video ()
-
-let flag_qscale = ref 0
-let qp2lambda = ref 0
-
-(* Looks like this is how ffmpeg CLI does it.
-   See: https://github.com/FFmpeg/FFmpeg/blob/4782124b90cf915ede2cebd871be82fc0267a135/fftools/ffmpeg_opt.c#L1567-L1570 *)
-let set_global_quality q f =
-  let flags =
-    match Hashtbl.find_opt f.Ffmpeg_format.other_opts "flags" with
-      | Some (`Int f) -> f
-      | Some _ -> assert false
-      | None -> 0
-  in
-  let flags = flags lor !flag_qscale in
-  Hashtbl.replace f.Ffmpeg_format.other_opts "flags" (`Int flags);
-  Hashtbl.replace f.Ffmpeg_format.other_opts "global_quality"
-    (`Float (float !qp2lambda *. q))
-
-let ffmpeg_gen params =
-  let defaults =
-    {
-      Ffmpeg_format.format = None;
-      output = `Stream;
-      channels = 2;
-      samplerate = Frame.audio_rate;
-      framerate = Frame.video_rate;
-      width = Frame.video_width;
-      height = Frame.video_height;
-      pixel_format = None;
-      audio_codec = None;
-      sample_format = None;
-      video_codec = None;
-      hwaccel = `Auto;
-      hwaccel_device = None;
-      audio_opts = Hashtbl.create 0;
-      video_opts = Hashtbl.create 0;
-      other_opts = Hashtbl.create 0;
-    }
-  in
-  let to_int t =
-    match t.value with
-      | Ground (Int i) -> i
-      | Ground (String s) -> int_of_string s
-      | Ground (Float f) -> int_of_float f
-      | _ -> Lang_encoder.raise_error ~pos:t.pos "integer expected"
-  in
-  let to_string t =
-    match t.value with
-      | Ground (Int i) -> Printf.sprintf "%i" i
-      | Ground (String s) -> s
-      | Ground (Float f) -> Printf.sprintf "%f" f
-      | _ -> Lang_encoder.raise_error ~pos:t.pos "string expected"
-  in
-  let to_float t =
-    match t.value with
-      | Ground (Int i) -> float i
-      | Ground (String s) -> float_of_string s
-      | Ground (Float f) -> f
-      | _ -> Lang_encoder.raise_error ~pos:t.pos "float expected"
-  in
-  let to_copy_opt t =
-    match t.value with
-      | Ground (String "wait_for_keyframe") -> `Wait_for_keyframe
-      | Ground (String "ignore_keyframe") -> `Ignore_keyframe
-      | _ ->
-          Lang_encoder.raise_error ~pos:t.pos
-            ("Invalid value for copy encoder parameter: " ^ Value.to_string t)
-  in
-  let rec parse_args ~format ~mode f = function
-    | [] -> f
-    (* Audio options *)
-    | ("channels", t) :: l when mode = `Audio ->
-        parse_args ~format ~mode { f with Ffmpeg_format.channels = to_int t } l
-    | ("ac", t) :: l when mode = `Audio ->
-        parse_args ~format ~mode { f with Ffmpeg_format.channels = to_int t } l
-    | ("samplerate", t) :: l when mode = `Audio ->
-        parse_args ~format ~mode
-          { f with Ffmpeg_format.samplerate = Lazy.from_val (to_int t) }
-          l
-    | ("ar", t) :: l when mode = `Audio ->
-        parse_args ~format ~mode
-          { f with Ffmpeg_format.samplerate = Lazy.from_val (to_int t) }
-          l
-    | ("sample_format", t) :: l when mode = `Audio ->
-        parse_args ~format ~mode
-          { f with Ffmpeg_format.sample_format = Some (to_string t) }
-          l
-    (* Video options *)
-    | ("framerate", t) :: l when mode = `Video ->
-        parse_args ~format ~mode
-          { f with Ffmpeg_format.framerate = Lazy.from_val (to_int t) }
-          l
-    | ("r", t) :: l when mode = `Video ->
-        parse_args ~format ~mode
-          { f with Ffmpeg_format.framerate = Lazy.from_val (to_int t) }
-          l
-    | ("width", t) :: l when mode = `Video ->
-        parse_args ~format ~mode
-          { f with Ffmpeg_format.width = Lazy.from_val (to_int t) }
-          l
-    | ("height", t) :: l when mode = `Video ->
-        parse_args ~format ~mode
-          { f with Ffmpeg_format.height = Lazy.from_val (to_int t) }
-          l
-    | ("pixel_format", { value = Ground (String "none"); _ }) :: l
-      when mode = `Video ->
-        parse_args ~format ~mode { f with Ffmpeg_format.pixel_format = None } l
-    | ("pixel_format", t) :: l when mode = `Video ->
-        parse_args ~format ~mode
-          { f with Ffmpeg_format.pixel_format = Some (to_string t) }
-          l
-    | ("hwaccel", { value = Ground (String "auto"); _ }) :: l when mode = `Video
-      ->
-        parse_args ~format ~mode { f with Ffmpeg_format.hwaccel = `Auto } l
-    | ("hwaccel", { value = Ground (String "none"); _ }) :: l when mode = `Video
-      ->
-        parse_args ~format ~mode { f with Ffmpeg_format.hwaccel = `None } l
-    | ("hwaccel_device", { value = Ground (String "none"); _ }) :: l
-      when mode = `Video ->
-        parse_args ~format ~mode
-          { f with Ffmpeg_format.hwaccel_device = None }
-          l
-    | ("hwaccel_device", t) :: l when mode = `Video ->
-        parse_args ~format ~mode
-          { f with Ffmpeg_format.hwaccel_device = Some (to_string t) }
-          l
-    (* Shared options *)
-    | ("codec", t) :: l ->
-        let f =
-          match (mode, format) with
-            | `Audio, `Internal ->
-                {
-                  f with
-                  Ffmpeg_format.audio_codec =
-                    Some (`Internal (Some (to_string t)));
-                }
-            | `Audio, `Raw ->
-                {
-                  f with
-                  Ffmpeg_format.audio_codec = Some (`Raw (Some (to_string t)));
-                }
-            | `Video, `Internal ->
-                {
-                  f with
-                  Ffmpeg_format.video_codec =
-                    Some (`Internal (Some (to_string t)));
-                }
-            | `Video, `Raw ->
-                {
-                  f with
-                  Ffmpeg_format.video_codec = Some (`Raw (Some (to_string t)));
-                }
-        in
-        parse_args ~format ~mode f l
-    | ("q", t) :: l | ("qscale", t) :: l ->
-        set_global_quality (to_float t) f;
-        parse_args ~format ~mode f l
-    | (k, { value = Ground (String s); _ }) :: l ->
-        (match mode with
-          | `Audio -> Hashtbl.add f.Ffmpeg_format.audio_opts k (`String s)
-          | `Video -> Hashtbl.add f.Ffmpeg_format.video_opts k (`String s));
-        parse_args ~format ~mode f l
-    | (k, { value = Ground (Int i); _ }) :: l ->
-        (match mode with
-          | `Audio -> Hashtbl.add f.Ffmpeg_format.audio_opts k (`Int i)
-          | `Video -> Hashtbl.add f.Ffmpeg_format.video_opts k (`Int i));
-        parse_args ~format ~mode f l
-    | (k, { value = Ground (Float fl); _ }) :: l ->
-        (match mode with
-          | `Audio -> Hashtbl.add f.Ffmpeg_format.audio_opts k (`Float fl)
-          | `Video -> Hashtbl.add f.Ffmpeg_format.video_opts k (`Float fl));
-        parse_args ~format ~mode f l
-    | (_, t) :: _ -> Lang_encoder.raise_error ~pos:t.pos "unexpected option"
-  in
-  List.fold_left
-    (fun f -> function
-      | `Audio_none -> { f with Ffmpeg_format.audio_codec = None; channels = 0 }
-      | `Audio_copy None ->
-          { f with Ffmpeg_format.audio_codec = Some (`Copy `Wait_for_keyframe) }
-      | `Audio_copy (Some t) ->
-          { f with Ffmpeg_format.audio_codec = Some (`Copy (to_copy_opt t)) }
-      | `Audio_raw l ->
-          let f = { f with Ffmpeg_format.audio_codec = Some (`Raw None) } in
-          parse_args ~format:`Raw ~mode:`Audio f l
-      | `Audio l ->
-          let f =
-            { f with Ffmpeg_format.audio_codec = Some (`Internal None) }
-          in
-          parse_args ~format:`Internal ~mode:`Audio f l
-      | `Video_none -> { f with Ffmpeg_format.video_codec = None }
-      | `Video_copy None ->
-          { f with Ffmpeg_format.video_codec = Some (`Copy `Wait_for_keyframe) }
-      | `Video_copy (Some t) ->
-          { f with Ffmpeg_format.video_codec = Some (`Copy (to_copy_opt t)) }
-      | `Video_raw l ->
-          let f = { f with Ffmpeg_format.video_codec = Some (`Raw None) } in
-          parse_args ~format:`Raw ~mode:`Video f l
-      | `Video l ->
-          let f =
-            { f with Ffmpeg_format.video_codec = Some (`Internal None) }
-          in
-          parse_args ~format:`Internal ~mode:`Video f l
-      | `Option ("format", { value = Ground (String "none"); _ }) ->
-          { f with Ffmpeg_format.format = None }
-      | `Option ("format", { value = Ground (String fmt); _ }) ->
-          { f with Ffmpeg_format.format = Some fmt }
-      | `Option (k, { value = Ground (String s); _ }) ->
-          Hashtbl.add f.Ffmpeg_format.other_opts k (`String s);
-          f
-      | `Option (k, { value = Ground (Int i); _ }) ->
-          Hashtbl.add f.Ffmpeg_format.other_opts k (`Int i);
-          f
-      | `Option (k, { value = Ground (Float i); _ }) ->
-          Hashtbl.add f.Ffmpeg_format.other_opts k (`Float i);
-          f
-      | `Option (l, v) -> Lang_encoder.raise_generic_error (l, `Value v))
-    defaults params
+                  ignore (Avcodec.Video.find_encoder_by_name codec);
+                  `Video
+                with _ -> raise (to_pos t)))
+          | None -> raise None)
 
 let copy_param = function
   | [] -> None
   | [("", t)] -> Some t
   | [(l, v)] | _ :: (l, v) :: _ -> Lang_encoder.raise_generic_error (l, `Value v)
 
+let parse_encoder_name name =
+  let field, mode =
+    match String.split_on_char '.' name with
+      | [field] -> (field, "")
+      | field :: mode :: _ -> (field, mode)
+      | _ -> failwith "invalid content field"
+  in
+  let mode =
+    match mode with
+      | "copy" -> `Copy
+      | "raw" -> `Raw
+      | "" -> `Internal
+      | _ -> failwith "invalid content field"
+  in
+  (field, mode)
+
+let parse_encoder_params ~to_pos (name, p) : parsed_encoder =
+  let field, mode = parse_encoder_name name in
+  let mode =
+    match mode with
+      | `Copy -> `Copy (copy_param p)
+      | `Raw ->
+          `Encode
+            ( `Raw,
+              stream_media_type ~to_string:Value.to_string ~to_pos name p,
+              p )
+      | `Internal ->
+          `Encode
+            ( `Internal,
+              stream_media_type ~to_string:Value.to_string ~to_pos name p,
+              p )
+  in
+  let field = Frame.Fields.register field in
+  (field, mode)
+
+let rec term_to_string = function
+  | `Term term -> Term.to_string term
+  | `Encoder (name, []) -> "%" ^ name
+  | `Encoder (name, args) ->
+      "%" ^ name ^ "("
+      ^ String.concat ","
+          (List.map
+             (fun (lbl, arg) -> Printf.sprintf "%s=%s" lbl (term_to_string arg))
+             args)
+      ^ ")"
+
+let term_pos = function
+  | `Term { Term.t = { Type.pos } } -> pos
+  | _ -> raise Exit
+
+let type_of_encoder =
+  List.fold_left
+    (fun content_type p ->
+      match p with
+        | "", `Encoder (name, args) ->
+            let field, mode = parse_encoder_name name in
+            let format =
+              match mode with
+                | `Copy ->
+                    Content.(default_format (kind_of_string "ffmpeg.copy"))
+                | `Raw -> (
+                    match
+                      stream_media_type ~to_pos:term_pos
+                        ~to_string:term_to_string name args
+                    with
+                      | `Audio ->
+                          Content.(
+                            default_format (kind_of_string "ffmpeg.audio.raw"))
+                      | `Video ->
+                          Content.(
+                            default_format (kind_of_string "ffmpeg.video.raw")))
+                | `Internal -> (
+                    match
+                      stream_media_type ~to_pos:term_pos
+                        ~to_string:term_to_string name args
+                    with
+                      | `Audio ->
+                          let channels =
+                            try
+                              let channels =
+                                try List.assoc "channels" args
+                                with Not_found -> List.assoc "ac" args
+                              in
+                              match channels with
+                                | `Term { Term.term = Term.Ground (Int n) } -> n
+                                | _ -> raise Exit
+                            with
+                              | Not_found -> 2
+                              | Exit -> raise Not_found
+                          in
+                          Content.(
+                            Audio.lift_params
+                              {
+                                Content.channel_layout =
+                                  lazy
+                                    (Audio_converter.Channel_layout
+                                     .layout_of_channels channels);
+                              })
+                      | `Video -> Content.(default_format Video.kind))
+            in
+            let field = Frame.Fields.register field in
+            Frame.Fields.add field
+              (Type.make (Format_type.descr (`Format format)))
+              content_type
+        | _ -> content_type)
+    Frame.Fields.empty
+
+let flag_qscale = ref 0
+let qp2lambda = ref 0
+
+(* Looks like this is how ffmpeg CLI does it.
+   See: https://github.com/FFmpeg/FFmpeg/blob/4782124b90cf915ede2cebd871be82fc0267a135/fftools/ffmpeg_opt.c#L1567-L1570 *)
+let set_global_quality q opts =
+  let flags =
+    match Hashtbl.find_opt opts "flags" with
+      | Some (`Int f) -> f
+      | Some _ -> assert false
+      | None -> 0
+  in
+  let flags = flags lor !flag_qscale in
+  Hashtbl.replace opts "flags" (`Int flags);
+  Hashtbl.replace opts "global_quality" (`Float (float !qp2lambda *. q))
+
+let ffmpeg_gen params =
+  let defaults =
+    {
+      Ffmpeg_format.format = None;
+      output = `Stream;
+      streams = Frame.Fields.empty;
+      opts = Hashtbl.create 0;
+    }
+  in
+
+  let default_audio =
+    {
+      Ffmpeg_format.channels = 2;
+      samplerate = Frame.audio_rate;
+      sample_format = None;
+    }
+  in
+
+  let default_video =
+    {
+      Ffmpeg_format.framerate = Frame.video_rate;
+      width = Frame.video_width;
+      height = Frame.video_height;
+      pixel_format = None;
+      hwaccel = `Auto;
+      hwaccel_device = None;
+    }
+  in
+
+  let parse_opts opts = function
+    | "q", t | "qscale", t -> set_global_quality (to_float t) opts
+    | "", { value = Ground (String "audio_content"); _ }
+    | "", { value = Ground (String "video_content"); _ }
+    | "codec", _ ->
+        ()
+    | k, { value = Ground (String s); _ } -> Hashtbl.add opts k (`String s)
+    | k, { value = Ground (Int i); _ } -> Hashtbl.add opts k (`Int i)
+    | k, { value = Ground (Float fl); _ } -> Hashtbl.add opts k (`Float fl)
+    | _, t -> Lang_encoder.raise_error ~pos:t.pos "unexpected option"
+  in
+
+  let rec parse_audio_args ~opts options = function
+    | [] -> options
+    (* Audio options *)
+    | ("channels", t) :: args ->
+        parse_audio_args ~opts
+          { options with Ffmpeg_format.channels = to_int t }
+          args
+    | ("ac", t) :: args ->
+        parse_audio_args ~opts
+          { options with Ffmpeg_format.channels = to_int t }
+          args
+    | ("samplerate", t) :: args ->
+        parse_audio_args ~opts
+          { options with Ffmpeg_format.samplerate = Lazy.from_val (to_int t) }
+          args
+    | ("ar", t) :: args ->
+        parse_audio_args ~opts
+          { options with Ffmpeg_format.samplerate = Lazy.from_val (to_int t) }
+          args
+    | ("sample_format", t) :: args ->
+        parse_audio_args ~opts
+          { options with Ffmpeg_format.sample_format = Some (to_string t) }
+          args
+    | arg :: args ->
+        parse_opts opts arg;
+        parse_audio_args ~opts options args
+  in
+  let rec parse_video_args ~opts options = function
+    | [] -> options
+    | ("framerate", t) :: args ->
+        parse_video_args ~opts
+          { options with Ffmpeg_format.framerate = Lazy.from_val (to_int t) }
+          args
+    | ("r", t) :: args ->
+        parse_video_args ~opts
+          { options with Ffmpeg_format.framerate = Lazy.from_val (to_int t) }
+          args
+    | ("width", t) :: args ->
+        parse_video_args ~opts
+          { options with Ffmpeg_format.width = Lazy.from_val (to_int t) }
+          args
+    | ("height", t) :: args ->
+        parse_video_args ~opts
+          { options with Ffmpeg_format.height = Lazy.from_val (to_int t) }
+          args
+    | ("pixel_format", { value = Ground (String "none"); _ }) :: args ->
+        parse_video_args ~opts
+          { options with Ffmpeg_format.pixel_format = None }
+          args
+    | ("pixel_format", t) :: args ->
+        parse_video_args ~opts
+          { options with Ffmpeg_format.pixel_format = Some (to_string t) }
+          args
+    | ("hwaccel", { value = Ground (String "auto"); _ }) :: args ->
+        parse_video_args ~opts
+          { options with Ffmpeg_format.hwaccel = `Auto }
+          args
+    | ("hwaccel", { value = Ground (String "none"); _ }) :: args ->
+        parse_video_args ~opts
+          { options with Ffmpeg_format.hwaccel = `None }
+          args
+    | ("hwaccel_device", { value = Ground (String "none"); _ }) :: args ->
+        parse_video_args ~opts
+          { options with Ffmpeg_format.hwaccel_device = None }
+          args
+    | ("hwaccel_device", t) :: args ->
+        parse_video_args ~opts
+          { options with Ffmpeg_format.hwaccel_device = Some (to_string t) }
+          args
+    | arg :: args ->
+        parse_opts opts arg;
+        parse_video_args ~opts options args
+  in
+
+  let parse_stream ~content_type args =
+    let opts = Hashtbl.create 0 in
+    let codec = Option.map to_string (List.assoc_opt "codec" args) in
+    match content_type with
+      | `Audio ->
+          let options = parse_audio_args ~opts default_audio args in
+          (codec, `Audio options, opts)
+      | `Video ->
+          let options = parse_video_args ~opts default_video args in
+          (codec, `Video options, opts)
+  in
+
+  List.fold_left
+    (fun f -> function
+      | `Encoder (field, `Copy None) ->
+          {
+            f with
+            Ffmpeg_format.streams =
+              Frame.Fields.add field (`Copy `Wait_for_keyframe)
+                f.Ffmpeg_format.streams;
+          }
+      | `Encoder (field, `Copy (Some t)) ->
+          {
+            f with
+            Ffmpeg_format.streams =
+              Frame.Fields.add field
+                (`Copy (to_copy_opt t))
+                f.Ffmpeg_format.streams;
+          }
+      | `Encoder (field, `Encode (mode, content_type, args)) ->
+          let codec, options, opts = parse_stream ~content_type args in
+          {
+            f with
+            Ffmpeg_format.streams =
+              Frame.Fields.add field
+                (`Encode { Ffmpeg_format.mode; options; codec; opts })
+                f.Ffmpeg_format.streams;
+          }
+      | `Option ("format", { value = Ground (String "none"); _ }) ->
+          { f with Ffmpeg_format.format = None }
+      | `Option ("format", { value = Ground (String fmt); _ }) ->
+          { f with Ffmpeg_format.format = Some fmt }
+      | `Option (k, { value = Ground (String s); _ }) ->
+          Hashtbl.add f.Ffmpeg_format.opts k (`String s);
+          f
+      | `Option (k, { value = Ground (Int i); _ }) ->
+          Hashtbl.add f.Ffmpeg_format.opts k (`Int i);
+          f
+      | `Option (k, { value = Ground (Float i); _ }) ->
+          Hashtbl.add f.Ffmpeg_format.opts k (`Float i);
+          f
+      | `Option (l, v) -> Lang_encoder.raise_generic_error (l, `Value v))
+    defaults params
+
 let make params =
   let params =
     List.map
       (function
-        | _, `Encoder (e, p) -> (
-            let p =
+        | _, `Encoder (name, args) ->
+            let args =
               List.filter_map
                 (function l, `Value v -> Some (l, v) | _, `Encoder _ -> None)
-                p
+                args
             in
-            match e with
-              | "audio.none" -> `Audio_none
-              | "audio.copy" -> `Audio_copy (copy_param p)
-              | "audio.raw" -> `Audio_raw p
-              | "audio" -> `Audio p
-              | "video.none" -> `Video_none
-              | "video.copy" -> `Video_copy (copy_param p)
-              | "video.raw" -> `Video_raw p
-              | "video" -> `Video p
-              | _ -> failwith "unknown subencoder")
+            `Encoder
+              (parse_encoder_params ~to_pos:(fun t -> t.pos) (name, args))
         | l, `Value v -> `Option (l, v))
       params
   in

--- a/src/core/outputs/icecast2.ml
+++ b/src/core/outputs/icecast2.ml
@@ -99,11 +99,24 @@ module Icecast = struct
           channels = Some m.Flac_format.channels;
         }
     | Encoder.Ffmpeg m ->
+        let audio_stream =
+          match
+            Frame.Fields.find_opt Frame.Fields.audio m.Ffmpeg_format.streams
+          with
+            | Some (`Encode { options = `Audio options }) -> Some options
+            | _ -> None
+        in
         {
           quality = None;
           bitrate = None;
-          samplerate = Some (Lazy.force m.Ffmpeg_format.samplerate);
-          channels = Some m.Ffmpeg_format.channels;
+          samplerate =
+            Option.map
+              (fun stream -> Lazy.force stream.Ffmpeg_format.samplerate)
+              audio_stream;
+          channels =
+            Option.map
+              (fun stream -> stream.Ffmpeg_format.channels)
+              audio_stream;
         }
     | Encoder.WAV m ->
         {

--- a/src/core/sources/noise.ml
+++ b/src/core/sources/noise.ml
@@ -29,20 +29,15 @@ class noise duration =
     inherit Synthesized.source ~seek:true ~name:"noise" duration
 
     method private synthesize frame off len =
-      (try
-         let off = Frame.audio_of_main off in
-         let len = Frame.audio_of_main len in
-         let b = AFrame.pcm frame in
-         Audio.Generator.white_noise b off len
-       with Content.Invalid -> ());
-      try
-        let off = Frame.video_of_main off in
-        let len = Frame.video_of_main len in
-        let b = VFrame.data frame in
-        Video.Canvas.map
-          (Video.Canvas.Image.iter Video.Image.randomize)
-          b off len
-      with Content.Invalid -> ()
+      Frame.Fields.iter
+        (fun _ content ->
+          try
+            let off = Frame.audio_of_main off in
+            let len = Frame.audio_of_main len in
+            let b = Content.Audio.get_data content in
+            Audio.Generator.white_noise b off len
+          with Content.Invalid -> ())
+        (Generator.peek frame)
   end
 
 let _ =

--- a/src/core/stream/frame.ml
+++ b/src/core/stream/frame.ml
@@ -33,10 +33,11 @@ let string_of_format = string_of_format
 let string_of_fields fn fields =
   Printf.sprintf "{%s}"
     (String.concat ","
-       (Fields.fold
-          (fun f v cur ->
-            Printf.sprintf "%s=%s" (Fields.string_of_field f) (fn v) :: cur)
-          fields []))
+       (List.sort Stdlib.compare
+          (Fields.fold
+             (fun f v cur ->
+               Printf.sprintf "%s=%s" (Fields.string_of_field f) (fn v) :: cur)
+             fields [])))
 
 let string_of_content_type = string_of_fields string_of_format
 

--- a/src/core/stream/frame_base.ml
+++ b/src/core/stream/frame_base.ml
@@ -63,11 +63,11 @@ module Fields = struct
 
   let audio_n = function
     | 0 -> audio
-    | n -> register (Printf.sprintf "audio_%d" n)
+    | n -> register (Printf.sprintf "audio_%d" (n + 1))
 
   let video_n = function
     | 0 -> video
-    | n -> register (Printf.sprintf "video_%d" n)
+    | n -> register (Printf.sprintf "video_%d" (n + 1))
 
   let make =
     let audio_f = audio in

--- a/src/core/stream/generator.ml
+++ b/src/core/stream/generator.ml
@@ -195,6 +195,7 @@ let _get ?length gen =
 
 let get ?length gen = Tutils.mutexify gen.lock (fun () -> _get ?length gen) ()
 let peek gen = Tutils.mutexify gen.lock (fun () -> gen.content) ()
+let peek_media gen = Tutils.mutexify gen.lock (fun () -> _media_content gen) ()
 
 (* The following is frame-specific and should hopefully go away when
    we switch to immutable content. *)

--- a/src/core/stream/generator.mli
+++ b/src/core/stream/generator.mli
@@ -84,6 +84,9 @@ val get : ?length:int -> t -> Content.data Frame_base.Fields.t
 (* Return the generator's content without removing it. *)
 val peek : t -> Content.data Frame_base.Fields.t
 
+(* Return the generator's media content (all tracks exclusing metadata and track_marks) without removing it. *)
+val peek_media : t -> Content.data Frame_base.Fields.t
+
 (* Insert a metadata at the given position. To be used over [put]
    for metadata. Default position is generator's length. *)
 val add_metadata : ?pos:int -> t -> Frame_base.metadata -> unit

--- a/src/lang/lexer.ml
+++ b/src/lang/lexer.ml
@@ -105,7 +105,7 @@ let var_lit =
     | Star '_', var_char, Star (var_char | decimal_digit | '_' | '\'') )]
 
 let var = [%sedlex.regexp? var_lit | so | math | other_math]
-let encoder = [%sedlex.regexp? '%', Plus (var_char | decimal_digit | '.')]
+let encoder = [%sedlex.regexp? '%', Plus (var_char | decimal_digit | '.' | '_')]
 
 let time =
   [%sedlex.regexp?

--- a/tests/language/type_errors.liq
+++ b/tests/language/type_errors.liq
@@ -12,7 +12,7 @@ def incorrect(expr)
     try
       let eval _ = expr
       test.fail()
-    catch _ : [error.eval] do
+    catch _ do
       ()
     end
   end
@@ -194,6 +194,19 @@ def f() =
         %video.copy)');
   correct('%ffmpeg(%audio.copy(ignore_keyframe), %video.copy(ignore_keyframe))');
   correct('%ffmpeg(%audio.copy(wait_for_keyframe), %video.copy(wait_for_keyframe))');
+
+  # Conventions for content type in %ffmpeg encoder:
+  correct('%ffmpeg(%foo_audio, %bla_video_gni)')
+  correct('%ffmpeg(%foo(audio_content), %bla(video_content))')
+  incorrect('%ffmpeg(%foo, %bla_gni)')
+
+  correct('%ffmpeg(%foo_audio.raw, %bla_video_gni.raw)')
+  correct('%ffmpeg(%foo.raw(audio_content), %bla.raw(video_content))')
+  incorrect('%ffmpeg(%foo.raw, %bla_gni.raw)')
+
+  correct('%ffmpeg(%foo_audio.copy, %bla_video_gni.copy)')
+  incorrect('%ffmpeg(%foo.copy(audio_content), %bla.copy(video_content))')
+  correct('%ffmpeg(%foo.copy, %bla_gni.copy)')
 
   # The following is not technically checking on type errors but runtime invalid values.
   section("INVALID VALUES");

--- a/tests/language/typing.liq
+++ b/tests/language/typing.liq
@@ -157,7 +157,7 @@ def f() =
   (noise():source(audio=pcm("5.1")))
   (noise():source)
 
-  (single("annotate:foo=\"bla\":/nonexistent"):source(audio=ffmpeg.audio.copy,video=ffmpeg.video.copy,midi=midi))
+  (single("annotate:foo=\"bla\":/nonexistent"):source(audio=ffmpeg.copy,video=ffmpeg.copy,midi=midi))
   (single("annotate:foo=\"bla\":/nonexistent"):source(audio=ffmpeg.audio.raw,video=ffmpeg.video.raw,midi=midi))
   (single("annotate:foo=\"bla\":/nonexistent"):source(audio=ffmpeg.audio.raw(sample_rate=44100, channel_layout="5.1"),video=ffmpeg.video.raw(pixel_format=yuva420p),midi=midi))
 

--- a/tests/media/dune.inc
+++ b/tests/media/dune.inc
@@ -162,13 +162,13 @@
 (rule
   (alias runtest)
   (package liquidsoap)
-  (target @ffmpeg[format='mp4',@audio[codec='aac'],@video.none]_encoder.liq)
+  (target @ffmpeg[format='mp4',@audio[codec='aac']]_encoder.liq)
   (deps
     (:mk_encoder_test ./mk_encoder_test.sh)
     (:test_encoder_in ./test_encoder.liq.in))
   (action
     (with-stdout-to %{target}
-      (run %{mk_encoder_test} "%ffmpeg(format=\"mp4\",%audio(codec=\"aac\"),%video.none)" sine "@ffmpeg[format='mp4',@audio[codec='aac'],@video.none].mp4"))))
+      (run %{mk_encoder_test} "%ffmpeg(format=\"mp4\",%audio(codec=\"aac\"))" sine "@ffmpeg[format='mp4',@audio[codec='aac']].mp4"))))
 (rule
   (alias runtest)
   (package liquidsoap)
@@ -192,13 +192,33 @@
 (rule
   (alias runtest)
   (package liquidsoap)
-  (target @ffmpeg[format='mp4',@audio.none,@video[codec='libx264']]_encoder.liq)
+  (target @ffmpeg[format='mp4',@audio[codec='aac',channels=2],@audio_2[codec='aac',channels=1],@video[codec='libx264'],@video_2[codec='libx264']]_encoder.liq)
   (deps
     (:mk_encoder_test ./mk_encoder_test.sh)
     (:test_encoder_in ./test_encoder.liq.in))
   (action
     (with-stdout-to %{target}
-      (run %{mk_encoder_test} "%ffmpeg(format=\"mp4\",%audio.none,%video(codec=\"libx264\"))" noise "@ffmpeg[format='mp4',@audio.none,@video[codec='libx264']].mp4"))))
+      (run %{mk_encoder_test} "%ffmpeg(format=\"mp4\",%audio(codec=\"aac\",channels=2),%audio_2(codec=\"aac\",channels=1),%video(codec=\"libx264\"),%video_2(codec=\"libx264\"))" noise "@ffmpeg[format='mp4',@audio[codec='aac',channels=2],@audio_2[codec='aac',channels=1],@video[codec='libx264'],@video_2[codec='libx264']].mp4"))))
+(rule
+  (alias runtest)
+  (package liquidsoap)
+  (target @ffmpeg[format='mp4',@gno[audio_content,codec='aac',channels=2],@gni[audio_content,codec='aac',channels=1],@bar[video_content,codec='libx264'],@foo[video_content,codec='libx264']]_encoder.liq)
+  (deps
+    (:mk_encoder_test ./mk_encoder_test.sh)
+    (:test_encoder_in ./test_encoder.liq.in))
+  (action
+    (with-stdout-to %{target}
+      (run %{mk_encoder_test} "%ffmpeg(format=\"mp4\",%gno(audio_content,codec=\"aac\",channels=2),%gni(audio_content,codec=\"aac\",channels=1),%bar(video_content,codec=\"libx264\"),%foo(video_content,codec=\"libx264\"))" noise "@ffmpeg[format='mp4',@gno[audio_content,codec='aac',channels=2],@gni[audio_content,codec='aac',channels=1],@bar[video_content,codec='libx264'],@foo[video_content,codec='libx264']].mp4"))))
+(rule
+  (alias runtest)
+  (package liquidsoap)
+  (target @ffmpeg[format='mp4',@video[codec='libx264']]_encoder.liq)
+  (deps
+    (:mk_encoder_test ./mk_encoder_test.sh)
+    (:test_encoder_in ./test_encoder.liq.in))
+  (action
+    (with-stdout-to %{target}
+      (run %{mk_encoder_test} "%ffmpeg(format=\"mp4\",%video(codec=\"libx264\"))" noise "@ffmpeg[format='mp4',@video[codec='libx264']].mp4"))))
 (rule
  (alias runtest)
  (package liquidsoap)
@@ -410,16 +430,16 @@
 (rule
  (alias runtest)
  (package liquidsoap)
- (target @ffmpeg[format='mp4',@audio[codec='aac'],@video.none].mp4)
+ (target @ffmpeg[format='mp4',@audio[codec='aac']].mp4)
  (deps
-  (:encoder @ffmpeg[format='mp4',@audio[codec='aac'],@video.none]_encoder.liq)
+  (:encoder @ffmpeg[format='mp4',@audio[codec='aac']]_encoder.liq)
   (source_tree ../../src/libs)
   ../../src/bin/liquidsoap.exe
   (:stdlib ../../src/libs/stdlib.liq)
   (:test_liq ../test.liq)
   (:run_test ../run_test.exe))
  (action
-   (run %{run_test} %{encoder} liquidsoap %{test_liq} %{encoder} -- "%ffmpeg(format=\"mp4\",%audio(codec=\"aac\"),%video.none)")))
+   (run %{run_test} %{encoder} liquidsoap %{test_liq} %{encoder} -- "%ffmpeg(format=\"mp4\",%audio(codec=\"aac\"))")))
 (rule
  (alias runtest)
  (package liquidsoap)
@@ -449,16 +469,42 @@
 (rule
  (alias runtest)
  (package liquidsoap)
- (target @ffmpeg[format='mp4',@audio.none,@video[codec='libx264']].mp4)
+ (target @ffmpeg[format='mp4',@audio[codec='aac',channels=2],@audio_2[codec='aac',channels=1],@video[codec='libx264'],@video_2[codec='libx264']].mp4)
  (deps
-  (:encoder @ffmpeg[format='mp4',@audio.none,@video[codec='libx264']]_encoder.liq)
+  (:encoder @ffmpeg[format='mp4',@audio[codec='aac',channels=2],@audio_2[codec='aac',channels=1],@video[codec='libx264'],@video_2[codec='libx264']]_encoder.liq)
   (source_tree ../../src/libs)
   ../../src/bin/liquidsoap.exe
   (:stdlib ../../src/libs/stdlib.liq)
   (:test_liq ../test.liq)
   (:run_test ../run_test.exe))
  (action
-   (run %{run_test} %{encoder} liquidsoap %{test_liq} %{encoder} -- "%ffmpeg(format=\"mp4\",%audio.none,%video(codec=\"libx264\"))")))
+   (run %{run_test} %{encoder} liquidsoap %{test_liq} %{encoder} -- "%ffmpeg(format=\"mp4\",%audio(codec=\"aac\",channels=2),%audio_2(codec=\"aac\",channels=1),%video(codec=\"libx264\"),%video_2(codec=\"libx264\"))")))
+(rule
+ (alias runtest)
+ (package liquidsoap)
+ (target @ffmpeg[format='mp4',@gno[audio_content,codec='aac',channels=2],@gni[audio_content,codec='aac',channels=1],@bar[video_content,codec='libx264'],@foo[video_content,codec='libx264']].mp4)
+ (deps
+  (:encoder @ffmpeg[format='mp4',@gno[audio_content,codec='aac',channels=2],@gni[audio_content,codec='aac',channels=1],@bar[video_content,codec='libx264'],@foo[video_content,codec='libx264']]_encoder.liq)
+  (source_tree ../../src/libs)
+  ../../src/bin/liquidsoap.exe
+  (:stdlib ../../src/libs/stdlib.liq)
+  (:test_liq ../test.liq)
+  (:run_test ../run_test.exe))
+ (action
+   (run %{run_test} %{encoder} liquidsoap %{test_liq} %{encoder} -- "%ffmpeg(format=\"mp4\",%gno(audio_content,codec=\"aac\",channels=2),%gni(audio_content,codec=\"aac\",channels=1),%bar(video_content,codec=\"libx264\"),%foo(video_content,codec=\"libx264\"))")))
+(rule
+ (alias runtest)
+ (package liquidsoap)
+ (target @ffmpeg[format='mp4',@video[codec='libx264']].mp4)
+ (deps
+  (:encoder @ffmpeg[format='mp4',@video[codec='libx264']]_encoder.liq)
+  (source_tree ../../src/libs)
+  ../../src/bin/liquidsoap.exe
+  (:stdlib ../../src/libs/stdlib.liq)
+  (:test_liq ../test.liq)
+  (:run_test ../run_test.exe))
+ (action
+   (run %{run_test} %{encoder} liquidsoap %{test_liq} %{encoder} -- "%ffmpeg(format=\"mp4\",%video(codec=\"libx264\"))")))
 (rule
   (alias runtest)
   (package liquidsoap)
@@ -480,10 +526,12 @@
 @ogg[@flac[stereo]].ogg
 @ogg[@opus[mono]].ogg
 @ogg[@opus[stereo]].ogg
-@ffmpeg[format='mp4',@audio[codec='aac'],@video.none].mp4
+@ffmpeg[format='mp4',@audio[codec='aac']].mp4
 @ffmpeg[format='mp4',@audio[codec='aac',channels=1],@video[codec='libx264']].mp4
 @ffmpeg[format='mp4',@audio[codec='aac',channels=2],@video[codec='libx264']].mp4
-@ffmpeg[format='mp4',@audio.none,@video[codec='libx264']].mp4)
+@ffmpeg[format='mp4',@audio[codec='aac',channels=2],@audio_2[codec='aac',channels=1],@video[codec='libx264'],@video_2[codec='libx264']].mp4
+@ffmpeg[format='mp4',@gno[audio_content,codec='aac',channels=2],@gni[audio_content,codec='aac',channels=1],@bar[video_content,codec='libx264'],@foo[video_content,codec='libx264']].mp4
+@ffmpeg[format='mp4',@video[codec='libx264']].mp4)
   (action (run touch %{target})))
 (rule
  (alias runtest)
@@ -1121,7 +1169,7 @@
   (:test_liq ../test.liq)
   (:run_test ../run_test.exe))
  (action
-  (run %{run_test} "Mono decoding test for @ffmpeg[format='mp4',@audio[codec='aac'],@video.none].mp4" liquidsoap %{test_liq} test_mono.liq -- "@ffmpeg[format='mp4',@audio[codec='aac'],@video.none].mp4")))
+  (run %{run_test} "Mono decoding test for @ffmpeg[format='mp4',@audio[codec='aac']].mp4" liquidsoap %{test_liq} test_mono.liq -- "@ffmpeg[format='mp4',@audio[codec='aac']].mp4")))
 (rule
  (alias runtest)
  (package liquidsoap)
@@ -1134,7 +1182,7 @@
   (:test_liq ../test.liq)
   (:run_test ../run_test.exe))
  (action
-  (run %{run_test} "Stereo decoding test for @ffmpeg[format='mp4',@audio[codec='aac'],@video.none].mp4" liquidsoap %{test_liq} test_stereo.liq -- "@ffmpeg[format='mp4',@audio[codec='aac'],@video.none].mp4")))
+  (run %{run_test} "Stereo decoding test for @ffmpeg[format='mp4',@audio[codec='aac']].mp4" liquidsoap %{test_liq} test_stereo.liq -- "@ffmpeg[format='mp4',@audio[codec='aac']].mp4")))
 (rule
  (alias runtest)
  (package liquidsoap)
@@ -1147,7 +1195,7 @@
   (:test_liq ../test.liq)
   (:run_test ../run_test.exe))
  (action
-  (run %{run_test} "FFmpeg audio decoder test for @ffmpeg[format='mp4',@audio[codec='aac'],@video.none].mp4" liquidsoap %{test_liq} test_ffmpeg_audio_decoder.liq -- "@ffmpeg[format='mp4',@audio[codec='aac'],@video.none].mp4")))
+  (run %{run_test} "FFmpeg audio decoder test for @ffmpeg[format='mp4',@audio[codec='aac']].mp4" liquidsoap %{test_liq} test_ffmpeg_audio_decoder.liq -- "@ffmpeg[format='mp4',@audio[codec='aac']].mp4")))
 (rule
  (alias runtest)
  (package liquidsoap)
@@ -1160,7 +1208,7 @@
   (:test_liq ../test.liq)
   (:run_test ../run_test.exe))
  (action
-  (run %{run_test} "FFmpeg video decoder test for @ffmpeg[format='mp4',@audio.none,@video[codec='libx264']].mp4" liquidsoap %{test_liq} test_ffmpeg_video_decoder.liq -- "@ffmpeg[format='mp4',@audio.none,@video[codec='libx264']].mp4")))
+  (run %{run_test} "FFmpeg video decoder test for @ffmpeg[format='mp4',@video[codec='libx264']].mp4" liquidsoap %{test_liq} test_ffmpeg_video_decoder.liq -- "@ffmpeg[format='mp4',@video[codec='libx264']].mp4")))
 (rule
  (alias runtest)
  (package liquidsoap)
@@ -1173,7 +1221,7 @@
   (:test_liq ../test.liq)
   (:run_test ../run_test.exe))
  (action
-  (run %{run_test} "FFmpeg video size test for @ffmpeg[format='mp4',@audio.none,@video[codec='libx264']].mp4" liquidsoap %{test_liq} test_video_size.liq -- "@ffmpeg[format='mp4',@audio.none,@video[codec='libx264']].mp4")))
+  (run %{run_test} "FFmpeg video size test for @ffmpeg[format='mp4',@video[codec='libx264']].mp4" liquidsoap %{test_liq} test_video_size.liq -- "@ffmpeg[format='mp4',@video[codec='libx264']].mp4")))
 (rule
  (alias runtest)
  (package liquidsoap)
@@ -1226,6 +1274,58 @@
   (:run_test ../run_test.exe))
  (action
   (run %{run_test} "FFmpeg video size test for @ffmpeg[format='mp4',@audio[codec='aac',channels=2],@video[codec='libx264']].mp4" liquidsoap %{test_liq} test_video_size.liq -- "@ffmpeg[format='mp4',@audio[codec='aac',channels=2],@video[codec='libx264']].mp4")))
+(rule
+ (alias runtest)
+ (package liquidsoap)
+ (deps
+  all_media_files
+  test_ffmpeg_video_decoder.liq
+  ../../src/bin/liquidsoap.exe
+  (source_tree ../../src/libs)
+  (:stdlib ../../src/libs/stdlib.liq)
+  (:test_liq ../test.liq)
+  (:run_test ../run_test.exe))
+ (action
+  (run %{run_test} "FFmpeg video decoder test for @ffmpeg[format='mp4',@audio[codec='aac',channels=2],@audio_2[codec='aac',channels=1],@video[codec='libx264'],@video_2[codec='libx264']].mp4" liquidsoap %{test_liq} test_ffmpeg_video_decoder.liq -- "@ffmpeg[format='mp4',@audio[codec='aac',channels=2],@audio_2[codec='aac',channels=1],@video[codec='libx264'],@video_2[codec='libx264']].mp4")))
+(rule
+ (alias runtest)
+ (package liquidsoap)
+ (deps
+  all_media_files
+  test_video_size.liq
+  ../../src/bin/liquidsoap.exe
+  (source_tree ../../src/libs)
+  (:stdlib ../../src/libs/stdlib.liq)
+  (:test_liq ../test.liq)
+  (:run_test ../run_test.exe))
+ (action
+  (run %{run_test} "FFmpeg video size test for @ffmpeg[format='mp4',@audio[codec='aac',channels=2],@audio_2[codec='aac',channels=1],@video[codec='libx264'],@video_2[codec='libx264']].mp4" liquidsoap %{test_liq} test_video_size.liq -- "@ffmpeg[format='mp4',@audio[codec='aac',channels=2],@audio_2[codec='aac',channels=1],@video[codec='libx264'],@video_2[codec='libx264']].mp4")))
+(rule
+ (alias runtest)
+ (package liquidsoap)
+ (deps
+  all_media_files
+  test_ffmpeg_video_decoder.liq
+  ../../src/bin/liquidsoap.exe
+  (source_tree ../../src/libs)
+  (:stdlib ../../src/libs/stdlib.liq)
+  (:test_liq ../test.liq)
+  (:run_test ../run_test.exe))
+ (action
+  (run %{run_test} "FFmpeg video decoder test for @ffmpeg[format='mp4',@gno[audio_content,codec='aac',channels=2],@gni[audio_content,codec='aac',channels=1],@bar[video_content,codec='libx264'],@foo[video_content,codec='libx264']].mp4" liquidsoap %{test_liq} test_ffmpeg_video_decoder.liq -- "@ffmpeg[format='mp4',@gno[audio_content,codec='aac',channels=2],@gni[audio_content,codec='aac',channels=1],@bar[video_content,codec='libx264'],@foo[video_content,codec='libx264']].mp4")))
+(rule
+ (alias runtest)
+ (package liquidsoap)
+ (deps
+  all_media_files
+  test_video_size.liq
+  ../../src/bin/liquidsoap.exe
+  (source_tree ../../src/libs)
+  (:stdlib ../../src/libs/stdlib.liq)
+  (:test_liq ../test.liq)
+  (:run_test ../run_test.exe))
+ (action
+  (run %{run_test} "FFmpeg video size test for @ffmpeg[format='mp4',@gno[audio_content,codec='aac',channels=2],@gni[audio_content,codec='aac',channels=1],@bar[video_content,codec='libx264'],@foo[video_content,codec='libx264']].mp4" liquidsoap %{test_liq} test_video_size.liq -- "@ffmpeg[format='mp4',@gno[audio_content,codec='aac',channels=2],@gni[audio_content,codec='aac',channels=1],@bar[video_content,codec='libx264'],@foo[video_content,codec='libx264']].mp4")))
 (rule
  (alias runtest)
  (package liquidsoap)
@@ -1408,6 +1508,188 @@
   (:run_test ../run_test.exe))
  (action
   (run %{run_test} "FFmpeg raw+copy decoder test for @ffmpeg[format='mp4',@audio[codec='aac',channels=2],@video[codec='libx264']].mp4" liquidsoap %{test_liq} test_ffmpeg_raw_and_copy_decoder.liq -- "@ffmpeg[format='mp4',@audio[codec='aac',channels=2],@video[codec='libx264']].mp4")))
+(rule
+ (alias runtest)
+ (package liquidsoap)
+ (deps
+  all_media_files
+  test_ffmpeg_add_text.liq
+  ../../src/bin/liquidsoap.exe
+  (source_tree ../../src/libs)
+  (:stdlib ../../src/libs/stdlib.liq)
+  (:test_liq ../test.liq)
+  (:run_test ../run_test.exe))
+ (action
+  (run %{run_test} "FFmpeg add text filter test for @ffmpeg[format='mp4',@audio[codec='aac',channels=2],@audio_2[codec='aac',channels=1],@video[codec='libx264'],@video_2[codec='libx264']].mp4" liquidsoap %{test_liq} test_ffmpeg_add_text.liq -- "@ffmpeg[format='mp4',@audio[codec='aac',channels=2],@audio_2[codec='aac',channels=1],@video[codec='libx264'],@video_2[codec='libx264']].mp4")))
+(rule
+ (alias runtest)
+ (package liquidsoap)
+ (deps
+  all_media_files
+  test_ffmpeg_copy_decoder.liq
+  ../../src/bin/liquidsoap.exe
+  (source_tree ../../src/libs)
+  (:stdlib ../../src/libs/stdlib.liq)
+  (:test_liq ../test.liq)
+  (:run_test ../run_test.exe))
+ (action
+  (run %{run_test} "FFmpeg copy decoder test for @ffmpeg[format='mp4',@audio[codec='aac',channels=2],@audio_2[codec='aac',channels=1],@video[codec='libx264'],@video_2[codec='libx264']].mp4" liquidsoap %{test_liq} test_ffmpeg_copy_decoder.liq -- "@ffmpeg[format='mp4',@audio[codec='aac',channels=2],@audio_2[codec='aac',channels=1],@video[codec='libx264'],@video_2[codec='libx264']].mp4")))
+(rule
+ (alias runtest)
+ (package liquidsoap)
+ (deps
+  all_media_files
+  test_ffmpeg_copy_and_encode_decoder.liq
+  ../../src/bin/liquidsoap.exe
+  (source_tree ../../src/libs)
+  (:stdlib ../../src/libs/stdlib.liq)
+  (:test_liq ../test.liq)
+  (:run_test ../run_test.exe))
+ (action
+  (run %{run_test} "FFmpeg copy+encode decode test for @ffmpeg[format='mp4',@audio[codec='aac',channels=2],@audio_2[codec='aac',channels=1],@video[codec='libx264'],@video_2[codec='libx264']].mp4" liquidsoap %{test_liq} test_ffmpeg_copy_and_encode_decoder.liq -- "@ffmpeg[format='mp4',@audio[codec='aac',channels=2],@audio_2[codec='aac',channels=1],@video[codec='libx264'],@video_2[codec='libx264']].mp4")))
+(rule
+ (alias runtest)
+ (package liquidsoap)
+ (deps
+  all_media_files
+  test_ffmpeg_filter.liq
+  ../../src/bin/liquidsoap.exe
+  (source_tree ../../src/libs)
+  (:stdlib ../../src/libs/stdlib.liq)
+  (:test_liq ../test.liq)
+  (:run_test ../run_test.exe))
+ (action
+  (run %{run_test} "FFmpeg filter test for @ffmpeg[format='mp4',@audio[codec='aac',channels=2],@audio_2[codec='aac',channels=1],@video[codec='libx264'],@video_2[codec='libx264']].mp4" liquidsoap %{test_liq} test_ffmpeg_filter.liq -- "@ffmpeg[format='mp4',@audio[codec='aac',channels=2],@audio_2[codec='aac',channels=1],@video[codec='libx264'],@video_2[codec='libx264']].mp4")))
+(rule
+ (alias runtest)
+ (package liquidsoap)
+ (deps
+  all_media_files
+  test_ffmpeg_raw_decoder.liq
+  ../../src/bin/liquidsoap.exe
+  (source_tree ../../src/libs)
+  (:stdlib ../../src/libs/stdlib.liq)
+  (:test_liq ../test.liq)
+  (:run_test ../run_test.exe))
+ (action
+  (run %{run_test} "FFmpeg raw decoder test test for @ffmpeg[format='mp4',@audio[codec='aac',channels=2],@audio_2[codec='aac',channels=1],@video[codec='libx264'],@video_2[codec='libx264']].mp4" liquidsoap %{test_liq} test_ffmpeg_raw_decoder.liq -- "@ffmpeg[format='mp4',@audio[codec='aac',channels=2],@audio_2[codec='aac',channels=1],@video[codec='libx264'],@video_2[codec='libx264']].mp4")))
+(rule
+ (alias runtest)
+ (package liquidsoap)
+ (deps
+  all_media_files
+  test_ffmpeg_raw_and_encode_decoder.liq
+  ../../src/bin/liquidsoap.exe
+  (source_tree ../../src/libs)
+  (:stdlib ../../src/libs/stdlib.liq)
+  (:test_liq ../test.liq)
+  (:run_test ../run_test.exe))
+ (action
+  (run %{run_test} "FFmpeg raw+encode decoder test for @ffmpeg[format='mp4',@audio[codec='aac',channels=2],@audio_2[codec='aac',channels=1],@video[codec='libx264'],@video_2[codec='libx264']].mp4" liquidsoap %{test_liq} test_ffmpeg_raw_and_encode_decoder.liq -- "@ffmpeg[format='mp4',@audio[codec='aac',channels=2],@audio_2[codec='aac',channels=1],@video[codec='libx264'],@video_2[codec='libx264']].mp4")))
+(rule
+ (alias runtest)
+ (package liquidsoap)
+ (deps
+  all_media_files
+  test_ffmpeg_raw_and_copy_decoder.liq
+  ../../src/bin/liquidsoap.exe
+  (source_tree ../../src/libs)
+  (:stdlib ../../src/libs/stdlib.liq)
+  (:test_liq ../test.liq)
+  (:run_test ../run_test.exe))
+ (action
+  (run %{run_test} "FFmpeg raw+copy decoder test for @ffmpeg[format='mp4',@audio[codec='aac',channels=2],@audio_2[codec='aac',channels=1],@video[codec='libx264'],@video_2[codec='libx264']].mp4" liquidsoap %{test_liq} test_ffmpeg_raw_and_copy_decoder.liq -- "@ffmpeg[format='mp4',@audio[codec='aac',channels=2],@audio_2[codec='aac',channels=1],@video[codec='libx264'],@video_2[codec='libx264']].mp4")))
+(rule
+ (alias runtest)
+ (package liquidsoap)
+ (deps
+  all_media_files
+  test_ffmpeg_add_text.liq
+  ../../src/bin/liquidsoap.exe
+  (source_tree ../../src/libs)
+  (:stdlib ../../src/libs/stdlib.liq)
+  (:test_liq ../test.liq)
+  (:run_test ../run_test.exe))
+ (action
+  (run %{run_test} "FFmpeg add text filter test for @ffmpeg[format='mp4',@gno[audio_content,codec='aac',channels=2],@gni[audio_content,codec='aac',channels=1],@bar[video_content,codec='libx264'],@foo[video_content,codec='libx264']].mp4" liquidsoap %{test_liq} test_ffmpeg_add_text.liq -- "@ffmpeg[format='mp4',@gno[audio_content,codec='aac',channels=2],@gni[audio_content,codec='aac',channels=1],@bar[video_content,codec='libx264'],@foo[video_content,codec='libx264']].mp4")))
+(rule
+ (alias runtest)
+ (package liquidsoap)
+ (deps
+  all_media_files
+  test_ffmpeg_copy_decoder.liq
+  ../../src/bin/liquidsoap.exe
+  (source_tree ../../src/libs)
+  (:stdlib ../../src/libs/stdlib.liq)
+  (:test_liq ../test.liq)
+  (:run_test ../run_test.exe))
+ (action
+  (run %{run_test} "FFmpeg copy decoder test for @ffmpeg[format='mp4',@gno[audio_content,codec='aac',channels=2],@gni[audio_content,codec='aac',channels=1],@bar[video_content,codec='libx264'],@foo[video_content,codec='libx264']].mp4" liquidsoap %{test_liq} test_ffmpeg_copy_decoder.liq -- "@ffmpeg[format='mp4',@gno[audio_content,codec='aac',channels=2],@gni[audio_content,codec='aac',channels=1],@bar[video_content,codec='libx264'],@foo[video_content,codec='libx264']].mp4")))
+(rule
+ (alias runtest)
+ (package liquidsoap)
+ (deps
+  all_media_files
+  test_ffmpeg_copy_and_encode_decoder.liq
+  ../../src/bin/liquidsoap.exe
+  (source_tree ../../src/libs)
+  (:stdlib ../../src/libs/stdlib.liq)
+  (:test_liq ../test.liq)
+  (:run_test ../run_test.exe))
+ (action
+  (run %{run_test} "FFmpeg copy+encode decode test for @ffmpeg[format='mp4',@gno[audio_content,codec='aac',channels=2],@gni[audio_content,codec='aac',channels=1],@bar[video_content,codec='libx264'],@foo[video_content,codec='libx264']].mp4" liquidsoap %{test_liq} test_ffmpeg_copy_and_encode_decoder.liq -- "@ffmpeg[format='mp4',@gno[audio_content,codec='aac',channels=2],@gni[audio_content,codec='aac',channels=1],@bar[video_content,codec='libx264'],@foo[video_content,codec='libx264']].mp4")))
+(rule
+ (alias runtest)
+ (package liquidsoap)
+ (deps
+  all_media_files
+  test_ffmpeg_filter.liq
+  ../../src/bin/liquidsoap.exe
+  (source_tree ../../src/libs)
+  (:stdlib ../../src/libs/stdlib.liq)
+  (:test_liq ../test.liq)
+  (:run_test ../run_test.exe))
+ (action
+  (run %{run_test} "FFmpeg filter test for @ffmpeg[format='mp4',@gno[audio_content,codec='aac',channels=2],@gni[audio_content,codec='aac',channels=1],@bar[video_content,codec='libx264'],@foo[video_content,codec='libx264']].mp4" liquidsoap %{test_liq} test_ffmpeg_filter.liq -- "@ffmpeg[format='mp4',@gno[audio_content,codec='aac',channels=2],@gni[audio_content,codec='aac',channels=1],@bar[video_content,codec='libx264'],@foo[video_content,codec='libx264']].mp4")))
+(rule
+ (alias runtest)
+ (package liquidsoap)
+ (deps
+  all_media_files
+  test_ffmpeg_raw_decoder.liq
+  ../../src/bin/liquidsoap.exe
+  (source_tree ../../src/libs)
+  (:stdlib ../../src/libs/stdlib.liq)
+  (:test_liq ../test.liq)
+  (:run_test ../run_test.exe))
+ (action
+  (run %{run_test} "FFmpeg raw decoder test test for @ffmpeg[format='mp4',@gno[audio_content,codec='aac',channels=2],@gni[audio_content,codec='aac',channels=1],@bar[video_content,codec='libx264'],@foo[video_content,codec='libx264']].mp4" liquidsoap %{test_liq} test_ffmpeg_raw_decoder.liq -- "@ffmpeg[format='mp4',@gno[audio_content,codec='aac',channels=2],@gni[audio_content,codec='aac',channels=1],@bar[video_content,codec='libx264'],@foo[video_content,codec='libx264']].mp4")))
+(rule
+ (alias runtest)
+ (package liquidsoap)
+ (deps
+  all_media_files
+  test_ffmpeg_raw_and_encode_decoder.liq
+  ../../src/bin/liquidsoap.exe
+  (source_tree ../../src/libs)
+  (:stdlib ../../src/libs/stdlib.liq)
+  (:test_liq ../test.liq)
+  (:run_test ../run_test.exe))
+ (action
+  (run %{run_test} "FFmpeg raw+encode decoder test for @ffmpeg[format='mp4',@gno[audio_content,codec='aac',channels=2],@gni[audio_content,codec='aac',channels=1],@bar[video_content,codec='libx264'],@foo[video_content,codec='libx264']].mp4" liquidsoap %{test_liq} test_ffmpeg_raw_and_encode_decoder.liq -- "@ffmpeg[format='mp4',@gno[audio_content,codec='aac',channels=2],@gni[audio_content,codec='aac',channels=1],@bar[video_content,codec='libx264'],@foo[video_content,codec='libx264']].mp4")))
+(rule
+ (alias runtest)
+ (package liquidsoap)
+ (deps
+  all_media_files
+  test_ffmpeg_raw_and_copy_decoder.liq
+  ../../src/bin/liquidsoap.exe
+  (source_tree ../../src/libs)
+  (:stdlib ../../src/libs/stdlib.liq)
+  (:test_liq ../test.liq)
+  (:run_test ../run_test.exe))
+ (action
+  (run %{run_test} "FFmpeg raw+copy decoder test for @ffmpeg[format='mp4',@gno[audio_content,codec='aac',channels=2],@gni[audio_content,codec='aac',channels=1],@bar[video_content,codec='libx264'],@foo[video_content,codec='libx264']].mp4" liquidsoap %{test_liq} test_ffmpeg_raw_and_copy_decoder.liq -- "@ffmpeg[format='mp4',@gno[audio_content,codec='aac',channels=2],@gni[audio_content,codec='aac',channels=1],@bar[video_content,codec='libx264'],@foo[video_content,codec='libx264']].mp4")))
 (rule
  (alias runtest)
  (package liquidsoap)

--- a/tests/media/gen_dune.ml
+++ b/tests/media/gen_dune.ml
@@ -50,16 +50,17 @@ let audio_formats =
     "%ogg(%flac(stereo)).ogg";
     "%ogg(%opus(mono)).ogg";
     "%ogg(%opus(stereo)).ogg";
-    {|%ffmpeg(format="mp4",%audio(codec="aac"),%video.none).mp4|};
+    {|%ffmpeg(format="mp4",%audio(codec="aac")).mp4|};
   ]
 
-let video_formats =
-  [{|%ffmpeg(format="mp4",%audio.none,%video(codec="libx264")).mp4|}]
+let video_formats = [{|%ffmpeg(format="mp4",%video(codec="libx264")).mp4|}]
 
 let audio_video_formats =
   [
     {|%ffmpeg(format="mp4",%audio(codec="aac",channels=1),%video(codec="libx264")).mp4|};
     {|%ffmpeg(format="mp4",%audio(codec="aac",channels=2),%video(codec="libx264")).mp4|};
+    {|%ffmpeg(format="mp4",%audio(codec="aac",channels=2),%audio_2(codec="aac",channels=1),%video(codec="libx264"),%video_2(codec="libx264")).mp4|};
+    {|%ffmpeg(format="mp4",%gno(audio_content,codec="aac",channels=2),%gni(audio_content,codec="aac",channels=1),%bar(video_content,codec="libx264"),%foo(video_content,codec="libx264")).mp4|};
   ]
 
 let formats = audio_formats @ audio_video_formats @ video_formats

--- a/tests/media/test_ffmpeg_copy_decoder.liq
+++ b/tests/media/test_ffmpeg_copy_decoder.liq
@@ -20,28 +20,34 @@ def on_done () =
 
   let json.parse ( iparsed : {
     streams: [{
+      index: int,
       channel_layout: string?,
       sample_rate: string?,
       sample_fmt: string?,
-      codec_name: string?,
+      codec_type: string,
       pix_fmt: string?
     }]
   }) = ijson
 
   let json.parse ( oparsed : {
     streams: [{
+      index: int,
       channel_layout: string?,
       sample_rate: string?,
       sample_fmt: string?,
-      codec_name: string?,
+      codec_type: string,
       pix_fmt: string?
     }]
   }) = ojson
 
-  filter = fun(l) -> list.filter(fun (s) -> null.defined(s.codec_name), l)
-  sort = fun (l) -> list.sort(fun (s1, s2) -> if s1.codec_name < s2.codec_name then -1 else 1 end, l)
-  let [iaudio, ivideo] = sort(filter(iparsed.streams))
-  let [oaudio, ovideo] = sort(filter(oparsed.streams))
+  filter = fun(type, l) -> list.filter(fun (s) -> s.codec_type == type, l)
+  sort = fun (l) -> list.sort(fun (s1, s2) -> if s1.index < s2.index then -1 else 1 end, l)
+
+  let [{index, ...iaudio}] = sort(filter("audio", iparsed.streams))
+  let [{index, ...ivideo}] = sort(filter("video", iparsed.streams))
+
+  let [{index, ...oaudio}] = sort(filter("audio", oparsed.streams))
+  let [{index, ...ovideo}] = sort(filter("video", oparsed.streams))
 
   if iaudio == oaudio and ivideo == ovideo then
     test.pass()

--- a/tests/media/test_ffmpeg_raw_and_copy_decoder.liq
+++ b/tests/media/test_ffmpeg_raw_and_copy_decoder.liq
@@ -20,28 +20,34 @@ def on_done () =
 
   let json.parse ( iparsed : {
     streams: [{
+      index: int,
       channel_layout: string?,
       sample_rate: string?,
       sample_fmt: string?,
-      codec_name: string?,
+      codec_type: string,
       pix_fmt: string?
     }]
   }) = ijson
 
   let json.parse ( oparsed : {
     streams: [{
+      index: int,
       channel_layout: string?,
       sample_rate: string?,
       sample_fmt: string?,
-      codec_name: string?,
+      codec_type: string,
       pix_fmt: string?
     }]
   }) = ojson
 
-  filter = fun(l) -> list.filter((fun (s) -> null.defined(s.codec_name)), l)
-  sort = fun(l) -> list.sort((fun (s1, s2) -> if s1.codec_name < s2.codec_name then -1 else 1 end), l)
-  let [iaudio, ivideo] = sort(filter(iparsed.streams))
-  let [oaudio, ovideo] = sort(filter(oparsed.streams))
+  filter = fun(type, l) -> list.filter(fun (s) -> s.codec_type == type, l)
+  sort = fun (l) -> list.sort(fun (s1, s2) -> if s1.index < s2.index then -1 else 1 end, l)
+
+  let [{index, ...iaudio}] = sort(filter("audio", iparsed.streams))
+  let [{index, ...ivideo}] = sort(filter("video", iparsed.streams))
+
+  let [{index, ...oaudio}] = sort(filter("audio", oparsed.streams))
+  let [{index, ...ovideo}] = sort(filter("video", oparsed.streams))
 
   if iaudio == oaudio and ivideo == ovideo then
     test.pass()

--- a/tests/media/test_ffmpeg_video_decoder.liq
+++ b/tests/media/test_ffmpeg_video_decoder.liq
@@ -35,4 +35,4 @@ def on_done () =
   end
 end
 
-output.file(fallible=true, on_stop=on_done, %ffmpeg(format="mp4",%audio.none,%video(codec="libx264")), out, s)
+output.file(fallible=true, on_stop=on_done, %ffmpeg(format="mp4",%video(codec="libx264")), out, s)


### PR DESCRIPTION
This PR adds support for encoding and decoding multi-track files using `%ffmpeg`. It is written in anticipation of the soon-to-come support for multi track at the language level.

On the encoding side, `%ffmpeg` encoders can now take any number of named tracks, for instance:
```
%ffmpeg(
  format="mvk",
  %audio_en(codec="aac", ...),
  %audio_fr(codec="aac", ...),
  %video(codec="libx264", ...)
)
```

Internally, this will be converted into a format of type: `format(audio_en=pcm, audio_fr=pcm, video=canvas)` which, in turn will inform the various operators that we are expecting content of this type.

Because of this, we need to know if a given track is audio or video (and later subtitle). The proposed convention is, in order of preference:
* If the track has `audio_content` or `video_content` as parameter (for instance `%foo(audio_content, ...)`) then it is considered, resp., `audio` or `video`.
* If the track name has `audio` or `video` in it (for instance `%dolby_audio_fr`) then it is considered, resp., `audio` or `video`
* If the track codec is hardcoded (for instance (`%foo(codec="aac", ...)`) then the codec is used to detect the content.

This also has the benefit of keeping everything backward compatible with existing code.

The decoder is also updated to support multitrack. This provides a limited support for multi-track end-to-end decoding and encoding that will be expanded later with the support of language-level track manipulation. Here's a simple end-to-end example:

```
# This a movie with two audio tracks (EN and FR) in a mkv container
s = single("/path/to/movie.mkv")

# We re-encode audio tracks to aac and keep video and mux in a mp4 container:
encoder = %ffmpeg(
  format="mp4",
  %audio(codec="aac",...),
  %audio_2(codec="aac", ...),
  %video.copy
)

output.file("/path/to/movie.mp4", encoder, s)
```

Technical notes:
* The ffmpeg copy audio and video content is merged into a single copy content. This makes sense since, with copy content, we are passing everything verbatim so we shouldn't even care about audio vs. video. This allows to simplify the encoder logic (no need for the above contention) but comes at a slightly annoying complication due to the fact that encoded content are types audio/video at the library level).
* ~~The convention for default tracks names is: `%audio` for first audio track, then `%audio_1`, `%audio_2` etc. While this is pretty intuitive for programmers, this might not be as easy for people used to `1-based` counting where the first object starts at `1`. Might change that later.~~
* Inline encoding and decoding operators are not heavily tested against those changes. It is anticipated that they will be reworked next to encode at the track level, getting rid of the multiple `audio`, `video` and `audio_video` variants. They shall be tested more intensively by then.
* There needs to be a way to ensure predictability and stability of a simple decoder/encoder with multi-track so that the same order of tracks is guaranteed in the output file compare to the input files. Since we don't have much to work on those at the moment, it seems that this is something to re-visit with concrete examples when the whole multi-track framework is in place so that this doesn't get over-engineered right now. The two possibilities that I have in mind are number indexes or string tags.