### PR TITLE
Switch to clock_nanosleep when available.

### DIFF
--- a/.github/scripts/build-posix.sh
+++ b/.github/scripts/build-posix.sh
@@ -32,8 +32,14 @@ echo "::endgroup::"
 echo "::group::Setting up specific dependencies"
 
 # TODO: Add those to docker CI images.
-cd ocaml-metadata && opam install -y .
-opam install -y fileutils
+cd ocaml-metadata && opam install -y . fileutils
+
+if [ -z "${LIQ_BUILD_MIN}" ]; then
+  git clone https://github.com/savonet/ocaml-posix.git
+  cd ocaml-posix && opam install -y . && cd ..
+  # See: https://github.com/whitequark/ocaml-inotify/pull/20
+  opam install -y uri inotify.2.3
+fi
 
 cd /tmp/liquidsoap-full/liquidsoap
 
@@ -61,9 +67,6 @@ git reset --hard
 echo "::endgroup::"
 
 echo "::group::Compiling"
-
-# See: https://github.com/whitequark/ocaml-inotify/pull/20
-opam install -y uri inotify.2.3
 
 cd /tmp/liquidsoap-full
 

--- a/.github/scripts/build-posix.sh
+++ b/.github/scripts/build-posix.sh
@@ -31,15 +31,15 @@ echo "::endgroup::"
 
 echo "::group::Setting up specific dependencies"
 
-# TODO: Add those to docker CI images.
-cd ocaml-metadata && opam install -y . fileutils
-
 if [ -z "${LIQ_BUILD_MIN}" ]; then
   git clone https://github.com/savonet/ocaml-posix.git
   cd ocaml-posix && opam install -y . && cd ..
   # See: https://github.com/whitequark/ocaml-inotify/pull/20
   opam install -y uri inotify.2.3
 fi
+
+# TODO: Add those to docker CI images.
+cd ocaml-metadata && opam install -y . fileutils
 
 cd /tmp/liquidsoap-full/liquidsoap
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,8 @@ jobs:
           echo "::endgroup::"
           cd liquidsoap
           ./.github/scripts/build-posix.sh ${{ steps.cpu_cores.outputs.count }}
+        env:
+          LIQ_BUILD_MIN: true
       - name: Build doc
         run: |
           cd /tmp/liquidsoap-full/liquidsoap

--- a/dune-project
+++ b/dune-project
@@ -64,7 +64,7 @@
     osc-unix
     osx-secure-transport
     portaudio
-    posix-time2
+    (posix-time2 (>= 2.1.0))
     pulseaudio
     prometheus-liquidsoap
     samplerate

--- a/liquidsoap.opam
+++ b/liquidsoap.opam
@@ -67,7 +67,7 @@ depopts: [
   "osc-unix"
   "osx-secure-transport"
   "portaudio"
-  "posix-time2"
+  "posix-time2" {>= "2.1.0"}
   "pulseaudio"
   "prometheus-liquidsoap"
   "samplerate"

--- a/src/core/tools/liq_posix_time.ml
+++ b/src/core/tools/liq_posix_time.ml
@@ -45,7 +45,10 @@ module Sys_time = struct
     else x.tv_sec <= y.tv_sec
 
   let rec sleep_until t =
-    try clock_nanosleep ~clock:`Monotonic ~absolute:true t
+    try
+      clock_nanosleep
+        ~clock:(if Sys.os_type = "Unix" then `Monotonic else `Realtime)
+        ~absolute:true t
     with Unix.Unix_error (Unix.EINTR, _, _) -> sleep_until t
 end
 

--- a/src/core/tools/liq_posix_time.ml
+++ b/src/core/tools/liq_posix_time.ml
@@ -44,7 +44,9 @@ module Sys_time = struct
     if Int64.equal x.tv_sec y.tv_sec then x.tv_nsec <= y.tv_nsec
     else x.tv_sec <= y.tv_sec
 
-  let sleep = nanosleep
+  let rec sleep_until t =
+    try clock_nanosleep ~clock:`Monotonic ~absolute:true t
+    with Unix.Unix_error (Unix.EINTR, _, _) -> sleep_until t
 end
 
 let posix_time : (module Liq_time.T) = (module Sys_time)

--- a/src/core/tools/liq_time.ml
+++ b/src/core/tools/liq_time.ml
@@ -3,7 +3,7 @@ module type T = sig
 
   val implementation : string
   val time : unit -> t
-  val sleep : t -> unit
+  val sleep_until : t -> unit
   val of_float : float -> t
   val to_float : t -> float
   val ( |+| ) : t -> t -> t
@@ -25,7 +25,12 @@ module Unix = struct
   let ( |*| ) x y = x *. y
   let ( |<| ) x y = x < y
   let ( |<=| ) x y = x <= y
-  let sleep = Thread.delay
+
+  let rec sleep_until t =
+    let delay = t -. time () in
+    if 0. < delay then (
+      try Thread.delay delay
+      with Unix.Unix_error (Unix.EINTR, _, _) -> sleep_until t)
 end
 
 let unix : (module T) = (module Unix)

--- a/src/core/tools/liq_time.mli
+++ b/src/core/tools/liq_time.mli
@@ -3,7 +3,7 @@ module type T = sig
 
   val implementation : string
   val time : unit -> t
-  val sleep : t -> unit
+  val sleep_until : t -> unit
   val of_float : float -> t
   val to_float : t -> float
   val ( |+| ) : t -> t -> t


### PR DESCRIPTION
This PR is a nit picking improvement when using posix time: when looping on `nanosleep`, if the thread is interrupted often, it is possible to oversleep because of lags and gaps between wake up time and the time the thread is scheduled again.

This is documented in the `nanosleep` function manpage:

> The fact that nanosleep() sleeps for a relative interval can be
> problematic if the call is repeatedly restarted after being
> interrupted by signals, since the time between the interruptions
> and restarts of the call will lead to drift in the time when the
> sleep finally completes.  This problem can be avoided by using
> clock_nanosleep(2) with an absolute time value.

This PR switches to `clock_nanosleep` in such cases.

Posix time is also available on mingw but in this case the clock to use for `clock_nanosleep` is the realtime one only.