### PR TITLE
Allow implicit int to float conversion.

### DIFF
--- a/src/lang/builtins_math.ml
+++ b/src/lang/builtins_math.ml
@@ -86,7 +86,8 @@ let () =
            match (a, b) with
              | `Int a, `Int b -> Lang.int (op_int a b)
              | `Float a, `Float b -> Lang.float (op_float a b)
-             | _ -> assert false))
+             | `Int a, `Float b -> Lang.float (op_float (float a) b)
+             | `Float a, `Int b -> Lang.float (op_float a (float b))))
   in
   register_op "Multiplication" "*" ( * ) ( *. );
   register_op "Division" "/" ( / ) ( /. );

--- a/src/lang/lang_core.ml
+++ b/src/lang/lang_core.ml
@@ -292,11 +292,17 @@ let to_string_getter t =
     | _ -> assert false
 
 let to_float t =
-  match (demeth t).value with Ground (Float s) -> s | _ -> assert false
+  match (demeth t).value with
+    | Ground (Float s) -> s
+    | Ground (Int n) -> float_of_int n
+    | _ -> assert false
 
 let to_float_getter t =
   match (demeth t).value with
     | Ground (Float s) -> fun () -> s
+    | Ground (Int n) ->
+        let n = float_of_int n in
+        fun () -> n
     | Fun _ | FFI _ -> (
         fun () ->
           match (apply t []).value with

--- a/src/lang/types/ground_type.ml
+++ b/src/lang/types/ground_type.ml
@@ -37,6 +37,7 @@ module Make (S : Spec) = struct
   type Type_base.custom += Type
 
   let () = types := Type :: !types
+  let typ = Type
   let get = function Type -> Type | _ -> assert false
 
   let is_descr = function
@@ -74,17 +75,32 @@ module Make (S : Spec) = struct
         Type_base.make (Type_base.Custom handler))
 end
 
-module Int = Make (struct
-  let name = "int"
-end)
-
-let int = Int.descr
-
 module Float = Make (struct
   let name = "float"
 end)
 
 let float = Float.descr
+
+module Int = struct
+  module Int = Make (struct
+    let name = "int"
+  end)
+
+  include Int
+
+  (* Add int <: float subtyping. *)
+  let handler =
+    let subtype _ _ c = assert (c = Int.typ || c = Float.typ) in
+    { handler with subtype }
+
+  let descr = Type_base.Custom handler
+
+  let () =
+    Type_base.register_type "int" (fun () ->
+        Type_base.make (Type_base.Custom handler))
+end
+
+let int = Int.descr
 
 module String = Make (struct
   let name = "string"

--- a/tests/language/casting.liq
+++ b/tests/language/casting.liq
@@ -1,0 +1,17 @@
+#!../../liquidsoap ../test.liq
+
+def t(x, y)
+  if x != y then
+    print("Failure: got #{x} instead of #{y}")
+    test.fail()
+  end
+end
+
+def f() =
+  def double(x) = 2. * x end
+
+  t(double(3), 6.)
+  test.pass()
+end
+
+test.check(f)


### PR DESCRIPTION
This will allow users to use an int where a float is expected. For instance:
```
def double(x) = 2. * x end
ten = double(5)
```