### PR TITLE
Clarify reloading logic in piped output

### DIFF
--- a/doc/content/migrating.md
+++ b/doc/content/migrating.md
@@ -22,6 +22,61 @@ In most cases, your script will not execute until you have updated your custom `
 values but you should also review all of them to make sure that they follow the new
 convention.
 
+### `reopen_*` arguments in `output.file` and similar
+
+The `reopen_*` arguments have been unified in `output.file`, `output.pipe` and similar operators. Instead
+of 3 different arguments for metadata, errors and regular reloads, which was making the logic pretty hard to
+understand, now a single `should_reload` callback is given.
+
+The callback receives two optional arguments, `metadata` and `error` and is called in 3 different conditions:
+
+- When a new metadata comes up, in which case the `metadata` argument is present
+- When an error occurs, in which case the `error` argument is present
+- As the stream is playing unless a reopen is already scheduled, in which case both `metadata` and `error` arguments are `null`
+
+Each time that the callback is executed, if it returns a positive floating value, then a reload is scheduled
+after that value (in seconds) has elapsed.
+
+For instance, to reload after `2.` seconds on errors and immediately on `metadata` but never otherwise, you can do:
+
+```liquidsoap
+def should_reload(~metadata, ~error) =
+  if null.defined(error) then
+    print("Reloading on error: #{error}")
+    2.
+  elsif null.defined(metadata) then
+    print("Reoloading on metadata")
+    0.
+  else
+    null()
+  end
+end
+```
+
+Another use-case is to reload on top of each hour and do nothing on `metadata` or `error`. This can be a little more tricky because the callback
+is called on every audio frame so several time per seconds. To prevent multiple reloads in a row, we block
+all reloads after the first one until minute `00` has passed:
+
+```liquidsoap
+# Use a ref to reload only once on minute 00:
+has_reloaded = ref(false)
+
+def should_reload(~metadata, ~restart) =
+  if null.defined(metadata) or null.defined(restart) then
+    null()
+  elsif 00m and not has_reloaded() then
+    has_reloaded := true
+    0.
+  else
+    if not 00m then
+      # Reset has_reloaded
+      has_reloaded := false
+    end
+    null()
+  end
+end
+```
+
 ### Harbor HTTP server
 
 The API for registering HTTP server endpoint was completely. It should be more flexible and

--- a/src/core/clock.mli
+++ b/src/core/clock.mli
@@ -112,7 +112,12 @@
   * which prevents inconsistent uses of the source. Clocks are assigned to
   * sources at the end of the typing phase. *)
 
-val clock : ?start:bool -> ?sync:Source.sync -> string -> Source.clock
+val clock :
+  ?start:bool ->
+  ?on_error:(exn -> Printexc.raw_backtrace -> unit) ->
+  ?sync:Source.sync ->
+  string ->
+  Source.clock
 
 (** Indicates whether the application has started to run or not. *)
 val running : unit -> bool

--- a/src/core/lang.mli
+++ b/src/core/lang.mli
@@ -269,8 +269,12 @@ val reference : (unit -> value) -> (value -> unit) -> value
 val http_transport : Http.transport -> value
 
 (** Build a function from an OCaml function. Items in the prototype indicate
-    the label and optional values. *)
+    the label and optional values. Second string value is used when renaming
+    argument name, e.g. `fun (foo=_, ...) -> ` *)
 val val_fun : (string * string * value option) list -> (env -> value) -> value
+
+(** Build a function from a term. *)
+val term_fun : (string * string * value option) list -> Term.t -> value
 
 (** Build a constant function.
   * It is slightly less opaque and allows the printing of the closure

--- a/src/lang/lang.mli
+++ b/src/lang/lang.mli
@@ -189,8 +189,12 @@ val record : (string * value) list -> value
 val reference : (unit -> value) -> (value -> unit) -> value
 
 (** Build a function from an OCaml function. Items in the prototype indicate
-    the label and optional values. *)
+    the label and optional values. Second string value is used when renaming
+    argument name, e.g. `fun (foo=_, ...) -> ` *)
 val val_fun : (string * string * value option) list -> (env -> value) -> value
+
+(** Build a function from a term. *)
+val term_fun : (string * string * value option) list -> Term.t -> value
 
 (** Build a constant function.
   * It is slightly less opaque and allows the printing of the closure

--- a/src/lang/lang_core.ml
+++ b/src/lang/lang_core.ml
@@ -94,6 +94,7 @@ let rec meth v0 = function
 
 let record = meth unit
 let val_fun p f = mk (FFI (p, f))
+let term_fun p tm = mk (Fun (p, [], tm))
 
 let val_cst_fun p c =
   let p = List.map (fun (l, d) -> (l, "_", d)) p in

--- a/src/lang/lang_core.ml
+++ b/src/lang/lang_core.ml
@@ -103,6 +103,7 @@ let val_cst_fun p c =
   (* Convert the value into a term if possible, to enable introspection, mostly
      for printing. *)
   match c.value with
+    | Null -> f (Type.var ()) Term.Null
     | Tuple [] -> f (Type.make Type.unit) Term.unit
     | Ground (Int i) ->
         f (mkg Type.Ground.int) (Term.Ground (Term.Ground.Int i))

--- a/src/lang/runtime.ml
+++ b/src/lang/runtime.ml
@@ -266,9 +266,14 @@ let from_string ?parse_only ~lib expr =
   let lexbuf = Sedlexing.Utf8.from_string expr in
   from_lexbuf ?parse_only ~ns:None ~lib lexbuf
 
-let eval ~ignored ~ty s =
+let parse_with_lexbuf s =
   let lexbuf = Sedlexing.Utf8.from_string s in
-  let expr = mk_expr ~pwd:(Sys.getcwd ()) Parser.program lexbuf in
+  (mk_expr ~pwd:(Sys.getcwd ()) Parser.program lexbuf, lexbuf)
+
+let parse s = fst (parse_with_lexbuf s)
+
+let eval ~ignored ~ty s =
+  let expr, lexbuf = parse_with_lexbuf s in
   let expr = Term.(make (Cast (expr, ty))) in
   !Hooks.collect_after (fun () ->
       report lexbuf (fun ~throw () -> Typechecking.check ~throw ~ignored expr);

--- a/src/lang/runtime.mli
+++ b/src/lang/runtime.mli
@@ -59,6 +59,9 @@ val from_string : ?parse_only:bool -> lib:bool -> string -> unit
 (** Interactive loop: read from command line, eval, print and loop. *)
 val interactive : unit -> unit
 
+(** Parse a string. *)
+val parse : string -> Term.t
+
 (** Evaluate a string. The result is checked to have the given type. *)
 val eval : ignored:bool -> ty:Type.t -> string -> Value.t
 

--- a/src/lang/term.ml
+++ b/src/lang/term.ml
@@ -249,7 +249,7 @@ let unit = Tuple []
 let rec is_ground x =
   match x.term with
     | List l | Tuple l -> List.for_all is_ground l
-    | Ground _ -> true
+    | Null | Ground _ -> true
     | _ -> false
 
 let rec string_of_pat = function

--- a/src/libs/error.liq
+++ b/src/libs/error.liq
@@ -1,13 +1,13 @@
-let error.not_found = error.register("not_found")
 let error.assertion = error.register("assertion")
-let error.invalid = error.register("invalid")
 let error.eval = error.register("eval")
 let error.file = error.register("file")
-let error.string = error.register("string")
-let error.json = error.register("json")
 let error.http = error.register("http")
-let error.socket = error.register("socket")
+let error.invalid = error.register("invalid")
 let error.json = error.register("json")
+let error.not_found = error.register("not_found")
+let error.output = error.register("output")
+let error.socket = error.register("socket")
+let error.string = error.register("string")
 
 # Ensure that a condition is satisfied (raise `error.assertion` exception
 # otherwise).

--- a/src/libs/video.liq
+++ b/src/libs/video.liq
@@ -130,19 +130,16 @@ end
 # @param ~flush Perform a flush after each write.
 # @param ~on_start Callback executed when outputting starts.
 # @param ~on_stop Callback executed when outputting stops.
-# @param ~reopen_delay Prevent re-opening within that delay, in seconds.
-# @param ~reopen_on_metadata Re-open on every new metadata information.
-# @param ~reopen_when When should the output be re-opened.
 # @param ~start Automatically start outputting whenever possible. If true, an infallible (normal) output will start outputting as soon as it is created, and a fallible output will (re)start as soon as its source becomes available for streaming.
+# @argsof output.external[should_reopen,on_reopen]
 def output.external.ffmpeg(~id=null(), ~show_command=false, ~flush=false, ~fallible=false,
-                           ~on_start={()}, ~on_stop={()}, ~reopen_delay=120.,
-                           ~reopen_on_metadata=false, ~reopen_when={false},
+                           ~on_start={()}, ~on_stop={()}, %argsof(output.external[should_reopen,on_reopen]),
                            ~start=true, outputopts, s)
   outputopts = (outputopts : string)
   cmd = "ffmpeg -f avi -vcodec rawvideo -r #{video.frame.rate()} -acodec pcm_s16le -i pipe:0 #{outputopts}"
   if show_command then log.important(label="output.external.ffmpeg", "command: #{cmd}") end
-  output.external(id=id, flush=flush, fallible=fallible, on_start=on_start, on_stop=on_stop, reopen_delay=reopen_delay,
-                  reopen_on_metadata=reopen_on_metadata, reopen_when=reopen_when, start=start, %avi, cmd, s)
+  output.external(id=id, flush=flush, fallible=fallible, on_start=on_start, on_stop=on_stop, %argsof(output.external[should_reopen,on_reopen]),
+                  start=start, %avi, cmd, s)
 end
 
 # Output a HLS playlist using ffmpeg
@@ -153,22 +150,19 @@ end
 # @param ~flush Perform a flush after each write.
 # @param ~on_start Callback executed when outputting starts.
 # @param ~on_stop Callback executed when outputting stops.
-# @param ~reopen_delay Prevent re-opening within that delay, in seconds.
-# @param ~reopen_on_metadata Re-open on every new metadata information.
-# @param ~reopen_when When should the output be re-opened.
 # @param ~start Automatically start outputting whenever possible. If true, an infallible (normal) output will start outputting as soon as it is created, and a fallible output will (re)start as soon as its source becomes available for streaming.
 # @param ~playlist Playlist name
 # @param ~directory Directory to write to
+# @argsof output.external[should_reopen,on_reopen]
 def output.file.hls.ffmpeg(~id=null(), ~flush=false, ~fallible=false,
-                           ~on_start={()}, ~on_stop={()}, ~reopen_delay=120.,
-                           ~reopen_on_metadata=false, ~reopen_when={false},
+                           ~on_start={()}, ~on_stop={()}, %argsof(output.external[should_reopen,on_reopen]),
                            ~start=true, ~playlist="stream.m3u8", ~directory, s)
   width = video.frame.width()
   height = video.frame.height()
   directory = (directory : string)
   cmd = "-profile:v baseline -pix_fmt yuv420p -level 3.0 -s #{width}x#{height} -start_number 0 -hls_time 10 -hls_list_size 0 -f hls #{directory}/#{playlist}"
-  output.external.ffmpeg(id=id, flush=flush, fallible=fallible, on_start=on_start, on_stop=on_stop, reopen_delay=reopen_delay,
-                         reopen_on_metadata=reopen_on_metadata, reopen_when=reopen_when, start=start, cmd, s)
+  output.external.ffmpeg(id=id, flush=flush, fallible=fallible, on_start=on_start, on_stop=on_stop, %argsof(output.external[should_reopen,on_reopen]),
+                         start=start, cmd, s)
 end
 
 let output.file.dash = ()
@@ -180,21 +174,19 @@ let output.file.dash = ()
 # @param ~flush Perform a flush after each write.
 # @param ~on_start Callback executed when outputting starts.
 # @param ~on_stop Callback executed when outputting stops.
-# @param ~reopen_delay Prevent re-opening within that delay, in seconds.
-# @param ~reopen_on_metadata Re-open on every new metadata information.
-# @param ~reopen_when When should the output be re-opened.
 # @param ~start Automatically start outputting whenever possible. If true, an infallible (normal) output will start outputting as soon as it is created, and a fallible output will (re)start as soon as its source becomes available for streaming.
 # @param ~playlist Playlist name
 # @param ~directory Directory to write to
+# @argsof output.external[should_reopen,on_reopen]
 def output.file.dash.ffmpeg(~id=null(), ~flush=false, ~fallible=false,
-                           ~on_start={()}, ~on_stop={()}, ~reopen_delay=120.,
-                           ~reopen_on_metadata=false, ~reopen_when={false},
+                           ~on_start={()}, ~on_stop={()},  %argsof(output.external[should_reopen,on_reopen]),
                            ~start=true, ~playlist="stream.mpd", ~directory, s)
   width = video.frame.width()
   height = video.frame.height()
   samplerate = audio.samplerate()
   cmd = "-map 0 -map 0 -c:a libfdk_aac -c:v libx264 -b:v:0 800k -b:v:1 300k -s:v:1 #{width}x#{height} -profile:v:1 baseline -profile:v:0 main -bf 1 -keyint_min 120 -g 120 -sc_threshold 0 -b_strategy 0 -ar:a:1 #{samplerate} -use_timeline 1 -use_template 1 -window_size 5 -adaptation_sets \"id=0,streams=v id=1,streams=a\" -f dash #{(directory:string)}/#{playlist}"
-  output.external.ffmpeg(id=id, flush=flush, fallible=fallible, on_start=on_start, on_stop=on_stop, reopen_delay=reopen_delay, reopen_on_metadata=reopen_on_metadata, reopen_when=reopen_when, start=start, show_command=true, cmd, s)
+  output.external.ffmpeg(id=id, flush=flush, fallible=fallible, on_start=on_start, on_stop=on_stop,  %argsof(output.external[should_reopen,on_reopen]),
+                         start=start, show_command=true, cmd, s)
 end
 
 let output.youtube = ()

--- a/tests/regression/GH2756-2.liq
+++ b/tests/regression/GH2756-2.liq
@@ -1,0 +1,59 @@
+def f() =
+  tmp = file.temp("foo", "bla")
+  on_shutdown({file.remove(tmp)})
+
+  s = insert_metadata(sine())
+  insert_metadata = s.insert_metadata
+
+  err = ref(null())
+  def on_frame() =
+    null.case(err(), {()}, fun (e) -> begin
+      err := null()
+      error.raise(e)
+    end)
+  end
+  s = source.on_frame(s, on_frame)
+
+  can_be_called_after = ref(0.)
+  reload_in = ref(-1.)
+  callstack = ref([])
+
+  def should_reopen(~error, ~metadata) =
+    if time() < can_be_called_after() then
+      test.fail()
+    end
+
+    if null.defined(metadata) then
+      print("Got metadata!")
+      callstack := [...(callstack()), "metadata"]
+      (-1.)
+    elsif null.defined(error) then
+      print("Got error!")
+      can_be_called_after := time() + 2.
+      callstack := [...(callstack()), "error"]
+      2.
+    else
+      r = reload_in()
+
+      if 0. <= r then
+        print("Got reopen!")
+        callstack := [...(callstack()), "reload"]
+        reload_in := -1.
+      end
+
+      can_be_called_after := time() + r
+      r
+    end
+  end
+
+  output.file(should_reopen=should_reopen,%wav,tmp,s)
+
+  thread.run(delay=1., {insert_metadata([("foo", "bla")])})
+  thread.run(delay=5., {err := error.failure})
+  thread.run(delay=8., {reload_in := 1.})
+  thread.run(delay=10., {begin
+    if callstack() == ["metadata","error","reload"] then test.pass() else test.fail() end
+  end})
+end
+
+test.check(f)

--- a/tests/regression/GH2756-2.liq
+++ b/tests/regression/GH2756-2.liq
@@ -15,7 +15,6 @@ def f() =
   s = source.on_frame(s, on_frame)
 
   can_be_called_after = ref(0.)
-  reload_in = ref(-1.)
   callstack = ref([])
 
   def should_reopen(~error, ~metadata) =
@@ -26,33 +25,24 @@ def f() =
     if null.defined(metadata) then
       print("Got metadata!")
       callstack := [...(callstack()), "metadata"]
-      (-1.)
     elsif null.defined(error) then
       print("Got error!")
-      can_be_called_after := time() + 2.
       callstack := [...(callstack()), "error"]
-      2.
-    else
-      r = reload_in()
-
-      if 0. <= r then
-        print("Got reopen!")
-        callstack := [...(callstack()), "reload"]
-        reload_in := -1.
-      end
-
-      can_be_called_after := time() + r
-      r
     end
+
+    (-1.)
   end
+
+  clock.assign_new(on_error=fun (_) -> begin
+    callstack := [...(callstack()), "streaming error"]
+  end, [s])
 
   output.file(should_reopen=should_reopen,%wav,tmp,s)
 
   thread.run(delay=1., {insert_metadata([("foo", "bla")])})
   thread.run(delay=5., {err := error.failure})
-  thread.run(delay=8., {reload_in := 1.})
-  thread.run(delay=10., {begin
-    if callstack() == ["metadata","error","reload"] then test.pass() else test.fail() end
+  thread.run(delay=6., {begin
+    if callstack() == ["metadata","error","streaming error"] then test.pass() else test.fail() end
   end})
 end
 

--- a/tests/regression/GH2756.liq
+++ b/tests/regression/GH2756.liq
@@ -1,0 +1,60 @@
+def f() =
+  tmp = file.temp("foo", "bla")
+  on_shutdown({file.remove(tmp)})
+
+  s = insert_metadata(sine())
+  insert_metadata = s.insert_metadata
+
+  err = ref(null())
+  def on_frame() =
+    null.case(err(), {()}, fun (e) -> begin
+      err := null()
+      error.raise(e)
+    end)
+  end
+  s = source.on_frame(s, on_frame)
+
+  can_be_called_after = ref(0.)
+  reload_in = ref(-1.)
+  callstack = ref([])
+
+  def should_reopen(~error, ~metadata) =
+    if time() < can_be_called_after() then
+      test.fail()
+    end
+
+    if null.defined(metadata) then
+      print("Got metadata!")
+      can_be_called_after := time() + 3.
+      callstack := [...(callstack()), "metadata"]
+      3.
+    elsif null.defined(error) then
+      print("Got error!")
+      can_be_called_after := time() + 2.
+      callstack := [...(callstack()), "error"]
+      2.
+    else
+      r = reload_in()
+
+      if 0. <= r then
+        print("Got reopen!")
+        callstack := [...(callstack()), "reload"]
+        reload_in := -1.
+      end
+
+      can_be_called_after := time() + r
+      r
+    end
+  end
+
+  output.file(should_reopen=should_reopen,%wav,tmp,s)
+
+  thread.run(delay=1., {insert_metadata([("foo", "bla")])})
+  thread.run(delay=5., {err := error.failure})
+  thread.run(delay=8., {reload_in := 1.})
+  thread.run(delay=10., {begin
+    if callstack() == ["metadata","error","reload"] then test.pass() else test.fail() end
+  end})
+end
+
+test.check(f)

--- a/tests/regression/dune.inc
+++ b/tests/regression/dune.inc
@@ -198,6 +198,19 @@
  (alias citest)
  (package liquidsoap)
  (deps
+  GH2756.liq
+  ../media/all_media_files
+  ../../src/bin/liquidsoap.exe
+  (source_tree ../../src/libs)
+  (:stdlib ../../src/libs/stdlib.liq)
+  (:test_liq ../test.liq)
+  (:run_test ../run_test.exe))
+ (action (run %{run_test} GH2756.liq liquidsoap %{test_liq} GH2756.liq)))
+
+(rule
+ (alias citest)
+ (package liquidsoap)
+ (deps
   metadata_cache.liq
   ../media/all_media_files
   ../../src/bin/liquidsoap.exe
@@ -258,6 +271,19 @@
   (:test_liq ../test.liq)
   (:run_test ../run_test.exe))
  (action (run %{run_test} BUG403.liq liquidsoap %{test_liq} BUG403.liq)))
+
+(rule
+ (alias citest)
+ (package liquidsoap)
+ (deps
+  GH2756-2.liq
+  ../media/all_media_files
+  ../../src/bin/liquidsoap.exe
+  (source_tree ../../src/libs)
+  (:stdlib ../../src/libs/stdlib.liq)
+  (:test_liq ../test.liq)
+  (:run_test ../run_test.exe))
+ (action (run %{run_test} GH2756-2.liq liquidsoap %{test_liq} GH2756-2.liq)))
 
 (rule
  (alias citest)


### PR DESCRIPTION
This PR clarifies and reimplements the reload logic in `output.file`.

It looks like the reload logic in piped output is all over the place, `reload_when`, `reload_delay`, `reload_on_error` and `reload_on_metadata` all make it pretty impossible to understand what is going on.

In this PR, the `reopen_*` arguments have been unified in `output.file`, `output.pipe` and similar operators. Instead
of 3 different arguments for metadata, errors and regular reloads, which was making the logic pretty hard to
understand, now a single `should_reload` callback is given.

The callback receives two optional arguments, `metadata` and `error` and is called in 3 different conditions:

- When a new metadata comes up, in which case the `metadata` argument is present
- When an error occurs, in which case the `error` argument is present
- As the stream is playing unless a reopen is already scheduled, in which case both `metadata` and `error` arguments are `null`

Each time that the callback is executed, if it returns a positive floating value, then a reload is scheduled after that value (in seconds) has elapsed.

For instance, to reload after `2.` seconds on errors and immediately on `metadata` but never otherwise, you can do:

```liquidsoap
def should_reload(~metadata, ~error) =
  if null.defined(error) then
    print("Reloading on error: #{error}")
    2.
  elsif null.defined(metadata) then
    print("Reoloading on metadata")
    0.
  else
    null()
  end
end
```

Another use-case is to reload on top of each hour and do nothing on `metadata` or `error`. This can be a little more tricky because the callback is called on every audio frame so several time per seconds. To prevent multiple reloads in a row, we block all reloads after the first one until minute `00` has passed:

```liquidsoap
# Use a ref to reload only once on minute 00:
has_reloaded = ref(false)

def should_reload(~metadata, ~restart) =
  if null.defined(metadata) or null.defined(restart) then
    null()
  elsif 00m and not has_reloaded() then
    has_reloaded := true
    0.
  else
    if not 00m then
      # Reset has_reloaded
      has_reloaded := false
    end
    null()
  end
end
```

Fixes: #2756