### PR TITLE
Add support for lazy methods.

### DIFF
--- a/src/core/builtins/builtins_settings.ml
+++ b/src/core/builtins/builtins_settings.ml
@@ -207,14 +207,14 @@ let filtered_settings = ["subordinate log level"]
 
 let print_settings () =
   let rec grab_descr cur = function
-    | Value.Meth ("description", d, v) ->
+    | Value.Meth (`Value ("description", d), v) ->
         grab_descr { cur with description = Lang.to_string d } v.Lang.value
-    | Value.Meth ("comments", c, v) ->
+    | Value.Meth (`Value ("comments", c), v) ->
         grab_descr { cur with comments = Lang.to_string c } v.Lang.value
-    | Value.Meth ("set", _, v) -> grab_descr cur v.Lang.value
-    | Value.Meth (key, _, v) when List.mem_assoc key cur.children ->
+    | Value.Meth (`Value ("set", _), v) -> grab_descr cur v.Lang.value
+    | Value.Meth (`Value (key, _), v) when List.mem_assoc key cur.children ->
         grab_descr cur v.Lang.value
-    | Value.Meth (key, c, v) ->
+    | Value.Meth (`Value (key, c), v) ->
         let descr =
           {
             description = "";
@@ -287,8 +287,9 @@ let _ =
     let rec grab links v =
       match (links, v.Value.value) with
         | [], _ -> v
-        | link :: links, Value.Meth (key, v, _) when key = link -> grab links v
-        | _, Value.Meth (_, _, v) -> grab links v
+        | link :: links, Value.Meth (`Value (key, v), _) when key = link ->
+            grab links v
+        | _, Value.Meth (_, v) -> grab links v
         | _ -> raise Not_found
     in
     grab path value

--- a/src/core/lang.mli
+++ b/src/core/lang.mli
@@ -56,13 +56,14 @@ type value = Liquidsoap_lang.Value.t = {
 
 and env = (string * value) list
 and lazy_env = (string * value Lazy.t) list
+and meth_value = [ `Value of string * value | `Lazy of string -> value ]
 
 and in_value = Liquidsoap_lang.Value.in_value =
   | Ground of Ground.t
   | List of value list
   | Tuple of value list
   | Null
-  | Meth of string * value * value
+  | Meth of meth_value * value
   | Ref of value Atomic.t
   | Fun of
       (string * string * value option) list * lazy_env * Liquidsoap_lang.Term.t
@@ -246,6 +247,7 @@ val source : Source.source -> value
 val product : value -> value -> value
 val tuple : value list -> value
 val meth : value -> (string * value) list -> value
+val lazy_meth : value -> (string -> value) -> value
 val record : (string * value) list -> value
 val reference : value Atomic.t -> value
 val http_transport : Http.transport -> value

--- a/src/lang/builtins_json.ml
+++ b/src/lang/builtins_json.ml
@@ -404,7 +404,7 @@ let rec deprecated_of_json d j =
           in
           list l
       (* Parse records. *)
-      | Meth (l, x, d), `Assoc a -> (
+      | Meth (`Value (l, x), d), `Assoc a -> (
           try
             let y = List.assoc l a in
             let v = deprecated_of_json x y in

--- a/src/lang/environment.ml
+++ b/src/lang/environment.ml
@@ -80,7 +80,7 @@ let add_builtin ?(override = false) ?(register = true) ?doc name ((g, t), v) =
                         vt ))
               in
               (* Update value for x.l1...li. *)
-              let value = Value.Meth (l, lv, v) in
+              let value = Value.Meth (`Value (l, lv), v) in
               ((vg, t), { Value.pos = v.Value.pos; value })
           | [] -> ((g, t), v)
         in

--- a/src/lang/lang.mli
+++ b/src/lang/lang.mli
@@ -50,13 +50,14 @@ end
 type value = Value.t = { pos : Pos.Option.t; value : in_value }
 and env = (string * value) list
 and lazy_env = (string * value Lazy.t) list
+and meth_value = [ `Value of string * value | `Lazy of string -> value ]
 
 and in_value = Value.in_value =
   | Ground of Ground.t
   | List of value list
   | Tuple of value list
   | Null
-  | Meth of string * value * value
+  | Meth of meth_value * value
   | Ref of value Atomic.t
   | Fun of (string * string * value option) list * lazy_env * Term.t
   (* A function with given arguments (argument label, argument variable, default
@@ -182,6 +183,7 @@ val error : Runtime_error.runtime_error -> value
 val product : value -> value -> value
 val tuple : value list -> value
 val meth : value -> (string * value) list -> value
+val lazy_meth : value -> (string -> value) -> value
 val record : (string * value) list -> value
 val reference : value Atomic.t -> value
 

--- a/src/lang/lang_core.ml
+++ b/src/lang/lang_core.ml
@@ -90,8 +90,9 @@ let null = mk Null
 
 let rec meth v0 = function
   | [] -> v0
-  | (l, v) :: r -> mk (Meth (l, v, meth v0 r))
+  | (l, v) :: r -> mk (Meth (`Value (l, v), meth v0 r))
 
+let lazy_meth v fn = mk (Meth (`Lazy fn, v))
 let record = meth unit
 let reference x = mk (Ref x)
 let val_fun p f = mk (FFI (p, f))

--- a/src/lang/parser_helper.ml
+++ b/src/lang/parser_helper.ml
@@ -192,7 +192,7 @@ let args_of, app_of =
                  (fun idx v -> term_of_value ~pos (get_tuple_type idx) v)
                  l)
         | Value.Null -> Term.Null
-        | Value.Meth (name, v, v') ->
+        | Value.Meth (`Value (name, v), v') ->
             let meth_value, t = get_meth_type name t in
             Term.Meth
               ( { name; meth_value = term_of_value ~pos meth_value v },

--- a/src/libs/request.liq
+++ b/src/libs/request.liq
@@ -83,7 +83,7 @@ def request.queue(~id=null(), ~interactive=true, ~prefetch=1, ~native=false, ~qu
   end
 
   def add(r) =
-    log.severe(label=s.id(), "Please use #{s.id()}.push instead of #{s.id()}.add()")
+    log.severe(label=s.id, "Please use #{s.id}.push instead of #{s.id}.add()")
     s.add(r)
   end
 

--- a/src/libs/telnet.liq
+++ b/src/libs/telnet.liq
@@ -72,7 +72,7 @@ def replaces output.external(%argsof(output.external), f, p, s) =
   s = output.external(%argsof(output.external), f, p, s)
 
   s.on_get_ready(memoize({
-    server.register(namespace=s.id(), description="Re-open the output.",
+    server.register(namespace=s.id, description="Re-open the output.",
                     "reopen", fun (_) -> begin
                       s.reopen()
                       "Done."

--- a/tests/language/eval.liq
+++ b/tests/language/eval.liq
@@ -54,7 +54,7 @@ def f() =
 
   # Eval with sources!
   let eval x = "output.dummy(id='bla', blank())"
-  t("20", { x.id() == "bla"})
+  t("20", { x.id == "bla"})
 
   # Eval with patterns
   let eval {foo, gni = [x, y]} = "{foo = 123, gni = [1,2]}"


### PR DESCRIPTION
This PR adds support for runtime lazy methods in values.

The idea is to be able to be a little more permissive as to when a value is actually computed while remaining safe, thanks to the typing system.

The use-case in this PR is for sources ID but this should prove pretty handy in the `source.tracks` implementation.