### PR TITLE
Make sure exceptions raised in `request.dynamic` never crashes the process.

### DIFF
--- a/src/core/sources/request_simple.ml
+++ b/src/core/sources/request_simple.ml
@@ -152,22 +152,26 @@ class dynamic ~retry_delay ~available (f : Lang.value) prefetch timeout =
             false
 
     method private get_next_request =
-      try
-        match
-          ( available (),
-            Lang.to_valued_option Request.Value.of_value (Lang.apply f []) )
-        with
-          | false, _ -> `Empty
-          | true, Some r ->
-              Request.set_root_metadata r "source" self#id;
-              `Request r
-          | true, None ->
-              let delay = retry_delay () in
-              retry_status <- Some (Unix.gettimeofday () +. delay);
-              `Retry (fun () -> delay)
-      with e ->
-        log#severe "Failed to obtain a media request!";
-        raise e
+      let retry () =
+        let delay = retry_delay () in
+        retry_status <- Some (Unix.gettimeofday () +. delay);
+        `Retry (fun () -> delay)
+      in
+      match
+        ( available (),
+          Lang.to_valued_option Request.Value.of_value (Lang.apply f []) )
+      with
+        | false, _ -> `Empty
+        | true, Some r ->
+            Request.set_root_metadata r "source" self#id;
+            `Request r
+        | true, None -> retry ()
+        | exception exn ->
+            let bt = Printexc.get_backtrace () in
+            Utils.log_exception ~log:self#log ~bt
+              (Printf.sprintf "Failed to obtain a media request: %s"
+                 (Printexc.to_string exn));
+            retry ()
   end
 
 let _ =

--- a/src/libs/native.liq
+++ b/src/libs/native.liq
@@ -83,6 +83,14 @@ def native.request.dynamic(%argsof(request.dynamic), f)
   ignore(available)
   ignore(timeout)
 
+  def f() =
+    try
+      f()
+    catch _ do
+      null()
+    end
+  end
+
   # Prepared requests
   queue = ref([])
 

--- a/tests/regression/GH2897.liq
+++ b/tests/regression/GH2897.liq
@@ -1,0 +1,21 @@
+def f() =
+  def a()
+    def next()
+      error.raise(error.not_found, "test")
+    end
+    request.dynamic(next)
+  end
+  output.dummy(fallible = true, a())
+
+  def a()
+    def next()
+      error.raise(error.not_found, "test")
+    end
+    native.request.dynamic(next)
+  end
+  output.dummy(fallible = true, a())
+
+  thread.run(delay=1.,test.pass)
+end
+
+test.check(f)

--- a/tests/regression/dune.inc
+++ b/tests/regression/dune.inc
@@ -302,6 +302,19 @@
  (alias citest)
  (package liquidsoap)
  (deps
+  GH2897.liq
+  ../media/all_media_files
+  ../../src/bin/liquidsoap.exe
+  (source_tree ../../src/libs)
+  (:stdlib ../../src/libs/stdlib.liq)
+  (:test_liq ../test.liq)
+  (:run_test ../run_test.exe))
+ (action (run %{run_test} GH2897.liq liquidsoap %{test_liq} GH2897.liq)))
+
+(rule
+ (alias citest)
+ (package liquidsoap)
+ (deps
   GH1151.liq
   ../media/all_media_files
   ../../src/bin/liquidsoap.exe


### PR DESCRIPTION
Fixes: #2897