### PR TITLE
Make encoders thread safe, cleanup mp3 encoder.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -111,6 +111,7 @@ Fixed:
   prevent listening socket from being re-created on listener disconnection (#2556)
 - Fixed race condition when switching `input.ffmpeg`-based urls (#2956)
 - Fixed deadlock in `%external` encoder (#3029)
+- Fixed crash in encoders due to concurrent access (#3064)
 
 ---
 

--- a/dune-project
+++ b/dune-project
@@ -96,7 +96,7 @@
     (gstreamer (< 0.3.1))
     (inotify (< 1.0))
     (ladspa (< 0.2.0))
-    (lame (< 0.3.5))
+    (lame (< 0.3.7))
     (lastfm (< 0.3.0))
     (lo (< 0.2.0))
     (liquidsoap (< 2.2.0))

--- a/liquidsoap.opam
+++ b/liquidsoap.opam
@@ -100,7 +100,7 @@ conflicts: [
   "gstreamer" {< "0.3.1"}
   "inotify" {< "1.0"}
   "ladspa" {< "0.2.0"}
-  "lame" {< "0.3.5"}
+  "lame" {< "0.3.7"}
   "lastfm" {< "0.3.0"}
   "lo" {< "0.2.0"}
   "liquidsoap" {< "2.2.0"}

--- a/src/core/encoder/lame_encoder.ml
+++ b/src/core/encoder/lame_encoder.ml
@@ -25,54 +25,6 @@
 open Encoder
 open Mp3_format
 
-let bit_at s pos =
-  let byte_pos = min (String.length s) (pos / 8) in
-  let byte = int_of_char s.[byte_pos] in
-  let bit_pos = 7 - (pos mod 8) in
-  (byte land (1 lsl bit_pos)) lsr bit_pos == 1
-
-type id3v2 = Waiting | Rendered of Strings.t | Done
-
-(* Notation: XYZ; X: copyright bit, Y: original bit, Z: private bit
- *           !: negation
- *
- * Coding: 1XY
- *         0ZT
- *         1UV
- *         etc..
- *
- * Synchronisation: at end of character:
- *         0XY
- *         1ZT
- *         1!Z!T <- Mark end
- *         0UV
- *
- * Or:     1XY
- *         0ZT
- *         0!Z!T <- Mark end
- *         1UV
- *
- * At beginning, previous bit is assumed to be 010 (Lame's default).
- * Thus, initial synchronisation bit is 001.
- *
- * Note: messages are strings. Hence, length is always even :-) *)
-
-let state = ref false
-
-(* Set s!T!Z, negating s _after_ *)
-let sync enc =
-  Lame.set_copyright enc !state;
-  Lame.set_original enc (not (Lame.get_original enc));
-  Lame.set_private enc (not (Lame.get_private enc));
-  state := !state
-
-(* Set sXY, negating s _before_ *)
-let bset enc x y =
-  state := not !state;
-  Lame.set_copyright enc !state;
-  Lame.set_original enc x;
-  Lame.set_private enc y
-
 let () =
   let create_encoder mp3 =
     let enc = Lame.create_encoder () in
@@ -119,65 +71,46 @@ let () =
             apply_constaints enc c
     end;
     Lame.set_out_samplerate enc (Lazy.force mp3.Mp3_format.samplerate);
+    Lame.set_bWriteVbrTag enc false;
     Lame.init_params enc;
     enc
   in
   let mp3_encoder mp3 metadata =
     let enc = create_encoder mp3 in
-    let id3v2 = ref Waiting in
-    let has_started = ref false in
-    let position = ref 0 in
-    let msg_position = ref 0 in
-    let msg_interval = Frame.audio_of_seconds mp3.Mp3_format.msg_interval in
-    let msg = Printf.sprintf "%s%c" mp3.Mp3_format.msg '\000' in
-    let msg_len = String.length msg * 8 in
-    let is_sync = ref true in
-    sync enc;
     let channels = if mp3.Mp3_format.stereo then 2 else 1 in
+    (* Lame accepts data of a fixed length.. *)
+    let frame_size = Frame.main_of_audio (Lame.frame_size enc) in
+    let pending_data =
+      Generator.create
+        (Frame.Fields.make
+           ~audio:(Content.Audio.format_of_channels channels)
+           ())
+    in
+    let encoded = Strings.Mutable.empty () in
+    (match mp3.id3v2 with
+      | Some f -> Strings.Mutable.add encoded (f metadata)
+      | None -> ());
     let encode frame start len =
       let b = AFrame.pcm frame in
-      let len = Frame.audio_of_main len in
-      let start = Frame.audio_of_main start in
-      position := !position + len;
-      if mp3.Mp3_format.msg <> "" && !position > msg_interval then (
-        match !is_sync with
-          | false ->
-              sync enc;
-              is_sync := true
-          | true ->
-              position := 0;
-              bset enc (bit_at msg !msg_position)
-                (bit_at msg (!msg_position + 1));
-              msg_position := (!msg_position + 2) mod msg_len;
-              if !msg_position mod 8 = 0 then is_sync := false);
-      let encoded () =
-        has_started := true;
-
-        if channels = 1 then
-          Lame.encode_buffer_float_part enc b.(0) b.(0) start len
-        else Lame.encode_buffer_float_part enc b.(0) b.(1) start len
-      in
-      match !id3v2 with
-        | Rendered s when not !has_started ->
-            id3v2 := Done;
-            Strings.add s (encoded ())
-        | _ -> Strings.of_string (encoded ())
+      Generator.put pending_data Frame.Fields.audio
+        (Content.sub (Content.Audio.lift_data b) start len);
+      while Generator.length pending_data > frame_size do
+        let pcm =
+          Content.Audio.get_data
+            (Frame.Fields.find Frame.Fields.audio
+               (Generator.get ~length:frame_size pending_data))
+        in
+        Strings.Mutable.add encoded
+          (if channels = 1 then
+             Lame.encode_buffer_float_part enc pcm.(0) pcm.(0) 0
+               (Array.length pcm.(0))
+           else
+             Lame.encode_buffer_float_part enc pcm.(0) pcm.(1) 0
+               (Array.length pcm.(0)))
+      done;
+      Strings.Mutable.flush encoded
     in
     let stop () = Strings.of_string (Lame.encode_flush enc) in
-    let insert_metadata =
-      match mp3.id3v2 with
-        | Some f -> (
-            fun (* Only insert metadata at the beginning.. *)
-                  m ->
-              match !id3v2 with
-                | Waiting ->
-                    if not (Meta_format.is_empty m) then
-                      id3v2 := Rendered (Strings.of_string (f m))
-                | _ -> ())
-        | None -> fun _ -> ()
-    in
-    (* Try to insert initial metadata now.. *)
-    insert_metadata metadata;
     let hls =
       {
         Encoder.init_encode = (fun f o l -> (None, encode f o l));
@@ -187,7 +120,13 @@ let () =
         video_size = (fun () -> None);
       }
     in
-    { insert_metadata; hls; encode; header = Strings.empty; stop }
+    {
+      insert_metadata = (fun _ -> ());
+      hls;
+      encode;
+      header = Strings.empty;
+      stop;
+    }
   in
   Plug.register Encoder.plug "lame" ~doc:"LAME mp3 encoder." (function
     | Encoder.MP3 mp3 -> Some (fun _ meta -> mp3_encoder mp3 meta)

--- a/src/core/encoder_formats/mp3_format.ml
+++ b/src/core/encoder_formats/mp3_format.ml
@@ -68,8 +68,6 @@ type t = {
   internal_quality : int;
   samplerate : int Lazy.t;
   id3v2 : id3v2_export option;
-  msg_interval : float;
-  msg : string;
 }
 
 let id3v2_export : id3v2_export option ref = ref None

--- a/src/core/lang_encoders/lang_mp3.ml
+++ b/src/core/lang_encoders/lang_mp3.ml
@@ -50,8 +50,6 @@ let mp3_base_defaults () =
     bitrate_control = Mp3_format.CBR 128;
     internal_quality = 2;
     id3v2 = None;
-    msg_interval = 0.1;
-    msg = "";
   }
 
 let mp3_base f = function
@@ -73,10 +71,6 @@ let mp3_base f = function
         Lang_encoder.raise_error ~pos
           "internal quality must be a value between 0 and 9";
       { f with Mp3_format.internal_quality = q }
-  | "msg_interval", `Value { value = Ground (Float i); _ } ->
-      { f with Mp3_format.msg_interval = i }
-  | "msg", `Value { value = Ground (String m); _ } ->
-      { f with Mp3_format.msg = m }
   | "samplerate", `Value { value = Ground (Int i); pos } ->
       { f with Mp3_format.samplerate = check_samplerate ~pos (Lazy.from_val i) }
   | "id3v2", `Value { value = Ground (Bool true); pos } -> (


### PR DESCRIPTION
Some encoder methods where never protected from concurrent access, leading to hard-to-track crashes due to concurrent calls such as a `stop` when an encoding was already happening..

This should fix: #3038 and probably other previously reported issues/discussions that I cannot find right now.