### PR TITLE
Fix some never stuff.

### DIFF
--- a/src/core/lang_source.ml
+++ b/src/core/lang_source.ml
@@ -295,6 +295,7 @@ let check_content v t =
          get an exponential blowup, see #1247. *)
       checked_values := v :: !checked_values;
       match (v.Value.value, (Type.deref t).Type.descr) with
+        | _, Type.Var _ -> ()
         | _ when V.is_value v ->
             let source_t = source_t (V.of_value v)#frame_type in
             check source_t t
@@ -315,9 +316,10 @@ let check_content v t =
             let meths, v = Value.split_meths v in
             let meths_t, t = Type.split_meths t in
             List.iter
-              (fun { Type.meth; scheme = s } ->
+              (fun { Type.meth; optional; scheme = s } ->
                 let t = Typing.instantiate ~level:(-1) s in
-                check_value (List.assoc meth meths) t)
+                try check_value (List.assoc meth meths) t
+                with Not_found when optional -> ())
               meths_t;
             check_value v t
         (* The type says that we should drop the method. *)

--- a/src/lang/types/ground_type.ml
+++ b/src/lang/types/ground_type.ml
@@ -28,6 +28,7 @@ module type Custom = sig
   type Type_base.custom += Type
 
   val descr : Type_base.descr
+  val is_descr : Type_base.descr -> bool
 end
 
 let types = ref []
@@ -37,6 +38,10 @@ module Make (S : Spec) = struct
 
   let () = types := Type :: !types
   let get = function Type -> Type | _ -> assert false
+
+  let is_descr = function
+    | Type_base.Custom { Type_base.typ = Type } -> true
+    | _ -> false
 
   let handler =
     {

--- a/src/lang/types/ground_type.mli
+++ b/src/lang/types/ground_type.mli
@@ -28,6 +28,7 @@ module type Custom = sig
   type Type_base.custom += Type
 
   val descr : Type_base.descr
+  val is_descr : Type_base.descr -> bool
 end
 
 module Make (S : Spec) : Custom

--- a/src/lang/typing.ml
+++ b/src/lang/typing.ml
@@ -340,10 +340,15 @@ and unify_meth a b l =
   assert (meth1 = l && meth2 = l);
   (* Handle explicitly this case in order to avoid #1842. *)
   (try
-     (* We want to allow: {foo:int?} <: {foo?:int} and {foo?:int?} <: {foo?:int} and
-        prohibit {foo?:int} <: {foo:int?} *)
+     (* We want to allow:
+        - {foo:int?} <: {foo?:int}
+        - {foo?:int?} <: {foo?:int}
+        - {foo?:never} <: {foo?:int}
+        and prohibit:
+         - {foo?:int} <: {foo:int?} *)
      let s1 =
        match (optional1, optional2, (deref (snd s1)).descr) with
+         | true, true, t when Ground_type.Never.is_descr t -> s2
          | _, true, Nullable t -> (fst s1, t)
          | true, false, _ -> raise (Error (Repr.make a, Repr.make b))
          | _ -> s1

--- a/tests/language/record.liq
+++ b/tests/language/record.liq
@@ -210,6 +210,15 @@ def f() =
   y = { bla = 3.14, ...x }
   test.equals(y, 1.{ foo = 123, gni = "aabb", bla = 3.14 })
 
+  # Make sure that a function that takes a record of the
+  # type { foo?: int} can take a record of the type: {foo?: never}
+  def f(x) =
+    (x?.foo ?? 1) + 2
+  end
+  x = {foo = 123}
+  let {foo = _, ...y} = x
+  test.equals(f(y), 3)
+
   test.pass()
 end
 


### PR DESCRIPTION
```
# Make sure that a function that takes a record of the
# type { foo?: int} can take a record of the type: {foo?: never}
def f(x) =
   (x?.foo ?? 1) + 2
end
x = {foo = 123}
let {foo = _, ...y} = x
test.equals(f(y), 3)
```