### PR TITLE
Add support for the proprietary stereotool operator.

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -37,6 +37,7 @@
     bjack
     camlimages
     camomile
+    ctypes-foreign
     dssi
     faad
     fdkaac

--- a/liquidsoap.opam
+++ b/liquidsoap.opam
@@ -40,6 +40,7 @@ depopts: [
   "bjack"
   "camlimages"
   "camomile"
+  "ctypes-foreign"
   "dssi"
   "faad"
   "fdkaac"

--- a/src/config/stereotool_option.disabled.ml
+++ b/src/config/stereotool_option.disabled.ml
@@ -1,0 +1,2 @@
+let detected = "no (requires ctypes-foreign)"
+let enabled = false

--- a/src/config/stereotool_option.enabled.ml
+++ b/src/config/stereotool_option.enabled.ml
@@ -1,0 +1,1 @@
+noop.enabled.ml

--- a/src/core/dune
+++ b/src/core/dune
@@ -659,6 +659,14 @@
  (modules ssl_base builtins_http_ssl))
 
 (library
+ (name liquidsoap_stereotool)
+ (libraries stereotool liquidsoap_core)
+ (library_flags -linkall)
+ (wrapped false)
+ (optional)
+ (modules stereotool_op))
+
+(library
  (name liquidsoap_taglib)
  (libraries taglib liquidsoap_core)
  (library_flags -linkall)
@@ -751,6 +759,7 @@
   speex_option
   srt_option
   ssl_option
+  stereotool_option
   taglib_option
   theora_option
   vorbis_option
@@ -974,6 +983,11 @@
    from
    (liquidsoap_ssl -> ssl_option.enabled.ml)
    (-> ssl_option.disabled.ml))
+  (select
+   stereotool_option.ml
+   from
+   (liquidsoap_stereotool -> stereotool_option.enabled.ml)
+   (-> stereotool_option.disabled.ml))
   (select
    taglib_option.ml
    from

--- a/src/core/operators/stereotool_op.ml
+++ b/src/core/operators/stereotool_op.ml
@@ -1,0 +1,169 @@
+(*****************************************************************************
+
+  Liquidsoap, a programmable audio stream generator.
+  Copyright 2003-2023 Savonet team
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details, fully stated in the COPYING
+  file at the root of the liquidsoap distribution.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA
+
+ *****************************************************************************)
+
+let load_type_of_string = function
+  | "totalinit" -> `Totalinit
+  | "all_settings" -> `All_settings
+  | "audiofm" -> `Audiofm
+  | "audio" -> `Audio
+  | "processing" -> `Processing
+  | "repair" -> `Repair
+  | "repair_no_pnr" -> `Repair_no_pnr
+  | "sublevel_pnr" -> `Sublevel_pnr
+  | _ -> raise Not_found
+
+class stereotool ~field ~preset ~load_type ~handler source =
+  object (self)
+    inherit Source.operator ~name:"stereotool" [source] as super
+    method api_version = Stereotool.api_version handler
+    method software_version = Stereotool.software_version handler
+
+    method private load_type load_type =
+      try load_type_of_string load_type
+      with Not_found ->
+        self#log#important "Invalid load type: %s" load_type;
+        `Totalinit
+
+    method load_preset ~load_type filename =
+      Stereotool.load_preset ~load_type:(self#load_type load_type) ~filename
+        handler
+
+    method valid_license = Stereotool.valid_license handler
+
+    method unlincensed_used_features =
+      Stereotool.unlincensed_used_features handler
+
+    val mutable latency = None
+
+    method latency =
+      match latency with
+        | Some v -> v
+        | None ->
+            let v =
+              Frame.seconds_of_audio
+                (Stereotool.latency
+                   ~samplerate:(Lazy.force Frame.audio_rate)
+                   ~feed_silence:true handler)
+            in
+            latency <- Some v;
+            v
+
+    method! wake_up l =
+      super#wake_up l;
+      (match preset with
+        | None -> ()
+        | Some filename ->
+            if not (self#load_preset ~load_type filename) then
+              self#log#important "Preset load failed!");
+      self#log#info
+        "Stereotool initialized! Valid license: %b, latency: %.02fs, \
+         API/software version: %d/%d"
+        self#valid_license self#latency self#api_version self#software_version;
+      match Stereotool.unlincensed_used_features handler with
+        | None -> ()
+        | Some s -> self#log#info "Using unlicensed features: %s" s
+
+    method stype = source#stype
+    method remaining = source#remaining
+    method seek = source#seek
+    method is_ready = source#is_ready
+    method abort_track = source#abort_track
+    method self_sync = source#self_sync
+
+    method private get_frame buf =
+      let offset = AFrame.position buf in
+      source#get buf;
+      let position = AFrame.position buf in
+      let b = Content.Audio.get_data (Frame.get buf field) in
+      Stereotool.process
+        ~samplerate:(Lazy.force Frame.audio_rate)
+        handler b offset (position - offset)
+  end
+
+let _ =
+  let frame_t = Format_type.audio () in
+  Lang.add_track_operator ~base:Modules.track_audio "stereotool"
+    [
+      ( "library_file",
+        Lang.string_t,
+        None,
+        Some "Path to the shared library file." );
+      ("license_key", Lang.nullable_t Lang.string_t, Some Lang.null, None);
+      ( "preset",
+        Lang.nullable_t Lang.string_t,
+        Some Lang.null,
+        Some "Path to a preset file to load when initializing the operator." );
+      ( "load_type",
+        Lang.string_t,
+        Some (Lang.string "totalinit"),
+        Some
+          "Load type for preset. One of: \"totalinit\", \"all_settings\", \
+           \"audiofm\", \"audio\", \"processing\", \"repair\", \
+           \"repair_no_pnr\" or \"sublevel_pnr\"." );
+      ("", frame_t, None, None);
+    ]
+    ~meth:
+      [
+        ( "api_version",
+          ([], Lang.fun_t [] Lang.int_t),
+          "API version.",
+          fun s -> Lang.val_fun [] (fun _ -> Lang.int s#api_version) );
+        ( "software_version",
+          ([], Lang.fun_t [] Lang.int_t),
+          "Software version.",
+          fun s -> Lang.val_fun [] (fun _ -> Lang.int s#api_version) );
+        ( "latency",
+          ([], Lang.fun_t [] Lang.float_t),
+          "Get the operator's latency.",
+          fun s -> Lang.val_fun [] (fun _ -> Lang.float s#latency) );
+        ( "valid_license",
+          ([], Lang.fun_t [] Lang.bool_t),
+          "Check if the license is valid for the current settings.",
+          fun s -> Lang.val_fun [] (fun _ -> Lang.bool s#valid_license) );
+        ( "unlincensed_used_features",
+          ([], Lang.fun_t [] (Lang.nullable_t Lang.string_t)),
+          "Check if the license is valid for the current settings.",
+          fun s ->
+            Lang.val_fun [] (fun _ ->
+                match s#unlincensed_used_features with
+                  | None -> Lang.null
+                  | Some s -> Lang.string s) );
+      ]
+    ~return_t:frame_t ~category:`Audio
+    ~descr:"Process the given audio track with StereoTool."
+    (fun p ->
+      let library = Lang.to_string (List.assoc "library_file" p) in
+      let license_key =
+        Lang.to_valued_option Lang.to_string (List.assoc "license_key" p)
+      in
+      let load_type = Lang.to_string (List.assoc "load_type" p) in
+      let preset =
+        Lang.to_valued_option Lang.to_string (List.assoc "preset" p)
+      in
+      let handler =
+        try Stereotool.init ?license_key ~filename:library ()
+        with Stereotool.Library_not_found ->
+          Runtime_error.raise ~pos:(Lang.pos p)
+            ~message:"Stereotool library not found or invalid!" "invalid"
+      in
+      let field, src = Lang.to_track (List.assoc "" p) in
+      (field, new stereotool ~field ~preset ~load_type ~handler src))

--- a/src/core/types/format_type.ml
+++ b/src/core/types/format_type.ml
@@ -155,10 +155,7 @@ let media ~strict () =
           | Type.Constr { params } when not strict ->
               List.iter (fun (_, typ) -> satisfies typ) params
           | Type.Meth _ when not strict ->
-              let meths, base_type = Type.split_meths b in
-              List.iter
-                (fun Type.{ scheme = _, field_type } -> satisfies field_type)
-                meths;
+              let _, base_type = Type.split_meths b in
               satisfies base_type
           | Type.Custom { Type.typ = Kind _ }
           | Type.Custom { Type.typ = Format _ } ->

--- a/src/lang/parser.mly
+++ b/src/lang/parser.mly
@@ -429,7 +429,8 @@ record_pattern:
   | LCUR meth_pattern_list RCUR { $2 }
 
 meth_spread_list:
-  | DOTDOTDOT VAR                          { Some (PVar [$2]), [] }
+  | DOTDOTDOT                              { Some (PVar ["_"]), [] }
+  | DOTDOTDOT optvar                       { Some (PVar [$2]), [] }
   | meth_pattern_el COMMA meth_spread_list { fst $3, $1::(snd $3) }
 
 record_spread_pattern:

--- a/src/libs/audio.liq
+++ b/src/libs/audio.liq
@@ -544,3 +544,19 @@ def metronome(~frequency=440., bpm=60.)
 
   amplify(f,s)
 end
+
+%ifdef track.audio.stereotool
+# Process an audio source using stereotool
+# @argsof track.audio.stereotool
+# @category Source / Audio processing
+def stereotool(~id=null("stereotool"), %argsof(track.audio.stereotool[!id]), s) =
+  let {audio, metadata, track_marks, ...} = source.tracks(s)
+  s = track.audio.stereotool(%argsof(track.audio.stereotool[!id]), audio)
+  let replaces s = source(id=id, {
+    audio       = (s:pcm),
+    metadata    = metadata,
+    track_marks = track_marks
+  })
+  s
+end
+%endif

--- a/src/runtime/build_config.ml
+++ b/src/runtime/build_config.ml
@@ -74,6 +74,7 @@ let build_config =
    - Lilv              : %{Lilv_option.detected}
    - Samplerate        : %{Samplerate_option.detected}
    - SoundTouch        : %{Soundtouch_option.detected}
+   - StereoTool        : %{Stereotool_option.detected}
 
  * Video manipulation
    - camlimages        : %{Camlimages_option.detected}

--- a/src/stereotool/dune
+++ b/src/stereotool/dune
@@ -1,0 +1,5 @@
+(library
+ (optional)
+ (name stereotool)
+ (modules stereotool)
+ (libraries ctypes ctypes.foreign))

--- a/src/stereotool/stereotool.ml
+++ b/src/stereotool/stereotool.ml
@@ -1,0 +1,152 @@
+open Ctypes
+open Foreign
+
+type handler = unit ptr
+
+let handler : handler typ = ptr void
+
+module type Config = sig
+  val filename : string
+end
+
+exception Library_not_found
+
+module C (Conf : Config) = struct
+  let lib =
+    try Dl.dlopen ~filename:Conf.filename ~flags:[Dl.RTLD_NOW]
+    with _ -> raise Library_not_found
+
+  let foreign = foreign ~from:lib
+
+  let software_version =
+    foreign "stereoTool_GetSoftwareVersion" (void @-> returning int)
+
+  let api_version = foreign "stereoTool_GetApiVersion" (void @-> returning int)
+  let create_ptr = foreign "stereoTool_Create" (ptr void @-> returning handler)
+  let create = foreign "stereoTool_Create" (string @-> returning handler)
+  let delete = foreign "stereoTool_Delete" (handler @-> returning void)
+
+  let valid_license =
+    foreign "stereoTool_CheckLicenseValid" (handler @-> returning bool)
+
+  let unlincensed_used_features =
+    foreign "stereoTool_GetUnlicensedUsedFeatures"
+      (handler @-> ocaml_bytes @-> int @-> returning bool)
+
+  let load_preset =
+    foreign "stereoTool_LoadPreset"
+      (handler @-> string @-> int @-> returning bool)
+
+  let save_preset =
+    foreign "stereoTool_SavePreset"
+      (handler @-> string @-> int @-> returning bool)
+
+  let reset = foreign "stereoTool_Reset" (handler @-> returning void)
+
+  let latency =
+    foreign "stereoTool_GetLatency2" (handler @-> int @-> bool @-> returning int)
+
+  let process =
+    foreign "stereoTool_Process"
+      (handler @-> ptr float @-> int @-> int @-> int @-> returning void)
+end
+
+module type C = module type of C (struct
+  let filename = "foo"
+end)
+
+type t = { handler : handler; _module : (module C) }
+
+type load_type =
+  [ `Totalinit
+  | `All_settings
+  | `Audiofm
+  | `Audio
+  | `Processing
+  | `Repair
+  | `Repair_no_pnr
+  | `Sublevel_pnr ]
+
+let int_of_load_type = function
+  | `Totalinit -> 10387
+  | `All_settings -> 10386
+  | `Audiofm -> 10385
+  | `Audio -> 10384
+  | `Processing -> 10709
+  | `Repair -> 10708
+  | `Repair_no_pnr -> 11069
+  | `Sublevel_pnr -> 10699
+
+let init ?license_key ~filename () =
+  try
+    let module C = C (struct
+      let filename = filename
+    end) in
+    let handler =
+      match license_key with
+        | None -> C.create_ptr null
+        | Some license_key -> C.create license_key
+    in
+    Gc.finalise C.delete handler;
+    { handler; _module = (module C : C) }
+  with _ -> raise Library_not_found
+
+let api_version { _module; _ } =
+  let module C = (val _module : C) in
+  C.api_version ()
+
+let software_version { _module; _ } =
+  let module C = (val _module : C) in
+  C.software_version ()
+
+let valid_license { handler; _module } =
+  let module C = (val _module : C) in
+  C.valid_license handler
+
+let unlincensed_used_features =
+  let buflen = 1024 in
+  let buf = Bytes.create buflen in
+  fun { handler; _module } ->
+    let module C = (val _module : C) in
+    if C.unlincensed_used_features handler (ocaml_bytes_start buf) buflen then
+      Some (Bytes.to_string buf)
+    else None
+
+let load_preset ?(load_type = `Totalinit) ~filename { handler; _module } =
+  let module C = (val _module : C) in
+  C.load_preset handler filename (int_of_load_type load_type)
+
+let latency ~samplerate ~feed_silence { handler; _module } =
+  let module C = (val _module : C) in
+  C.latency handler samplerate feed_silence
+
+let process_interleaved ~samplerate ~channels { handler; _module } samples ofs
+    len =
+  let module C = (val _module : C) in
+  let buf = CArray.make float len in
+  for i = 0 to len - 1 do
+    CArray.unsafe_set buf i samples.(ofs + i)
+  done;
+  C.process handler (CArray.start buf) len channels samplerate;
+  for i = 0 to len - 1 do
+    samples.(ofs + i) <- CArray.unsafe_get buf i
+  done
+
+let process ~samplerate { handler; _module } samples ofs len =
+  let channels = Array.length samples in
+  if 0 < channels && 0 < len then (
+    let module C = (val _module : C) in
+    let buf = CArray.make float (channels * len) in
+    for c = 0 to channels - 1 do
+      let chan = samples.(c) in
+      for i = 0 to len - 1 do
+        CArray.unsafe_set buf ((i * channels) + c) chan.(ofs + i)
+      done
+    done;
+    C.process handler (CArray.start buf) len channels samplerate;
+    for c = 0 to channels - 1 do
+      let chan = samples.(c) in
+      for i = 0 to len - 1 do
+        chan.(ofs + i) <- CArray.unsafe_get buf ((i * channels) + c)
+      done
+    done)

--- a/src/stereotool/stereotool.mli
+++ b/src/stereotool/stereotool.mli
@@ -1,0 +1,30 @@
+(** Binding to the proprietary StereoTool processing library.
+    Please refer to the library's documentation for details
+    regarding this binding's functions. *)
+
+type t
+
+type load_type =
+  [ `Totalinit
+  | `All_settings
+  | `Audiofm
+  | `Audio
+  | `Processing
+  | `Repair
+  | `Repair_no_pnr
+  | `Sublevel_pnr ]
+
+exception Library_not_found
+
+val init : ?license_key:string -> filename:string -> unit -> t
+val software_version : t -> int
+val api_version : t -> int
+val valid_license : t -> bool
+val unlincensed_used_features : t -> string option
+val load_preset : ?load_type:load_type -> filename:string -> t -> bool
+val latency : samplerate:int -> feed_silence:bool -> t -> int
+
+val process_interleaved :
+  samplerate:int -> channels:int -> t -> float array -> int -> int -> unit
+
+val process : samplerate:int -> t -> float array array -> int -> int -> unit

--- a/tests/performance/dune
+++ b/tests/performance/dune
@@ -11,7 +11,7 @@
  (deps
   (:gen_bigrecord ./gen_bigrecord.exe))
  (action
-   (run %{gen_bigrecord} %{target})))
+  (run %{gen_bigrecord} %{target})))
 
 (rule
  (alias perftest)


### PR DESCRIPTION
This PR adds support for the proprietary `stereotool` processing shared library as disclosed in https://github.com/savonet/liquidsoap/discussions/1782#discussioncomment-4939967

The operator provides a low level `track.audio.stereotool` track operator that processes the audio data and a higher level `stereotool` operator that processes the audio of a source with a `audio` track.

~~The `stereotool` operator also takes care of delaying metadata and track marks to match the delay introduced by the audio processing~~. _Nevermind_  This part of the PR was too involved and was removed. Track marks are still too tricky to allow this. Typical delay I'm seeing is 90ms so that's not too bad either for now. Will reconsider once we're moved to immutable content.

Other tracks are dropped as they would be getting out of sync after applying the processing. It is still possible to add them back but this should be reserved for advanced users that can also potentially use a `ffmpeg` filter to delay the video accordingly and etc.

Doc:

`track.audio.stereotool`:
```Process the given audio track with StereoTool.

Type: (?id : string?, library_file : string, ?license_key : string?,
 ?presets : string?, ?load_type : string, pcm('a)) -> pcm('a)

Category: Track / Audio processing

Arguments:

 * id : string? (default: null)
     Force the value of the track ID.

 * library_file : string
     Path to the shared library file.

 * license_key : string? (default: null)


 * presets : string? (default: null)
     Path to a preset file to load when initializing the operator.

 * load_type : string (default: "totalinit")
     Load type for preset. One of: "totalinit", "all_settings", "audiofm", "audio",
     "processing", "repair", "repair_no_pnr" or "sublevel_pnr".

 * (unlabeled) : pcm('a)


Methods:

 * api_version : () -> int
     API version.

 * latency : () -> float
     Get the operator's latency.

 * software_version : () -> int
     Software version.

 * unlincensed_used_features : () -> string?
     Check if the license is valid for the current settings.

 * valid_license : () -> bool
     Check if the license is valid for the current settings.
```

`stereotool`:
```
Process an audio source using stereotool

Type: (?id : string?, library_file : string, ?license_key : string?,
 ?presets : string?, ?load_type : string, source(audio=pcm('a), 'b)) ->
source(audio=pcm('a))

Category: Source / Audio processing

Arguments:

 * id : string? (default: "stereotool")
     Force the value of the track ID.

 * library_file : string
     Path to the shared library file.

 * license_key : string? (default: null)


 * presets : string? (default: null)
     Path to a preset file to load when initializing the operator.

 * load_type : string (default: "totalinit")
     Load type for preset. One of: "totalinit", "all_settings", "audiofm", "audio",
     "processing", "repair", "repair_no_pnr" or "sublevel_pnr".

 * (unlabeled) : source(audio=pcm('a), 'b)


Methods:
... same as track.audio.stereotool + regular source methods.
```