### PR TITLE
Make ogg muxer compliant with the ffmpeg demuxer (and the spec).

### DIFF
--- a/.github/opam/liquidsoap-windows.opam
+++ b/.github/opam/liquidsoap-windows.opam
@@ -106,7 +106,7 @@ conflicts: [
   "magic-windows" {< "0.6"}
   "mem_usage-windows" {< "0.0.3"}
   "curl-windows" {< "0.9.2"}
-  "ogg-windows" {< "0.7.0"}
+  "ogg-windows" {< "0.7.4"}
   "opus-windows" {< "0.2.0"}
   "portaudio-windows" {< "0.2.0"}
   "pulseaudio-windows" {< "0.1.4"}

--- a/dune-project
+++ b/dune-project
@@ -103,7 +103,7 @@
     (mad (< 0.5.0))
     (magic (< 0.6))
     (mem_usage (< 0.0.3))
-    (ogg (< 0.7.0))
+    (ogg (< 0.7.4))
     (opus (< 0.2.0))
     (portaudio (< 0.2.0))
     (posix-time2 (< 2.0.2))

--- a/src/core/dune
+++ b/src/core/dune
@@ -415,6 +415,9 @@
  (library_flags -linkall)
  (wrapped false)
  (optional)
+ (foreign_stubs
+  (language c)
+  (names ogg_flac_encoder_stubs))
  (modules liq_flac_ogg_decoder ogg_flac_encoder ogg_flac_duration))
 
 (library

--- a/src/core/ogg_formats/ogg_flac_encoder.ml
+++ b/src/core/ogg_formats/ogg_flac_encoder.ml
@@ -20,6 +20,9 @@
 
  *****************************************************************************)
 
+external set_stream_eos : Ogg.Stream.stream -> unit
+  = "liq_ocaml_ogg_stream_set_eos"
+
 let create_encoder ~flac ~comments () =
   let samplerate = Lazy.force flac.Flac_format.samplerate in
   let p =
@@ -33,22 +36,33 @@ let create_encoder ~flac ~comments () =
   in
   let enc = ref None in
   let started = ref false in
+  let m = Mutex.create () in
+  let pages = ref [] in
+  let write_cb = Tutils.mutexify m (fun p -> pages := p :: !pages) in
+  let flush_pages =
+    Tutils.mutexify m (fun () ->
+        let p = !pages in
+        pages := [];
+        List.rev p)
+  in
   let get_enc os =
     match !enc with
       | Some x -> x
       | None ->
-          let x = Flac_ogg.Encoder.create ~comments p os in
+          let x =
+            Flac_ogg.Encoder.create ~comments ~serialno:(Ogg.Stream.serialno os)
+              p write_cb
+          in
           enc := Some x;
           x
   in
-  let cb = Flac_ogg.Encoder.callbacks in
   let empty_data () =
     Array.make (Lazy.force Frame.audio_channels) (Array.make 1 0.)
   in
   let header_encoder os =
-    let _, p, _ = get_enc os in
-    Ogg.Stream.put_packet os p;
-    Ogg.Stream.flush_page os
+    match get_enc os with
+      | { Flac_ogg.Encoder.first_pages = p :: _ } -> p
+      | _ -> raise Ogg_muxer.Invalid_data
   in
   let fisbone_packet os =
     Some
@@ -56,18 +70,19 @@ let create_encoder ~flac ~comments () =
          ~samplerate:(Int64.of_int samplerate) ())
   in
   let stream_start os =
-    let _, _, l = get_enc os in
-    List.iter (Ogg.Stream.put_packet os) l;
-    Ogg_muxer.flush_pages os
+    match get_enc os with
+      | { Flac_ogg.Encoder.first_pages = _ :: pages } -> pages
+      | _ -> raise Ogg_muxer.Invalid_data
   in
-  let data_encoder data os _ =
+  let data_encoder data os write_page =
     if not !started then started := true;
     let b, ofs, len =
       (data.Ogg_muxer.data, data.Ogg_muxer.offset, data.Ogg_muxer.length)
     in
     let b = Array.map (fun x -> Array.sub x ofs len) b in
-    let enc, _, _ = get_enc os in
-    Flac.Encoder.process enc cb b
+    let { Flac_ogg.Encoder.encoder; callbacks } = get_enc os in
+    Flac.Encoder.process encoder callbacks b;
+    List.iter write_page (flush_pages ())
   in
   let end_of_page p =
     let granulepos = Ogg.Page.granulepos p in
@@ -75,13 +90,14 @@ let create_encoder ~flac ~comments () =
     else Ogg_muxer.Time (Int64.to_float granulepos /. float samplerate)
   in
   let end_of_stream os =
-    let enc, _, _ = get_enc os in
+    let { Flac_ogg.Encoder.encoder; callbacks } = get_enc os in
     (* Assert that at least some data was encoded.. *)
     if not !started then (
       let b = empty_data () in
-      Flac.Encoder.process enc cb b);
-    Flac.Encoder.finish enc cb;
-    Flac_ogg.Encoder.finish enc
+      Flac.Encoder.process encoder callbacks b);
+    Flac.Encoder.finish encoder callbacks;
+    set_stream_eos os;
+    flush_pages ()
   in
   {
     Ogg_muxer.header_encoder;

--- a/src/core/ogg_formats/ogg_flac_encoder_stubs.c
+++ b/src/core/ogg_formats/ogg_flac_encoder_stubs.c
@@ -1,0 +1,10 @@
+#include <caml/mlvalues.h>
+#include <caml/memory.h>
+#include <ocaml-ogg.h>
+
+CAMLprim value liq_ocaml_ogg_stream_set_eos(value o_stream_state) {
+  CAMLparam1(o_stream_state);
+  ogg_stream_state *os = Stream_state_val(o_stream_state);
+  os->e_o_s = 1;
+  CAMLreturn(Val_unit);
+}

--- a/src/core/ogg_formats/ogg_muxer.ml
+++ b/src/core/ogg_formats/ogg_muxer.ml
@@ -42,7 +42,7 @@ type page_end_time = Ogg.Page.t -> position
 type header_encoder = Ogg.Stream.stream -> Ogg.Page.t
 type fisbone_packet = Ogg.Stream.stream -> Ogg.Stream.packet option
 type stream_start = Ogg.Stream.stream -> Ogg.Page.t list
-type end_of_stream = Ogg.Stream.stream -> unit
+type end_of_stream = Ogg.Stream.stream -> Ogg.Page.t list
 
 type 'a stream = {
   os : Ogg.Stream.stream;
@@ -343,6 +343,8 @@ let add_available src encoder =
   if is_empty src then
     Hashtbl.remove encoder.tracks (Ogg.Stream.serialno src.os)
 
+let queue_add src p = Queue.add p src.available
+
 (** Encode data. Implicitly calls [streams_start]
   * if not called before. *)
 let encode encoder id data =
@@ -350,7 +352,6 @@ let encode encoder id data =
   if encoder.state = Eos then (
     log#info "%s: Cannot encode: ogg stream finished.." encoder.id;
     raise Invalid_usage);
-  let queue_add src p = Queue.add p src.available in
   match data with
     | Audio_data x -> (
         match Hashtbl.find encoder.tracks id with
@@ -377,12 +378,12 @@ let end_of_track encoder id =
     | Video_track x ->
         if not (Ogg.Stream.eos x.os) then (
           log#info "%s: Setting end of track %nx." encoder.id id;
-          x.stream_end x.os);
+          List.iter (queue_add x) (x.stream_end x.os));
         add_available x encoder
     | Audio_track x ->
         if not (Ogg.Stream.eos x.os) then (
           log#info "%s: Setting end of track %nx." encoder.id id;
-          x.stream_end x.os);
+          List.iter (queue_add x) (x.stream_end x.os));
         add_available x encoder
 
 (** Flush data from all tracks in the stream. *)

--- a/src/core/ogg_formats/ogg_muxer.mli
+++ b/src/core/ogg_formats/ogg_muxer.mli
@@ -71,7 +71,7 @@ type fisbone_packet = Ogg.Stream.stream -> Ogg.Stream.packet option
 type stream_start = Ogg.Stream.stream -> Ogg.Page.t list
 
 (** Ends the track. *)
-type end_of_stream = Ogg.Stream.stream -> unit
+type end_of_stream = Ogg.Stream.stream -> Ogg.Page.t list
 
 (** A data encoder is an encoder for either a audio or a video track. *)
 type data_encoder =

--- a/src/core/ogg_formats/opus_encoder.ml
+++ b/src/core/ogg_formats/opus_encoder.ml
@@ -111,10 +111,9 @@ let create_encoder ~opus ~comments () =
     else Ogg_muxer.Time (Int64.to_float granulepos /. 48000.)
   in
   let end_of_stream os =
-    let enc = get_enc os in
     (* Assert that at least some data was encoded.. *)
     if not !started then data_encoder (empty_data ()) os ();
-    Opus.Encoder.eos enc
+    Ogg.Stream.terminate os
   in
   {
     Ogg_muxer.header_encoder;

--- a/src/core/ogg_formats/speex_encoder.ml
+++ b/src/core/ogg_formats/speex_encoder.ml
@@ -145,7 +145,7 @@ let create speex ~metadata () =
     if granulepos < Int64.zero then Ogg_muxer.Unknown
     else Ogg_muxer.Time (Int64.to_float granulepos /. float rate)
   in
-  let end_of_stream os = Speex.Encoder.eos enc os in
+  let end_of_stream os = Ogg.Stream.terminate os in
   {
     Ogg_muxer.header_encoder;
     fisbone_packet;

--- a/src/core/ogg_formats/theora_encoder.ml
+++ b/src/core/ogg_formats/theora_encoder.ml
@@ -148,7 +148,7 @@ let create_encoder ~theora ~metadata () =
       in
       Image.YUV420.blank_all yuv;
       Theora.Encoder.encode_buffer enc os theora_yuv);
-    Theora.Encoder.eos enc os
+    Ogg.Stream.terminate os
   in
   {
     Ogg_muxer.header_encoder;

--- a/src/core/ogg_formats/vorbis_encoder.ml
+++ b/src/core/ogg_formats/vorbis_encoder.ml
@@ -58,7 +58,8 @@ let create_gen enc freq m =
     if not !started then (
       let b = empty_data () in
       Vorbis.Encoder.encode_buffer_float enc os b 0 (Array.length b.(0)));
-    Vorbis.Encoder.end_of_stream enc os
+    Vorbis.Encoder.end_of_stream enc os;
+    []
   in
   {
     Ogg_muxer.header_encoder;


### PR DESCRIPTION
There's been a couple of issues reported lately pointing to some problems with chained ogg bitstreams, most notably https://github.com/savonet/liquidsoap/issues/2965, https://github.com/savonet/liquidsoap/issues/3010, https://github.com/savonet/liquidsoap/issues/2917 so I started investigating it.

The issues that we are tracking are:
* The validity of chained ogg bitstreams (that is bitstreams with more than one track)

Are the stream we implement valid? Where is the spec? What are the other implementations saying?

* Support for metadata in chained ogg bitstreams

Can other demuxers read metadata we produce on chained bitstreams? Can we read metadata on chained bitstreams?

This has raised some interesting issues that should be relevant for the icecast streaming community at large, now that liquidsdoap is used widely in this field.

### ⚠️ Invalid chained ogg bitstream ⚠️

Back in the days when we wrote our ogg muxer, and we're talking about 2009, some 14 years ago (see: https://github.com/savonet/liquidsoap/commit/cc5a44da019e135bae1b719879dd5e97bc06ef7b), there wasn't a lot of clarity in how to synchronously end a logical ogg stream. That is, take an encoder at any point and ask it to end the stream and flush all remaining pages in it.

`libvorbis` provided an API for it but this was the only library being explicitly coupled with `libogg`. For all other libraries, the encoder might not have any data to flush when ending it and `libogg` required at least some data to produce the last page.

Thus, we went with the trick of submitting an empty ogg packet with the `e_o_s` flag set on it. Nothing in the spec prohibited it and it seems reasonable to expect that a decoder would simply consider an empty packet as the end of stream as is standard in unix.

Fast forward 14 years, two things happened:
* The FFmpeg implementation for ogg demuxing considers an empty packet as invalid data.
* The opus spec started using empty packets for packet loss control

This means that the 2016 rfc for ogg/opus encapsulation now prohibits empty packets: https://datatracker.ietf.org/doc/html/rfc7845#section-6. A better knowledge of opus codec from the 2012 codec spec could have pointed to this: https://datatracker.ietf.org/doc/html/rfc6716#section-3.4. This is the same time we did our own implementation of the ogg encapsulation (see: https://github.com/savonet/ocaml-opus/commit/c0cd32b3bb91a2f5638285eef3f149cf8b472f76)

This means that our original assumption is no longer valid and that we are producing invalid ogg bitstreams at least from the perspective of FFmpeg (for all non-vorbis codecs) and all fully compliant opus decoders.

To fix that, a semi hacked `Ogg.Stream.terminate` was implemented in https://github.com/savonet/ocaml-ogg/commit/78edbb2dcc38eebda0c566e5f206d65b81a38912 to allow the production of a final, empty EOS page when needed, something that, this time, is actually explicitly allowed by the spec: https://datatracker.ietf.org/doc/html/rfc3533#section-4
> Eos pages may be 'nil' pages, that is, pages
   containing no content but simply a page header with position
   information and the eos flag set in the page header.

This PR adds support for this new function to all ogg codecs that previously relied on pushing an empty eos packet. This applies to speex, theora and opus.

For flac, this PR and https://github.com/savonet/ocaml-flac/commit/10aecfc2908a99e9a90d3c498521a555035bfbd1 switch to `libflac` native ogg encapsulation implementation, which also makes us compliant with their spec and future-proof. This should fix #2965

### Chained metadata

The other side of this problem is that, for too long, we were testing ogg streams in a closed off environment, that is, decoding streams produced by our own encoder. But now that `input.http` is using ffmpeg internally, it became clear that something was off with ogg chained bitstream metadata.

After fixing our internal bitstream, FFmpeg started being able to parse all metadata in ogg/opus streams, albeit with a memory leak as the library forgets to clear previous metadata when adding new, which results in the new metadata being appended. This PR implements a workaround for that and a patch will be submitted to FFmpeg soon.

However, ogg/flac streams are still missing chained stream metadata. This is due to a different ways that FFmpeg parses chained ogg/flac bitstream. A patch has already been submitted and will hopefully be applied at some point.