### PR TITLE
Add request.body() function.

### DIFF
--- a/doc/content/harbor_http.md
+++ b/doc/content/harbor_http.md
@@ -9,23 +9,22 @@ HTTP response implementation. This function receives a record describing the req
 the HTTP response.
 
 The request passed to the function contains all expected information from the underlying HTTP
-query. Its `data` method is a _string getter_, that is a function of type: `() -> string`
-which returns the empty string `""` when all data has been consumed. The convenience function
-`harbor.http.request.body` can be used to read all the data from the request and return it at
-once.
+query.
+
+The `data` method on a request is a _string getter_, that is a function of type: `() -> string`
+which returns the empty string `""` when all data has been consumed. You can use this function
+to e.g. write the request data to a file using `file.write.stream`.
+
+The `body` method can be used to read all of the request's data and store it in
+memory. Make sure to only use it if you know that the response should be small enough!
 
 For convenience, a HTTP response builder is provided via `harbor.http.response`. Here's an example:
 
 ```liquidsoap
 def handler(request) =
-  # Read the whole response data. This should be done only once. It can also be a very
-  # large string, in which case you might want to save it in a file instead of
-  # holding it in memory like this:
-  data = harbor.http.request.body(request.data)
-
   log("Got a request on path #{request.path}, protocol version: #{request.http_version}, \
        method: #{request.method}, headers: #{request.headers}, query: #{request.query}, \
-       data: #{data}")
+       body: #{request.body()}")
 
   harbor.http.response(
     content_type="text/html",
@@ -49,14 +48,9 @@ Its API is very similar to the node/express API. Here's an example:
 
 ```liquidsoap
 def handler(request, response) =
-  # Read the whole response data. This should be done only once. It can also be a very
-  # large string, in which case you might want to save it in a file instead of
-  # holding it in memory like this:
-  data = harbor.http.request.body(request.data)
-
   log("Got a request on path #{request.path}, protocol version: #{request.http_version}, \
        method: #{request.method}, headers: #{request.headers}, query: #{request.query}, \
-       data: #{data}")
+       body: #{request.body()}")
 
   # Set response code. Defaults to 200
   response.status_code(201)

--- a/src/libs/http.liq
+++ b/src/libs/http.liq
@@ -254,12 +254,50 @@ def harbor.http.regexp_of_path(path) =
   regexp("^#{rex}$")
 end
 
+# @flag hidden
+def harbor.http.mk_body(get_data) =
+  done = ref(false)
+  data = ref("")
+  def body(~timeout=10.) =
+    if done() then data() else
+      start_time = time()
+      def rec read() =
+        if done() then data() else
+          if start_time+timeout < time() then
+            error.raise(error.http, "Timeout!")
+          end
+
+          r = get_data(timeout=timeout)
+          if r == "" then data() else
+            data := "#{data()}#{r}"
+            read()
+          end
+        end
+      end
+      read()
+    end
+  end
+
+  body
+end
+
 # Register a HTTP handler on the harbor. This function offers a simple API,
 # suitable for quick implementation of HTTP handlers. See `harbor.http.register`
 # for a node/express like alternative API.
 # @category Internet
 # @argsof harbor.http.register
 def harbor.http.register.simple(%argsof(harbor.http.register), path, handler) =
+  def handler(request) =
+    def data(~timeout=10.) =
+      request.data(timeout=timeout)
+    end
+
+    handler(request.{
+      data = data,
+      body = harbor.http.mk_body(data)
+    })
+  end
+
   harbor.http.register(%argsof(harbor.http.register), harbor.http.regexp_of_path(path), handler)
 end
 
@@ -312,6 +350,7 @@ def harbor.http.register.regexp(%argsof(harbor.http.register), path, handler) =
     end
 
     request = {
+      body = harbor.http.mk_body(data),
       data = data,
       headers = request.headers,
       http_version = request.http_version,
@@ -528,32 +567,6 @@ def http.put.file(~name="file", ~content_type=null(), ~headers=[], ~boundary=nul
 end
 
 let harbor.http.request = ()
-
-# Read all data from a HTTP request
-# @category Internet
-# @param ~timeout Read timeout
-# @param req HTTP request
-def harbor.http.request.body(~timeout=10., req) =
-  # This is for typing purposes
-  if false then
-    harbor.http.register("/foo", fun (r, _) -> ignore(if false then r else req end))
-  end
-
-  data = ref("")
-  start_time = time()
-  def rec read() =
-    if start_time+timeout < time() then
-      error.raise(error.http, "Timeout!")
-    end
-
-    r = req.data(timeout=timeout)
-    if r == "" then data() else
-      data := "#{data()}#{r}"
-      read()
-    end
-  end
-  read()
-end
 
 let settings.http = settings.make.void(
   "Settings for HTTP requests"

--- a/src/libs/interactive.liq
+++ b/src/libs/interactive.liq
@@ -418,7 +418,7 @@ def interactive.harbor(~transport=http.transport.unix, ~port=8000, ~uri="/intera
   harbor.http.register(transport=transport, port=port, method="GET", uri, webpage)
 
   def setter(request, _)
-    data = url.split_args(harbor.http.request.body(request))
+    data = url.split_args(request.body())
     def update(nv)
       let (name, v) = nv
       try

--- a/src/libs/server.liq
+++ b/src/libs/server.liq
@@ -134,7 +134,7 @@ def server.harbor(~transport=http.transport.unix, ~port=8000, ~uri="/telnet")
 
   def setter(request, response)
     log.info("Executing command: #{request.data}")
-    answer = server.execute(harbor.http.request.body(request))
+    answer = server.execute(request.body())
     answer = string.concat(separator="\n", answer) ^ "\n"
     response.data(answer)
   end

--- a/tests/harbor/http.liq
+++ b/tests/harbor/http.liq
@@ -3,7 +3,7 @@ def f() =
   def handler(req, _) =
    test.equals(req.http_version, "1.1")
    test.equals(req.method, "GET")
-   test.equals(harbor.http.request.body(timeout=5.0, req), "")
+   test.equals(req.body(timeout=5.0), "")
    test.equals(req.query, [])
    test.equals(req.path, "/default")
   end
@@ -34,7 +34,7 @@ def f() =
   def handler(req, _) =
    test.equals(req.http_version, "1.1")
    test.equals(req.method, "GET")
-   test.equals(harbor.http.request.body(timeout=5.0, req), "")
+   test.equals(req.body(timeout=5.0), "")
    test.equals(req.query, [("gni", "gno"), ("bla", "blo")])
    test.equals(req.path, "/path/gno/blo")
   end
@@ -61,7 +61,7 @@ def f() =
       ("content-type", "application/x-www-form-urlencoded")
     ])
    test.equals(req.path, "/some/path/with/full/in/it")
-   test.equals(harbor.http.request.body(timeout=5.0, req), "foobarlol")
+   test.equals(req.body(timeout=5.0), "foobarlol")
 
     res.status_code(201)
     res.status_message("YYR")
@@ -108,7 +108,7 @@ def f() =
       ("content-type", "application/x-www-form-urlencoded"),
     ])
    test.equals(req.path, "/large_non_chunked")
-   test.equals(string.length(harbor.http.request.body(timeout=5.0, req)), 10_000)
+   test.equals(string.length(req.body(timeout=5.0)), 10_000)
   end
 
   harbor.http.register("/large_non_chunked", method="POST", port=3456, handler)
@@ -134,7 +134,7 @@ def f() =
       ("expect", "100-continue")
     ])
    test.equals(req.path, "/chunked")
-   test.equals(harbor.http.request.body(timeout=5.0, req), "foobarlol")
+   test.equals(req.body(timeout=5.0), "foobarlol")
   end
 
   harbor.http.register("/chunked", method="POST", port=3456, handler)
@@ -157,10 +157,10 @@ def f() =
 
   # Large chunked query
   def handler(req, res) =
-   test.equals(req.http_version, "1.1")
-   test.equals(req.method, "POST")
-   test.equals(req.query, [])
-   test.equals(req.headers, [
+    test.equals(req.http_version, "1.1")
+    test.equals(req.method, "POST")
+    test.equals(req.query, [])
+    test.equals(req.headers, [
       ("host", "localhost:3456"),
       ("user-agent", http.user_agent),
       ("accept", "*/*"),
@@ -168,7 +168,7 @@ def f() =
       ("content-type", "application/x-www-form-urlencoded"),
       ("expect", "100-continue")
     ])
-   test.equals(req.path, "/large_chunked")
+    test.equals(req.path, "/large_chunked")
 
     def rec f(count) =
       ret = req.data()

--- a/tests/harbor/post.liq
+++ b/tests/harbor/post.liq
@@ -74,7 +74,7 @@ def f() =
     ])
    test.equals(req.path, "/file_upload")
    test.equals(
-      harbor.http.request.body(timeout=5.0, req),
+      req.body(timeout=5.0),
       "--#{boundary}\r\n\
        Content-Disposition: form-data; name=\"file\"; filename=\"#{fname}\"\r\n\
        Content-Type: text/plain\r\n\
@@ -111,7 +111,7 @@ def f() =
     ])
    test.equals(req.path, "/in_memory_file_upload")
    test.equals(
-      harbor.http.request.body(timeout=5.0, req),
+      req.body(timeout=5.0),
       "--#{boundary}\r\n\
        Content-Disposition: form-data; name=\"file\"; filename=\"foo.txt\"\r\n\
        Content-Type: text/plain\r\n\
@@ -148,7 +148,7 @@ def f() =
     ])
    test.equals(req.path, "/json_post")
    test.equals(
-      harbor.http.request.body(timeout=5.0, req),
+      req.body(timeout=5.0),
       data)
   end
 

--- a/tests/harbor/put.liq
+++ b/tests/harbor/put.liq
@@ -74,7 +74,7 @@ def f() =
     ])
    test.equals(req.path, "/large_non_chunked")
    test.equals(
-      harbor.http.request.body(timeout=5.0, req),
+      req.body(timeout=5.0),
       "--#{boundary}\r\n\
        Content-Disposition: form-data; name=\"file\"; filename=\"#{fname}\"\r\n\
        Content-Type: text/plain\r\n\
@@ -112,7 +112,7 @@ def f() =
     ])
    test.equals(req.path, "/in_memory_file_upload")
    test.equals(
-      harbor.http.request.body(timeout=5.0, req),
+      req.body(timeout=5.0),
       "--#{boundary}\r\n\
        Content-Disposition: form-data; name=\"file\"; filename=\"foo.txt\"\r\n\
        Content-Type: text/plain\r\n\
@@ -150,7 +150,7 @@ def f() =
     ])
    test.equals(req.path, "/json_put")
    test.equals(
-      harbor.http.request.body(timeout=5.0, req),
+      req.body(timeout=5.0),
       data)
   end
 


### PR DESCRIPTION
After some user feedback, it is clear that the method to retrieve a HTTP request data needs to be simplified so we're adding a `body` method that memoizes the entire request's data. To be used when the data is short!