### PR TITLE
Clock follower enhancements

### DIFF
--- a/src/core/builtins/builtins_ffmpeg_decoder.ml
+++ b/src/core/builtins/builtins_ffmpeg_decoder.ml
@@ -511,8 +511,8 @@ let mk_encoder mode =
 
          new Producer_consumer.producer
          (* We are expecting real-rate with a couple of hickups.. *)
-           ~check_self_sync:false ~consumers:[consumer] ~name:(id ^ ".producer")
-           ()))
+           ~create_known_clock:false ~check_self_sync:false
+           ~consumers:[consumer] ~name:(id ^ ".producer") ()))
 
 let () =
   List.iter mk_encoder

--- a/src/core/builtins/builtins_ffmpeg_encoder.ml
+++ b/src/core/builtins/builtins_ffmpeg_encoder.ml
@@ -668,8 +668,8 @@ let mk_encoder mode =
 
          new Producer_consumer.producer
          (* We are expecting real-rate with a couple of hickups.. *)
-           ~check_self_sync:false ~consumers:[consumer] ~name:(id ^ ".producer")
-           ()))
+           ~create_known_clock:false ~check_self_sync:false
+           ~consumers:[consumer] ~name:(id ^ ".producer") ()))
 
 let () =
   List.iter mk_encoder

--- a/src/core/builtins/builtins_ffmpeg_filters.ml
+++ b/src/core/builtins/builtins_ffmpeg_filters.ml
@@ -886,7 +886,7 @@ let _ =
       in
       unify_clocks ~clock:input_clock graph.graph_inputs;
       let output_clock =
-        Clock.create_unknown ~sources:[] ~sub_clocks:[input_clock]
+        Clock.create_unknown ~sources:[] ~sub_clocks:[input_clock] ()
       in
       unify_clocks ~clock:output_clock graph.graph_outputs;
       Queue.add

--- a/src/core/clock.mli
+++ b/src/core/clock.mli
@@ -159,8 +159,10 @@ type clock_variable = Source.clock_variable
 val to_string : clock_variable -> string
 
 val create_unknown :
+  ?start:bool ->
   sources:Source.active_source list ->
   sub_clocks:clock_variable list ->
+  unit ->
   clock_variable
 
 val create_known : Source.clock -> clock_variable

--- a/src/core/lang_source.ml
+++ b/src/core/lang_source.ml
@@ -342,8 +342,12 @@ let add_operator ~(category : Doc.Value.source) ~descr ?(flags = [])
       in
       _meth v (List.map (fun (name, _, _, fn) -> (name, fn src)) meth)
     with
-      | Source.Clock_conflict (a, b) -> raise (Error.Clock_conflict (pos, a, b))
-      | Source.Clock_loop (a, b) -> raise (Error.Clock_loop (pos, a, b))
+      | Source.Clock_conflict (a, b) ->
+          let bt = Printexc.get_raw_backtrace () in
+          Printexc.raise_with_backtrace (Error.Clock_conflict (pos, a, b)) bt
+      | Source.Clock_loop (a, b) ->
+          let bt = Printexc.get_raw_backtrace () in
+          Printexc.raise_with_backtrace (Error.Clock_loop (pos, a, b)) bt
   in
   let base_t =
     if category = `Output then unit_t else source_t ~methods:false return_t

--- a/src/core/source.mli
+++ b/src/core/source.mli
@@ -262,6 +262,7 @@ class type clock =
     method id : string
 
     method sync_mode : sync
+    method start : bool
 
     (** Attach an active source to the clock. *)
     method attach : active_source -> unit
@@ -292,8 +293,10 @@ module Clock_variables : sig
   val to_string : clock_variable -> string
 
   val create_unknown :
+    ?start:bool ->
     sources:active_source list ->
     sub_clocks:clock_variable list ->
+    unit ->
     clock_variable
 
   val create_known : clock -> clock_variable
@@ -301,6 +304,7 @@ module Clock_variables : sig
   val forget : clock_variable -> clock_variable -> unit
   val get : clock_variable -> clock
   val is_known : clock_variable -> bool
+  val should_start : clock_variable -> bool
 
   (* This is exported for testing purposes only at the moment. *)
   val subclocks : clock_variable -> clock_variable list

--- a/src/core/tools/producer_consumer.ml
+++ b/src/core/tools/producer_consumer.ml
@@ -65,7 +65,7 @@ class consumer ~write_frame ~name ~source () =
 (** The source which produces data by reading the buffer.
     We do NOT want to use [operator] here b/c the [consumers]
     may have different content-kind when this is used in the muxers. *)
-class producer ~check_self_sync ~consumers ~name () =
+class producer ?create_known_clock ~check_self_sync ~consumers ~name () =
   let infallible = List.for_all (fun s -> s#stype = `Infallible) consumers in
   let self_sync_type = Utils.self_sync_type consumers in
   object (self)
@@ -73,7 +73,7 @@ class producer ~check_self_sync ~consumers ~name () =
 
     inherit!
       Child_support.base
-        ~check_self_sync
+        ?create_known_clock ~check_self_sync
         (List.map (fun s -> Lang.source (s :> Source.source)) consumers) as child_support
 
     method self_sync =

--- a/tests/core/source_test.ml
+++ b/tests/core/source_test.ml
@@ -3,9 +3,9 @@ open Source.Clock_variables
 (* Reference: https://github.com/savonet/liquidsoap/pull/1272 *)
 
 let () =
-  let c1 = create_unknown ~sources:[] ~sub_clocks:[] in
-  let c2 = create_unknown ~sources:[] ~sub_clocks:[c1] in
-  let c3 = create_unknown ~sources:[] ~sub_clocks:[c1] in
+  let c1 = create_unknown ~sources:[] ~sub_clocks:[] () in
+  let c2 = create_unknown ~sources:[] ~sub_clocks:[c1] () in
+  let c3 = create_unknown ~sources:[] ~sub_clocks:[c1] () in
   (* Make sure unification of a variable with itself
      works as expected. *)
   unify c2 c2;


### PR DESCRIPTION
Ho boy, this is a another dirty take on the clock system, which is planned to be re-implemented in the next major development cycle.

## Description of the problem

This PR relates to complications stemming from inline `ffmpeg` encoders and decoders and, though not touched in recent changes, probably to ffmpeg filters implementations.

The problem with `ffmpeg` inline encoders/decoders is that they cannot happen synchronously. Typically, a given video packet may contain a `B` frame which needs to wait for a future key frame to be decodable. Likewise, but perhaps less complicated, a given audio packet may span over two internal frames.

The way to solve that is to consider that those encoders needs to have a follower clock that is considered _almost_ real time like the main clock, give or take a couple hiccups.

For instance, when trying to generated one decoded frame, the decoder may need to process two frames from the encoded data to get to the nearest video keyframe, fill up the currently decoded frame with the resulting data and buffer the rest for the next frame to decode. Overall, though, the two clocks should never drift appart too much.

<img width="730" alt="Screenshot 2023-01-12 at 8 25 10 AM" src="https://user-images.githubusercontent.com/871060/212092304-6e4da2f5-1543-4146-8d5b-0bec3643bd87.png">

This also means, though, that we have to consider the same restrictions as we do with all clocks, in particular when checking if a source belongs to two clocks.

For instance, if we have something like this:
```ruby
s = sine()

encoded_sine = ffmpeg.encode.audio(%ffmpeg(%audio(codec="aac")), s)

output.ao(fallbakc([s, blank()])
```
This will fail because `s` belongs the `ao` (soundcard) clock as well as the follower clock set up by the `ffmpeg` encoder as described above.

While this was already fun, this gets even more interesting with tracks support. First, inline encoding is pushed down to track level, for instance:
```
track.ffmpeg.decode.audio: ffmpeg.copy('a) -> pcm('b)
```

And, keep in mind that under the hood, a track is just a source with a specific field of interest so, `track.ffmpeg.decode.audio` is, essentially, `ffmpeg.decode.audio` applied to a source `s` with that field of interest in it, which is why we have kept this label in the schemas below.

And, now, we want to lift this to re-implement the source-level `ffmpeg.audio.decode` operator at the script level. A naive implementation would be:
```
def ffmpeg.decode.audio(s) =
  let {audio, metadata, track_marks} = source.tracks(s)
  source({
    track_marks = track_marks,
    metadata    = metadata,
    audio       = track.ffmpeg.decode.audio(audio)
  })
end
```

<img width="539" alt="Screenshot 2023-01-12 at 8 32 18 AM" src="https://user-images.githubusercontent.com/871060/212093992-cf8ed0fd-548f-476f-bb05-d252dcb69ee7.png">

This won't work because `metadata` and `track_marks` are tracks from the `s` source which belongs to the follow clock setup by `track.ffmpeg.decode.audio(audio)` to do the decoding, as explained above, while `audio` comes from the `track.ffmpeg.decode.audio(audio)` underlying source, which belongs to the top-level clock driving the follow-clock.

This can, fortunately, be solved by picking up `metadata` and `track_marks` from the encoded track (remember tracks are just a source along with a field of interest and all sources have `metadata` and `track_marks` fields so this works):

```
def ffmpeg.decode.audio(s) =
  audio = track.ffmpeg.decode.audio(source.tracks(s).audio)
  source(id=id, {
    track_marks = track.track_marks(audio),
    metadata    = track.metadata(audio),
    audio       = audio
  })
end
```

<img width="566" alt="Screenshot 2023-01-12 at 8 34 02 AM" src="https://user-images.githubusercontent.com/871060/212094360-501e0f4e-49a7-4e57-bbd1-48427732ca44.png">

So, that's pretty cool but now let's look at the `audio_video` counter part:

```
def ffmpeg.decode.audio_video(s) =
  let {audio, video} = source.tracks(s)
  audio = track.ffmpeg.decode.audio(audio)
  video = track.ffmpeg.decode.video(video)
  source(id=id, {
    track_marks = track.track_marks(audio),
    metadata    = track.metadata(audio),
    audio       = audio,
    video       = video
  })
end
```

<img width="697" alt="Screenshot 2023-01-12 at 8 41 49 AM" src="https://user-images.githubusercontent.com/871060/212096335-66598220-6e16-47fc-a278-68d1609a3b39.png">


Here, we encode both `audio` and `video` track and pick one to extract `track_marks` and `metadata`. But the problem is, the current implementation for follow-clock will create a follow-clock for both the `audio` and `video` track and these clocks will fail to unify.

## Proposed solution

This PR proposes a new mechanism to allow follow-clocks to be unified. Instead of creating a known clock when initializing the follow clock, only a clock variable is set and this variable is initialized during the clock unification process.

<img width="752" alt="Screenshot 2023-01-12 at 8 36 31 AM" src="https://user-images.githubusercontent.com/871060/212096371-ad74d24f-2771-4ead-af09-45370695a581.png">

When the unified follow-clock ticks, both its `audio` and `video` consumers get the proper data they need and they can, in turn, return a decoded/encoded data within their own clock cycle.

If the `audio` source is animated first to produce data, the underlying source also sends data generated during its follow clock tick to the `video` source, which can buffer it and use it for its own operation when it gets ticked next.

Ideally, both `audio` and `video` should be also guaranteed to be in the same clock but that's not something easy to do while this implementation should work in most reasonable case such as the `audio_video` implementation above.

### Implementation

By using terms such as `follow clock` here, I am anticipating the future rewrite. Currently, our clock code is pretty old and did not anticipate any of this. Technically, a `follow clock` means two things:
* A clock that does not run its own streaming thread, marked by a `false` value for `start`
* A relationship with another operator that is in charge of animating this clock when it needs some data from it.

These two assumptions are captured by `Producer_consumer` and `Child_support`.

We have two different areas that use follow-clock:
1. Operators with different time scale. For instance, `soundtouch` and `resample`. These operator want a full control over their children clock to accelerate and etc.
2. Operators with the same time scale with a couple of hiccups. These are the inline encoders and decoders as well as ffmpeg filter inputs/outputs

Historically, both situations have been solved with the same tool, `Producer_consumer`, which was wrong. Because we are planning a full rewrite of all this, this PR does not try to separate them right now but adds another opt-in behavior, allowing the consumer to not create a known clock instead leaving its clock as unknown to be unified later.

Likewise, unknown clocks are given an optional `start` parameter which, when resolving, informs that the clock to initialize for them should be a follow clock, i.e. a clock with no streaming thread.