### PR TITLE
HLS custom tags

### DIFF
--- a/src/core/outputs/hls_output.ml
+++ b/src/core/outputs/hls_output.ml
@@ -912,11 +912,8 @@ class hls_output p =
         (Option.map
            (fun b ->
              Strings.iter (output_substring (Option.get out_channel)) b;
-             self#mutexify
-               (fun () ->
-                 self#close_segment s;
-                 self#open_segment s)
-               ())
+             self#close_segment s;
+             self#open_segment s)
            flushed);
       let { out_channel } = Option.get s.current_segment in
       Strings.iter (output_substring (Option.get out_channel)) data

--- a/tests/media/ffmpeg_distributed_hls_state.json
+++ b/tests/media/ffmpeg_distributed_hls_state.json
@@ -3,11 +3,13 @@
     {
       "name": "mp4",
       "position": 7,
+      "pending_extra_tags": [],
       "discontinuity_count": 1
     },
     {
       "name": "mpegts",
       "position": 7,
+      "pending_extra_tags": [],
       "discontinuity_count": 1
     }
   ],
@@ -19,6 +21,7 @@
         "current_discontinuity": 0,
         "filename": "/tmp/mp4_1617977940_1.m4s",
         "init_filename": "/tmp/mp4_1617977940_0.m4s",
+        "extra_tags": [],
         "len": 441000
       },
       {
@@ -27,6 +30,7 @@
         "current_discontinuity": 0,
         "filename": "/tmp/mp4_1617977950_2.m4s",
         "init_filename": "/tmp/mp4_1617977940_0.m4s",
+        "extra_tags": [],
         "len": 439236
       },
       {
@@ -35,6 +39,7 @@
         "current_discontinuity": 0,
         "filename": "/tmp/mp4_1617977960_3.m4s",
         "init_filename": "/tmp/mp4_1617977940_0.m4s",
+        "extra_tags": [],
         "len": 340452
       },
       {
@@ -43,6 +48,7 @@
         "current_discontinuity": 0,
         "filename": "/tmp/mp4_1617977985_5.m4s",
         "init_filename": "/tmp/mp4_1617977985_4.m4s",
+        "extra_tags": [],
         "len": 441000
       },
       {
@@ -51,6 +57,7 @@
         "current_discontinuity": 1,
         "filename": "/tmp/mp4_1617977995_6.m4s",
         "init_filename": "/tmp/mp4_1617977985_4.m4s",
+        "extra_tags": [],
         "len": 386316
       }
     ],
@@ -61,6 +68,7 @@
         "current_discontinuity": 0,
         "filename": "/tmp/mpegts_1617977940_1.ts",
         "init_filename": null,
+        "extra_tags": [],
         "len": 441000
       },
       {
@@ -69,6 +77,7 @@
         "current_discontinuity": 0,
         "filename": "/tmp/mpegts_1617977950_2.ts",
         "init_filename": null,
+        "extra_tags": [],
         "len": 439236
       },
       {
@@ -77,6 +86,7 @@
         "current_discontinuity": 0,
         "filename": "/tmp/mpegts_1617977960_3.ts",
         "init_filename": null,
+        "extra_tags": [],
         "len": 340452
       },
       {
@@ -85,6 +95,7 @@
         "current_discontinuity": 0,
         "filename": "/tmp/mpegts_1617977985_5.ts",
         "init_filename": null,
+        "extra_tags": [],
         "len": 441000
       },
       {
@@ -93,6 +104,7 @@
         "current_discontinuity": 1,
         "filename": "/tmp/mpegts_1617977995_6.ts",
         "init_filename": null,
+        "extra_tags": [],
         "len": 386316
       }
     ]

--- a/tests/streams/hls_custom_tags.liq
+++ b/tests/streams/hls_custom_tags.liq
@@ -1,0 +1,74 @@
+s = sine()
+
+s = mksafe(s)
+
+tmp_dir = file.temp_dir("tmp")
+on_shutdown({file.rmdir(tmp_dir)})
+
+main_tags = ref(false)
+aac_flags = ref(false)
+mp4_flags = ref(false)
+global_insert_flags = ref(0)
+aac_insert_flags = ref(false)
+
+def on_file_change(~state, p) =
+  fname = path.basename(p)
+  if state == "closed" then
+    if fname == "main.m3u8" and
+       string.contains(substring="X-CUSTOM", file.contents(p)) then
+      main_tags := true
+    end
+
+    if fname == "aac.m3u8" then
+      contents = file.contents(p)
+
+      if string.contains(substring="X-CUSTOM", contents) then
+        aac_flags := true
+      end
+
+      if string.contains(substring="X-CUSTOM-AAC-INSERT", contents) then
+        aac_insert_flags := true
+      end
+
+      if string.contains(substring="X-CUSTOM-GLOBAL-INSERT", contents) then
+        global_insert_flags := global_insert_flags() + 1
+      end
+    end
+
+    if fname == "mp4.m3u8" then
+      contents = file.contents(p)
+
+      if string.contains(substring="X-CUSTOM", contents) then
+        mp4_flags := true
+      end
+
+      if string.contains(substring="X-CUSTOM-GLOBAL-INSERT", contents) then
+        global_insert_flags := global_insert_flags() + 1
+      end
+    end
+  end
+
+  if main_tags() and aac_flags() and
+     mp4_flags() and global_insert_flags() == 2 and
+     aac_insert_flags() then
+    test.pass()
+  end
+end
+
+o = output.file.hls(
+  playlist="main.m3u8",
+  extra_tags=["X-CUSTOM \n"],
+  on_file_change=on_file_change,
+  tmp_dir,
+  [
+   ("aac", %ffmpeg(format="adts",%audio(codec="aac")).{extra_tags=["X-CUSTOM"]}),
+   ("mp4", %ffmpeg(format="mp4",frag_duration=10,movflags="+dash+skip_sidx+skip_trailer+frag_custom",%audio(codec="aac")).{extra_tags=["X-CUSTOM"]})
+  ],
+  s
+)
+
+thread.run(delay=2., {o.insert_tag(stream="aac", "X-CUSTOM-AAC-INSERT")})
+thread.run(delay=3., {o.insert_tag("X-CUSTOM-GLOBAL-INSERT")})
+
+
+clock.assign_new(sync="none",[s])

--- a/tests/streams/hls_custom_tags.liq
+++ b/tests/streams/hls_custom_tags.liq
@@ -8,7 +8,6 @@ on_shutdown({file.rmdir(tmp_dir)})
 main_tags = ref(false)
 aac_flags = ref(false)
 mp4_flags = ref(false)
-global_insert_flags = ref(0)
 aac_insert_flags = ref(false)
 
 def on_file_change(~state, p) =
@@ -29,10 +28,6 @@ def on_file_change(~state, p) =
       if string.contains(substring="X-CUSTOM-AAC-INSERT", contents) then
         aac_insert_flags := true
       end
-
-      if string.contains(substring="X-CUSTOM-GLOBAL-INSERT", contents) then
-        global_insert_flags := global_insert_flags() + 1
-      end
     end
 
     if fname == "mp4.m3u8" then
@@ -41,16 +36,11 @@ def on_file_change(~state, p) =
       if string.contains(substring="X-CUSTOM", contents) then
         mp4_flags := true
       end
-
-      if string.contains(substring="X-CUSTOM-GLOBAL-INSERT", contents) then
-        global_insert_flags := global_insert_flags() + 1
-      end
     end
   end
 
   if main_tags() and aac_flags() and
-     mp4_flags() and global_insert_flags() == 2 and
-     aac_insert_flags() then
+     mp4_flags() and aac_insert_flags() then
     test.pass()
   end
 end
@@ -67,8 +57,7 @@ o = output.file.hls(
   s
 )
 
-thread.run(delay=2., {o.insert_tag(stream="aac", "X-CUSTOM-AAC-INSERT")})
-thread.run(delay=3., {o.insert_tag("X-CUSTOM-GLOBAL-INSERT")})
+thread.run(delay=2., {list.hd(o.streams()).insert_tag("X-CUSTOM-AAC-INSERT")})
 
 
 clock.assign_new(sync="none",[s])


### PR DESCRIPTION
This PR adds the ability to define extra tags on HLS playlists. It adds 3 distinct ways of doing it:

* The `extra_tags` argument on the operator adds extra tags to the main playlist.
* The optional `extra_tags` method on the stream list adds extra tags to the given stream.
* The return output (of `unit`) type has a `streams` method which returns the list of streams with their attributes (encoder, name, bandwidth) and a `insert_tag` to insert a tag into their playlist
* Tags inserted via the `insert_tag` cause the current segment to end. The tag is the written to the playlist and a new segment begins.

Example:

Script:
```liquidsoap
# Add X-CUSTOM-TAG to the main playlist:
o = output.file.hls(
  extra_tags["X-CUSTOM-TAG"],
 "/tmp/hls",
  [(
    "stream", 
    %ffmpeg(format="mpegts", %audio(codec="aac")).{
        # Adds an extra tag to this stream.
       extra_tags = ["X-CUSTOM-STREAM-TAG"]
    })
  ]
  s
)

# Insert a tag to all streams
list.iter(fun s -> s.insert_tag("X-CUSTOM-STREAM-TAG"), o.streams())
```