### PR TITLE
Make sure there's only one metadata at at given frame position.

### DIFF
--- a/src/core/stream/frame.ml
+++ b/src/core/stream/frame.ml
@@ -97,6 +97,7 @@ let get_all_metadata frame =
   Content.Metadata.get_data (get frame Fields.metadata)
 
 let set_all_metadata frame data =
+  let data = List.sort_uniq (fun (p, _) (p', _) -> Stdlib.compare p p') data in
   Content.Metadata.set_data (get frame Fields.metadata) data
 
 let set_metadata b t m = set_all_metadata b ((t, m) :: get_all_metadata b)

--- a/tests/core/content_test.ml
+++ b/tests/core/content_test.ml
@@ -1,5 +1,7 @@
 open Content
 
+let () = Frame_settings.lazy_config_eval := true
+
 let () =
   let marks ?(offset = 0) len = List.init len (fun x -> x + offset) in
   let c = Track_marks.(lift_data (make ~length:1000 ())) in
@@ -12,3 +14,19 @@ let () =
   Track_marks.set_data c' [];
   Content.blit c' 0 c 5 10;
   assert (Track_marks.get_data c = marks 5 @ marks ~offset:15 (1000 - 15))
+
+(* Test metadata uniqueness. *)
+let () =
+  let ctype =
+    Frame_type.content_type
+      (Lang.frame_t Lang.unit_t
+         (Frame.Fields.make ~audio:(Format_type.audio ()) ()))
+  in
+  let frame = Frame.create ctype in
+  let m = Hashtbl.create 12 in
+  Hashtbl.add m "foo" "bla";
+  Frame.set_metadata frame 123 m;
+  let m = Hashtbl.create 12 in
+  Hashtbl.add m "gni" "gno";
+  Frame.set_metadata frame 123 m;
+  assert (Frame.get_all_metadata frame = [(123, m)])


### PR DESCRIPTION
While debugging the new `tracks` branch I cam accros a situation where:
* A cached frame was adding the same metadata twice at position `0`.
* The `deduplicate` operator was considering the second one as a repeat and deleting it
* The `map_metadata` and `free_metadata` (weird name!) API both assumes that there is at most one metadata at a given position: https://github.com/savonet/liquidsoap/blob/main/src/core/operators/map_metadata.ml#L65

The real underlying problem is that our filling boundaries currently aren't mutually exclusive. Break, for instance, can be added several time at the same position to specify empty tracks, and metadata are usually added at the same time.

Thus, until we finally tackle the immutable content/streaming API rewrite, it seems to be that the best course of action is to make sure that metadata (not breaks!) are unique when sorted by position.

This PR does that with a quick `sort_uniq`. The other alternative would be a hash or map but this is too involved since we know we will eventually rework the whole thing.