### PR TITLE
Fix copy-pasted functions description in pulseaudio_io.ml

### DIFF
--- a/src/core/io/pulseaudio_io.ml
+++ b/src/core/io/pulseaudio_io.ml
@@ -178,7 +178,7 @@ let _ =
   Lang.add_operator ~base:Modules.output "pulseaudio"
     (Output.proto @ proto @ [("", Lang.source_t frame_t, None, None)])
     ~return_t:frame_t ~category:`Output ~meth:Output.meth
-    ~descr:"Output the source's stream to a portaudio output device."
+    ~descr:"Output the source's stream to a pulseaudio output device."
     (fun p ->
       let infallible = not (Lang.to_bool (List.assoc "fallible" p)) in
       let start = Lang.to_bool (List.assoc "start" p) in
@@ -201,5 +201,5 @@ let _ =
     (Start_stop.active_source_proto ~clock_safe:true ~fallible_opt:(`Yep false)
     @ proto)
     ~return_t ~category:`Input ~meth:(Start_stop.meth ())
-    ~descr:"Stream from a portaudio input device."
+    ~descr:"Stream from a pulseaudio input device."
     (fun p -> new input p)


### PR DESCRIPTION
The description for some functions in pulseaudio was copy-pasted from portaudio module.