### PR TITLE
Implement references as objects.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,6 +24,10 @@ New:
 - Added `file.{copy, move}` (#2771)
 - Detect functions defining multiple arguments with the same label (#2823).
 - Added `null.map`.
+- References of type `'a` are now objects of type `(()->'a).{set : ('a) -> unit}`. This means that you should use `x()` instead of `!x` in order to get
+  the value of a reference. Setting a reference can be done both by `x.set(v)`
+  and `x := v` (which is still supported as a notation). `ref.getter` has no
+  more use and has been removed (#2881).
 
 Changed:
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -26,8 +26,7 @@ New:
 - Added `null.map`.
 - References of type `'a` are now objects of type `(()->'a).{set : ('a) -> unit}`. This means that you should use `x()` instead of `!x` in order to get
   the value of a reference. Setting a reference can be done both by `x.set(v)`
-  and `x := v` (which is still supported as a notation). `ref.getter` has no
-  more use and has been removed (#2881).
+  and `x := v`, which is still supported as a notation (#2881).
 
 Changed:
 

--- a/src/core/lang.mli
+++ b/src/core/lang.mli
@@ -63,7 +63,6 @@ and in_value = Liquidsoap_lang.Value.in_value =
   | Tuple of value list
   | Null
   | Meth of string * value * value
-  | Ref of value Atomic.t
   | Fun of
       (string * string * value option) list * lazy_env * Liquidsoap_lang.Term.t
   (* A function with given arguments (argument label, argument variable, default
@@ -75,10 +74,10 @@ val split_meths : value -> (string * value) list * value
 
 (** Iter a function over all sources contained in a value. This only applies to
     statically referenced objects, i.e. it does not explore inside reference
-    cells. [on_reference] is used when we encounter a reference cell that may
+    cells. [on_imprecise] is used when we encounter a value cell that may
     contain a source. If not passed, we display a warning log. *)
 val iter_sources :
-  ?on_reference:(unit -> unit) -> (Source.source -> unit) -> value -> unit
+  ?on_imprecise:(unit -> unit) -> (Source.source -> unit) -> value -> unit
 
 (** {2 Computation} *)
 
@@ -183,7 +182,6 @@ val to_valued_option : (value -> 'a) -> value -> 'a option
 val to_default_option : default:'a -> (value -> 'a) -> value -> 'a
 val to_product : value -> value * value
 val to_tuple : value -> value list
-val to_ref : value -> value Atomic.t
 val to_metadata_list : value -> (string * string) list
 val to_metadata : value -> Frame.metadata
 val to_string_list : value -> string list
@@ -214,7 +212,6 @@ val optional_method_t : t -> (string * scheme * string) list -> t
 val list_t : t -> t
 val of_list_t : t -> t
 val nullable_t : t -> t
-val ref_t : t -> t
 val error_t : t
 val source_t : ?methods:bool -> t -> t
 val of_source_t : t -> t
@@ -262,7 +259,6 @@ val product : value -> value -> value
 val tuple : value list -> value
 val meth : value -> (string * value) list -> value
 val record : (string * value) list -> value
-val reference : value Atomic.t -> value
 val http_transport : Http.transport -> value
 
 (** Build a function from an OCaml function. Items in the prototype indicate

--- a/src/core/lang_source.ml
+++ b/src/core/lang_source.ml
@@ -343,8 +343,6 @@ let check_content v t =
             check_value v t
         (* The type says that we should drop the method. *)
         | Value.Meth (_, _, v), _ -> check_value v t
-        | Ref r, Type.Constr { Type.constructor = "ref"; params = [(_, t)] } ->
-            check_value (Atomic.get r) t
         (* We don't check functions, assuming anything creating a source is a
            FFI registered via add_operator so the check will happen there. *)
         | Fun _, _ | FFI _, _ -> ()
@@ -482,7 +480,9 @@ let add_track_operator ~(category : Doc.Value.source) ~descr ?(flags = [])
   let category = `Source category in
   add_builtin ~category ~descr ~flags ?base name arguments return_t f
 
-let iter_sources ?on_reference ~static_analysis_failed f v =
+let iter_sources ?on_imprecise f v =
+  (* TODO *)
+  ignore on_imprecise;
   let itered_values = ref [] in
   let rec iter_term env v =
     match v.Term.term with
@@ -542,6 +542,7 @@ let iter_sources ?on_reference ~static_analysis_failed f v =
             List.iter (function _, _, Some v -> iter_value v | _ -> ()) proto
         | FFI (proto, _) ->
             List.iter (function _, _, Some v -> iter_value v | _ -> ()) proto
+      (*
         | Ref r ->
             if List.memq r !static_analysis_failed then ()
             else (
@@ -574,8 +575,9 @@ let iter_sources ?on_reference ~static_analysis_failed f v =
                         "WARNING! Found a reference, potentially containing \
                          sources, inside a dynamic source-producing function. \
                          Static analysis cannot be performed: make sure you \
-                         are not sharing sources contained in references!")))
+                         are not sharing sources contained in references!"))
+               *))
   in
   iter_value v
 
-let iter_sources = iter_sources ~static_analysis_failed:(ref [])
+let iter_sources = iter_sources

--- a/src/core/lang_source.ml
+++ b/src/core/lang_source.ml
@@ -480,9 +480,7 @@ let add_track_operator ~(category : Doc.Value.source) ~descr ?(flags = [])
   let category = `Track category in
   add_builtin ~category ~descr ~flags ?base name arguments return_t f
 
-let iter_sources ?on_imprecise f v =
-  (* TODO *)
-  ignore on_imprecise;
+let iter_sources ?(on_imprecise = fun () -> ()) f v =
   let itered_values = ref [] in
   let rec iter_term env v =
     match v.Term.term with
@@ -541,6 +539,7 @@ let iter_sources ?on_imprecise f v =
             iter_term env body;
             List.iter (function _, _, Some v -> iter_value v | _ -> ()) proto
         | FFI (proto, _) ->
+            on_imprecise ();
             List.iter (function _, _, Some v -> iter_value v | _ -> ()) proto
       (*
         | Ref r ->

--- a/src/core/operators/append.ml
+++ b/src/core/operators/append.ml
@@ -27,7 +27,7 @@ class append ~insert_missing ~merge source f =
   let failed = ref false in
   let () =
     Lang.iter_sources
-      ~on_reference:(fun () -> failed := true)
+      ~on_imprecise:(fun () -> failed := true)
       (fun s -> sources := s :: !sources)
       f
   in

--- a/src/core/operators/switch.ml
+++ b/src/core/operators/switch.ml
@@ -44,7 +44,7 @@ class virtual switch ~name ~override_meta ~transition_length
   let () =
     List.iter
       (Lang.iter_sources
-         ~on_reference:(fun () -> failed := true)
+         ~on_imprecise:(fun () -> failed := true)
          (fun s -> sources := s :: !sources))
       (List.map (fun c -> c.transition) cases)
   in

--- a/src/lang/builtins_ref.ml
+++ b/src/lang/builtins_ref.ml
@@ -20,34 +20,23 @@
 
  *****************************************************************************)
 
+let ref_t a =
+  Lang.record_t
+    [("get", Lang.fun_t [] a); ("set", Lang.fun_t [(false, "", a)] Lang.unit_t)]
+
 let ref =
   let a = Lang.univ_t () in
   Lang.add_builtin "ref" ~category:`Programming
     ~descr:"Create a reference, i.e. a value which can be modified."
     [("", a, None, None)]
-    (Lang.ref_t a)
+    (ref_t a)
     (fun p ->
-      let x = List.assoc "" p in
-      Lang.reference (Atomic.make x))
-
-let _ =
-  let a = Lang.univ_t () in
-  Lang.add_builtin ~base:ref "get" ~category:`Programming
-    ~descr:"Retrieve the contents of a reference."
-    [("", Lang.ref_t a, None, None)]
-    a
-    (fun p ->
-      let r = Lang.to_ref (List.assoc "" p) in
-      Atomic.get r)
-
-let _ =
-  let a = Lang.univ_t () in
-  Lang.add_builtin ~base:ref "set" ~category:`Programming
-    ~descr:"Set the value of a reference."
-    [("", Lang.ref_t a, None, None); ("", a, None, None)]
-    Lang.unit_t
-    (fun p ->
-      let r = Lang.to_ref (Lang.assoc "" 1 p) in
-      let v = Lang.assoc "" 2 p in
-      Atomic.set r v;
-      Lang.unit)
+      let x = List.assoc "" p |> Atomic.make in
+      Lang.record
+        [
+          ("get", Lang.val_fun [] (fun _ -> Atomic.get x));
+          ( "set",
+            Lang.val_fun [] (fun p ->
+                List.assoc "" p |> Atomic.set x;
+                Lang.unit) );
+        ])

--- a/src/lang/builtins_ref.ml
+++ b/src/lang/builtins_ref.ml
@@ -21,8 +21,12 @@
  *****************************************************************************)
 
 let ref_t a =
-  Lang.record_t
-    [("get", Lang.fun_t [] a); ("set", Lang.fun_t [(false, "", a)] Lang.unit_t)]
+  Lang.method_t (Lang.fun_t [] a)
+    [
+      ( "set",
+        ([], Lang.fun_t [(false, "", a)] Lang.unit_t),
+        "Set the value of the reference." );
+    ]
 
 let ref =
   let a = Lang.univ_t () in
@@ -32,11 +36,12 @@ let ref =
     (ref_t a)
     (fun p ->
       let x = List.assoc "" p |> Atomic.make in
-      Lang.record
-        [
-          ("get", Lang.val_fun [] (fun _ -> Atomic.get x));
-          ( "set",
-            Lang.val_fun [] (fun p ->
-                List.assoc "" p |> Atomic.set x;
-                Lang.unit) );
-        ])
+      let get = Lang.val_fun [] (fun _ -> Atomic.get x) in
+      let set =
+        Lang.val_fun
+          [("", "", None)]
+          (fun p ->
+            List.assoc "" p |> Atomic.set x;
+            Lang.unit)
+      in
+      Lang.meth get [("set", set)])

--- a/src/lang/builtins_ref.ml
+++ b/src/lang/builtins_ref.ml
@@ -20,28 +20,14 @@
 
  *****************************************************************************)
 
-let ref_t a =
-  Lang.method_t (Lang.fun_t [] a)
-    [
-      ( "set",
-        ([], Lang.fun_t [(false, "", a)] Lang.unit_t),
-        "Set the value of the reference." );
-    ]
-
 let ref =
   let a = Lang.univ_t () in
   Lang.add_builtin "ref" ~category:`Programming
     ~descr:"Create a reference, i.e. a value which can be modified."
     [("", a, None, None)]
-    (ref_t a)
+    (Lang.ref_t a)
     (fun p ->
       let x = List.assoc "" p |> Atomic.make in
-      let get = Lang.val_fun [] (fun _ -> Atomic.get x) in
-      let set =
-        Lang.val_fun
-          [("", "", None)]
-          (fun p ->
-            List.assoc "" p |> Atomic.set x;
-            Lang.unit)
-      in
-      Lang.meth get [("set", set)])
+      let get () = Atomic.get x in
+      let set v = Atomic.set x v in
+      Lang.reference get set)

--- a/src/lang/lang.mli
+++ b/src/lang/lang.mli
@@ -57,7 +57,6 @@ and in_value = Value.in_value =
   | Tuple of value list
   | Null
   | Meth of string * value * value
-  | Ref of value Atomic.t
   | Fun of (string * string * value option) list * lazy_env * Term.t
   (* A function with given arguments (argument label, argument variable, default
      value), closure and value. *)
@@ -128,7 +127,6 @@ val to_valued_option : (value -> 'a) -> value -> 'a option
 val to_default_option : default:'a -> (value -> 'a) -> value -> 'a
 val to_product : value -> value * value
 val to_tuple : value -> value list
-val to_ref : value -> value Atomic.t
 val to_string_list : value -> string list
 val to_int_list : value -> int list
 val to_fun : value -> (string * value) list -> value
@@ -155,7 +153,6 @@ val optional_method_t : t -> (string * scheme * string) list -> t
 val list_t : t -> t
 val of_list_t : t -> t
 val nullable_t : t -> t
-val ref_t : t -> t
 val error_t : t
 
 (** [fun_t args r] is the type of a function taking [args] as parameters
@@ -183,7 +180,6 @@ val product : value -> value -> value
 val tuple : value list -> value
 val meth : value -> (string * value) list -> value
 val record : (string * value) list -> value
-val reference : value Atomic.t -> value
 
 (** Build a function from an OCaml function. Items in the prototype indicate
     the label and optional values. *)

--- a/src/lang/lang.mli
+++ b/src/lang/lang.mli
@@ -127,6 +127,11 @@ val to_valued_option : (value -> 'a) -> value -> 'a option
 val to_default_option : default:'a -> (value -> 'a) -> value -> 'a
 val to_product : value -> value * value
 val to_tuple : value -> value list
+val to_ref : value -> (unit -> value) * (value -> unit)
+
+val to_valued_ref :
+  (value -> 'a) -> ('a -> value) -> value -> (unit -> 'a) * ('a -> unit)
+
 val to_string_list : value -> string list
 val to_int_list : value -> int list
 val to_fun : value -> (string * value) list -> value
@@ -153,6 +158,7 @@ val optional_method_t : t -> (string * scheme * string) list -> t
 val list_t : t -> t
 val of_list_t : t -> t
 val nullable_t : t -> t
+val ref_t : t -> t
 val error_t : t
 
 (** [fun_t args r] is the type of a function taking [args] as parameters
@@ -180,6 +186,7 @@ val product : value -> value -> value
 val tuple : value list -> value
 val meth : value -> (string * value) list -> value
 val record : (string * value) list -> value
+val reference : (unit -> value) -> (value -> unit) -> value
 
 (** Build a function from an OCaml function. Items in the prototype indicate
     the label and optional values. *)

--- a/src/lang/lang_core.ml
+++ b/src/lang/lang_core.ml
@@ -71,7 +71,6 @@ let of_list_t t =
     | _ -> assert false
 
 let nullable_t t = Type.make (Type.Nullable t)
-let ref_t t = Term.ref_t t
 let univ_t ?(constraints = []) () = Type.var ~constraints ()
 let getter_t a = Type.make (Type.Getter a)
 
@@ -93,7 +92,6 @@ let rec meth v0 = function
   | (l, v) :: r -> mk (Meth (l, v, meth v0 r))
 
 let record = meth unit
-let reference x = mk (Ref x)
 let val_fun p f = mk (FFI (p, f))
 
 let val_cst_fun p c =
@@ -324,7 +322,6 @@ let to_default_option ~default convert v =
 let to_product t =
   match (demeth t).value with Tuple [a; b] -> (a, b) | _ -> assert false
 
-let to_ref t = match (demeth t).value with Ref r -> r | _ -> assert false
 let to_string_list l = List.map to_string (to_list l)
 let to_int_list l = List.map to_int (to_list l)
 

--- a/src/lang/parser.mly
+++ b/src/lang/parser.mly
@@ -207,8 +207,8 @@ expr:
   | STRING                           { mk ~pos:$loc (Ground (String $1)) }
   | VAR                              { mk ~pos:$loc (Var $1) }
   | varlist                          { mk_list ~pos:$loc $1 }
-  | GET expr                         { mk ~pos:$loc (App (mk ~pos:$loc($1) (Invoke ({invoked = mk ~pos:$loc($1) (Var "ref"); default = None; meth = "get"})), ["", $2])) }
-  | expr SET expr                    { mk ~pos:$loc (App (mk ~pos:$loc($2) (Invoke ({invoked = mk ~pos:$loc($1) (Var "ref"); default = None; meth =  "set"})), ["", $1; "", $3])) }
+  | GET expr                         { mk ~pos:$loc (App ($2, [])) }
+  | expr SET expr                    { mk ~pos:$loc (App (mk ~pos:$loc($2) (Invoke {invoked = $1; default = None; meth = "set"}), ["", $3])) }
   | ENCODER encoder_opt              { mk_encoder ~pos:$loc $1 $2 }
   | LPAR RPAR                        { mk ~pos:$loc (Tuple []) }
   | LPAR inner_tuple RPAR            { mk ~pos:$loc (Tuple $2) }

--- a/src/lang/parser.mly
+++ b/src/lang/parser.mly
@@ -207,7 +207,7 @@ expr:
   | STRING                           { mk ~pos:$loc (Ground (String $1)) }
   | VAR                              { mk ~pos:$loc (Var $1) }
   | varlist                          { mk_list ~pos:$loc $1 }
-  | GET expr                         { mk ~pos:$loc (App ($2, [])) }
+  | GET expr                         { Printf.eprintf "Warning, %s: the notation !x for references is deprecated, please use x() instead.\n%!" (Pos.to_string $loc); mk ~pos:$loc (App ($2, [])) }
   | expr SET expr                    { mk ~pos:$loc (App (mk ~pos:$loc($2) (Invoke {invoked = $1; default = None; meth = "set"}), ["", $3])) }
   | ENCODER encoder_opt              { mk_encoder ~pos:$loc $1 $2 }
   | LPAR RPAR                        { mk ~pos:$loc (Tuple []) }

--- a/src/lang/repr.ml
+++ b/src/lang/repr.ml
@@ -520,7 +520,9 @@ let print_type_error ~formatter error_header
   match b with
     | `Meth (R.{ name = l; scheme = [], `Ellipsis }, `Ellipsis) when not flipped
       ->
-        Format.fprintf formatter "this value has no method `%s`@." l
+        Format.fprintf formatter
+          "this value has no method `%s`@.@[<2>  Its type is %s.@]@." l
+          (string_of_type ta)
     | _ ->
         let inferred_pos a =
           let dpos = (deref a).pos in

--- a/src/lang/term.ml
+++ b/src/lang/term.ml
@@ -246,8 +246,7 @@ type term = t
 let unit = Tuple []
 
 (* Only used for printing very simple functions. *)
-let is_ground x =
-  match x.term with Ground _ -> true (* | Ref x -> is_ground x *) | _ -> false
+let is_ground x = match x.term with Ground _ -> true | _ -> false
 
 let rec string_of_pat = function
   | PVar l -> String.concat "." l

--- a/src/lang/value.ml
+++ b/src/lang/value.ml
@@ -40,7 +40,6 @@ and in_value =
      value than a constructor here. However, I am keeping as is for now because
      implementation is safer this way. *)
   | Meth of string * t * t
-  | Ref of t Atomic.t
   (* Function with given list of argument name, argument variable and default
      value, the (relevant part of the) closure, and the body. *)
   | Fun of (string * string * t option) list * lazy_env * Term.t
@@ -58,7 +57,6 @@ let rec to_string v =
   match v.value with
     | Ground g -> Ground.to_string g
     | List l -> "[" ^ String.concat ", " (List.map to_string l) ^ "]"
-    | Ref a -> Printf.sprintf "ref(%s)" (to_string (Atomic.get a))
     | Tuple l -> "(" ^ String.concat ", " (List.map to_string l) ^ ")"
     | Null -> "null"
     | Meth (l, v, e) when Lazy.force Term.debug ->

--- a/src/libs/audio.liq
+++ b/src/libs/audio.liq
@@ -337,12 +337,9 @@ def mix(~id=null(), ~register_server_commands=true, sources) =
       is_single   = ref(false)
 
       {
-        volume = {volume()},
-        set_volume = volume.set,
-        selected = {is_selected()},
-        set_selected = is_selected.set,
-        single = {is_single()},
-        set_single = is_single.set,
+        volume = volume,
+        selected = is_selected,
+        single = is_single,
         source = s
       }
     end, sources)
@@ -354,7 +351,7 @@ def mix(~id=null(), ~register_server_commands=true, sources) =
       s = amplify(input.volume, input.source)
       s = source.on_track(s, fun (_) ->
          if input.single() then
-           input.set_selected(false)
+           input.selected := false
          end
       )
       s = source.on_metadata(s, fun (m) ->
@@ -389,7 +386,7 @@ def mix(~id=null(), ~register_server_commands=true, sources) =
                          try
                            let [i, v] = r/\s/.split(v)
                            input = list.nth(inputs, int_of_string(i))
-                           input.set_volume(float_of_string(v))
+                           input.volume := float_of_string(v)
                            status(input)
                          catch _ do
                            "Usage: volume <source nb> <vol%>"
@@ -400,7 +397,7 @@ def mix(~id=null(), ~register_server_commands=true, sources) =
                          try
                            let [i, b] = r/\s/.split(arg)
                            input = list.nth(inputs, int_of_string(i))
-                           input.set_selected(b == "true")
+                           input.selected := (b == "true")
                            status(input)
                          catch _ do
                            "Usage: select <source nb> <true|false>"
@@ -411,7 +408,7 @@ def mix(~id=null(), ~register_server_commands=true, sources) =
                          try
                            let [i, b] = r/\s/.split(arg)
                            input = list.nth(inputs, int_of_string(i))
-                           input.set_single(b == "true")
+                           input.single := (b == "true")
                            status(input)
                          catch _ do
                            "Usage: single <source nb> <true|false>"

--- a/src/libs/audio.liq
+++ b/src/libs/audio.liq
@@ -106,26 +106,26 @@ def replaces normalize(~id=null(), ~target=getter(-13.), ~up=getter(10.), ~down=
     threshold = lin_of_dB(getter.get(threshold))
     rms       = rms()
     if rms >= threshold then
-      if !v * rms <= target then
+      if v() * rms <= target then
         up = 1. - exp (0. - frame / getter.get(up))
-        v := !v + up * ((target / rms) - !v)
+        v := v() + up * ((target / rms) - v())
       else
         down = 1. - exp (0. - frame / getter.get(down))
-        v := !v + down * ((target / rms) - !v)
+        v := v() + down * ((target / rms) - v())
       end
-      v := max(gain_min, min(gain_max, !v))
+      v := max(gain_min, min(gain_max, v()))
     end
   end
   def target_gain () = lin_of_dB(getter.get(target)) / rms() end
   s =
     if null.defined(debug) then
-      source.run(s, every=null.get(debug), {log.debug("rms: #{rms()} / #{lin_of_dB(getter.get(target))}\tgain: #{!v} / #{target_gain()}")})
+      source.run(s, every=null.get(debug), {log.debug("rms: #{rms()} / #{lin_of_dB(getter.get(target))}\tgain: #{v()} / #{target_gain()}")})
     else
       s
     end
   s = source.on_frame(s, update)
   s = if track_sensitive then source.on_track(s, fun (_) -> v := 1.) else s end
-  amplify(id=id, {!v}, delay_line(lookahead, s)).{ rms = rms, gain = fun() -> !v, target_gain = target_gain }
+  amplify(id=id, {v()}, delay_line(lookahead, s)).{ rms = rms, gain = {v()}, target_gain = target_gain }
 end
 
 
@@ -314,10 +314,10 @@ def replaces dtmf(~duration=0.1, ~delay=0.05, dtmf)
         (0., 0.)
       end
     s = add([sine(row, duration=duration), sine(col, duration=duration)])
-    l := blank(duration=delay) :: !l
-    l := s :: !l
+    l := blank(duration=delay) :: l()
+    l := s :: l()
   end
-  l = list.rev(!l)
+  l = list.rev(l())
   sequence(l)
 end
 
@@ -337,12 +337,12 @@ def mix(~id=null(), ~register_server_commands=true, sources) =
       is_single   = ref(false)
 
       {
-        volume = fun () -> !volume,
-        set_volume = fun (v) -> volume := v,
-        selected = fun () -> !is_selected,
-        set_selected = fun (b) -> is_selected := b,
-        single = fun () -> !is_single,
-        set_single = fun (b) -> is_single := b,
+        volume = {volume()},
+        set_volume = volume.set,
+        selected = {is_selected()},
+        set_selected = is_selected.set,
+        single = {is_single()},
+        set_single = is_single.set,
         source = s
       }
     end, sources)
@@ -359,7 +359,7 @@ def mix(~id=null(), ~register_server_commands=true, sources) =
       )
       s = source.on_metadata(s, fun (m) ->
         begin
-          fn = !insert_metadata_fn
+          fn = insert_metadata_fn()
           fn(m)
         end
       )

--- a/src/libs/fades.liq
+++ b/src/libs/fades.liq
@@ -48,11 +48,11 @@ def mkfade(~type="lin",~start=0.,~stop=1.,~duration=3.,~on_done={()},s) =
 
   start_time = ref(-1.)
   def fade() =
-    if !start_time < 0. then
+    if start_time() < 0. then
       start_time := source.time(s)
     end
 
-    t = source.time(s) - !start_time
+    t = source.time(s) - start_time()
     if t >= duration then
       on_done ()
       stop
@@ -100,20 +100,20 @@ def fade.out(~id="fade.out",~duration=3.,
   started = ref(false)
 
   def start_fade(d,_) =
-    log("Fading out with type #{!type}, duration: #{!duration} and #{d}s remaining.")
+    log("Fading out with type #{type()}, duration: #{duration()} and #{d}s remaining.")
     start_time := source.time(s)
-    d = if d < !duration then d else !duration end
-    fn := mkfade(start=1.,stop=0.,type=!type,duration=d,s)
+    d = if d < duration() then d else duration() end
+    fn := mkfade(start=1.,stop=0.,type=type(),duration=d,s)
     started := true
   end
 
   def apply() =
-    fn = !fn
+    fn = fn()
     fn()
   end
 
   def stop_fade(_) =
-    if !started then
+    if started() then
       fn := fun () -> 1.
       started := false
     end
@@ -121,13 +121,13 @@ def fade.out(~id="fade.out",~duration=3.,
 
   def update_fade(m) =
     if m[override_duration] != "" then
-      duration := float_of_string(default=!duration,m[override_duration])
-      log("New fade duration: #{!duration}s.")
+      duration := float_of_string(default=duration(),m[override_duration])
+      log("New fade duration: #{duration()}s.")
     end
 
     if m[override_type] != "" then
       type := m[override_type]
-      log("New fade type: #{!type}.")
+      log("New fade type: #{type()}.")
     end
   end
 
@@ -144,13 +144,13 @@ def fade.out(~id="fade.out",~duration=3.,
     if track_sensitive then
       source.on_track(s, stop_fade)
     else
-      start_fade(!duration, [])
+      start_fade(duration(), [])
       s
     end
 
-  delay = fun () -> !duration
+  delay = fun () -> duration()
   s = if track_sensitive then source.on_end(s, delay=delay, start_fade) else s end
-  fade.scale(id=id, apply, s).{fade_duration = {!duration}, fade_type = {!type}}
+  fade.scale(id=id, apply, s).{fade_duration = {duration()}, fade_type = {type()}}
 end
 
 # Fade when the metadata trigger is received and then skip.
@@ -176,7 +176,7 @@ def fade.skip(~id="fade.skip",~duration=5.,
   duration = ref(duration)
 
   def apply() =
-    fn = !fn
+    fn = fn()
     fn()
   end
 
@@ -192,19 +192,19 @@ def fade.skip(~id="fade.skip",~duration=5.,
   def update_fade(m) =
     if m[override_skip] == "true" then
       remaining = source.remaining(s)
-      duration = if remaining < !duration then remaining else !duration end
+      duration = if remaining < duration() then remaining else duration() end
       log("Skip fade executed for: #{duration}s")
-      fn := mkfade(start=1.,stop=0.,type=!type,duration=duration, on_done=skip,s)
+      fn := mkfade(start=1.,stop=0.,type=type(),duration=duration, on_done=skip,s)
     end
 
     if m[override_duration] != "" then
-      duration := float_of_string(default=!duration,m[override_duration])
-      log("New fade duration: #{!duration}")
+      duration := float_of_string(default=duration(),m[override_duration])
+      log("New fade duration: #{duration()}")
     end
 
     if m[override_type] != "" then
       type := m[override_type]
-      log("New fade type: #{!type}")
+      log("New fade type: #{type()}")
     end
   end
 
@@ -218,7 +218,7 @@ def fade.skip(~id="fade.skip",~duration=5.,
   s = source.on_track(s, reset_overrides)
   s = source.on_metadata(s, update_fade)
   s = source.on_track(s, stop_fade)
-  fade.scale(id=id, apply, s).{fade_duration = {!duration}, fade_type = {!type} }
+  fade.scale(id=id, apply, s).{fade_duration = {duration()}, fade_type = {type()} }
 end
 
 # Fade the beginning of tracks.
@@ -244,24 +244,24 @@ def fade.in(~id="fade.in",~duration=3.,
   type = ref(type)
 
   def apply() =
-    fn = !fn
+    fn = fn()
     fn()
   end
 
   def start_fade(_) =
-    log("Fading in with type: #{!type} and duration: #{!duration}s.")
-    fn := mkfade(start=0.,stop=1.,type=!type,duration=!duration,s)
+    log("Fading in with type: #{type()} and duration: #{duration()}s.")
+    fn := mkfade(start=0.,stop=1.,type=type(),duration=duration(),s)
   end
 
   def update_fade(m) =
     if m[override_duration] != "" then
-      duration := float_of_string(default=!duration,m[override_duration])
-      log("New fade duration: #{!duration}s.")
+      duration := float_of_string(default=duration(),m[override_duration])
+      log("New fade duration: #{duration()}s.")
     end
 
     if m[override_type] != "" then
       type := m[override_type]
-      log("New fade type: #{!type}.")
+      log("New fade type: #{type()}.")
     end
   end
 
@@ -276,7 +276,7 @@ def fade.in(~id="fade.in",~duration=3.,
   s = source.on_metadata(s, update_fade)
   s = if track_sensitive then source.on_track(s, start_fade) else start_fade([]); s end
 
-  fade.scale(id=id, apply, s).{fade_duration = {!duration}, fade_type = {!type} }
+  fade.scale(id=id, apply, s).{fade_duration = {duration()}, fade_type = {type()} }
 end
 
 # Simple transition for crossfade
@@ -458,7 +458,7 @@ def smooth_add(~duration=1., ~p=getter(0.2), ~normal, ~special)
 
   def c(fn,s) =
     def v() =
-      fn = !fn
+      fn = fn()
       fn()
     end
     fade.scale(v,s)
@@ -472,15 +472,15 @@ def smooth_add(~duration=1., ~p=getter(0.2), ~normal, ~special)
 
   def to_special(_,special) =
     last_p := p()
-    q = 1. - !last_p
-    normal_volume := mkfade(start=1.,stop=!last_p,duration=duration,normal)
+    q = 1. - last_p()
+    normal_volume := mkfade(start=1.,stop=last_p(),duration=duration,normal)
     special_volume := mkfade(stop=q,duration=duration,special)
     special
   end
 
   def to_blank(special,b)
-    normal_volume := mkfade(start=!last_p,duration=duration,normal)
-    special_volume := mkfade(start=1.-!last_p,duration=duration,special)
+    normal_volume := mkfade(start=last_p(),duration=duration,normal)
+    special_volume := mkfade(start=1.-last_p(),duration=duration,special)
     sequence([special,b])
   end
 

--- a/src/libs/ffmpeg.liq
+++ b/src/libs/ffmpeg.liq
@@ -220,17 +220,17 @@ def video.add_text.ffmpeg.raw.filter(
       getter({
         begin
           cur_time = time()
-          traveled_to = int(float(speed) * (cur_time - !last_time))
+          traveled_to = int(float(speed) * (cur_time - last_time()))
           last_time := cur_time
           if changed() then
             effective_x := getter.get(x)
           else
-            effective_x := !effective_x - traveled_to
+            effective_x := effective_x() - traveled_to
           end
-          if !effective_x < 0 then
-            effective_x := settings.frame.video.width() - !effective_x
+          if effective_x() < 0 then
+            effective_x := settings.frame.video.width() - effective_x()
           end
-          !effective_x
+          effective_x()
         end})
     else
       x
@@ -322,11 +322,11 @@ def replaces video.add_text.ffmpeg.raw(
   on_frame = ref (fun () -> ())
   on_metadata = ref (fun (_) -> ())
   s = source.on_metadata(s, fun (m) -> begin
-    fn = !on_metadata
+    fn = on_metadata()
     fn(m)
   end)
   s = source.on_frame(s, fun () -> begin
-    fn = !on_frame
+    fn = on_frame()
     fn()
   end)
 
@@ -374,7 +374,7 @@ def video.add_text.ffmpeg.internal(~id=null(),~color=0xffffff,~cycle=true,~font=
 end
 
 let replaces video.add_text.ffmpeg = video.add_text.ffmpeg.internal
-# video.add_text.available := [("ffmpeg", video.add_text.ffmpeg.internal), ...!video.add_text.available]
+# video.add_text.available := [("ffmpeg", video.add_text.ffmpeg.internal), ...video.add_text.available()]
 
 # if settings.video.add_text() != "sdl" then
 #   settings.video.add_text.set("ffmpeg")

--- a/src/libs/file.liq
+++ b/src/libs/file.liq
@@ -5,12 +5,12 @@ def file.read(fname) =
   fd = file.open(write=false, fname)
   is_done = ref(false)
   def read() =
-    if !is_done then
+    if is_done() then
       ""
     else
       s = fd.read()
       is_done := s == ""
-      if !is_done then
+      if is_done() then
         fd.close()
       end
       s
@@ -134,7 +134,7 @@ def file.getter(fname)
   end
   update()
   ignore(file.watch(fname, update))
-  {!contents}
+  ref.getter(contents)
 end
 
 # Float getter from a file.
@@ -160,14 +160,14 @@ def file.metadata.flac.cover.decode(s) =
   i = ref(0)
 
   def read_int() =
-    ret = string.binary.to_int(little_endian=false, string.sub(s, start=!i, length=4))
-    i := !i + 4
+    ret = string.binary.to_int(little_endian=false, string.sub(s, start=i(), length=4))
+    i := i() + 4
     ret
   end
 
   def read_string(len) =
-    ret = string.sub(s, start=!i, length=len)
-    i := !i + len
+    ret = string.sub(s, start=i(), length=len)
+    i := i() + len
     (ret:string)
   end
 
@@ -182,7 +182,7 @@ def file.metadata.flac.cover.decode(s) =
   number_of_colors = read_int()
   number_of_colors = number_of_colors > 0 ? null(number_of_colors) : null()
   data_len = read_int()
-  data = string.sub(s, start=!i, length=data_len)
+  data = string.sub(s, start=i(), length=data_len)
 
   if data == "" then
     log.info("Failed to read cover metadata")
@@ -267,7 +267,7 @@ def playlog(~duration=infinity, ~persistency=null(), ~hash=fun(m)->m["filename"]
   # Save into persistency file
   def save()
     if null.defined(persistency) then
-      data = json.stringify(!l)
+      data = json.stringify(l())
       file.write(data=data, null.get(persistency))
     end
   end
@@ -275,20 +275,20 @@ def playlog(~duration=infinity, ~persistency=null(), ~hash=fun(m)->m["filename"]
   def prune()
     if duration != infinity then
       t = time()
-      l := list.assoc.filter(fun(_, tf) -> t - tf <= duration, !l)
+      l := list.assoc.filter(fun(_, tf) -> t - tf <= duration, l())
     end
   end
   # Add a new entry
   def add(m)
     prune()
     f = hash(m)
-    l := (f, time()) :: !l
+    l := (f, time()) :: l()
     save()
   end
   # Last time this entry was played
   def last(m)
     f = hash(m)
-    time() - list.assoc(default = 0.-infinity, f, !l)
+    time() - list.assoc(default = 0.-infinity, f, l())
   end
   { add=add, last=last }
 end

--- a/src/libs/getter.liq
+++ b/src/libs/getter.liq
@@ -29,7 +29,7 @@ def getter.on_change(f, x)
   old = ref(x())
   fun () -> begin
     new = x()
-    if !old != new then old := new; f(new) end
+    if old() != new then old := new; f(new) end
     new
   end
 end
@@ -40,7 +40,7 @@ def getter.changes(x)
   old = ref(getter.get(x))
   fun () -> begin
     new = getter.get(x)
-    if !old != new then old := new; true
+    if old() != new then old := new; true
     else false end
   end
 end
@@ -54,6 +54,6 @@ def getter.merge(x, y)
   fun () -> begin
     ignore(x())
     ignore(y())
-    !v
+    v()
   end
 end

--- a/src/libs/hls.liq
+++ b/src/libs/hls.liq
@@ -13,7 +13,7 @@ def input.hls.native(~id=null(),~reload=10.,uri)
   id = string.id.default(default="input.hls.native", id)
 
   def load_playlist () =
-    pl = request.create(!playlist_uri)
+    pl = request.create(playlist_uri())
     if request.resolve(pl) then
       pl = request.filename(pl)
 
@@ -22,7 +22,7 @@ def input.hls.native(~id=null(),~reload=10.,uri)
       log.info(label=id,"Sequence: " ^ pl_sequence)
       pl_sequence = int_of_string(default=0,pl_sequence)
 
-      files = playlist.parse(path=path.dirname(!playlist_uri)^"/",pl)
+      files = playlist.parse(path=path.dirname(playlist_uri())^"/",pl)
 
       def file_request(idx,el) =
         let (meta,file) = el
@@ -33,7 +33,7 @@ def input.hls.native(~id=null(),~reload=10.,uri)
 
       files = list.mapi(file_request,files)
 
-      let (first_idx, _) = list.hd(default=(-1,""),!playlistr)
+      let (first_idx, _) = list.hd(default=(-1,""),playlistr())
 
       def add_file(playlist, file) =
         let (idx,_) = file
@@ -44,7 +44,7 @@ def input.hls.native(~id=null(),~reload=10.,uri)
         end
       end
 
-      playlistr := list.fold(add_file, !playlistr, files)
+      playlistr := list.fold(add_file, playlistr(), files)
     else
       log.severe(label=id,"Couldn't read playlist: request resolution failed.")
       playlistr := []
@@ -53,10 +53,10 @@ def input.hls.native(~id=null(),~reload=10.,uri)
   end
 
   def rec next () =
-    if list.length(!playlistr) > 0 then
-      let (_,ret) = list.hd(default=(1,""),!playlistr)
-      playlistr := list.tl(!playlistr)
-      sequence := !sequence + 1
+    if list.length(playlistr()) > 0 then
+      let (_,ret) = list.hd(default=(1,""),playlistr())
+      playlistr := list.tl(playlistr())
+      sequence := sequence() + 1
       request.create(ret)
     else
       null()
@@ -64,17 +64,17 @@ def input.hls.native(~id=null(),~reload=10.,uri)
   end
 
   def find_stream () =
-    pl = request.create(!playlist_uri)
+    pl = request.create(playlist_uri())
     if request.resolve(pl) then
       plfile = request.filename(pl)
 
       m = r/#EXT-X-STREAM-INF[^\n]*\n([^\r\n]*)\r?\n/.exec(file.contents(plfile))
-      playlist_uri := list.assoc(default=!playlist_uri,1,m)
+      playlist_uri := list.assoc(default=playlist_uri(),1,m)
 
-      if not (string.contains(substring="/", !playlist_uri)) then
-        playlist_uri := path.dirname(request.uri(pl)) ^ "/" ^ !playlist_uri
+      if not (string.contains(substring="/", playlist_uri())) then
+        playlist_uri := path.dirname(request.uri(pl)) ^ "/" ^ playlist_uri()
       end
-      log(label=id,"Playlist: " ^ !playlist_uri)
+      log(label=id,"Playlist: " ^ playlist_uri())
     end
   end
   find_stream ()

--- a/src/libs/http.liq
+++ b/src/libs/http.liq
@@ -93,17 +93,17 @@ def http.response(~http_version="1.1",
   def mk_status() =
     status_sent := true
 
-    http_version = !http_version
-    status_code = !status_code
+    http_version = http_version()
+    status_code = status_code()
 
     status_code =
-      if status_code == 100 and getter.get(!data) != "" then
+      if status_code == 100 and getter.get(data()) != "" then
         200
       else
         status_code
       end
 
-    status_message = !status_message ?? http.codes[status_code]
+    status_message = status_message() ?? http.codes[status_code]
 
     "HTTP/#{http_version} #{status_code} #{status_message}\r\n"
   end
@@ -111,9 +111,9 @@ def http.response(~http_version="1.1",
   def mk_headers() =
     headers_sent := true
 
-    headers = !headers
-    content_type = !content_type
-    data = !data
+    headers = headers()
+    content_type = content_type()
+    data = data()
 
     headers =
       if getter.is_constant(data) then
@@ -144,7 +144,7 @@ def http.response(~http_version="1.1",
   def mk_data() =
     data_sent := true
 
-    data = !data
+    data = data()
 
     if getter.is_constant(data) then
       response_ended := true
@@ -157,11 +157,11 @@ def http.response(~http_version="1.1",
   end
 
   def response() =
-    if !response_ended then
+    if response_ended() then
       ""
-    elsif not !status_sent then
+    elsif not status_sent() then
       mk_status()
-    elsif not !headers_sent then
+    elsif not headers_sent() then
       mk_headers()
     else
       mk_data()
@@ -170,24 +170,24 @@ def http.response(~http_version="1.1",
 
   def attr_method(sent, attr) =
     def set(v) =
-      if !sent then
+      if sent() then
         error.raise(error.invalid, "HTTP response has already been sent for this value!")
       end
       attr := v
     end
 
-    def get() = !attr end
+    def get() = attr() end
 
     set.{current=get}
   end
 
   def header(k, v) =
-    headers := (k, v)::!headers
+    headers := (k, v)::headers()
   end
 
   code = status_code
   def redirect(~status_code=301, location) =
-    if !status_sent then
+    if status_sent() then
       error.raise(error.invalid, "HTTP response has already been sent for this value!")
     end
     code := status_code
@@ -195,7 +195,7 @@ def http.response(~http_version="1.1",
   end
 
   def json(v) =
-    if !headers_sent then
+    if headers_sent() then
       error.raise(error.invalid, "HTTP response has already been sent for this value!")
     end
     content_type := "application/json; charset=utf-8"
@@ -203,7 +203,7 @@ def http.response(~http_version="1.1",
   end
 
   def html(d) =
-    if !headers_sent then
+    if headers_sent() then
       error.raise(error.invalid, "HTTP response has already been sent for this value!")
     end
     content_type := "text/html"
@@ -211,13 +211,13 @@ def http.response(~http_version="1.1",
   end
 
   def send_status(socket) =
-    if not !status_sent then
+    if not status_sent() then
       socket.write(mk_status())
     end
   end
 
   def multipart_form(~boundary=null(), contents) =
-    if !headers_sent then
+    if headers_sent() then
       error.raise(error.invalid, "HTTP response has already been sent for this value!")
     end
 
@@ -240,7 +240,7 @@ def http.response(~http_version="1.1",
     multipart_form = multipart_form,
     data = attr_method(data_sent, data),
     send_status = send_status,
-    status_sent = {!status_sent}
+    status_sent = {status_sent()}
   }
 end
 
@@ -278,7 +278,7 @@ let harbor.http.middleware = ref(fun (req, res, next) -> next(req, res))
 # Register a new harbor middleware
 # @category Internet
 def harbor.http.middleware.register(fn) =
-  middleware = !harbor.http.middleware
+  middleware = harbor.http.middleware()
   harbor.http.middleware := fun (req, res, next) -> begin
     middleware(req, res, fun (res, res) ->
       fn(req, res, next))
@@ -301,7 +301,7 @@ def harbor.http.register.regexp(%argsof(harbor.http.register), path, handler) =
     end
 
     def data(~timeout=10.) =
-      if !is_response_done then
+      if is_response_done() then
         error.raise(error.http, "Response ended!")
       end
 
@@ -321,7 +321,7 @@ def harbor.http.register.regexp(%argsof(harbor.http.register), path, handler) =
     }
 
     handler = fun (req, res) -> begin
-      middleware = !harbor.http.middleware
+      middleware = harbor.http.middleware()
       middleware(req, res, fun (req, res) -> handler(req, res))
     end
 
@@ -385,7 +385,7 @@ def harbor.http.static.base(serve,~content_type,~basepath,~headers,~browse,direc
         else
           page = ref("")
           def add(s)
-            page := !page ^ s ^ "\n"
+            page := page() ^ s ^ "\n"
           end
           def add_file(f)
             add("<li><a href=\"#{request.path}/#{url.encode(f)}\">#{f}</a></li>")
@@ -394,7 +394,7 @@ def harbor.http.static.base(serve,~content_type,~basepath,~headers,~browse,direc
           list.iter(add_file, file.ls(sorted=true, fname))
           add("</ul></body>")
           response.content_type("text/html; charset=UTF-8")
-          response.data({!page})
+          response.data(page)
         end
       else
         mime = content_type(fname)
@@ -546,8 +546,8 @@ def harbor.http.request.body(~timeout=10., req) =
     end
 
     r = req.data(timeout=timeout)
-    if r == "" then !data else
-      data := "#{!data}#{r}"
+    if r == "" then data() else
+      data := "#{data()}#{r}"
       read()
     end
   end

--- a/src/libs/http_extra.liq
+++ b/src/libs/http_extra.liq
@@ -30,13 +30,13 @@ def harbor.http.middleware.cors(
     vary = ref([])
 
     def add_vary() =
-      if !vary != [] then
-        res.header("Vary", string.concat(separator=",", !vary))
+      if vary() != [] then
+        res.header("Vary", string.concat(separator=",", vary()))
       end
     end
 
     def vary(v) =
-      vary := v::!vary
+      vary := v::vary()
     end
 
     def add_origin(origin) =

--- a/src/libs/interactive.liq
+++ b/src/libs/interactive.liq
@@ -22,7 +22,7 @@ let interactive.error = error.register("interactive.error")
 
 # @flag hidden
 def interactive.list(_)
-  l = !variables
+  l = variables()
   l = list.map(fun(xv) -> begin
     let (x,v) = xv
     "#{x} : #{v.type}"
@@ -34,43 +34,43 @@ server.register(usage="list", description="List available interactive variables.
 # Description of an interactive variable.
 # @flag hidden
 def interactive.description(name)
-  list.assoc(name, !variables).description
+  list.assoc(name, variables()).description
 end
 
 # Type of an interactive variable.
 # @flag hidden
 def interactive.type(name)
-  list.assoc(name, !variables).type
+  list.assoc(name, variables()).type
 end
 
 # @flag hidden
 def interactive.float.ref(name)
-  list.assoc(name, !variables_float).ref
+  list.assoc(name, variables_float()).ref
 end
 
 # @flag hidden
 def interactive.int.ref(name)
-  list.assoc(name, !variables_int).ref
+  list.assoc(name, variables_int()).ref
 end
 
 # @flag hidden
 def interactive.bool.ref(name)
-  list.assoc(name, !variables_bool).ref
+  list.assoc(name, variables_bool()).ref
 end
 
 # @flag hidden
 def interactive.string.ref(name)
-  list.assoc(name, !variables_string).ref
+  list.assoc(name, variables_string()).ref
 end
 
 # @flag hidden
 def interactive.unit.handler(name)
-  list.assoc(name, !variables_unit).handler
+  list.assoc(name, variables_unit()).handler
 end
 
 # @flag hidden
 def interactive.remove(name)
-  variables := list.assoc.remove.all(name, !variables)
+  variables := list.assoc.remove.all(name, variables())
 end
 
 # Remove an interactive variable.
@@ -79,7 +79,7 @@ end
 # @flag hidden
 def interactive.float.remove(name)
   interactive.remove(name)
-  variables_float := list.assoc.remove.all(name, !variables_float)
+  variables_float := list.assoc.remove.all(name, variables_float())
 end
 
 # Remove an interactive variable.
@@ -88,7 +88,7 @@ end
 # @flag hidden
 def interactive.int.remove(name)
   interactive.remove(name)
-  variables_int := list.assoc.remove.all(name, !variables_int)
+  variables_int := list.assoc.remove.all(name, variables_int())
 end
 
 # Remove an interactive variable.
@@ -97,7 +97,7 @@ end
 # @flag hidden
 def interactive.bool.remove(name)
   interactive.remove(name)
-  variables_bool := list.assoc.remove.all(name, !variables_bool)
+  variables_bool := list.assoc.remove.all(name, variables_bool())
 end
 
 # Remove an interactive variable.
@@ -106,7 +106,7 @@ end
 # @flag hidden
 def interactive.string.remove(name)
   interactive.remove(name)
-  variables_string := list.assoc.remove.all(name, !variables_string)
+  variables_string := list.assoc.remove.all(name, variables_string())
 end
 
 # Remove an interactive variable.
@@ -115,7 +115,7 @@ end
 # @flag hidden
 def interactive.unit.remove(name)
   interactive.remove(name)
-  variables_unit := list.assoc.remove.all(name, !variables_unit)
+  variables_unit := list.assoc.remove.all(name, variables_unit())
 end
 
 # Function called to ensure persistency of data.
@@ -124,28 +124,28 @@ let interactive.persistency = ref(fun()->())
 # @flag hidden
 def interactive.float.set(name, v)
   interactive.float.ref(name) := v
-  p = !interactive.persistency
+  p = interactive.persistency()
   p()
 end
 
 # @flag hidden
 def interactive.int.set(name, v)
   interactive.int.ref(name) := v
-  p = !interactive.persistency
+  p = interactive.persistency()
   p()
 end
 
 # @flag hidden
 def interactive.bool.set(name, v)
   interactive.bool.ref(name) := v
-  p = !interactive.persistency
+  p = interactive.persistency()
   p()
 end
 
 # @flag hidden
 def interactive.string.set(name, v)
   interactive.string.ref(name) := v
-  p = !interactive.persistency
+  p = interactive.persistency()
   p()
 end
 
@@ -166,9 +166,9 @@ let stdlib_osc = osc
 # @param ~osc OSC address for the variable.
 # @param ~type Type of the variable.
 def interactive.create(~name, ~description="", ~osc="", ~type)
-  if list.assoc.mem(name, !variables) then error.raise(interactive.error, "variable already registered") end
-  variables := (name, { type=type, description=description }) :: !variables
-  variables := list.sort(fun(n, n') -> if fst(n) < fst(n') then -1 else 1 end, !variables)
+  if list.assoc.mem(name, variables()) then error.raise(interactive.error, "variable already registered") end
+  variables := (name, { type=type, description=description }) :: variables()
+  variables := list.sort(fun(n, n') -> if fst(n) < fst(n') then -1 else 1 end, variables())
 %ifdef osc.on_float
   if osc != "" then
     if type == "float" then
@@ -196,16 +196,16 @@ try
     t = interactive.type(name)
     if t == "float" then
       r = interactive.float.ref(name)
-      string.float(decimal_places=3, !r)
+      string.float(decimal_places=3, r())
     elsif t == "int" then
       r = interactive.int.ref(name)
-      string(!r)
+      string(r())
     elsif t == "bool" then
       r = interactive.bool.ref(name)
-      string(!r)
+      string(r())
     elsif t == "string" then
       r = interactive.string.ref(name)
-      !r
+      r()
     elsif t == "unit" then
       "()"
     else
@@ -249,10 +249,10 @@ server.register(usage="set <name> = <value>", description="Set the value of a va
 # @param fname Name of the file.
 def interactive.save(fname)
   data = json.stringify({
-    float = list.map(fun (nv) -> begin let (name, v) = nv; (name, !v.ref) end, !variables_float),
-    int = list.map(fun (nv) -> begin let (name, v) = nv; (name, !v.ref) end, !variables_int),
-    bool = list.map(fun (nv) -> begin let (name, v) = nv; (name, !v.ref) end, !variables_bool),
-    string = list.map(fun (nv) -> begin let (name, v) = nv; (name, !v.ref) end, !variables_string)
+    float = list.map(fun (nv) -> begin let (name, v) = nv; (name, v.ref()) end, variables_float()),
+    int = list.map(fun (nv) -> begin let (name, v) = nv; (name, v.ref()) end, variables_int()),
+    bool = list.map(fun (nv) -> begin let (name, v) = nv; (name, v.ref()) end, variables_bool()),
+    string = list.map(fun (nv) -> begin let (name, v) = nv; (name, v.ref()) end, variables_string())
   })
 
   file.write(data=data, fname)
@@ -301,7 +301,7 @@ def interactive.harbor(~transport=http.transport.unix, ~port=8000, ~uri="/intera
     form_data = request.data
     data = ref("")
     def add(s) =
-      data := !data ^ s ^ "\n"
+      data := data() ^ s ^ "\n"
     end
     title = "Interactive values"
     add("<!DOCTYPE html><html><head>")
@@ -379,29 +379,29 @@ def interactive.harbor(~transport=http.transport.unix, ~port=8000, ~uri="/intera
       add("<label for=#{name}>#{description}</label>")
       common = "id='#{name}' name='#{name}' class='interactive' onchange=\"send()\""
       if v.type == "float" then
-        v = list.assoc(name, !variables_float)
-        value = http.string_of_float(!v.ref)
+        v = list.assoc(name, variables_float())
+        value = http.string_of_float(v.ref())
         if v.min == 0.-infinity or v.max == infinity then
           add("<input type='number' #{common} step='#{v.step}' value='#{value}'>")
         else
           min = http.string_of_float(v.min)
           max = http.string_of_float(v.max)
           step = http.string_of_float(v.step)
-          value = http.string_of_float(!v.ref)
+          value = http.string_of_float(v.ref())
           unit = if v.unit == "" then "" else " "^v.unit end
           add("<div><input type='range' #{common} min='#{min}' max='#{max}' step='#{step}' value='#{value}' oninput='document.getElementById(\"#{name}-value\").innerHTML = this.value+\"#{unit}\"'><text id='#{name}-value' style='inline'>#{value}#{unit}</text></div>")
         end
       elsif v.type == "int" then
-        v = list.assoc(name, !variables_int)
-        value = string(!v.ref)
+        v = list.assoc(name, variables_int())
+        value = string(v.ref())
         add("<input type='number' #{common} step='1' value='#{value}'>")
       elsif v.type == "bool" then
-        v = list.assoc(name, !variables_bool)
-        c = (!v.ref) ? "checked" : ""
+        v = list.assoc(name, variables_bool())
+        c = (v.ref()) ? "checked" : ""
         add("<input type='checkbox' #{common} value='true' #{c}>")
       elsif v.type == "string" then
-        v = list.assoc(name, !variables_string)
-        add("<input type='text' #{common} value='#{!v.ref}'>")
+        v = list.assoc(name, variables_string())
+        add("<input type='text' #{common} value='#{v.ref()}'>")
       elsif v.type == "unit" then
         add("<button type='button' #{common} onclick=\"sendUnit('#{name}')\">#{name}</button>")
       else
@@ -409,10 +409,10 @@ def interactive.harbor(~transport=http.transport.unix, ~port=8000, ~uri="/intera
       end
     end
     add("<form>")
-    list.iter(add_var, !variables)
+    list.iter(add_var, variables())
     add("</form>")
     add("</body>")
-    response.html(!data)
+    response.html(data())
   end
 
   harbor.http.register(transport=transport, port=port, method="GET", uri, webpage)
@@ -458,7 +458,7 @@ end
 def replaces interactive.float(~min=0.-infinity, ~max=infinity, ~step=0.1, ~description="", ~unit="", ~osc="", name, v)
   interactive.create(name=name, description=description, osc=osc, type="float")
   r = ref(v)
-  variables_float := (name, {ref=r, unit=unit, min=min, max=max, step=step }) :: !variables_float
+  variables_float := (name, {ref=r, unit=unit, min=min, max=max, step=step }) :: variables_float()
   r.{set = fun(x) -> interactive.float.set(name, x), remove = {interactive.float.remove(name)}}
 end
 
@@ -471,7 +471,7 @@ end
 def replaces interactive.int(~description="", ~osc="", name, v)
   interactive.create(name=name, description=description, osc=osc, type="int")
   r = ref(v)
-  variables_int := (name, {ref=r }) :: !variables_int
+  variables_int := (name, {ref=r }) :: variables_int()
   r.{set = fun(x) -> interactive.int.set(name, x), remove = {interactive.int.remove(name)}}
 end
 
@@ -484,7 +484,7 @@ end
 def replaces interactive.bool(~description="", ~osc="", name, v)
   interactive.create(name=name, description=description, osc=osc, type="bool")
   r = ref(v)
-  variables_bool := (name, { ref=r }) :: !variables_bool
+  variables_bool := (name, { ref=r }) :: variables_bool()
   r.{set = fun(x) -> interactive.bool.set(name, x), remove = {interactive.bool.remove(name)}}
 end
 
@@ -497,7 +497,7 @@ end
 def replaces interactive.string(~description="", ~osc="", name, v)
   interactive.create(name=name, description=description, osc=osc, type="string")
   r = ref(v)
-  variables_string := (name, { ref=r }) :: !variables_string
+  variables_string := (name, { ref=r }) :: variables_string()
   r.{set = fun(x) -> interactive.string.set(name, x), remove = {interactive.string.remove(name)}}
 end
 
@@ -509,7 +509,7 @@ end
 # @param f Function triggered when the value is set.
 def replaces interactive.unit(~description="", ~osc="", name, f)
   interactive.create(name=name, description=description, osc=osc, type="unit")
-  variables_unit := (name, { handler=f }) :: !variables_unit
+  variables_unit := (name, { handler=f }) :: variables_unit()
   {set = f, remove = {interactive.float.remove(name)}}
 end
 

--- a/src/libs/interactive.liq
+++ b/src/libs/interactive.liq
@@ -459,7 +459,7 @@ def replaces interactive.float(~min=0.-infinity, ~max=infinity, ~step=0.1, ~desc
   interactive.create(name=name, description=description, osc=osc, type="float")
   r = ref(v)
   variables_float := (name, {ref=r, unit=unit, min=min, max=max, step=step }) :: !variables_float
-  ref.getter(r).{set = fun(x) -> interactive.float.set(name, x), remove = {interactive.float.remove(name)}}
+  r.{set = fun(x) -> interactive.float.set(name, x), remove = {interactive.float.remove(name)}}
 end
 
 # Read an integer from an interactive input.
@@ -472,7 +472,7 @@ def replaces interactive.int(~description="", ~osc="", name, v)
   interactive.create(name=name, description=description, osc=osc, type="int")
   r = ref(v)
   variables_int := (name, {ref=r }) :: !variables_int
-  ref.getter(r).{set = fun(x) -> interactive.int.set(name, x), remove = {interactive.int.remove(name)}}
+  r.{set = fun(x) -> interactive.int.set(name, x), remove = {interactive.int.remove(name)}}
 end
 
 # Read a boolean from an interactive input.
@@ -485,7 +485,7 @@ def replaces interactive.bool(~description="", ~osc="", name, v)
   interactive.create(name=name, description=description, osc=osc, type="bool")
   r = ref(v)
   variables_bool := (name, { ref=r }) :: !variables_bool
-  ref.getter(r).{set = fun(x) -> interactive.bool.set(name, x), remove = {interactive.bool.remove(name)}}
+  r.{set = fun(x) -> interactive.bool.set(name, x), remove = {interactive.bool.remove(name)}}
 end
 
 # Read a string from an interactive input.
@@ -498,7 +498,7 @@ def replaces interactive.string(~description="", ~osc="", name, v)
   interactive.create(name=name, description=description, osc=osc, type="string")
   r = ref(v)
   variables_string := (name, { ref=r }) :: !variables_string
-  ref.getter(r).{set = fun(x) -> interactive.string.set(name, x), remove = {interactive.string.remove(name)}}
+  r.{set = fun(x) -> interactive.string.set(name, x), remove = {interactive.string.remove(name)}}
 end
 
 # Register a callback when a unit interactive input is set.

--- a/src/libs/list.liq
+++ b/src/libs/list.liq
@@ -96,7 +96,7 @@ end
 def list.iteri(f, l)
   n = ref(0)
   def rec aux(l)
-    i = !n
+    i = n()
     n := i + 1
     list.case(l, (), fun (x, l) -> begin (f(i, x):unit); aux(l) end)
   end
@@ -124,7 +124,7 @@ end
 def list.mapi(f, l)
   n = ref(0)
   def f(x) =
-    i = !n
+    i = n()
     n := i + 1
     f(i, x)
   end
@@ -321,7 +321,7 @@ end
 def list.iterator(l)
   l = ref(l)
   def f()
-    list.case(!l, null(), fun (x,t) -> begin l := t; x end)
+    list.case(l(), null(), fun (x,t) -> begin l := t; x end)
   end
   f
 end

--- a/src/libs/metadata.liq
+++ b/src/libs/metadata.liq
@@ -14,7 +14,7 @@ def metadata.getter.base(init, map, metadata, s)
     if v != "" then x := map(v) end
   end
   s.on_metadata(f)
-  {!x}
+  ref.getter(x)
 end
 
 # Create a getter from a metadata: this is a string, whose value can be changed

--- a/src/libs/native.liq
+++ b/src/libs/native.liq
@@ -9,7 +9,7 @@ def native.once(s)
   # source.available(track_sensitive=true, s, predicate.first({true}))
   a = ref(true)
   s = source.on_track(s, fun(_) -> a := false)
-  source.available(s, {!a})
+  source.available(s, a)
 end
 
 # At the beginning of each track, select the first ready child.
@@ -40,8 +40,8 @@ def native.sequence(~id=null(), sources)
   fail = source.fail()
 
   def rec s()
-    sn = list.nth(default=list.last(default=fail, sources), sources, !n)
-    if source.is_ready(sn) or !n >= len - 1 then
+    sn = list.nth(default=list.last(default=fail, sources), sources, n())
+    if source.is_ready(sn) or n() >= len - 1 then
       sn
     else
       ref.incr(n)
@@ -54,7 +54,7 @@ def native.sequence(~id=null(), sources)
   first = ref(true)
   def ot(_)
     # Drop the first track
-    if !first then first := false else
+    if first() then first := false else
       ref.incr(n)
     end
   end
@@ -90,13 +90,13 @@ def native.request.dynamic(%argsof(request.dynamic), f)
     def get_request(s) =
       s.request
     end
-    list.map(get_request, !queue)
+    list.map(get_request, queue())
   end
 
   def add(r) =
     s = request.once(r)
     if s.resolve() then
-      queue := [...!queue, s]
+      queue := [...queue(), s]
       true
     else
       false
@@ -111,8 +111,8 @@ def native.request.dynamic(%argsof(request.dynamic), f)
   current = ref(null())
 
   def get_current() =
-    if null.defined(!current) then
-      s = null.get(!current)
+    if null.defined(current()) then
+      s = null.get(current())
       s.request
     else
       null()
@@ -127,7 +127,7 @@ def native.request.dynamic(%argsof(request.dynamic), f)
       s = request.once(r)
       if s.resolve() then
         log.info("Added request on queue: #{request.uri(r)}.")
-        queue := [...!queue, s]
+        queue := [...queue(), s]
         true
       else
         log.important("Failed to resolve request #{request.uri(r)}.")
@@ -139,7 +139,7 @@ def native.request.dynamic(%argsof(request.dynamic), f)
   end
 
   def fill() =
-    if list.length(!queue) < prefetch then
+    if list.length(queue()) < prefetch then
       ignore(fetch())
     end
   end
@@ -148,8 +148,8 @@ def native.request.dynamic(%argsof(request.dynamic), f)
 
   # Source
   def s()
-    if not list.is_empty(!queue) then
-      let [s, ...rest] = !queue
+    if not list.is_empty(queue()) then
+      let [s, ...rest] = queue()
       queue := rest
       current := s
       s

--- a/src/libs/playlist.liq
+++ b/src/libs/playlist.liq
@@ -121,7 +121,7 @@ def playlist.list(~id=null(), ~check_next=null(), ~prefetch=1, ~loop=true,
   next_fun = ref(fun () -> null())
 
   def next()
-    f = !next_fun
+    f = next_fun()
     f()
   end
 
@@ -130,7 +130,7 @@ def playlist.list(~id=null(), ~check_next=null(), ~prefetch=1, ~loop=true,
     if native then
       stdlib_native.request.dynamic(id=id, next)
     else
-      request.dynamic(id=id, prefetch=prefetch, timeout=timeout, retry_delay=1., available={not !has_stopped}, next)
+      request.dynamic(id=id, prefetch=prefetch, timeout=timeout, retry_delay=1., available={not has_stopped()}, next)
     end
   source.set_name(s, "playlist.list.reloadable")
 
@@ -138,7 +138,7 @@ def playlist.list(~id=null(), ~check_next=null(), ~prefetch=1, ~loop=true,
   def reload(~empty_queue=true, p) =
     log.debug(label=id, "Reloading playlist.")
     playlist_orig := p
-    playlist := randomize(!playlist_orig)
+    playlist := randomize(playlist_orig())
     has_stopped := false
 
     if empty_queue then
@@ -156,33 +156,33 @@ def playlist.list(~id=null(), ~check_next=null(), ~prefetch=1, ~loop=true,
 
   # The (real) next function
   def rec next() =
-    if loop and list.is_empty(!playlist) then
+    if loop and list.is_empty(playlist()) then
       on_loop()
       # The above function might have reloaded the playlist
-      if list.is_empty(!playlist) then
-        playlist := randomize(!playlist_orig)
+      if list.is_empty(playlist()) then
+        playlist := randomize(playlist_orig())
       end
     end
     file =
-      if list.length(!playlist) > 0 then
+      if list.length(playlist()) > 0 then
         if mode == "random" then
-          n = random.int(min=0, max=list.length(!playlist))
-          list.nth(default="", !playlist, n)
+          n = random.int(min=0, max=list.length(playlist()))
+          list.nth(default="", playlist(), n)
         else
-          ret = list.hd(default="", !playlist)
-          playlist := list.tl(!playlist)
+          ret = list.hd(default="", playlist())
+          playlist := list.tl(playlist())
           ret
         end
       else
         # Playlist finished
-        if not !has_stopped then
+        if not has_stopped() then
           has_stopped := true
           log.info(label=id, "Playlist stopped.")
           on_done()
         end
         ""
       end
-    if file == "" or (!failed_count >= max_fail and time() < !failed_time + 1.) then
+    if file == "" or (failed_count() >= max_fail and time() < failed_time() + 1.) then
       # Playlist failed too many times recently, don't try next for now.
       null()
     else
@@ -193,7 +193,7 @@ def playlist.list(~id=null(), ~check_next=null(), ~prefetch=1, ~loop=true,
         request.destroy(r)
         ref.incr(failed_count)
         # Playlist failed, call handler.
-        if !failed_count < max_fail then
+        if failed_count() < max_fail then
           log.info(label=id, "Playlist failed.")
           if null.defined(on_fail) then
             f = null.get(on_fail)
@@ -219,7 +219,7 @@ def playlist.list(~id=null(), ~check_next=null(), ~prefetch=1, ~loop=true,
 
   # List of songs remaining to be played
   def remaining_files()
-    !playlist
+    playlist()
   end
 
   # Return
@@ -283,7 +283,7 @@ def replaces playlist(
 
   # The load function
   def load_playlist() =
-    playlist_uri = path.home.unrelate(!playlist_uri)
+    playlist_uri = path.home.unrelate(playlist_uri())
     log.info(label=id, "Reloading playlist.")
     files = playlist.files(id=id, mime_type=mime_type, timeout=timeout, playlist_uri)
     list.map.right(fun(file) -> prefix^file, files)
@@ -308,10 +308,10 @@ def replaces playlist(
 
   # Reload when the playlist is done
   def on_loop()
-    reloader = !reloader_ref
+    reloader = reloader_ref()
     if reload_mode == "rounds" and reload > 0 then
-      round := !round + 1
-      if !round >= reload then
+      round := round() + 1
+      if round() >= reload then
         round := 0
         reloader()
       end
@@ -321,29 +321,29 @@ def replaces playlist(
   watcher_reload_ref = ref(fun (_) -> ())
 
   def on_reload(uri) =
-    watcher_reload = !watcher_reload_ref
+    watcher_reload = watcher_reload_ref()
     watcher_reload(uri)
     on_reload(uri)
   end
 
   s = playlist.list(
     id=id, check_next=check_next, prefetch=prefetch, loop=loop, mode=mode,
-    native=native, on_loop=on_loop, on_fail=on_fail, timeout=timeout, !files)
+    native=native, on_loop=on_loop, on_fail=on_fail, timeout=timeout, files())
 
   # The reload function
   def s.reload(~empty_queue=true, ~uri=null()) =
     if null.defined(uri)  then
       playlist_uri := null.get(uri)
     end
-    log(label=id,"Reloading playlist with URI #{!playlist_uri}.")
+    log(label=id,"Reloading playlist with URI #{playlist_uri()}.")
     files := load_playlist()
-    s.reload(empty_queue=empty_queue, !files)
-    on_reload(!playlist_uri)
+    s.reload(empty_queue=empty_queue, files())
+    on_reload(playlist_uri())
   end
   reloader_ref := s.reload
 
   def s.length() =
-    list.length(!files)
+    list.length(files())
   end
 
   source.set_name(s, "playlist")
@@ -354,17 +354,17 @@ def replaces playlist(
     thread.run(delay=n, every=n, s.reload)
   elsif reload_mode == "watch" then
     watcher =
-      if file.exists(!playlist_uri) then
-         ref(null(file.watch(!playlist_uri, s.reload)))
+      if file.exists(playlist_uri()) then
+         ref(null(file.watch(playlist_uri(), s.reload)))
       else
          ref(null())
       end
 
-    watched_uri = ref(!playlist_uri)
+    watched_uri = ref(playlist_uri())
 
     def watcher_reload(uri) =
-      if uri != !watched_uri then
-        w = !watcher
+      if uri != watched_uri() then
+        w = watcher()
 
         if null.defined(w) then
           null.get(w).unwatch()
@@ -382,7 +382,7 @@ def replaces playlist(
     watcher_reload_ref := watcher_reload
 
     def watcher_shutdown() =
-      w = !watcher
+      w = watcher()
       if null.defined(w) then
         null.get(w).unwatch()
       end
@@ -406,7 +406,7 @@ def replaces playlist(
   server.register(namespace=id, description="Reload the playlist, unless already being loaded.", usage="reload", "reload", fun (_) -> begin s.reload(); "OK" end)
 
   def uri_cmd (uri') =
-    if uri' == "" then !playlist_uri
+    if uri' == "" then playlist_uri()
     else
       if reload_mode == "watch" then
         log.important(label=id, "Warning: the watched file is not updated for now when changing the uri!")

--- a/src/libs/predicate.liq
+++ b/src/libs/predicate.liq
@@ -8,7 +8,7 @@ def predicate.activates(~init=false, p)
   last = ref(not init)
   fun () -> begin
     cur = p()
-    ans = (not !last) and cur
+    ans = (not last()) and cur
     last := cur
     ans
   end
@@ -30,7 +30,7 @@ def predicate.at_most(n, p)
   fun () -> begin
     if p() then
       ref.incr(k)
-      !k <= n
+      k() <= n
     else
       k := 0
       false
@@ -45,7 +45,7 @@ def predicate.changes(p)
   last = ref(p())
   fun () -> begin
     cur = p()
-    ans = (cur != !last)
+    ans = (cur != last())
     last := cur
     ans
   end
@@ -57,7 +57,7 @@ end
 def predicate.first(p)
   done = ref(false)
   fun () -> begin
-    if !done then
+    if done() then
       false
     else
       if p() then
@@ -80,7 +80,7 @@ def predicate.signal()
     state := true
   end
   def p ()
-    if !state then
+    if state() then
       state := false
       true
     else

--- a/src/libs/protocols.liq
+++ b/src/libs/protocols.liq
@@ -690,18 +690,18 @@ def synth_protocol(~rlog=_, ~maxtime=_, text) =
     list.iter(set, args)
     def synth(s)
       file = file.temp("liq-synth",".wav")
-      log.info(label="synth", "Synthesizing #{!shape} in #{file}.")
+      log.info(label="synth", "Synthesizing #{shape()} in #{file}.")
       source.dump(%wav, file, once(s))
       [file]
     end
-    if !shape == "sine" then
-      synth(sine(duration=!duration, !frequency))
-    elsif !shape == "saw" then
-      synth(saw(duration=!duration, !frequency))
-    elsif !shape == "square" then
-      synth(square(duration=!duration, !frequency))
-    elsif !shape == "blank" then
-      synth(blank(duration=!duration))
+    if shape() == "sine" then
+      synth(sine(duration=duration(), frequency()))
+    elsif shape() == "saw" then
+      synth(saw(duration=duration(), frequency()))
+    elsif shape() == "square" then
+      synth(square(duration=duration(), frequency()))
+    elsif shape() == "blank" then
+      synth(blank(duration=duration()))
     else
       []
     end

--- a/src/libs/ref.liq
+++ b/src/libs/ref.liq
@@ -1,3 +1,11 @@
+# Create a getter from a reference (sometimes useful to remove the `set`
+# method).
+# @category Programming
+def ref.getter(r) =
+  {r()}
+end
+
+
 # Increment a reference to an integer.
 # @category Programming
 def ref.incr(r)

--- a/src/libs/ref.liq
+++ b/src/libs/ref.liq
@@ -1,11 +1,5 @@
-# Create a getter from a reference.
-# @category Programming
-def ref.getter(r) =
-  {!r}.{set = fun(v) -> r := v}
-end
-
 # Increment a reference to an integer.
 # @category Programming
 def ref.incr(r)
-  r := !r + 1
+  r := r() + 1
 end

--- a/src/libs/request.liq
+++ b/src/libs/request.liq
@@ -28,8 +28,8 @@ def request.queue(~id=null(), ~interactive=true, ~prefetch=1, ~native=false, ~qu
   queue = ref(queue)
   fetch = ref(fun () -> true)
   def next() =
-    if !queue != [] then
-      let [r, ...q] = !queue
+    if queue() != [] then
+      let [r, ...q] = queue()
       queue := q
       (r:request)
     else
@@ -38,8 +38,8 @@ def request.queue(~id=null(), ~interactive=true, ~prefetch=1, ~native=false, ~qu
   end
   def push(r)
     log.info(label=id, "Pushing #{r} on the queue.")
-    queue := [...!queue, r]
-    fn = !fetch
+    queue := [...queue(), r]
+    fn = fetch()
     ignore(fn())
   end
   def push_uri(uri)
@@ -50,7 +50,7 @@ def request.queue(~id=null(), ~interactive=true, ~prefetch=1, ~native=false, ~qu
     if native then
       stdlib_native.request.dynamic(id=id, timeout=timeout, next)
     else
-      request.dynamic(id=id, prefetch=prefetch, timeout=timeout, available={not list.is_empty(!queue)}, next)
+      request.dynamic(id=id, prefetch=prefetch, timeout=timeout, available={not list.is_empty(queue())}, next)
     end
   source.set_name(s, "request.queue")
   fetch := s.fetch
@@ -72,7 +72,7 @@ def request.queue(~id=null(), ~interactive=true, ~prefetch=1, ~native=false, ~qu
                         end)
         server.register(namespace=source.id(s), description="Push a new request in the queue.", usage="push <uri>", "push", push)
         def show_queue(_) =
-          queue = [...s.queue(), ...(!queue)]
+          queue = [...s.queue(), ...(queue())]
           string.concat(separator=" ", list.map(fun (r) -> string(request.id(r)), queue))
         end
         server.register(namespace=source.id(s), description="Display current queue content.", usage="queue", "queue", show_queue)
@@ -95,7 +95,7 @@ def request.queue(~id=null(), ~interactive=true, ~prefetch=1, ~native=false, ~qu
   s.{
     add=add,
     push=push.{uri=push_uri},
-    length={list.length(!queue)+list.length(s.queue())},
+    length={list.length(queue())+list.length(s.queue())},
     set_queue=set_queue
   }
 end
@@ -113,15 +113,15 @@ def request.player(~simultaneous=true)
     # Perform some garbage collection in order to avoid that the list grows too
     # much.
     def collect()
-      l := list.filter(source.is_ready, !l)
+      l := list.filter(source.is_ready, l())
     end
 
     def play(r)
       collect()
-      l := request.once(r)::!l
+      l := request.once(r)::l()
     end
 
-    source.dynamic({add(normalize=false, !l)}).{play=play, length={collect(); list.length(!l)}}
+    source.dynamic({add(normalize=false, l())}).{play=play, length={collect(); list.length(l())}}
   else
     s = source.dynamic()
     def play(r)

--- a/src/libs/settings.liq
+++ b/src/libs/settings.liq
@@ -3,10 +3,9 @@
 # @flag hidden
 def settings.make(~comments="", ~(description:string), v) =
   current_value = ref(v)
-  {!current_value}.{
+  current_value.{
     description = description,
-    comments    = comments,
-    set         = (fun (v) -> current_value := v)
+    comments    = comments
   }
 end
 

--- a/src/libs/source.liq
+++ b/src/libs/source.liq
@@ -66,7 +66,7 @@ end
 def track.metadata.deduplicate(t) =
   last_meta = ref([])
   def f(m) =
-    if m == !last_meta then
+    if m == last_meta() then
       []
     else
       last_meta := m
@@ -158,7 +158,7 @@ def rotate.merge(~id=null(),~transitions=[],~weights=[],sources)
   duration = frame.duration()
 
   def to_first(_,new) =
-    ready := (not !ready)
+    ready := (not ready())
     sequence(merge=true,[blank(duration=duration),(new:source)])
   end
 
@@ -176,7 +176,7 @@ def rotate.merge(~id=null(),~transitions=[],~weights=[],sources)
   let {track_marks=_, ...tracks} = source.tracks(s)
   s = source(tracks)
 
-  switch(id=id,replay_metadata=false,track_sensitive=false,[({!ready}, s), ({(not !ready)}, s)])
+  switch(id=id,replay_metadata=false,track_sensitive=false,[(ready, s), ({not ready()}, s)])
 end
 
 # Rotate between overlapping sources. Next track starts according
@@ -193,7 +193,7 @@ def overlap_sources(~id=null(),~normalize=false,
   length   = list.length(sources)
 
   def current_position() =
-    pos = !position
+    pos = position()
     position := (pos + 1) mod length
     pos
   end
@@ -227,7 +227,7 @@ def overlap_sources(~id=null(),~normalize=false,
   send_to_main_source = ref(fun (_) -> ())
 
   def relay_metadata(m) =
-    fn = !send_to_main_source
+    fn = send_to_main_source()
     fn(m)
   end
   list.iter(fun (s) -> s.on_metadata(relay_metadata),sources)
@@ -243,7 +243,7 @@ def overlap_sources(~id=null(),~normalize=false,
   # Wrap sources into switches.
   def make_switch(pos,source) =
     is_ready = grab_ready(pos)
-    switch(track_sensitive=true,[({!is_ready},source)])
+    switch(track_sensitive=true,[(is_ready,source)])
   end
   sources = list.mapi(make_switch,sources)
 
@@ -289,8 +289,8 @@ end
 def source.run(s, ~delay=0., ~every=null(), f)
   next = ref(delay)
   def check()
-    if source.time(s) >= !next then
-      null.case(every, {next := infinity}, fun (every) -> next := !next + every)
+    if source.time(s) >= next() then
+      null.case(every, {next := infinity}, fun (every) -> next := next() + every)
       f()
     end
   end
@@ -308,7 +308,7 @@ def chop(~every=getter(3.), ~metadata=getter([]), s) =
   # Track time in the source's context:
   start_time = ref(0.)
   def f() =
-    if getter.get(every) <= s.time() - !start_time then
+    if getter.get(every) <= s.time() - start_time() then
       start_time := s.time()
       s.insert_metadata(new_track=true, getter.get(metadata))
     end
@@ -325,7 +325,7 @@ end
 def skipper(~every=getter(5.), s) =
   start_time = ref(0.)
   def f() =
-    if getter.get(every) <= s.time() - !start_time then
+    if getter.get(every) <= s.time() - start_time() then
       start_time := s.time()
       s.skip()
     end

--- a/src/libs/string.liq
+++ b/src/libs/string.liq
@@ -45,22 +45,22 @@ def string.contains(~prefix="", ~substring="", ~suffix="", s)
   ans = ref(prefix == "" and substring == "" and suffix == "")
 
   if prefix != "" then
-    ans := !ans or string.sub(s, start=0, length=string.length(prefix)) == prefix
+    ans := ans() or string.sub(s, start=0, length=string.length(prefix)) == prefix
   end
 
   if suffix != "" then
     suflen = string.length(suffix)
-    ans := !ans or string.sub(s, start=string.length(s)-suflen, length=suflen) == suffix
+    ans := ans() or string.sub(s, start=string.length(s)-suflen, length=suflen) == suffix
   end
 
   if substring != "" then
     sublen = string.length(substring)
     for i = 0 to string.length(s)-sublen do
-      ans := !ans or (string.sub(s, start=i, length=sublen) == substring)
+      ans := ans() or (string.sub(s, start=i, length=sublen) == substring)
     end
   end
 
-  !ans
+  ans()
 end
 
 # What remains of a string after a given prefix.
@@ -108,9 +108,9 @@ def string.binary.to_int(~little_endian=true, s)
   ans = ref(0)
   n = string.length(s)
   for i = 0 to n-1 do
-    ans := lsl(!ans,8) + string.nth(s, if little_endian then n-1-i else i end)
+    ans := lsl(ans(),8) + string.nth(s, if little_endian then n-1-i else i end)
   end
-  !ans
+  ans()
 end
 
 # Encode a positive (unsigned) integer using native memory representation.
@@ -241,8 +241,8 @@ def string.getter.concat(l) =
   pos = ref(0)
 
   def rec f() =
-    if !pos == len then "" else
-      gen = list.nth(l, !pos)
+    if pos() == len then "" else
+      gen = list.nth(l, pos())
       ret = getter.get(gen)
 
       if ret == "" or getter.is_constant(gen) then

--- a/src/libs/switches.liq
+++ b/src/libs/switches.liq
@@ -30,9 +30,9 @@ def fallback.skip(s,~fallback=null())
   fallback = fallback ?? (blank():source)
   avail = ref(true)
   def check()
-    old = !avail
+    old = avail()
     avail := source.is_ready(s)
-    if not old and !avail then
+    if not old and avail() then
       source.skip(fallback)
     end
   end
@@ -81,7 +81,7 @@ def rotate(~id=null(), ~override="liq_transition_length", ~replay_metadata=true,
           f((index + 1) mod list.length(sources))
         end
       end
-      f((!picked_index+1) mod list.length(sources))
+      f((picked_index()+1) mod list.length(sources))
     else
       picked_index := -1
     end
@@ -90,17 +90,18 @@ def rotate(~id=null(), ~override="liq_transition_length", ~replay_metadata=true,
   # Add condition to i-th source.
   def add_condition(index, s) =
     def cond() =
-      if !picked_index == -1 then pick() end
+      if picked_index() == -1 then pick() end
 
-      if !picked_index != -1 then
-        picked_weight = list.nth(default=default_weight, weights, !picked_index)
-        picked_source = list.nth(sources, !picked_index)
-        if picked_weight () <= !list.assoc(source.id(picked_source), tracks_played()) then
+      if picked_index() != -1 then
+        picked_weight = list.nth(default=default_weight, weights, picked_index())
+        picked_source = list.nth(sources, picked_index())
+        fn = list.assoc(source.id(picked_source), tracks_played())
+        if picked_weight () <= fn() then
           pick()
         end
       end
 
-      !picked_index == index
+      picked_index() == index
     end
 
     (cond, s)
@@ -186,8 +187,8 @@ def replaces random(~id=null(), ~override="liq_transition_length", ~replay_metad
 
   def add_condition(index, s) =
     def cond() =
-      if !next_index == -1 then pick() end
-      !next_index == index
+      if next_index() == -1 then pick() end
+      next_index() == index
     end
 
     (cond, s)

--- a/src/libs/thread.liq
+++ b/src/libs/thread.liq
@@ -24,7 +24,7 @@ def thread.when(~fast=true, ~every=1., ~once=false, ~changed=true, p, f)
   last = ref(false)
   def check()
     b = p()
-    if b and not (changed and !last) then f() end
+    if b and not (changed and last()) then f() end
     last := b
     if b and once then (-1.) else every end
   end

--- a/src/libs/utils.liq
+++ b/src/libs/utils.liq
@@ -48,8 +48,8 @@ end
 def memoize(fn) =
   cached_result = ref([])
   fun () -> begin
-    if !cached_result != [] then
-      list.hd(!cached_result)
+    if cached_result() != [] then
+      list.hd(cached_result())
     else
       result = fn()
       cached_result := [result]

--- a/src/libs/video.liq
+++ b/src/libs/video.liq
@@ -281,7 +281,7 @@ def add_text_builder(f) =
 
     # Handle modifying the text with metadata.
     tref = ref(getter.get(text))
-    text = null.defined(metadata) ? {!tref} : text
+    text = null.defined(metadata) ? tref : text
     def on_metadata(m)
       if null.defined(metadata) then
         m = m[null.get(metadata)]
@@ -299,9 +299,9 @@ def add_text_builder(f) =
       fps = video.frame.rate()
       x = ref(getter.get(x))
       def x()
-        if cycle and !x < 0 - t.width() then on_cycle(); x := video.frame.width() end
-        x := !x - getter.get(speed) / fps
-        !x
+        if cycle and x() < 0 - t.width() then on_cycle(); x := video.frame.width() end
+        x := x() - getter.get(speed) / fps
+        x()
       end
       x
     end
@@ -334,10 +334,10 @@ let video.text.available = ref([])
 # @params d Text to display.
 def video.add_text.native = add_text_builder(video.text.native) end
 
-video.text.available := [("native", video.text.native), ...!video.text.available]
+video.text.available := [("native", video.text.native), ...video.text.available()]
 
 %ifdef video.text.gd
-video.text.available := [("gd", video.text.gd), ...!video.text.available]
+video.text.available := [("gd", video.text.gd), ...video.text.available()]
 
 # Add a text to a stream (GD implementation).
 # @category Source / Video processing
@@ -355,7 +355,7 @@ def video.text.gd = add_text_builder(video.text.gd) end
 %endif
 
 %ifdef video.text.gstreamer
-video.text.available := [("gstreamer", video.text.gstreamer), ...!video.text.available]
+video.text.available := [("gstreamer", video.text.gstreamer), ...video.text.available()]
 
 # Add a text to a stream (GStreamer implementation).
 # @category Source / Video processing
@@ -373,7 +373,7 @@ def video.add_text.gstreamer = add_text_builder(video.text.gstreamer) end
 %endif
 
 %ifdef video.text.sdl
-video.text.available := [("sdl", video.text.sdl), ...!video.text.available]
+video.text.available := [("sdl", video.text.sdl), ...video.text.available()]
 
 # Add a text to a stream (SDL implementation).
 # @category Source / Video processing
@@ -391,7 +391,7 @@ def video.add_text.sdl = add_text_builder(video.text.sdl) end
 %endif
 
 %ifdef video.text.camlimages
-video.text.available := [("camlimages", video.text.camlimages), ...!video.text.available]
+video.text.available := [("camlimages", video.text.camlimages), ...video.text.available()]
 
 # Add a text to a stream (camlimages implementation).
 # @category Source / Video processing
@@ -410,16 +410,16 @@ def video.add_text.camlimages = add_text_builder(video.text.camlimages) end
 
 let settings.video.text = settings.make(
   description="`video.text` implementation.",
-  fst(list.hd(!video.text.available))
+  fst(list.hd(video.text.available()))
 )
 
 thread.run.recurrent((fun () ->
   begin
     text = settings.video.text()
-    if list.assoc.mem(text, !video.text.available) then
+    if list.assoc.mem(text, video.text.available()) then
       log.important(label="video.text", "Using #{text} implementation")
     else
-      log.severe(label="video.text", "Cannot find #{text} implementation for `video.text`, using default #{fst(list.hd(!video.text.available))}")
+      log.severe(label="video.text", "Cannot find #{text} implementation for `video.text`, using default #{fst(list.hd(video.text.available()))}")
     end
     (-1.)
   end))
@@ -433,7 +433,7 @@ thread.run.recurrent((fun () ->
 # @param ~size Font size.
 # @param text Text to display.
 def replaces video.text(~id=null(), ~color=getter(0xffffff), ~duration=null(), ~font=null(), ~size=getter(18), text)
-  f = list.assoc(default=snd(list.hd(!video.text.available)), settings.video.text(), !video.text.available)
+  f = list.assoc(default=snd(list.hd(video.text.available())), settings.video.text(), video.text.available())
   f(id=id, color=color, duration=duration, font=font, size=size, text)
 end
 
@@ -464,7 +464,7 @@ end
 # @param s Source.
 def video.add_subtitle(~override="subtitle", ~size=18, ~color=0xffffff, ~offset=20, s)
   subtitle = ref("")
-  t = video.text(size=size, color=color, {!subtitle})
+  t = video.text(size=size, color=color, subtitle)
   t = video.bounding_box(t)
   x = {(video.frame.width() - t.width())/2}
   y = {video.frame.height() - t.height() - offset}
@@ -494,25 +494,25 @@ def video.slideshow(~id=null(), ~cyclic=getter(true), ~advance=getter(-1.), l=[]
   n = ref(-1)
   s = source.dynamic()
   def current()
-    list.nth(!l, !n)
+    list.nth(l(), n())
   end
   # Set current file to the nth.
   def set(n')
-    if 0 <= n' and n' < list.length(!l) and n' != !n then
+    if 0 <= n' and n' < list.length(l()) and n' != n() then
       n := n'
       s.set(request.once(request.create(current())))
     end
   end
   def next()
     log.debug(label=id, "Going to next file")
-    n' = !n + 1
-    n' = if n' >= list.length(!l) then if getter.get(cyclic) then 0 else list.length(!l) - 1 end else n' end
+    n' = n() + 1
+    n' = if n' >= list.length(l()) then if getter.get(cyclic) then 0 else list.length(l()) - 1 end else n' end
     set(n')
   end
   def prev()
     log.debug(label=id, "Going to previous file")
-    n' = !n - 1
-    n' = if n' < 0 then if getter.get(cyclic) then list.length(!l) - 1 else 0 end else n' end
+    n' = n() - 1
+    n' = if n' < 0 then if getter.get(cyclic) then list.length(l()) - 1 else 0 end else n' end
     set(n')
   end
   def clear()
@@ -520,7 +520,7 @@ def video.slideshow(~id=null(), ~cyclic=getter(true), ~advance=getter(-1.), l=[]
     n := 0
   end
   def append(l')
-    l := list.append(!l, l')
+    l := list.append(l(), l')
   end
   set(0)
   if getter.get(advance) >= 0. then thread.run(delay=getter.get(advance), every=advance, next) end

--- a/src/libs/visualization.liq
+++ b/src/libs/visualization.liq
@@ -17,11 +17,11 @@ def vumeter(~rms_min=-25., ~rms_max=-5., ~window=0.5, ~scroll=false, s)
     n = int_of_float(x * float_of_int(bar_width))
     bar = ref("")
     if not scroll then bar := "\r" end
-    for _ = 0 to n-1 do bar := !bar ^ "=" end
-    for _ = 0 to bar_width-n-1 do bar := !bar ^ "." end
-    bar := !bar ^ " " ^ string(v)
-    if scroll then bar := !bar ^ "\n" end
-    print(newline=false, !bar)
+    for _ = 0 to n-1 do bar := bar() ^ "=" end
+    for _ = 0 to bar_width-n-1 do bar := bar() ^ "." end
+    bar := bar() ^ " " ^ string(v)
+    if scroll then bar := bar() ^ "\n" end
+    print(newline=false, bar())
   end
   thread.run(fast=true, every=window, display)
   s
@@ -48,6 +48,6 @@ def video.vumeter(~rms_min=-35., ~rms_max=0., ~window=0.1, ~color=0xff0000, ~per
     width := int_of_float(x * float_of_int(video.frame.width()))
   end
   thread.run(fast=true, every=window, update)
-  s = video.rectangle(width={!width}, height=height, color=color, s)
+  s = video.rectangle(width=width, height=height, color=color, s)
   video.persistence(duration=persistence, s)
 end

--- a/tests/failures/ref.liq
+++ b/tests/failures/ref.liq
@@ -1,3 +1,5 @@
+#!../../liquidsoap
+
 # Ensure that value restriction prevents the usual problems.
 
 def id(x) = x end

--- a/tests/harbor/http.liq
+++ b/tests/harbor/http.liq
@@ -69,8 +69,8 @@ def f() =
 
     data_count = ref(3)
     def data() =
-      if !data_count >= 0 then
-        data_count := !data_count - 1
+      if data_count() >= 0 then
+        data_count := data_count() - 1
         "gnigno"
       else
         ""
@@ -142,7 +142,7 @@ def f() =
   data = begin
     is_done = ref(false)
     fun () ->
-      if !is_done then "" else
+      if is_done() then "" else
         is_done := true
         "foobarlol"
       end
@@ -189,8 +189,8 @@ def f() =
     tmp = string.make(10_000)
     count = ref(10_000_000 / 10_000)
     fun () ->
-      if 0 < !count then
-        count := !count - 1
+      if 0 < count() then
+        count := count() - 1
         tmp
       else
         ""
@@ -251,7 +251,7 @@ def f() =
   test.equals(resp.status_code, 200)
 
   try
-    fn = !read
+    fn = read()
     fn(timeout=10.)
     test.fail()
   catch err: [error.http] do

--- a/tests/language/bool.liq
+++ b/tests/language/bool.liq
@@ -10,7 +10,7 @@ def f() =
   l = ref(false)
   r = ref(false)
   if begin l := true; true end or begin r := true; true end then () end
-  t(!l and (not !r), true)
+  t(l() and (not r()), true)
 
   ignore(true == false ? 5 : 6)
   test.pass()

--- a/tests/language/error.liq
+++ b/tests/language/error.liq
@@ -110,11 +110,11 @@ def f() =
     ()
   end
 
-  if (!on_error).kind != e.kind then
+  if (on_error()).kind != e.kind then
     test.fail()
   end
 
-  if (!on_error).message != "On done callback" then
+  if (on_error()).message != "On done callback" then
     test.fail()
   end
 

--- a/tests/language/eval.liq
+++ b/tests/language/eval.liq
@@ -7,7 +7,7 @@ def echo(s)
   if s != string(!count) then
     fail := true
   end
-  count := !count + 1
+  count := count() + 1
   ()
 end
 
@@ -67,7 +67,7 @@ def f() =
   let eval ([x, y]:[int]) = "[123,456]"
   t("25", { (x, y) == (123, 456) })
 
-  if !fail then test.fail() else test.pass() end
+  if fail() then test.fail() else test.pass() end
 end
 
 test.check(f)

--- a/tests/language/file.watch.liq
+++ b/tests/language/file.watch.liq
@@ -13,7 +13,7 @@ def f() =
   file.write(data="xxx", fname)
   sleep(1.)
 
-  if !success then test.pass() else test.fail() end
+  if success() then test.pass() else test.fail() end
 end
 
 test.check(f)

--- a/tests/language/file.watch2.liq
+++ b/tests/language/file.watch2.liq
@@ -18,7 +18,7 @@ end
 thread.run(delay=1., write)
 
 def check() =
-  if !success then test.pass() else test.fail() end
+  if success() then test.pass() else test.fail() end
 end
 
 thread.run(delay=3., check)

--- a/tests/language/getter.liq
+++ b/tests/language/getter.liq
@@ -1,3 +1,5 @@
+#!../../liquidsoap ../test.liq
+
 # Test getters, see #1181
 
 def f(~x)
@@ -18,7 +20,6 @@ def tests() =
   g(x={4})
 
   r = ref(5)
-  r = ref.getter(r)
   f(x=r)
   g(x=r)
   r.set(r()+2)

--- a/tests/language/getter.liq
+++ b/tests/language/getter.liq
@@ -33,7 +33,7 @@ def tests() =
   def gen =
     pos = ref(0)
     fun () -> begin
-      if !pos == 3 then "" else
+      if pos() == 3 then "" else
         ref.incr(pos)
         "foobar"
       end
@@ -46,7 +46,7 @@ def tests() =
   def gen =
     pos = ref(0)
     fun () -> begin
-      if !pos == 3 then "" else
+      if pos() == 3 then "" else
         ref.incr(pos)
         "foobar"
       end

--- a/tests/language/interactive.liq
+++ b/tests/language/interactive.liq
@@ -35,7 +35,7 @@ def f() =
     log.important("Inexistent variable use detected: #{e}")
   end
 
-  if !success then test.pass() else test.fail() end
+  if success() then test.pass() else test.fail() end
 end
 
 test.check(f)

--- a/tests/language/list.liq
+++ b/tests/language/list.liq
@@ -103,7 +103,7 @@ def f() =
   # Test huge lists, see #2162.
   # l = list.init(100000, fun(i) -> i)
 
-  if !success then test.pass() else test.fail() end
+  if success() then test.pass() else test.fail() end
 end
 
 test.check(f)

--- a/tests/language/loop.liq
+++ b/tests/language/loop.liq
@@ -9,30 +9,30 @@ end
 
 def f() =
   n = ref(1)
-  while !n < 10 do
-    n := !n * 2
+  while n() < 10 do
+    n := n() * 2
   end
-  t(!n, 16)
+  t(n(), 16)
 
   n = ref(0)
   for i = 0 to 10 do
-    n := !n + i
+    n := n() + i
   end
-  t(!n, 55)
+  t(n(), 55)
 
   n = ref(0)
   for i = list.iterator([0,1,2,3,4,5,6,7,8,9,10]) do
-    n := !n + i
+    n := n() + i
   end
-  t(!n, 55)
+  t(n(), 55)
 
   s = ref("")
   for i = list.iterator(["a","b","c"]) do
-    s := !s ^ i
+    s := s() ^ i
   end
-  t(!s, "abc")
+  t(s(), "abc")
 
-  if !success then test.pass() else test.fail() end
+  if success() then test.pass() else test.fail() end
 end
 
 test.check(f)

--- a/tests/language/osc.liq
+++ b/tests/language/osc.liq
@@ -10,20 +10,20 @@ def f() =
   osc.on_float("/bla", fun(x) -> if x == 42. then print("got float"); success := true end)
   osc.send_float(host="localhost", port=settings.osc.port(), "/bla", 42.)
   sleep(1.)
-  if not !success then test.fail() end
+  if not success() then test.fail() end
 
   # Test native OSC
   success := false
   osc.native.on_float("/bla", fun(x) -> if x == 42. then print("got float"); success := true end)
   osc.native.send_float(host="localhost", port=settings.oscnative.port(), "/bla", 42.)
   sleep(1.)
-  if not !success then test.fail() end
+  if not success() then test.fail() end
 
   success := false
   osc.native.on_string("/bla", fun(x) -> if x == "xxx" then print("got string"); success := true end)
   osc.native.send_string(host="localhost", port=settings.oscnative.port(), "/bla", "xxx")
   sleep(1.)
-  if not !success then test.fail() end
+  if not success() then test.fail() end
 
   test.pass()
 end

--- a/tests/language/predicate.liq
+++ b/tests/language/predicate.liq
@@ -8,7 +8,7 @@ def predicate.nth(n)
   i = ref(-1)
   fun () -> begin
     ref.incr(i)
-    !i == n
+    i() == n
   end
 end
 
@@ -16,7 +16,7 @@ def predicate.from(n)
   i = ref(-1)
   fun () -> begin
     ref.incr(i)
-    !i >= n
+    i() >= n
   end
 end
 
@@ -44,7 +44,7 @@ def f() =
   t(p(), true)
   t(p(), false)
 
-  if !success then test.pass() else test.fail() end
+  if success() then test.pass() else test.fail() end
 end
 
 test.check(f)

--- a/tests/language/ref.liq
+++ b/tests/language/ref.liq
@@ -15,14 +15,14 @@ def incr(n) = n + 1 end
 def f() =
   n = ref(0)
   n := 5
-  t(!n, 5)
+  t(n(), 5)
   s = ref("a")
   s := "b"
-  t(!s, "b")
+  t(s(), "b")
   f = ref(id)
   f := incr
 
-  if !success then test.pass() else test.fail() end
+  if success() then test.pass() else test.fail() end
 end
 
 test.check(f)

--- a/tests/language/ref.liq
+++ b/tests/language/ref.liq
@@ -1,3 +1,5 @@
+#!../../liquidsoap ../test.liq
+
 success = ref(true)
 
 def t(x, y)

--- a/tests/language/stdlib.liq
+++ b/tests/language/stdlib.liq
@@ -16,7 +16,7 @@ def f() =
   t(liquidsoap.version.at_least("2.0.0"), true)
   t(liquidsoap.version.at_least("666.0.0"), false)
 
-  if !success then test.pass() else test.fail() end
+  if success() then test.pass() else test.fail() end
 end
 
 test.check(f)

--- a/tests/media/multitrack.liq
+++ b/tests/media/multitrack.liq
@@ -44,7 +44,7 @@ s.on_track(fun (_) -> ref.incr(file_track_seen))
 
 should_stop = ref(false)
 
-s = switch(track_sensitive=false, [({not !should_stop}, s)])
+s = switch(track_sensitive=false, [({not should_stop()}, s)])
 
 enc = %ffmpeg(
   format="mp4",
@@ -54,10 +54,10 @@ enc = %ffmpeg(
 )
 
 def on_stop() =
-  test.equals(!meta_seen, true)
-  test.equals(!track_seen, true)
-  test.equals(!file_no_meta_seen, true)
-  test.equals(!file_track_seen, 1)
+  test.equals(meta_seen(), true)
+  test.equals(track_seen(), true)
+  test.equals(file_no_meta_seen(), true)
+  test.equals(file_track_seen(), 1)
 
   ojson = process.read("ffprobe -v quiet -print_format json -show_streams #{process.quote(out)}")
 
@@ -90,7 +90,7 @@ output.file(fallible=true, on_stop=on_stop, enc, out, s)
 meta_count = ref(0)
 
 thread.run(every=2., fun () -> begin
-  if !meta_count < 2 then
+  if meta_count() < 2 then
     s4.insert_metadata([("foo", "bla")])
     ref.incr(meta_count)
   else

--- a/tests/performance/gen_bigrecord.ml
+++ b/tests/performance/gen_bigrecord.ml
@@ -6,7 +6,7 @@ let () =
   in
   let sums =
     String.concat "\n"
-      (List.map (fun idx -> [%string "n := !n + r.a%{idx}"]) indexes)
+      (List.map (fun idx -> [%string "n := n() + r.a%{idx}"]) indexes)
   in
   Printf.printf "%s"
     [%string

--- a/tests/performance/small-record.liq
+++ b/tests/performance/small-record.liq
@@ -2,7 +2,7 @@ def r2()
   r = {a0 = 0, a1 = 1}
   x = ref(0)
   for _ = 1 to 200000 do
-    x := !x + r.a0 + r.a1
+    x := x() + r.a0 + r.a1
   end
 end
 
@@ -10,7 +10,7 @@ def r5()
   r = {a0 = 0, a1 = 1, a2 = 2, a3 = 3, a4 = 4}
   x = ref(0)
   for _ = 1 to 200000 do
-    x := !x + r.a0 + r.a1 + r.a2 + r.a3 + r.a4
+    x := x() + r.a0 + r.a1 + r.a2 + r.a3 + r.a4
   end
 end
 
@@ -18,7 +18,7 @@ def r10()
   r = {a0 = 0, a1 = 1, a2 = 2, a3 = 3, a4 = 4, a5 = 5, a6 = 6, a7 = 7, a8 = 8, a9 = 9}
   x = ref(0)
   for _ = 1 to 200000 do
-    x := !x + r.a0 + r.a1 + r.a2 + r.a3 + r.a4 + r.a5 + r.a6 + r.a7 + r.a8 + r.a9
+    x := x() + r.a0 + r.a1 + r.a2 + r.a3 + r.a4 + r.a5 + r.a6 + r.a7 + r.a8 + r.a9
   end
 end
 
@@ -27,7 +27,7 @@ def r20()
        a10 = 0, a11 = 1, a12 = 2, a13 = 3, a14 = 4, a15 = 5, a16 = 6, a17 = 7, a18 = 8, a19 = 9}
   x = ref(0)
   for _ = 1 to 200000 do
-    x := !x
+    x := x()
          + r.a00 + r.a01 + r.a02 + r.a03 + r.a04 + r.a05 + r.a06 + r.a07 + r.a08 + r.a09
          + r.a10 + r.a11 + r.a12 + r.a13 + r.a14 + r.a15 + r.a16 + r.a17 + r.a18 + r.a19
   end

--- a/tests/streams/197.liq
+++ b/tests/streams/197.liq
@@ -1,11 +1,11 @@
 first = ref("")
 def filter(r)
   m = request.metadata(r)
-  if !first == "" then
+  if first() == "" then
     first := m["filename"]
     false
   else
-    m["filename"] != !first
+    m["filename"] != first()
   end
 end
 

--- a/tests/streams/autostart.liq
+++ b/tests/streams/autostart.liq
@@ -17,7 +17,7 @@ output.dummy(id="no_autostart", start=false, on_start=on_unwanted_autostart, s)
 output.dummy(id="autostart", start=true, on_start=on_wanted_autostart, s)
 
 def on_done() =
-  if !test_no_autostart and !test_autostart then
+  if test_no_autostart() and test_autostart() then
     test.pass()
   else
     test.fail()

--- a/tests/streams/cross-override.liq
+++ b/tests/streams/cross-override.liq
@@ -18,12 +18,12 @@ track_count = ref(0)
 def on_metadata(m) =
   ref.incr(track_count)
 
-  if !track_count == 1 then
+  if track_count() == 1 then
     if m["source"] != "b" then test.fail() end
     if s.cross_duration() != 1.1 then test.fail() end
   end
 
-  if !track_count == 2 then
+  if track_count() == 2 then
     if m["source"] != "c" then test.fail() end
     if s.cross_duration() != 5. then test.fail() end
     success := true

--- a/tests/streams/cross-persist-override.liq
+++ b/tests/streams/cross-persist-override.liq
@@ -18,12 +18,12 @@ track_count = ref(0)
 def on_metadata(m) =
   ref.incr(track_count)
 
-  if !track_count == 1 then
+  if track_count() == 1 then
     if m["source"] != "b" then test.fail() end
     if s.cross_duration() != 1.1 then test.fail() end
   end
 
-  if !track_count == 2 then
+  if track_count() == 2 then
     if m["source"] != "c" then test.fail() end
     if s.cross_duration() != 1.1 then test.fail() end
     success := true

--- a/tests/streams/cross.liq
+++ b/tests/streams/cross.liq
@@ -22,10 +22,10 @@ seen_b = ref(false)
 
 def check_duplicate(m) =
   if m["title"] == "a" then
-    if !seen_a then test.fail() else seen_a := true end
+    if seen_a() then test.fail() else seen_a := true end
   end
   if m["title"] == "b" then
-    if !seen_b then test.fail() else seen_b := true end
+    if seen_b() then test.fail() else seen_b := true end
   end
 end
 
@@ -34,7 +34,7 @@ s.on_metadata(check_duplicate)
 clock.assign_new(sync="none",[s])
 
 def on_stop () =
-  if !seen_a and !seen_b then
+  if seen_a() and seen_b() then
     test.pass()
   else
     test.fail()

--- a/tests/streams/crossfade.liq
+++ b/tests/streams/crossfade.liq
@@ -31,16 +31,16 @@ dup_b = ref(0)
 
 def check_duplicate(m) =
   if m["title"] == "a1" then
-    dedup_a := !dedup_a + 1
+    dedup_a := dedup_a() + 1
   end
   if m["title"] == "b1" then
-    dedup_b := !dedup_b + 1
+    dedup_b := dedup_b() + 1
   end
   if m["title"] == "a2" then
-    dup_a := !dup_a + 1
+    dup_a := dup_a() + 1
   end
   if m["title"] == "b2" then
-    dup_b := !dup_b + 1
+    dup_b := dup_b() + 1
   end
 end
 

--- a/tests/streams/ctype2.liq
+++ b/tests/streams/ctype2.liq
@@ -7,7 +7,7 @@ log.level.set(4)
 first = ref(true)
 
 def f()
-  if !first then
+  if first() then
     first := false
     sine(id="sineF",880.)
   else

--- a/tests/streams/random.liq
+++ b/tests/streams/random.liq
@@ -15,7 +15,7 @@ s1 = metadata.map(m1,s1)
 
 s1_ready = ref(true)
 
-s1 = switch(id="s1",[({!s1_ready},s1)])
+s1 = switch(id="s1",[(s1_ready,s1)])
 
 s1_weight = ref(1)
 
@@ -29,17 +29,17 @@ s2 = metadata.map(id="s2",m2,s2)
 
 s2_ready = ref(false)
 
-s2 = switch(id="s2",[({!s2_ready},s2)])
+s2 = switch(id="s2",[(s2_ready,s2)])
 
 s2_weight = ref(1)
 
 round = ref(1)
 
 def f(m) =
-  if !round == 1 then
+  if round() == 1 then
     s1_ready := false
     s2_ready := true
-  elsif !round == 2 then
+  elsif round() == 2 then
     s1_ready := true
     s2_ready := true
     s2_weight := 0
@@ -49,18 +49,18 @@ def f(m) =
     s2_ready := true
     s2_weight := 1
   end
-  round := !round + 1
-  selected := list.cons(m["id"],!selected)
+  round := round() + 1
+  selected := list.cons(m["id"],selected())
 end
 
-s = random(weights=[{!s1_weight}, {!s2_weight}], [s1,s2])
+s = random(weights=[s1_weight, s2_weight], [s1,s2])
 
 s.on_track(f)
 
 output.dummy(fallible=true, s)
 
 def on_done () =
-  s = list.rev(!selected)
+  s = list.rev(selected())
   if list.nth(default="",s,0) == "s1" and
      list.nth(default="",s,1) == "s2" and
      list.nth(default="",s,2) == "s1" then

--- a/tests/streams/say.liq
+++ b/tests/streams/say.liq
@@ -8,8 +8,8 @@ end
 
 n = ref(0)
 def f(_)
-  if !n < 1 then
-    n := !n + 1
+  if n() < 1 then
+    n := n() + 1
   else
     test.pass(); shutdown()
   end

--- a/tests/test.liq
+++ b/tests/test.liq
@@ -30,23 +30,23 @@ def test.check_non_repeating(~nb_files,~nb_rounds,s)
   iterations = ref(0)
 
   def already(fname)
-    list.assoc(default=false, fname, !seen)
+    list.assoc(default=false, fname, seen())
   end
 
   def check(m)
     fname = m["filename"]
     print("I: Playing #{fname}")
-    if !iterations < nb_rounds and already(fname) then
+    if iterations() < nb_rounds and already(fname) then
       print("I: Already seen #{fname}")
       test.fail()
     else
-      if list.length(!seen) < nb_files-1 then
-        seen := list.add((fname,true),!seen)
+      if list.length(seen()) < nb_files-1 then
+        seen := list.add((fname,true),seen())
       else
         print("I: ===")
         seen := []
-        iterations := !iterations+1
-        if !iterations == nb_rounds then
+        iterations := iterations()+1
+        if iterations() == nb_rounds then
           print("I: Test passed")
           test.pass()
         end


### PR DESCRIPTION
Implement references as objects: `ref('a)` is now `(() -> 'a).{set : ('a) -> unit}`. For instance,
```
x = ref(5)
x.set(x() + 2)
x := x() + 2
```
(the `:=` syntax is still supported for now)