### PR TITLE
Make sure base type on a sup is always a fresh variable.

### DIFF
--- a/src/lang/typing.ml
+++ b/src/lang/typing.ml
@@ -199,7 +199,14 @@ exception Incompatible
     function so that it should always be followed by a subtyping. *)
 let rec sup ~pos a b =
   (* Printf.printf "  sup: %s \\/ %s\n%!" (Type.to_string a) (Type.to_string b); *)
-  let sup = sup ~pos in
+  let sup a b =
+    let s = sup ~pos a b in
+    match (demeth s).descr with
+      | Var _ ->
+          let v = Type.var () in
+          remeth s v
+      | _ -> s
+  in
   let mk descr = Type.make ?pos descr in
   let scheme_sup t t' =
     match (t, t') with ([], t), ([], t') -> ([], sup t t') | _ -> t'

--- a/tests/core/types.ml
+++ b/tests/core/types.ml
@@ -218,5 +218,7 @@ let () =
 
   (* sup 'a.{gni:int} 'a.{gni:int, foo?:int} *)
   let s = Typing.sup ~pos:a.Type.pos a b in
+  Printf.printf "The sup of %s and %s is %s.\n\n%!" (to_string a) (to_string b)
+    (to_string s);
   Typing.(a <: s);
   Typing.(b <: s)

--- a/tests/core/types.ml
+++ b/tests/core/types.ml
@@ -204,3 +204,19 @@ let () =
 
   (* This should work: {gni:int} <: {foo: float}.{foo?:int} *)
   Typing.(a_meth <: b_meth)
+
+let () =
+  (* 'a *)
+  let a_base = Lang.univ_t () in
+
+  (* 'a.{gni:int} *)
+  let a = Type.meth "gni" ([], Lang.int_t) a_base in
+
+  (* 'a.{gni:int, foo?:int} *)
+  let b = Type.meth ~optional:false "gni" ([], Lang.int_t) a_base in
+  let b = Type.meth ~optional:true "foo" ([], Lang.int_t) b in
+
+  (* sup 'a.{gni:int} 'a.{gni:int, foo?:int} *)
+  let s = Typing.sup ~pos:a.Type.pos a b in
+  Typing.(a <: s);
+  Typing.(b <: s)


### PR DESCRIPTION
I have seen cases where the `sup` of a two types still contains an original universal variable that then clashes during type unification between the two types and their sup.

This is the corresponding test:
```ocaml
  (* 'a *)
  let a_base = Lang.univ_t () in

  (* 'a.{gni:int} *)
  let a = Type.meth "gni" ([], Lang.int_t) a_base in

  (* 'a.{gni:int, foo?:int} *)
  let b = Type.meth ~optional:false "gni" ([], Lang.int_t) a_base in
  let b = Type.meth ~optional:true "foo" ([], Lang.int_t) b in

  (* sup 'a.{gni:int} 'a.{gni:int, foo?:int} *)
  let s = Typing.sup ~pos:a.Type.pos a b in
  Typing.(a <: s);
  Typing.(b <: s)
```

This PR simply replaces the root type of a `sup` with a fresh universal variable when it is already a universal variable. Since sups are supposed to be unified with their two lower parts afterward, this should be safe to do.