### PR TITLE
Add track.metadata.merge

### DIFF
--- a/src/core/builtins/builtins_ffmpeg_filters.ml
+++ b/src/core/builtins/builtins_ffmpeg_filters.ml
@@ -718,7 +718,7 @@ let _ =
        [
          ( "pass_metadata",
            Lang.bool_t,
-           Some (Lang.bool false),
+           Some (Lang.bool true),
            Some "Pass liquidsoap's metadata to this stream" );
          ("", Graph.t, None, None);
          ("", video_frame_t, None, None);
@@ -786,7 +786,7 @@ let _ =
     [
       ( "pass_metadata",
         Lang.bool_t,
-        Some (Lang.bool false),
+        Some (Lang.bool true),
         Some "Pass ffmpeg stream metadata to liquidsoap" );
       ( "fps",
         Lang.nullable_t Lang.int_t,

--- a/src/core/dune
+++ b/src/core/dune
@@ -162,6 +162,7 @@
   max_duration
   mean
   meta_format
+  merge_metadata
   midi_decoder
   midi_routing
   midimeter

--- a/src/core/operators/muxer.ml
+++ b/src/core/operators/muxer.ml
@@ -170,6 +170,21 @@ let source =
           []
           (fst (Lang.split_meths tracks))
       in
+      if
+        List.for_all
+          (fun { fields } ->
+            List.for_all
+              (fun { target_field } ->
+                target_field = Frame.Fields.metadata
+                || target_field = Frame.Fields.track_marks)
+              fields)
+          tracks
+      then
+        Runtime_error.raise ~pos:(Lang.pos p)
+          ~message:
+            "source muxer needs at least one track with content that is not \
+             metadata or track_marks!"
+          "invalid";
       let s = new muxer tracks in
       let target_fields =
         List.fold_left
@@ -210,7 +225,7 @@ let _ =
       let _, s = Lang.to_track (List.assoc "" p) in
       (Frame.Fields.track_marks, s))
 
-let _ =
+let track_metadata =
   let track_t = Type.var ~constraints:[Format_type.media ~strict:true ()] () in
   let return_t = Format_type.metadata in
   Lang.add_track_operator ~base:Modules.track "metadata" ~category:`Track

--- a/src/core/operators/track/merge_metadata.ml
+++ b/src/core/operators/track/merge_metadata.ml
@@ -1,0 +1,87 @@
+(*****************************************************************************
+
+  Liquidsoap, a programmable stream generator.
+  Copyright 2003-2023 Savonet team
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details, fully stated in the COPYING
+  file at the root of the liquidsoap distribution.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+ *****************************************************************************)
+
+class merge_metadata tracks =
+  let sources = List.map snd tracks in
+  let stype =
+    if List.for_all (fun s -> s#stype = `Infallible) sources then `Infallible
+    else `Fallible
+  in
+  let self_sync_type = Utils.self_sync_type sources in
+  object (self)
+    inherit Source.operator ~name:"track.metadata.merge" sources as super
+    method stype = stype
+
+    method self_sync =
+      (Lazy.force self_sync_type, List.exists (fun s -> snd s#self_sync) sources)
+
+    method abort_track = List.iter (fun s -> s#abort_track) sources
+    method private sources_ready = List.for_all (fun s -> s#is_ready) sources
+    method is_ready = List.for_all (fun s -> s#is_ready) sources
+    method seek len = len
+    method remaining = -1
+    val mutable track_frames = Hashtbl.create (List.length tracks)
+
+    method private track_frame source =
+      try Hashtbl.find track_frames source
+      with Not_found ->
+        let f = Frame.create source#content_type in
+        Hashtbl.add track_frames source f;
+        f
+
+    method get_frame buf =
+      let pos = Frame.position buf in
+      let max_pos =
+        List.fold_left
+          (fun max_pos source ->
+            let tmp_frame = self#track_frame source in
+            if source#is_ready && Frame.is_partial tmp_frame then (
+              source#get tmp_frame;
+              List.iter
+                (fun (p, m) ->
+                  if pos <= p then (
+                    match Frame.get_metadata buf p with
+                      | None -> Frame.set_metadata buf p m
+                      | Some m' -> Hashtbl.iter (Hashtbl.add m') m))
+                (Frame.get_all_metadata tmp_frame));
+            max max_pos (Frame.position tmp_frame))
+          (Frame.position buf) sources
+      in
+      Frame.add_break buf max_pos
+
+    method! advance =
+      super#advance;
+      Hashtbl.iter (fun _ frame -> Frame.clear frame) track_frames
+  end
+
+let _ =
+  let metadata_t = Format_type.metadata in
+  Lang.add_track_operator ~base:Muxer.track_metadata "merge" ~category:`Track
+    ~descr:
+      "Merge metadata from all given tracks. If two sources have metadata with \
+       the same label at the same time, the one from the last source in the \
+       list takes precedence."
+    ~return_t:metadata_t
+    [("", Lang.list_t metadata_t, None, None)]
+    (fun p ->
+      let tracks = List.map Lang.to_track (Lang.to_list (List.assoc "" p)) in
+      (Frame.Fields.metadata, new merge_metadata tracks))

--- a/tests/streams/dune.inc
+++ b/tests/streams/dune.inc
@@ -210,6 +210,29 @@
  (alias citest)
  (package liquidsoap)
  (deps
+  merge_metadata.liq
+  ./file1.mp3
+  ./file2.mp3
+  ./file3.mp3
+  ./jingle1.mp3
+  ./jingle2.mp3
+  ./jingle3.mp3
+  ./file1.png
+  ./file2.png
+  ./jingles
+  ./playlist
+  ./huge_playlist
+  ../media/all_media_files
+  ../../src/bin/liquidsoap.exe
+  (package liquidsoap)
+  (:test_liq ../test.liq)
+  (:run_test ../run_test.exe))
+ (action (run %{run_test} merge_metadata.liq liquidsoap %{test_liq} merge_metadata.liq)))
+
+(rule
+ (alias citest)
+ (package liquidsoap)
+ (deps
   ctype2.liq
   ./file1.mp3
   ./file2.mp3

--- a/tests/streams/merge_metadata.liq
+++ b/tests/streams/merge_metadata.liq
@@ -1,0 +1,36 @@
+log.level.set(4)
+
+def f(m)
+  print("Got metadata!")
+  if m == [("s", "That's me!"), ("test", "bla"), ("s'", "That's me!"), ("test", "blo")] then
+    test.pass()
+  else
+    test.fail()
+  end
+end
+
+s = sine()
+s = insert_metadata(s)
+
+s' = sine()
+s' = insert_metadata(s')
+
+def insert()
+  print("Inserting metadata")
+  s.insert_metadata([("test", "bla"), ("s","That's me!")])
+  s'.insert_metadata([("test", "blo"), ("s'","That's me!")])
+end
+
+s = source({
+  audio = source.tracks(s).audio,
+  metadata = track.metadata.merge([
+    source.tracks(s).metadata,
+    source.tracks(s').metadata
+  ])
+})
+
+s = source.on_metadata(s,f)
+
+thread.run(delay=1., insert)
+
+output.dummy(s)


### PR DESCRIPTION
This PRs adds a new `track.metadata.merge` operator that can be used to merge multiple metadata tracks.

Metadata from different tracks but at the same position are merged key-wise. If the same key is provided multiple times, the last source in the array takes precedence.

The PR also turns on `pass_metadata` in all filter input and output. The different values were originally b/c `2.1.x` wasn't able to discriminate tracks and, most of the time, we only want the audio track metadata. With this operator and track muxing, we can now give the user control back on this.

Typical use:
```liquidsoap
def filter_bbox(s) =
  def mkfilter(graph) =
    let {audio,video} = source.tracks(s)
    video = ffmpeg.filter.video.input(graph, video)
    audio = ffmpeg.filter.audio.input(graph, audio)

    video = ffmpeg.filter.bbox(graph, video)
    audio = ffmpeg.filter.acopy(graph, audio)

    video = ffmpeg.filter.video.output(graph, video)
    audio = ffmpeg.filter.audio.output(graph, audio)

    source({
      audio=audio,
      video=video,
      metadata = track.metadata.merge([
        track.metadata(video),
        track.metadata(audio)
      ])
    })
  end
  ffmpeg.filter.create(mkfilter)
end
```
