### PR TITLE
[2.1] Fix copy-pasted functions description in pulseaudio_io.ml

### DIFF
--- a/src/io/pulseaudio_io.ml
+++ b/src/io/pulseaudio_io.ml
@@ -176,7 +176,7 @@ let () =
   Lang.add_operator "output.pulseaudio"
     (Output.proto @ proto @ [("", Lang.source_t k, None, None)])
     ~return_t:k ~category:`Output ~meth:Output.meth
-    ~descr:"Output the source's stream to a portaudio output device."
+    ~descr:"Output the source's stream to a pulseaudio output device."
     (fun p ->
       let infallible = not (Lang.to_bool (List.assoc "fallible" p)) in
       let start = Lang.to_bool (List.assoc "start" p) in
@@ -195,7 +195,7 @@ let () =
     (Start_stop.active_source_proto ~clock_safe:true ~fallible_opt:(`Yep false)
     @ proto)
     ~return_t:k ~category:`Input ~meth:(Start_stop.meth ())
-    ~descr:"Stream from a portaudio input device."
+    ~descr:"Stream from a pulseaudio input device."
     (fun p ->
       let kind = Kind.of_kind kind in
       new input ~kind p)


### PR DESCRIPTION
## Summary
The description for some functions in pulseaudio was copy-pasted from portaudio module.

Backport of #2910