### PR TITLE
Relaxed runtime check & constraints cleanup

### DIFF
--- a/src/core/hooks_implementations.ml
+++ b/src/core/hooks_implementations.ml
@@ -79,7 +79,7 @@ let mk_field_t ~pos (kind, params) =
         | [] -> Type.make (Format_type.descr (`Kind k))
         | [("", "any")] -> Type.var ()
         | [("", "internal")] ->
-            Type.var ~constraints:[Format_type.internal_media] ()
+            Type.var ~constraints:[Format_type.internal_tracks] ()
         | param :: params ->
             let mk_format (label, value) = Content.parse_param k label value in
             let f = mk_format param in

--- a/src/core/lang.ml
+++ b/src/core/lang.ml
@@ -13,7 +13,7 @@ let add_protocol ~syntax ~doc ~static name resolver =
   Plug.register Request.protocols ~doc name spec
 
 let frame_t base_type fields = Frame_type.make base_type fields
-let internal_t () = Frame_type.internal ()
+let internal_tracks_t () = Frame_type.internal_tracks ()
 
 let format_t t =
   Type.make

--- a/src/core/lang.mli
+++ b/src/core/lang.mli
@@ -233,6 +233,8 @@ val error_t : t
 val source_t : ?methods:bool -> t -> t
 val of_source_t : t -> t
 val format_t : t -> t
+val metadata_track_t : t
+val track_marks_t : t
 
 (* [frame_t base_type fields] returns a frame with [base_type] as
    its base type and [fields] as explicit fields. Equivalent to:
@@ -241,7 +243,7 @@ val frame_t : t -> t Frame.Fields.t -> t
 
 (* Return a generic frame type with the internal media constraint
    applied. Equivalent to: ['a where 'a is an internal media type] *)
-val internal_t : unit -> t
+val internal_tracks_t : unit -> t
 
 (** [fun_t args r] is the type of a function taking [args] as parameters
   * and returning values of type [r].

--- a/src/core/lang_source.ml
+++ b/src/core/lang_source.ml
@@ -41,6 +41,9 @@ let to_metadata t =
 let metadata m =
   list (Hashtbl.fold (fun k v l -> product (string k) (string v) :: l) m [])
 
+let metadata_track_t = Format_type.metadata
+let track_marks_t = Format_type.track_marks
+
 module Source_val = Liquidsoap_lang.Lang_core.MkAbstract (struct
   type content = Source.source
 

--- a/src/core/lang_source.ml
+++ b/src/core/lang_source.ml
@@ -303,11 +303,7 @@ type 'a operator_method = string * scheme * string * ('a -> value)
 (** Ensure that the frame contents of all the sources occurring in the value agree with [t]. *)
 let check_content v t =
   let checked_values = ref [] in
-  let check t t' =
-    Typing.(
-      t <: t';
-      t' <: t)
-  in
+  let check t t' = Typing.(t <: t') in
   let rec check_value v t =
     if not (List.memq v !checked_values) then (
       (* We need to avoid checking the same value multiple times, otherwise we

--- a/src/core/operators/muxer.ml
+++ b/src/core/operators/muxer.ml
@@ -140,11 +140,7 @@ class muxer tracks =
   end
 
 let source =
-  let frame_t =
-    Lang.frame_t
-      (Type.var ~constraints:[Format_type.media ~strict:false ()] ())
-      Frame.Fields.empty
-  in
+  let frame_t = Lang.univ_t ~constraints:[Format_type.muxed_tracks] () in
   let tracks_t =
     Type.meth ~optional:true "track_marks"
       ([], Format_type.track_marks)
@@ -216,7 +212,7 @@ let source =
       s)
 
 let _ =
-  let track_t = Type.var ~constraints:[Format_type.media ~strict:true ()] () in
+  let track_t = Lang.univ_t ~constraints:[Format_type.track] () in
   let return_t = Format_type.track_marks in
   Lang.add_track_operator ~base:Modules.track "track_marks" ~category:`Track
     ~descr:"Return the track marks associated with the given track" ~return_t
@@ -226,7 +222,7 @@ let _ =
       (Frame.Fields.track_marks, s))
 
 let track_metadata =
-  let track_t = Type.var ~constraints:[Format_type.media ~strict:true ()] () in
+  let track_t = Lang.univ_t ~constraints:[Format_type.track] () in
   let return_t = Format_type.metadata in
   Lang.add_track_operator ~base:Modules.track "metadata" ~category:`Track
     ~descr:"Return the metadata associated with the given track" ~return_t

--- a/src/core/sources/blank.ml
+++ b/src/core/sources/blank.ml
@@ -69,7 +69,7 @@ class blank duration =
   end
 
 let blank =
-  let return_t = Lang.internal_t () in
+  let return_t = Lang.internal_tracks_t () in
   Lang.add_operator "blank" ~category:`Input
     ~descr:"Produce silence and blank images." ~return_t
     [

--- a/src/core/sources/noise.ml
+++ b/src/core/sources/noise.ml
@@ -50,7 +50,7 @@ class noise duration =
   end
 
 let _ =
-  let return_t = Lang.internal_t () in
+  let return_t = Lang.internal_tracks_t () in
   Lang.add_operator "noise" ~category:`Input
     ~descr:"Generate audio/video noise source."
     [

--- a/src/core/sources/video_board.ml
+++ b/src/core/sources/video_board.ml
@@ -133,8 +133,8 @@ let _ =
         Some Lang.null,
         Some "Initial height of the video (defaults ot the same as frame)." );
     ]
-    ~return_t:(Lang.internal_t ()) ~category:`Video
-    ~descr:"A plane where one can draw."
+    ~return_t:(Lang.internal_tracks_t ())
+    ~category:`Video ~descr:"A plane where one can draw."
     ~meth:
       [
         ("clear", ([], Lang.fun_t [] Lang.unit_t), "Clear the board.", clear);

--- a/src/core/sources/video_testsrc.ml
+++ b/src/core/sources/video_testsrc.ml
@@ -74,7 +74,7 @@ class testsrc ?(duration = None) ~width ~height () =
   end
 
 let _ =
-  let return_t = Lang.internal_t () in
+  let return_t = Lang.internal_tracks_t () in
   Lang.add_operator ~base:Modules.video "testsrc" ~category:`Input
     ~descr:"Generate a test video."
     [

--- a/src/core/tools/utils.ml
+++ b/src/core/tools/utils.ml
@@ -472,3 +472,11 @@ let subst_vars s =
   List.fold_left
     (fun v (r, s) -> Str.global_replace (Str.regexp r) (s ()) v)
     s !substs
+
+let concat_with_last ~last sep l =
+  match List.rev l with
+    | [] -> ""
+    | [x] -> x
+    | [x; y] -> Printf.sprintf "%s %s %s" y last x
+    | x :: l ->
+        Printf.sprintf "%s %s %s" (String.concat sep (List.rev l)) last x

--- a/src/core/types/format_type.ml
+++ b/src/core/types/format_type.ml
@@ -159,6 +159,7 @@ let internal_track =
         let b = Type.demeth b in
         match b.Type.descr with
           | Type.Var _ -> satisfies b
+          | Type.(Custom { typ = Ground.Never.Type }) -> ()
           | Type.Custom { Type.typ = Kind (k, _) }
             when List.exists (is_kind k) internal_modules ->
               ()
@@ -182,6 +183,7 @@ let internal_tracks =
         List.iter
           (fun { Type.scheme = _, typ } ->
             match (Type.demeth typ).Type.descr with
+              | Type.(Custom { typ = Ground.Never.Type }) -> ()
               | Type.Custom { Type.typ = Kind (k, _) }
                 when List.exists (is_kind k) internal_modules ->
                   ()
@@ -204,6 +206,7 @@ let track =
         let b = Type.demeth b in
         match b.Type.descr with
           | Type.Var _ -> satisfies b
+          | Type.(Custom { typ = Ground.Never.Type })
           | Type.Custom { Type.typ = Kind _ }
           | Type.Custom { Type.typ = Format _ } ->
               ()
@@ -224,6 +227,7 @@ let muxed_tracks =
         List.iter
           (fun { Type.scheme = _, typ } ->
             match (Type.demeth typ).Type.descr with
+              | Type.(Custom { typ = Ground.Never.Type }) -> ()
               | Type.Custom { Type.typ = Kind _ }
               | Type.Custom { Type.typ = Format _ } ->
                   ()

--- a/src/core/types/format_type.ml
+++ b/src/core/types/format_type.ml
@@ -22,7 +22,7 @@
 
 type Type.custom += Kind of (Content_base.kind * Type.t)
 type Type.custom += Format of Content_base.format
-type Type.constr_t += InternalMedia | Media
+type Type.constr_t += Track | MuxedTracks | InternalTrack | InternalTracks
 type descr = [ `Format of Content_base.format | `Kind of Content_base.kind ]
 
 let get_format = function Format f -> f | _ -> assert false
@@ -102,68 +102,138 @@ let descr descr =
   in
   Type.Custom (kind_handler k)
 
-let rec content_type ~default ty =
+let rec content_type ?kind ty =
   match (Type.demeth ty).Type.descr with
-    | Type.Custom { Type.typ = Kind (k, ty) } ->
-        content_type ~default:(fun () -> Content_base.default_format k) ty
+    | Type.Custom { Type.typ = Kind (kind, ty) } -> content_type ~kind ty
     | Type.Custom { Type.typ = Format f } -> f
-    | Type.Var _ -> default ()
+    | Type.Var _ -> Content_base.default_format (Option.get kind)
     | _ -> assert false
 
-let internal_media =
+module type Content = sig
+  val kind : Content_base.kind
+  val is_kind : Content_base.kind -> bool
+  val is_format : Content_base.format -> bool
+end
+
+module Content_metadata = struct
+  include Content_timed.Metadata
+
+  let kind = Content_base.kind format
+end
+
+module Content_track_marks = struct
+  include Content_timed.Track_marks
+
+  let kind = Content_base.kind format
+end
+
+let internal_modules =
+  [
+    (module Content_audio : Content);
+    (module Content_video : Content);
+    (module Content_metadata : Content);
+    (module Content_track_marks : Content);
+  ]
+
+let string_of_kind m =
+  let module Content = (val m : Content) in
+  Content_base.string_of_kind Content.kind
+
+let is_kind k m =
+  let module Content = (val m : Content) in
+  Content.is_kind k
+
+let is_format f m =
+  let module Content = (val m : Content) in
+  Content.is_format f
+
+let internal_track =
   {
-    Type.t = InternalMedia;
+    Type.t = InternalTrack;
     constr_descr =
-      Printf.sprintf "an internal media type (%s or %s)"
-        (Content_base.string_of_kind Content_audio.kind)
-        (Content_base.string_of_kind Content_video.kind);
+      Printf.sprintf "an internal track type (%s)"
+        (Utils.concat_with_last ~last:"or" ", "
+           (List.map string_of_kind internal_modules));
     satisfied =
       (fun ~subtype:_ ~satisfies b ->
-        match (Type.deref b).Type.descr with
-          | Type.Tuple [] -> ()
-          | Type.Constr { params } ->
-              List.iter (fun (_, typ) -> satisfies typ) params
-          | Type.Meth _ ->
-              let meths, base_type = Type.split_meths b in
-              List.iter
-                (fun Type.{ scheme = _, field_type } -> satisfies field_type)
-                meths;
-              satisfies base_type
-          | Type.Custom { Type.typ = Kind (k, _) } when Content_audio.is_kind k
-            ->
+        let b = Type.demeth b in
+        match b.Type.descr with
+          | Type.Var _ -> satisfies b
+          | Type.Custom { Type.typ = Kind (k, _) }
+            when List.exists (is_kind k) internal_modules ->
               ()
-          | Type.Custom { Type.typ = Kind (k, _) } when Content_video.is_kind k
-            ->
-              ()
-          | Type.Custom { Type.typ = Format f } when Content_audio.is_format f
-            ->
-              ()
-          | Type.Custom { Type.typ = Format f } when Content_video.is_format f
-            ->
+          | Type.Custom { Type.typ = Format f }
+            when List.exists (is_format f) internal_modules ->
               ()
           | _ -> raise Type.Unsatisfied_constraint);
   }
 
-let media ~strict () =
+let internal_tracks =
   {
-    Type.t = Media;
-    constr_descr = "any media type (pcm, etc...)";
+    Type.t = InternalTracks;
+    constr_descr = "a set of internal tracks";
     satisfied =
       (fun ~subtype:_ ~satisfies b ->
-        match (Type.deref b).Type.descr with
+        let meths, base_type = Type.split_meths b in
+        (match base_type.Type.descr with
+          | Type.Var _ -> satisfies base_type
           | Type.Tuple [] -> ()
-          | Type.Constr { params } when not strict ->
-              List.iter (fun (_, typ) -> satisfies typ) params
-          | Type.Meth _ when not strict ->
-              let _, base_type = Type.split_meths b in
-              satisfies base_type
+          | _ -> raise Type.Unsatisfied_constraint);
+        List.iter
+          (fun { Type.scheme = _, typ } ->
+            match (Type.demeth typ).Type.descr with
+              | Type.Custom { Type.typ = Kind (k, _) }
+                when List.exists (is_kind k) internal_modules ->
+                  ()
+              | Type.Custom { Type.typ = Format f }
+                when List.exists (is_format f) internal_modules ->
+                  ()
+              | Type.Var { contents = Free v } ->
+                  v.constraints <-
+                    Type.Constraints.add internal_track v.constraints
+              | _ -> raise Type.Unsatisfied_constraint)
+          meths);
+  }
+
+let track =
+  {
+    Type.t = Track;
+    constr_descr = "a source track";
+    satisfied =
+      (fun ~subtype:_ ~satisfies b ->
+        let b = Type.demeth b in
+        match b.Type.descr with
+          | Type.Var _ -> satisfies b
           | Type.Custom { Type.typ = Kind _ }
           | Type.Custom { Type.typ = Format _ } ->
               ()
           | _ -> raise Type.Unsatisfied_constraint);
   }
 
-let content_type = content_type ~default:(fun _ -> assert false)
+let muxed_tracks =
+  {
+    Type.t = MuxedTracks;
+    constr_descr = "a set of tracks to be muxed into a source";
+    satisfied =
+      (fun ~subtype:_ ~satisfies b ->
+        let meths, base_type = Type.split_meths b in
+        (match (Type.demeth base_type).Type.descr with
+          | Type.Var _ -> satisfies base_type
+          | Type.Tuple [] -> ()
+          | _ -> raise Type.Unsatisfied_constraint);
+        List.iter
+          (fun { Type.scheme = _, typ } ->
+            match (Type.demeth typ).Type.descr with
+              | Type.Custom { Type.typ = Kind _ }
+              | Type.Custom { Type.typ = Format _ } ->
+                  ()
+              | Type.Var { contents = Free v } ->
+                  v.constraints <- Type.Constraints.add track v.constraints
+              | _ -> raise Type.Unsatisfied_constraint)
+          meths);
+  }
+
+let content_type ty = content_type ty
 let audio () = Type.make (descr (`Kind Content_audio.kind))
 
 let () =
@@ -210,10 +280,10 @@ let track_marks = Type.make (descr (`Format Content_timed.Track_marks.format))
 
 let () =
   Type.register_type "track_marks" (fun () ->
-      Type.make (Type.Custom (format_handler Content_timed.Track_marks.format)))
+      Type.make (descr (`Format Content_timed.Track_marks.format)))
 
 let metadata = Type.make (descr (`Format Content_timed.Metadata.format))
 
 let () =
   Type.register_type "metadata" (fun () ->
-      Type.make (Type.Custom (format_handler Content_timed.Track_marks.format)))
+      Type.make (descr (`Format Content_timed.Track_marks.format)))

--- a/src/core/types/format_type.mli
+++ b/src/core/types/format_type.mli
@@ -23,8 +23,9 @@
 type descr = [ `Format of Content_base.format | `Kind of Content_base.kind ]
 
 val descr : descr -> Type.descr
-val internal_media : Type.constr
-val media : strict:bool -> unit -> Type.constr
+val track : Type.constr
+val muxed_tracks : Type.constr
+val internal_tracks : Type.constr
 val content_type : Type.t -> Content_base.format
 val kind_handler : Content_base.kind * Type.t -> Type.custom_handler
 

--- a/src/core/types/frame_type.ml
+++ b/src/core/types/frame_type.ml
@@ -38,8 +38,8 @@ let make ?pos base_type fields =
       Type.make ?pos (Type.Meth (meth, typ)))
     fields base_type
 
-let internal ?pos () =
-  Type.var ?pos ~constraints:[Format_type.internal_media] ()
+let internal_tracks ?pos () =
+  Type.var ?pos ~constraints:[Format_type.internal_tracks] ()
 
 let set_field frame_type field field_type =
   let field = Frame.Fields.string_of_field field in
@@ -95,7 +95,7 @@ let content_type frame_type =
           (try
              (* Map audio and video fields to their default value when possible.
                 This is in case the source has types such as { audio = 'a } *)
-             Typing.satisfies_constraint base_type Format_type.internal_media;
+             Typing.satisfies_constraint base_type Format_type.internal_tracks;
              List.iter
                (function
                  | { Type.meth = "audio"; scheme = [], ty } ->

--- a/src/core/types/frame_type.ml
+++ b/src/core/types/frame_type.ml
@@ -93,7 +93,8 @@ let content_type frame_type =
           default_t
       | _ ->
           (try
-             (* Map audio and video fields to their default value when possible. *)
+             (* Map audio and video fields to their default value when possible.
+                This is in case the source has types such as { audio = 'a } *)
              Typing.satisfies_constraint base_type Format_type.internal_media;
              List.iter
                (function

--- a/src/core/types/frame_type.mli
+++ b/src/core/types/frame_type.mli
@@ -28,8 +28,8 @@ open Liquidsoap_lang
 (* Same as [Lang.frame_t] (with position) *)
 val make : ?pos:Pos.t -> Type.t -> Type.t Frame.Fields.t -> Type.t
 
-(* Same as [Lang.internal_t] (with position) *)
-val internal : ?pos:Pos.t -> unit -> Type.t
+(* Same as [Lang.internal_tracks_t] (with position) *)
+val internal_tracks : ?pos:Pos.t -> unit -> Type.t
 
 (* [set_field frame_type field field_type] assigns a field to a frame type. *)
 val set_field : Type.t -> Frame.field -> Type.t -> Type.t

--- a/src/lang/type.ml
+++ b/src/lang/type.ml
@@ -32,6 +32,7 @@ let num_constr =
       (fun ~subtype:_ ~satisfies:_ b ->
         let b = demeth b in
         match b.descr with
+          | Custom { typ = Ground.Never.Type }
           | Custom { typ = Ground.Int.Type }
           | Custom { typ = Ground.Float.Type } ->
               ()

--- a/src/lang/type.ml
+++ b/src/lang/type.ml
@@ -46,6 +46,7 @@ let ord_constr =
       (fun ~subtype:_ ~satisfies b ->
         let m, b = split_meths b in
         match b.descr with
+          | Var _ -> satisfies b
           | Custom c when Ground_type.is_ground c.Type_base.typ -> ()
           | Tuple [] ->
               (* For records, we want to ensure that all fields are ordered. *)

--- a/src/lang/typing.ml
+++ b/src/lang/typing.ml
@@ -292,7 +292,7 @@ let () =
 
 (** Ensure that a type satisfies a given constraint, i.e. morally that b <: c. *)
 let rec satisfies_constraint b c =
-  match (demeth b).descr with
+  match (deref b).descr with
     | Var { contents = Free v } ->
         v.constraints <- Constraints.add c v.constraints
     | _ ->

--- a/tests/regression/dune.inc
+++ b/tests/regression/dune.inc
@@ -497,6 +497,19 @@
  (alias citest)
  (package liquidsoap)
  (deps
+  video-only.liq
+  ../media/all_media_files
+  ../../src/bin/liquidsoap.exe
+  (package liquidsoap)
+  (:stdlib ../../src/libs/stdlib.liq)
+  (:test_liq ../test.liq)
+  (:run_test ../run_test.exe))
+ (action (run %{run_test} video-only.liq liquidsoap %{test_liq} video-only.liq)))
+
+(rule
+ (alias citest)
+ (package liquidsoap)
+ (deps
   LS268.liq
   ../media/all_media_files
   ../../src/bin/liquidsoap.exe

--- a/tests/regression/video-only.liq
+++ b/tests/regression/video-only.liq
@@ -1,0 +1,15 @@
+a = sine()
+v = blank()
+
+s = source(
+  source.tracks(a).{
+    video = source.tracks(v).video
+  }
+)
+
+s = source.on_track(s, fun (_) -> test.pass())
+
+tmp = file.temp("foo", "mp3")
+on_shutdown({file.remove(tmp)})
+
+output.file(%mp3, tmp, s)

--- a/tests/regression/video-only.liq
+++ b/tests/regression/video-only.liq
@@ -13,7 +13,7 @@ tmp = file.temp("foo", "flv")
 on_shutdown({file.remove(tmp)})
 
 output.file(
-  %ffmpeg(format="flv",%video.raw(codec="libx264")),
+  %ffmpeg(format="flv",%video(codec="libx264")),
   tmp,
   s
 )

--- a/tests/regression/video-only.liq
+++ b/tests/regression/video-only.liq
@@ -9,7 +9,11 @@ s = source(
 
 s = source.on_track(s, fun (_) -> test.pass())
 
-tmp = file.temp("foo", "mp3")
+tmp = file.temp("foo", "flv")
 on_shutdown({file.remove(tmp)})
 
-output.file(%mp3, tmp, s)
+output.file(
+  %ffmpeg(format="flv",%video.raw(codec="libx264")),
+  tmp,
+  s
+)


### PR DESCRIPTION
This PR relaxes the runtime check on sources so that, for all  arguments and returned values in source and track operators, we have:
```
runtume_frame_type <: operator_declared_frame_type
```
Before, the relationship was checked both ways which was creating restrictions such as not being able to pass a source with audio and video tracks to an encoder with only video track.

While working on this, it became clear that the constraints system also needed some love, namely:
* We need to let each constraints decide what do with a type methods.
 
Before, we would simply bind the constraint to the demethed root when it's a variable, which seems wrong.

This means that the constraints resolution function gets exposed to universal variables to some extend. 

* We need finer-grained constrains for content

The `internal_media` constraints worked in `2.1.x` and was pretty loose. Now that we have types for content and also muxer, tracks and factored out contraints we need:
1. A constraint for anything that is a track. This one demeth a type and checks if it's strictly a format or kind (remember, kind = generic content type like pcm or video with any params, format.= fully parametrized content)
2. A constraint for anything that is a set of muxed tracks. This means nothing but record of tracks. This is where we need the constraint to decide what to do with methods.
3. A constraint for anything internal tracks. That is tracks whose content we can produce, pcm, video, metadata and track_marks
4. A constraint for anything that is a set of internal tracks. This is the old internal media, used for operator that can produce generic content based on runtime source content such as `blank` and `noise`.

TODO: Add back constraint description to type print out.