### PR TITLE
Fix metadata json parse function

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -73,6 +73,7 @@ Fixed:
   could lead to incorrectly randomized playlists (#2507, #2500).
 - Fixed srt output in listener mode to allow more than one listener at a time and
   prevent listening socket from being re-created on listener disconnection (#2556)
+- Fixed `metadata.json.parse` always returns an empty list (#2815).
 
 ---
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -73,7 +73,6 @@ Fixed:
   could lead to incorrectly randomized playlists (#2507, #2500).
 - Fixed srt output in listener mode to allow more than one listener at a time and
   prevent listening socket from being re-created on listener disconnection (#2556)
-- Fixed `metadata.json.parse` always returns an empty list (#2815).
 
 ---
 

--- a/src/libs/metadata.liq
+++ b/src/libs/metadata.liq
@@ -172,7 +172,7 @@ end
 
 # Parse metadata from JSON object.
 # @category Metadata
-def metadata.json.parse(s) =
-  let json.parse ( m : [(string * string)]? ) = s
-  m ?? []
+def metadata.json.parse(json_string) =
+  let json.parse ( metadata_list : [(string * string)] as json.object ) = json_string
+  metadata_list
 end

--- a/tests/language/metadata.liq
+++ b/tests/language/metadata.liq
@@ -50,4 +50,46 @@ def f() =
   test.pass()
 end
 
+def test_metadata_json_stringify() =
+  file_metadata = [
+    ("filename", "test.mp3"),
+    ("temporary", "false"),
+    ("initial_uri", "test.mp3"),
+    ("encoder", "Lavf59.27.100"),
+    ("status", "ready"),
+    ("rid", "0"),
+    ("artist", "Artist")
+  ]
+  expected_json_string = '{ "artist": "Artist" }'
+
+  json_string = metadata.json.stringify(file_metadata)
+  t(json_string, expected_json_string)
+
+  empty_file_metadata = []
+  expected_json_string = '{}'
+
+  json_string = metadata.json.stringify(empty_file_metadata)
+  t(json_string, expected_json_string)
+
+  test.pass()
+end
+
+def test_metadata_json_parse() =
+  metadata_json_string = '{"artist": "Artist"}'
+  expected_parsed_metadata = [("artist", "Artist")]
+
+  parsed_metadata = metadata.json.parse(metadata_json_string)
+  t(parsed_metadata, expected_parsed_metadata)
+
+  empty_metadata_json_string = '{}'
+  expected_parsed_metadata = []
+
+  parsed_metadata = metadata.json.parse(empty_metadata_json_string)
+  t(parsed_metadata, expected_parsed_metadata)
+
+  test.pass()
+end
+
 test.check(f)
+test.check(test_metadata_json_stringify)
+test.check(test_metadata_json_parse)


### PR DESCRIPTION
## Summary
Fix incorrect `json.parse` usage in `metadata.json.parse`.

Test functions
- `metadata.json.stringify`
- `metadata.json.parse`

Fixes #2812.
