### PR TITLE
Add multiline comments.

### DIFF
--- a/doc/content/language.md
+++ b/doc/content/language.md
@@ -1343,6 +1343,7 @@ Simple multiline comments:
 ```
 
 Multiline comments can be nested:
+
 ```liquidsoap
 #<
 This is a top-level comment
@@ -1351,11 +1352,12 @@ This is a top-level comment
 
   #<
     This is a nested code comment
-  ># 
+  >#
 >#
 ```
 
 Fancy looking multiline comment
+
 ```liquidsoap
 #<------- BEGIN CODE COMMENT ----#
 Comments can also look like this

--- a/doc/content/language.md
+++ b/doc/content/language.md
@@ -1325,3 +1325,33 @@ output.icecast(%mp3, host="localhost", port=8000,
 ```
 
 so that passwords are not shown in the main script.
+
+### Code comments
+
+Comments can be added to your code in two ways:
+
+_Multi-line comments_ are comments that can span multiple lines. They are delimitated
+by the sequence of characters `#<` at the beginning and `>#` at the end. Anything
+in between those two sequences is considered code comment. Nested code comments
+are also accepted:
+
+```liquidsoap
+#<------- BEGIN CODE COMMENT ----#
+    This is a comment
+
+# This is also a comment
+
+  #< This is a nested code comment >#
+
+#--------- END CODE COMMENT ----->#
+```
+
+_Single-line comments_ are comments that are limited to the current line. Such comments
+are started with the character `#` without a following `<`. Anything after the initial
+`#` character and until the end of the line is considered code comment:
+
+```liquidsoap
+def f(x) = # This is a single line comment.
+  123
+end
+```

--- a/doc/content/language.md
+++ b/doc/content/language.md
@@ -1332,17 +1332,33 @@ Comments can be added to your code in two ways:
 
 _Multi-line comments_ are comments that can span multiple lines. They are delimitated
 by the sequence of characters `#<` at the beginning and `>#` at the end. Anything
-in between those two sequences is considered code comment. Nested code comments
-are also accepted:
+in between those two sequences is considered code comment.
+
+Here are some examples:
+
+Simple multiline comments:
 
 ```liquidsoap
+#< This is a comment >#
+```
+
+Multiline comments can be nested:
+```liquidsoap
+#<
+This is a top-level comment
+
+  # This is also a comment
+
+  #<
+    This is a nested code comment
+  ># 
+>#
+```
+
+Fancy looking multiline comment
+```liquidsoap
 #<------- BEGIN CODE COMMENT ----#
-    This is a comment
-
-# This is also a comment
-
-  #< This is a nested code comment >#
-
+Comments can also look like this
 #--------- END CODE COMMENT ----->#
 ```
 

--- a/tests/language/comments.liq
+++ b/tests/language/comments.liq
@@ -1,33 +1,44 @@
-#------#
+#<------#
 This is
 a multiline comment
-#------#
+with > some # of
+these characters in it.
+#------>#
 
-#---------------#
+#<---------------
 # Yet another
 # form of multiline comment
-#----------------#
+ ---------------->#
 
-   #-----#
+   #<
 multiline comment can start and end
 in the middle of a line
-   #----#
+      >#
 
-#-----#
+#<-----#
 Anything following them
 is executed
-#----#x = 1
+#---->#x = 1
 
-#-----#y = x + 2.
+#<-----#y = x + 2.
 Anything after the mark
 is comment
-#----#
+#---->#
+
+#<---------------
+# Nested comments
+
+   #<
+     Are accepted
+   >#
+
+#---------------->#
 
 def f() =
   test.equals(x, 1)
 
   try
-    let eval _ = "#----#
+    let eval _ = "#<----#
 This comment is not terminated"
     test.fail()
   catch _ do

--- a/tests/language/comments.liq
+++ b/tests/language/comments.liq
@@ -1,27 +1,5 @@
-#-
-# This is
-a
-multiline
-comment -#
-
-#-this is another -
-multiline -
-comment
--#
-
-#- this is also
-a multiline
-comment -#
-
-#-
-Maybe the
-more standard form
-of multiline
-comment?
--#
-
 #------#
-and this is also
+This is
 a multiline comment
 #------#
 
@@ -30,14 +8,34 @@ a multiline comment
 # form of multiline comment
 #----------------#
 
-#-
-Multiline comment
-# leading dash
-  # and leading dash with spaces around them
-are trimmed
--#
+   #-----#
+multiline comment can start and end
+in the middle of a line
+   #----#
+
+#-----#
+Anything following them
+is executed
+#----#x = 1
+
+#-----#y = x + 2.
+Anything after the mark
+is comment
+#----#
 
 def f() =
+  test.equals(x, 1)
+
+  try
+    let eval _ = "#----#
+This comment is not terminated"
+    test.fail()
+  catch _ do
+    ()
+  end
+
+  let eval _ = "# single line comment can be followed by EOF"
+
   test.pass()
 end
 

--- a/tests/language/comments.liq
+++ b/tests/language/comments.liq
@@ -64,6 +64,11 @@ This comment is not terminated"
 
   let eval _ = "# single line comment can be followed by EOF"
 
+  test.equals("a#b", string.base64.decode("YSNi"))
+  test.equals(string(r/a#b/), "r/a#b/")
+  test.equals("a#<b>#c", string.base64.decode("YSM8Yj4jYw=="))
+  test.equals(string(r/a#<b>#c/), "r/a#<b>#c/")
+
   test.pass()
 end
 

--- a/tests/language/comments.liq
+++ b/tests/language/comments.liq
@@ -1,0 +1,44 @@
+#-
+# This is
+a
+multiline
+comment -#
+
+#-this is another -
+multiline -
+comment
+-#
+
+#- this is also
+a multiline
+comment -#
+
+#-
+Maybe the
+more standard form
+of multiline
+comment?
+-#
+
+#------#
+and this is also
+a multiline comment
+#------#
+
+#---------------#
+# Yet another
+# form of multiline comment
+#----------------#
+
+#-
+Multiline comment
+# leading dash
+  # and leading dash with spaces around them
+are trimmed
+-#
+
+def f() =
+  test.pass()
+end
+
+test.check(f)

--- a/tests/language/comments.liq
+++ b/tests/language/comments.liq
@@ -34,6 +34,23 @@ is comment
 
 #---------------->#
 
+s = "foo
+#<-----
+this is a comment inside a string,
+it is not a code comment!
+#---->
+bar
+"
+ignore(s)
+
+r = r/foo
+#<-----
+this is a comment inside a regexp,
+it is not a code comment!
+#---->
+bar/
+ignore(r)
+
 def f() =
   test.equals(x, 1)
 

--- a/tests/language/dune.inc
+++ b/tests/language/dune.inc
@@ -289,6 +289,19 @@
  (alias citest)
  (package liquidsoap)
  (deps
+  comments.liq
+  ../media/all_media_files
+  ../../src/bin/liquidsoap.exe
+  (source_tree ../../src/libs)
+  (:stdlib ../../src/libs/stdlib.liq)
+  (:test_liq ../test.liq)
+  (:run_test ../run_test.exe))
+ (action (run %{run_test} comments.liq liquidsoap %{test_liq} comments.liq)))
+
+(rule
+ (alias runtest)
+ (package liquidsoap)
+ (deps
   pattern.liq
   ../media/all_media_files
   ../../src/bin/liquidsoap.exe


### PR DESCRIPTION
This is a proposal for multiline comments. Multiline comments are started with:
```
#<
```

and ended with:

```
>#
```

This mimicks the `/*` and `*/` for C/javascript but allows some nice additional ASCII art

Syntax is intended to allow several nice combinations such as:
```
#<------#
This is
a multiline comment
#------>#

#<---------------#
# Yet another
# form of multiline comment
#---------------->#

   #<
multiline comment can start and end
in the middle of a line
   >#
   
      #<
    #<------
        Also nested comments are cool
    ---->#
   >#

#<-----#
Anything following them
is executed
#---->#x = 1

#<-----#y = x + 2.
Anything after the mark
is comment
#---->#
```

