### PR TITLE
Detect functions defining the same label multiple times.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,6 +21,7 @@ New:
 - Added syntactic sugar for record spread: `let {foo, gni, ..y} = x`
   and `y = { foo = 123, gni = "aabb", ...x}` (#2737)
 - Added `file.{copy, move}` (#2771)
+- Detect functions defining multiple arguments with the same label (#2823).
 
 Changed:
 

--- a/src/lang/runtime.ml
+++ b/src/lang/runtime.ml
@@ -125,6 +125,11 @@ let throw ?(formatter = Format.std_formatter) lexbuf =
         (if lbl = "" then "unlabeled argument"
         else Format.sprintf "argument labeled %S" lbl);
       raise Error
+  | Term.Duplicate_label (pos, lbl) ->
+      error_header ~formatter 6 pos;
+      Format.fprintf formatter
+        "Function has multiple arguments with the same label: %s@]@." lbl;
+      raise Error
   | Error.Invalid_value (v, msg) ->
       error_header ~formatter 7 v.Value.pos;
       Format.fprintf formatter "Invalid value:@ %s@]@." msg;

--- a/src/lang/term.ml
+++ b/src/lang/term.ml
@@ -426,7 +426,7 @@ exception Ignored of t
     helpful. *)
 exception No_label of t * string * bool * t
 
-(** A function defines multiple times a given label. *)
+(** A function defines multiple arguments with the same label. *)
 exception Duplicate_label of Pos.Option.t * string
 
 (** Some mandatory arguments with given label and typed were not passed to the

--- a/src/lang/term.ml
+++ b/src/lang/term.ml
@@ -413,25 +413,30 @@ let can_ignore t =
 
 (** {1 Basic checks and errors} *)
 
+(** Trying to use an unbound variable. *)
 exception Unbound of Pos.Option.t * string
+
+(** Silently discarding a meaningful value. *)
 exception Ignored of t
 
 (** [No_label (f,lbl,first,x)] indicates that the parameter [x] could not be
-  * passed to the function [f] because the latter has no label [lbl].
-  * The [first] information tells whether [lbl=x] is the first parameter with
-  * label [lbl] in the considered application, which makes the message a bit
-  * more helpful. *)
+    passed to the function [f] because the latter has no label [lbl].  The
+    [first] information tells whether [lbl=x] is the first parameter with label
+    [lbl] in the considered application, which makes the message a bit more
+    helpful. *)
 exception No_label of t * string * bool * t
+
+(** A function defines multiple times a given label. *)
+exception Duplicate_label of Pos.Option.t * string
 
 (** Some mandatory arguments with given label and typed were not passed to the
     function during an application. *)
 exception Missing_arguments of Pos.Option.t * (string * Type.t) list
 
-(** Check that all let-bound variables are used.
-  * No check is performed for variable arguments.
-  * This cannot be done at parse-time (as for the computatin of the
-  * free variables of functions) because we need types, as well as
-  * the ability to distinguish toplevel and inner let-in terms. *)
+(** Check that all let-bound variables are used. No check is performed for
+    variable arguments. This cannot be done at parse-time (as for the
+    computation of the free variables of functions) because we need types, as
+    well as the ability to distinguish toplevel and inner let-in terms. *)
 exception Unused_variable of (string * Pos.t)
 
 let check_unused ~throw ~lib tm =

--- a/src/lang/typechecking.ml
+++ b/src/lang/typechecking.ml
@@ -162,6 +162,15 @@ let rec check ?(print_toplevel = false) ~throw ~level ~(env : Typing.env) e =
         ([], env) proto
     in
     let proto_t = List.rev proto_t in
+    (* Ensure that we don't have the same label twice. *)
+    List.fold_left
+      (fun labels (_, l, _) ->
+        if l = "" then labels
+        else (
+          if List.mem l labels then raise (Duplicate_label (e.t.Type.pos, l));
+          l :: labels))
+      [] proto_t
+    |> ignore;
     check ~level ~env body;
     e.t >: mk (Type.Arrow (proto_t, body.t))
   in

--- a/src/libs/shoutcast.liq
+++ b/src/libs/shoutcast.liq
@@ -11,7 +11,7 @@ def output.shoutcast(
   %argsof(
    output.icecast[!headers,!description,!protocol]
   ),
-  ~icy_reset=true,~icy_id=1,~dj={""},
+  ~icy_reset=true,~dj={""},
   ~aim="",~icq="",~irc="",
   e, s) =
   icy_reset = if icy_reset then "1" else "0" end

--- a/tests/language/type_errors.liq
+++ b/tests/language/type_errors.liq
@@ -82,6 +82,7 @@ def f() =
   correct('fallback(transitions=[fun(x,y,a=2)->x],[blank()])')
   incorrect('fallback(transitions=[fun(x,y)->y+1],[blank()])')
   correct('x=fun(f)->f(3) y=x(fun(f,u="1")->u) ignore(y)')
+  incorrect('f=fun(~l,~l) -> l')
 
   section("CONTENT KIND")
   incorrect('output.file(%vorbis(stereo),"foo",mean(blank()))')


### PR DESCRIPTION
This avoids situations such as #2819.