### PR TITLE
Turn all timeout into float values in seconds

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -36,6 +36,8 @@ Changed:
 - Changed `cry` to be a required dependency.
 - Changed default character encoding in `output.harbor`, `output.icecast`
   `output.shoutcast` to `UTF-8` (#2704)
+- BREAKING: all `timeout` settings and parameters are now `float` values
+  and in seconds (#2809)
 - Added support for a Javascript build an interpreter.
 - Removed support for `%define` variables, superseded by support for actual
   variables in encoders.

--- a/doc/content/migrating.md
+++ b/doc/content/migrating.md
@@ -11,6 +11,17 @@ The `!x` notation for getting the value of a reference is now deprecated. You
 should write `x()` instead. And `x := v` is now an alias for `x.set(v)` (both
 can be used interchangeably).
 
+### Timeout
+
+We used to have timeout values labelled `timeout` or `timeout_ms`, some of these would be integer and
+in milliseconds, other floating point and in seconds etc. This was pretty confusing so, now all `timeout`
+settings and arguments have been unified to be named `timeout` and hold a floating point value representing
+a number of seconds.
+
+In most cases, your script will not execute until you have updated your custom `timeout`
+values but you should also review all of them to make sure that they follow the new
+convention.
+
 ### Harbor HTTP server
 
 The API for registering HTTP server endpoint was completely. It should be more flexible and

--- a/src/core/builtins/builtins_http.ml
+++ b/src/core/builtins/builtins_http.ml
@@ -69,10 +69,10 @@ let add_http_request ~base ~stream_body ~descr ~request name =
           Lang.bool_t,
           Some (Lang.bool true),
           Some "Perform redirections if needed." );
-        ( "timeout_ms",
-          Lang.nullable_t Lang.int_t,
-          Some (Lang.int 10000),
-          Some "Timeout for network operations in milliseconds." );
+        ( "timeout",
+          Lang.nullable_t Lang.float_t,
+          Some (Lang.float 10.),
+          Some "Timeout for network operations in seconds." );
         ( "",
           Lang.string_t,
           None,
@@ -99,7 +99,9 @@ let add_http_request ~base ~stream_body ~descr ~request name =
         List.map (fun (x, y) -> (Lang.to_string x, Lang.to_string y)) headers
       in
       let timeout =
-        Lang.to_valued_option Lang.to_int (List.assoc "timeout_ms" p)
+        Lang.to_valued_option
+          (fun v -> int_of_float (1000. *. Lang.to_float v))
+          (List.assoc "timeout" p)
       in
       let http_version =
         Option.map Lang.to_string (Lang.to_option (List.assoc "http_version" p))

--- a/src/libs/externals.liq
+++ b/src/libs/externals.liq
@@ -331,13 +331,14 @@ end
 # @flag extra
 # @param ~urgency Urgency (low|normal|critical).
 # @param ~icon    Icon filename or stock icon to display.
-# @param ~time    Timeout in milliseconds.
+# @param ~timeout Timeout in seconds.
 # @param ~display Function used to display a metadata packet.
 # @param ~title   Title of the notification message.
 # @category Source / Track processing
-def notify_metadata(~urgency="low",~icon="stock_smiley-22",~time=3000,
+def notify_metadata(~urgency="low",~icon="stock_smiley-22",~timeout=3.,
            ~display=string_of_metadata,
            ~title="Liquidsoap: new track",s)
+  time = int_of_float(timeout * 1000.)
   send = 'notify-send -i #{icon} -u #{urgency}'
        ^ ' -t #{time} #{process.quote(title)} '
   s.on_metadata(fun (m) -> ignore(process.run(send^process.quote(display(m)))))

--- a/src/libs/file.liq
+++ b/src/libs/file.liq
@@ -236,7 +236,7 @@ def file.download(~filename, ~timeout=5., url) =
 
   response = http.get.stream(
     on_body_data=file_writer,
-    timeout_ms=int_of_float(timeout * 1000.),
+    timeout=timeout,
     url
   )
 

--- a/src/libs/http.liq
+++ b/src/libs/http.liq
@@ -485,7 +485,7 @@ upload_file_fn = fun (~name, ~content_type, ~headers, ~boundary, ~filename, ~fil
   }])
   headers = ("Content-Type", "multipart/form-data; boundary=#{data.boundary}")::headers
 
-  fn(headers=headers, timeout_ms=timeout, redirect=redirect, data=data.contents, url)
+  fn(headers=headers, timeout=timeout, redirect=redirect, data=data.contents, url)
 end
 
 # Send a file via POST request encoded in multipart/form-data. The contents can
@@ -499,7 +499,7 @@ end
 # @param ~filename File name sent in the request.
 # @param ~file File whose contents is to be sent in the request.
 # @param ~contents Contents of the file sent in the request.
-# @param ~timeout Timeout in ms.
+# @param ~timeout Timeout in seconds.
 # @param ~redirect Follow reidrections.
 # @param url URL to post to.
 def http.post.file(~name="file", ~content_type=null(), ~headers=[], ~boundary=null(), ~filename=null(), ~file=null(), ~contents=null(), ~timeout=null(), ~redirect=true, url)
@@ -518,7 +518,7 @@ end
 # @param ~filename File name sent in the request.
 # @param ~file File whose contents is to be sent in the request.
 # @param ~contents Contents of the file sent in the request.
-# @param ~timeout Timeout in ms.
+# @param ~timeout Timeout in seconds.
 # @param ~redirect Follow reidrections.
 # @param url URL to put to.
 def http.put.file(~name="file", ~content_type=null(), ~headers=[], ~boundary=null(), ~filename=null(), ~file=null(), ~contents=null(), ~timeout=null(), ~redirect=true, url)

--- a/src/libs/protocols.liq
+++ b/src/libs/protocols.liq
@@ -158,7 +158,7 @@ def protocol.http(proto,~rlog,~maxtime,arg) =
 
   timeout = maxtime - time()
 
-  ret = http.head(timeout_ms=int_of_float(timeout*1000.), uri)
+  ret = http.head(timeout=timeout, uri)
   code = ret.status_code ?? 999
   headers = ret.headers
 
@@ -198,7 +198,7 @@ def protocol.http(proto,~rlog,~maxtime,arg) =
   try
     response = http.get.stream(
       on_body_data=file_writer,
-      timeout_ms=int_of_float(timeout * 1000.),
+      timeout=timeout,
       uri
     )
 


### PR DESCRIPTION
This is a bit of a breaking change but I think that it would prove valuable: require that all timeout settings and parameters be labelled `timeout` (or `read_timeout` etc) and hold a floating point value in seconds.

Fixes: #2809