### PR TITLE
Fix optional method type inference.

### DIFF
--- a/src/lang/typing.ml
+++ b/src/lang/typing.ml
@@ -572,7 +572,7 @@ and ( <: ) a b =
           try a <: t2 with Error (a, b) -> raise (Error (a, `Nullable b)))
       | Meth ({ meth = l }, _), _ when Type.has_meth b l -> unify_meth a b l
       | _, Meth ({ meth = l }, _) when Type.has_meth a l -> unify_meth a b l
-      | _, Meth ({ meth = l; optional; scheme = g2, t2; json_name }, _) -> (
+      | _, Meth ({ meth = l; optional; scheme = g2, t2; json_name }, c) -> (
           let a' = demeth a in
           match a'.descr with
             | Var { contents = Free _ } ->
@@ -593,7 +593,7 @@ and ( <: ) a b =
                           },
                           var () ));
                 a <: b
-            | _ when optional -> ()
+            | _ when optional -> a <: hide_meth l c
             | _ ->
                 raise
                   (Error

--- a/tests/language/record.liq
+++ b/tests/language/record.liq
@@ -105,8 +105,8 @@ def f() =
   def f(x) =
     [x, {foo = 123}]
   end
-  ignore(f(())?.foo)
-  (f({foo = 345}):{foo?:int})
+  ignore(list.hd(f(()))?.foo)
+  ignore((f({foo = 345}):[{foo?:int}]))
 
   x = { }
   ignore(x.foo ?? 123)


### PR DESCRIPTION
This PR fixes a gap in optional record method typing when doing subtyping of the form:
```
{ foo: int } <: 'a.{ gni?: float}
```
Currently, the typechecker stops when it finds a missing optional method, which means that `'a` in the above is never unified with `{foo: int}`

This PR continues the typechecking algorithm instead in this case, after removing the optional method from the underlying type so that:
* `{ foo: int } <: 'a.{ gni?: float}` results in the right hand side being unified to `{foo: int, gni?: float}`
* `{ foo: int } <: {gni: int}.{ gni?: float}` is a valid subtyping.

Both assumptions above are added as tests.