### PR TITLE
Add decoder parameters to the ffmpeg stream and file decoders

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,8 @@ New:
 - Added support for the proprietary shared stereotool library (#2953)
 - Added `video.align`.
 - Added `string.index`.
+- Added support for ffmpeg decoder parameters to allow decoding of
+  raw PCM stream and file (#3066)
 - Added support for unit interactive variables: those call a handler when their
   value is set.
 - Added support for id3v2 `v2.2.0` frames and pictures.

--- a/doc/content/cookbook.md
+++ b/doc/content/cookbook.md
@@ -103,6 +103,33 @@ output.file(%vorbis, output,fallible=true,
                      on_stop=shutdown,source)
 ```
 
+## Transmitting signal
+
+It is possible to send raw PCM signal between two instances using the [FFmpeg encoder](ffmpeg.html). Here's an example using
+the SRT transport protocol:
+
+Sender:
+
+```liquidsoap
+enc = %ffmpeg(
+  format="s16le",
+  %audio(
+    codec="pcm_s16le",
+    ac=2,
+    ar=48000
+  )
+)
+output.srt(enc, s)
+```
+
+Receiver:
+
+```liquidsoap
+s = input.srt(
+  content_type="application/ffmpeg;format=s16le,ch_layout=stereo,sample_rate=48000"
+)
+```
+
 ## Scheduling
 
 ```liquidsoap

--- a/doc/content/replay_gain.md
+++ b/doc/content/replay_gain.md
@@ -56,7 +56,7 @@ behind some `request.dynamic.list` operator. If you are using the
 Protocols can be chained, for instance:
 
 ```
-annotate:foo=\"bar":replaygain:/path/to/file.mp3
+annotate:foo="bar":replaygain:/path/to/file.mp3
 ```
 
 ### Applying replay gain information

--- a/src/core/builtins/builtins_files.ml
+++ b/src/core/builtins/builtins_files.ml
@@ -459,6 +459,12 @@ let () =
           ignore
             (Lang.add_builtin ~base:file_metadata name ~category:`File
                [
+                 ( "metadata",
+                   Lang.metadata_t,
+                   Some (Lang.list []),
+                   Some
+                     "Optional metadata used to decode the file, e.g. \
+                      `ffmpeg_options`." );
                  ( "",
                    Lang.string_t,
                    None,
@@ -469,7 +475,8 @@ let () =
                  ("Read metadata from a file using the " ^ name ^ " decoder.")
                (fun p ->
                  let uri = Lang.to_string (List.assoc "" p) in
-                 let m = try decoder uri with _ -> [] in
+                 let metadata = Lang.to_metadata (List.assoc "metadata" p) in
+                 let m = try decoder ~metadata uri with _ -> [] in
                  let m =
                    List.map (fun (k, v) -> (String.lowercase_ascii k, v)) m
                  in

--- a/src/core/builtins/builtins_request.ml
+++ b/src/core/builtins/builtins_request.ml
@@ -181,12 +181,12 @@ let _ =
 let _ =
   Lang.add_builtin ~base:request "duration" ~category:`Liquidsoap
     [
-      ("", Lang.string_t, None, None);
-      ( "",
+      ( "metadata",
         Lang.metadata_t,
         Some (Lang.list []),
         Some "Optional metadata used to decode the file, e.g. `ffmpeg_options`."
       );
+      ("", Lang.string_t, None, None);
     ]
     (Lang.nullable_t Lang.float_t)
     ~descr:

--- a/src/core/builtins/builtins_request.ml
+++ b/src/core/builtins/builtins_request.ml
@@ -180,7 +180,14 @@ let _ =
 
 let _ =
   Lang.add_builtin ~base:request "duration" ~category:`Liquidsoap
-    [("", Lang.string_t, None, None)]
+    [
+      ("", Lang.string_t, None, None);
+      ( "",
+        Lang.metadata_t,
+        Some (Lang.list []),
+        Some "Optional metadata used to decode the file, e.g. `ffmpeg_options`."
+      );
+    ]
     (Lang.nullable_t Lang.float_t)
     ~descr:
       "Compute the duration in seconds of audio data contained in a request. \
@@ -188,7 +195,8 @@ let _ =
        typically if the file was not recognized as valid audio."
     (fun p ->
       let f = Lang.to_string (List.assoc "" p) in
-      try Lang.float (Request.duration f) with _ -> Lang.null)
+      let metadata = Lang.to_metadata (List.assoc "metadata" p) in
+      try Lang.float (Request.duration ~metadata f) with _ -> Lang.null)
 
 let _ =
   Lang.add_builtin ~base:request "id" ~category:`Liquidsoap

--- a/src/core/builtins/builtins_resolvers.ml
+++ b/src/core/builtins/builtins_resolvers.ml
@@ -23,7 +23,11 @@
 let decoder_metadata = Lang.add_module ~base:Modules.decoder "metadata"
 
 let _ =
-  let resolver_t = Lang.fun_t [(false, "", Lang.string_t)] Lang.metadata_t in
+  let resolver_t =
+    Lang.fun_t
+      [(false, "metadata", Lang.metadata_t); (false, "", Lang.string_t)]
+      Lang.metadata_t
+  in
   Lang.add_builtin ~base:decoder_metadata "add" ~category:`Liquidsoap
     ~descr:"Register an external file metadata decoder."
     [
@@ -39,8 +43,11 @@ let _ =
     (fun p ->
       let format = Lang.to_string (Lang.assoc "" 1 p) in
       let f = Lang.assoc "" 2 p in
-      let resolver name =
-        let ret = Lang.apply f [("", Lang.string name)] in
+      let resolver ~metadata name =
+        let ret =
+          Lang.apply f
+            [("metadata", Lang.metadata metadata); ("", Lang.string name)]
+        in
         let ret = Lang.to_list ret in
         let ret = List.map Lang.to_product ret in
         let ret =

--- a/src/core/decoder/aac_decoder.ml
+++ b/src/core/decoder/aac_decoder.ml
@@ -144,7 +144,7 @@ let aac_priority =
     "Priority for the AAC decoder" ~d:1
 
 (* Get the number of channels of audio in an AAC file. *)
-let file_type ~ctype:_ filename =
+let file_type ~metadata:_ ~ctype:_ filename =
   let fd = Unix.openfile filename [Unix.O_RDONLY; Unix.O_CLOEXEC] 0o644 in
   Tutils.finalize
     ~k:(fun () -> Unix.close fd)
@@ -223,7 +223,7 @@ let create_decoder input =
   { Decoder.decode; seek }
 
 (* Get the number of channels of audio in an MP4 file. *)
-let file_type ~ctype:_ filename =
+let file_type ~metadata:_ ~ctype:_ filename =
   let dec = Faad.create () in
   let fd = Unix.openfile filename [Unix.O_RDONLY; Unix.O_CLOEXEC] 0o644 in
   Tutils.finalize
@@ -276,7 +276,7 @@ let () =
 
 let log = Log.make ["metadata"; "mp4"]
 
-let get_tags file =
+let get_tags ~metadata:_ file =
   if
     not
       (Decoder.test_file ~log ~mimes:mp4_mime_types#get

--- a/src/core/decoder/decoder.mli
+++ b/src/core/decoder/decoder.mli
@@ -88,7 +88,11 @@ type decoder_specs = {
    * None means accept all mime-types. *)
   mime_types : unit -> string list option;
   (* None means no decodable content for that file. *)
-  file_type : ctype:Frame.content_type -> string -> Frame.content_type option;
+  file_type :
+    metadata:Frame.metadata ->
+    ctype:Frame.content_type ->
+    string ->
+    Frame.content_type option;
   file_decoder : file_decoder option;
   (* String argument is the full mime-type. *)
   stream_decoder : (ctype:Frame.content_type -> string -> stream_decoder) option;

--- a/src/core/decoder/external_decoder.ml
+++ b/src/core/decoder/external_decoder.ml
@@ -114,13 +114,14 @@ let register_stdin ~name ~doc ~priority ~mimes ~file_extensions ~test process =
       priority = (fun () -> priority);
       file_extensions = (fun () -> file_extensions);
       mime_types = (fun () -> mimes);
-      file_type = (fun ~ctype:_ filename -> test_ctype test filename);
+      file_type =
+        (fun ~metadata:_ ~ctype:_ filename -> test_ctype test filename);
       file_decoder =
         Some (fun ~metadata:_ ~ctype filename -> create process ctype filename);
       stream_decoder = Some (fun ~ctype:_ _ -> create_stream process);
     };
 
-  let duration filename =
+  let duration ~metadata:_ filename =
     let process =
       Printf.sprintf "cat %s | %s" (Filename.quote filename) process
     in
@@ -186,7 +187,8 @@ let register_oblivious ~name ~doc ~priority ~mimes ~file_extensions ~test
       priority = (fun () -> priority);
       file_extensions = (fun () -> file_extensions);
       mime_types = (fun () -> mimes);
-      file_type = (fun ~ctype:_ filename -> test_ctype test filename);
+      file_type =
+        (fun ~metadata:_ ~ctype:_ filename -> test_ctype test filename);
       file_decoder =
         Some
           (fun ~metadata:_ ~ctype:_ filename ->
@@ -194,5 +196,5 @@ let register_oblivious ~name ~doc ~priority ~mimes ~file_extensions ~test
       stream_decoder = None;
     };
 
-  let duration filename = duration (process filename) in
+  let duration ~metadata:_ filename = duration (process filename) in
   Plug.register Request.dresolvers name ~doc duration

--- a/src/core/decoder/ffmpeg_decoder.ml
+++ b/src/core/decoder/ffmpeg_decoder.ml
@@ -534,8 +534,8 @@ let duration ~metadata file =
   let opts = Hashtbl.create 10 in
   List.iter (fun (k, v) -> Hashtbl.add opts k v) args;
   let container = Av.open_input ?format ~opts file in
-  Tutils.finalize
-    ~k:(fun () -> Av.close container)
+  Fun.protect
+    ~finally:(fun () -> Av.close container)
     (fun () ->
       let duration = Av.get_input_duration container ~format:`Millisecond in
       Option.map (fun d -> Int64.to_float d /. 1000.) duration)
@@ -553,8 +553,8 @@ let get_tags ~metadata file =
   let opts = Hashtbl.create 10 in
   List.iter (fun (k, v) -> Hashtbl.add opts k v) args;
   let container = Av.open_input ?format ~opts file in
-  Tutils.finalize
-    ~k:(fun () -> Av.close container)
+  Fun.protect
+    ~finally:(fun () -> Av.close container)
     (fun () ->
       (* For now we only add the metadata from the best audio track *)
       let audio_tags =
@@ -1033,8 +1033,8 @@ let get_file_type ~metadata ~ctype filename =
         let opts = Hashtbl.create 10 in
         List.iter (fun (k, v) -> Hashtbl.add opts k v) args;
         let container = Av.open_input ?format ~opts filename in
-        Tutils.finalize
-          ~k:(fun () -> Av.close container)
+        Fun.protect
+          ~finally:(fun () -> Av.close container)
           (fun () -> get_type ~ctype ~url:filename container)
 
 let () =

--- a/src/core/decoder/flac_metadata_plug.ml
+++ b/src/core/decoder/flac_metadata_plug.ml
@@ -39,7 +39,7 @@ let file_extensions =
     "File extensions used for decoding metadata using native FLAC parser."
     ~d:["flac"]
 
-let get_tags parse fname =
+let get_tags ~metadata:_ parse fname =
   try
     if
       not

--- a/src/core/decoder/id3_plug.ml
+++ b/src/core/decoder/id3_plug.ml
@@ -55,7 +55,7 @@ let file_extensions =
      parser"
     ~d:["mp3"; "wav"]
 
-let get_tags parse fname =
+let get_tags ~metadata:_ parse fname =
   try
     if
       not

--- a/src/core/decoder/image_decoder.ml
+++ b/src/core/decoder/image_decoder.ml
@@ -154,7 +154,7 @@ let () =
       file_extensions = (fun () -> None);
       mime_types = (fun () -> None);
       file_type =
-        (fun ~ctype filename ->
+        (fun ~metadata:_ ~ctype filename ->
           if
             Decoder.get_image_file_decoder filename <> None
             && is_audio_compatible ctype && is_video_compatible ctype

--- a/src/core/decoder/image_plug.ml
+++ b/src/core/decoder/image_plug.ml
@@ -40,7 +40,7 @@ let file_extensions =
     "File extensions used for decoding metadata using native parser."
     ~d:["png"; "jpg"; "jpeg"]
 
-let get_tags fname =
+let get_tags ~metadata:_ fname =
   try
     if
       not

--- a/src/core/decoder/liq_flac_decoder.ml
+++ b/src/core/decoder/liq_flac_decoder.ml
@@ -142,14 +142,14 @@ let () =
       priority = (fun () -> priority#get);
       file_extensions = (fun () -> Some file_extensions#get);
       mime_types = (fun () -> Some mime_types#get);
-      file_type = (fun ~ctype:_ filename -> file_type filename);
+      file_type = (fun ~metadata:_ ~ctype:_ filename -> file_type filename);
       file_decoder = Some file_decoder;
       stream_decoder = Some (fun ~ctype:_ _ -> create_decoder);
     }
 
 let log = Log.make ["metadata"; "flac"]
 
-let get_tags file =
+let get_tags ~metadata:_ file =
   if
     not
       (Decoder.test_file ~log ~mimes:mime_types#get
@@ -174,7 +174,7 @@ let check filename =
           true
         with _ -> false)
 
-let duration file =
+let duration ~metadata:_ file =
   if not (check file) then raise Not_found;
   let fd = Unix.openfile file [Unix.O_RDONLY; Unix.O_CLOEXEC] 0o640 in
   Tutils.finalize

--- a/src/core/decoder/liq_ogg_decoder.ml
+++ b/src/core/decoder/liq_ogg_decoder.ml
@@ -229,7 +229,7 @@ let create_decoder ?(merge_tracks = false) source input =
 
 (** File decoder *)
 
-let file_type ~ctype:_ filename =
+let file_type ~metadata:_ ~ctype:_ filename =
   let decoder, fd = Ogg_decoder.init_from_file ~log:demuxer_log filename in
   let tracks = Ogg_decoder.get_standard_tracks decoder in
   Tutils.finalize
@@ -300,7 +300,7 @@ let () =
 
 (** Metadata *)
 
-let get_tags file =
+let get_tags ~metadata:_ file =
   if
     not
       (Decoder.test_file ~log ~mimes:mime_types#get

--- a/src/core/decoder/mad_decoder.ml
+++ b/src/core/decoder/mad_decoder.ml
@@ -175,7 +175,7 @@ let () =
       priority = (fun () -> priority#get);
       file_extensions = (fun () -> Some file_extensions#get);
       mime_types = (fun () -> Some mime_types#get);
-      file_type = (fun ~ctype:_ f -> file_type f);
+      file_type = (fun ~metadata:_ ~ctype:_ f -> file_type f);
       file_decoder = Some create_file_decoder;
       stream_decoder = Some (fun ~ctype:_ _ -> create_decoder);
     }
@@ -189,7 +189,7 @@ let check filename =
           true
         with _ -> false)
 
-let duration file =
+let duration ~metadata:_ file =
   if not (check file) then raise Not_found;
   let ans = Mad.duration file in
   match ans with 0. -> raise Not_found | _ -> ans

--- a/src/core/decoder/midi_decoder.ml
+++ b/src/core/decoder/midi_decoder.ml
@@ -67,7 +67,7 @@ let () =
       file_extensions = (fun () -> Some ["mid"]);
       mime_types = (fun () -> Some ["audio/midi"]);
       file_type =
-        (fun ~ctype:_ _ ->
+        (fun ~metadata:_ ~ctype:_ _ ->
           Some
             (Frame.Fields.make
                ~midi:Content.(Midi.lift_params { Content.channels = 16 })

--- a/src/core/decoder/ogg_flac_duration.ml
+++ b/src/core/decoder/ogg_flac_duration.ml
@@ -22,7 +22,7 @@
 
 (** Read duration of ogg/flac files. *)
 
-let duration file =
+let duration ~metadata:_ file =
   let sync, fd = Ogg.Sync.create_from_file file in
   Tutils.finalize
     ~k:(fun () -> Unix.close fd)

--- a/src/core/decoder/ogg_metadata_plug.ml
+++ b/src/core/decoder/ogg_metadata_plug.ml
@@ -39,7 +39,7 @@ let file_extensions =
     "File extensions used for decoding metadata using native ogg parser."
     ~d:["ogg"]
 
-let get_tags parse fname =
+let get_tags ~metadata:_ parse fname =
   try
     if
       not

--- a/src/core/decoder/raw_audio_decoder.ml
+++ b/src/core/decoder/raw_audio_decoder.ml
@@ -153,7 +153,7 @@ let () =
       priority = (fun () -> 1);
       file_extensions = (fun () -> None);
       mime_types = (fun () -> Some ["audio/x-raw"]);
-      file_type = (fun ~ctype:_ _ -> None);
+      file_type = (fun ~metadata:_ ~ctype:_ _ -> None);
       file_decoder = None;
       stream_decoder =
         Some

--- a/src/core/decoder/srt_decoder.ml
+++ b/src/core/decoder/srt_decoder.ml
@@ -47,7 +47,7 @@ let () =
       file_extensions = (fun () -> Some srt_file_extensions#get);
       mime_types = (fun () -> Some srt_mime_types#get);
       file_type =
-        (fun ~ctype fname ->
+        (fun ~metadata:_ ~ctype fname ->
           if Srt_parser.check_file fname then
             Some
               (Frame.Fields.make

--- a/src/core/decoder/taglib_plug.ml
+++ b/src/core/decoder/taglib_plug.ml
@@ -55,7 +55,7 @@ let tag_aliases = [("track", "tracknumber")]
 
 (** We used to force the format. However, now that we check extensions, taglib's
   * automatic format detection should work. *)
-let get_tags fname =
+let get_tags ~metadata:_ fname =
   try
     if
       not

--- a/src/core/decoder/video_plug.ml
+++ b/src/core/decoder/video_plug.ml
@@ -40,7 +40,7 @@ let file_extensions =
     "File extensions used for decoding metadata using native parser."
     ~d:["avi"; "mp4"]
 
-let get_tags fname =
+let get_tags ~metadata:_ fname =
   try
     if
       not

--- a/src/core/decoder/vorbisduration.ml
+++ b/src/core/decoder/vorbisduration.ml
@@ -22,7 +22,7 @@
 
 (** Read duration of ogg/vorbis files. *)
 
-let duration file =
+let duration ~metadata:_ file =
   let dec, fd = Vorbis.File.Decoder.openfile file in
   Tutils.finalize
     ~k:(fun () -> Unix.close fd)

--- a/src/core/decoder/wav_aiff_decoder.ml
+++ b/src/core/decoder/wav_aiff_decoder.ml
@@ -116,7 +116,7 @@ let create ?header input =
 
 (* File decoding *)
 
-let file_type ~ctype:_ filename =
+let file_type ~metadata:_ ~ctype:_ filename =
   let header = Wav_aiff.fopen filename in
   Tutils.finalize
     ~k:(fun () -> Wav_aiff.close header)
@@ -216,7 +216,7 @@ let () =
     }
 
 let () =
-  let duration file =
+  let duration ~metadata:_ file =
     let w = Wav_aiff.fopen file in
     let ret = Wav_aiff.duration w in
     Wav_aiff.close w;
@@ -243,7 +243,7 @@ let () =
       priority = (fun () -> basic_priorities#get);
       file_extensions = (fun () -> None);
       mime_types = (fun () -> Some basic_mime_types#get);
-      file_type = (fun ~ctype:_ _ -> None);
+      file_type = (fun ~metadata:_ ~ctype:_ _ -> None);
       file_decoder = None;
       stream_decoder =
         Some (fun ~ctype:_ _ -> create ~header:(`Wav, 8, 2, 8000, -1));

--- a/src/core/request.ml
+++ b/src/core/request.ml
@@ -159,11 +159,11 @@ let dresolvers = Plug.create ~doc:dresolvers_doc "audio file formats (duration)"
 
 exception Duration of float
 
-let duration file =
+let duration ~metadata file =
   try
     Plug.iter dresolvers (fun _ resolver ->
         try
-          let ans = resolver file in
+          let ans = resolver ~metadata file in
           raise (Duration ans)
         with
           | Duration e -> raise (Duration e)
@@ -327,7 +327,7 @@ let read_metadata t =
       List.iter
         (fun (_, resolver) ->
           try
-            let ans = resolver name in
+            let ans = resolver ~metadata:indicator.metadata name in
             List.iter
               (fun (k, v) ->
                 let k = String.lowercase_ascii k in
@@ -337,7 +337,7 @@ let read_metadata t =
             if conf_duration#get && get_metadata t "duration" = None then (
               try
                 Hashtbl.replace indicator.metadata "duration"
-                  (string_of_float (duration name))
+                  (string_of_float (duration ~metadata:indicator.metadata name))
               with Not_found -> ())
           with _ -> ())
         (get_decoders conf_metadata_decoders mresolvers))

--- a/src/core/request.mli
+++ b/src/core/request.mli
@@ -175,10 +175,10 @@ val on_air : t -> unit
 (** Query whether a request is currently being streamed. *)
 val is_on_air : t -> bool
 
-(** [duration filename] computes the duration of audio data contained in
+(** [duration ~metadata filename] computes the duration of audio data contained in
     [filename]. The computation may be expensive.
     @raise Not_found if no duration computation method is found. *)
-val duration : string -> float
+val duration : metadata:Frame.metadata -> string -> float
 
 (** Return a decoder if the file has been resolved, guaranteed to have
     available data to deliver. *)
@@ -187,11 +187,12 @@ val get_decoder : t -> Decoder.file_decoder_ops option
 (** {1 Plugs} *)
 
 (** Functions for computing duration. *)
-val dresolvers : (string -> float) Plug.t
+val dresolvers : (metadata:Frame.metadata -> string -> float) Plug.t
 
 (** Functions for resolving metadata. Metadata filling isn't included in Decoder
     because we want it to occur immediately after request resolution. *)
-val mresolvers : (string -> (string * string) list) Plug.t
+val mresolvers :
+  (metadata:Frame.metadata -> string -> (string * string) list) Plug.t
 
 (** Functions for resolving URIs. *)
 val protocols : protocol Plug.t

--- a/src/core/tools/liqfm.ml
+++ b/src/core/tools/liqfm.ml
@@ -135,7 +135,10 @@ let init host =
                 match request with
                   | Some s -> (
                       match Request.get_filename s with
-                        | Some file -> Request.duration file
+                        | Some file ->
+                            Request.duration
+                              ~metadata:(Request.get_all_metadata s)
+                              file
                         | None -> raise Not_found)
                   | None -> raise Not_found
               with

--- a/src/core/tools/log.ml
+++ b/src/core/tools/log.ml
@@ -43,12 +43,19 @@ let make path : t =
     }
   in
   let log = Dtools.Log.make path in
-  object
+  object (self)
     (** Is that level active (i.e. will it print logs) *)
     method active lvl = log#active lvl
 
     (** Logging function. *)
-    method f : 'a. int -> ('a, unit, string, unit) format4 -> 'a = log#f
+    method f : 'a. int -> ('a, unit, string, unit) format4 -> 'a =
+      function
+      | 1 -> self#critical
+      | 2 -> self#severe
+      | 3 -> self#important
+      | 4 -> self#info
+      | 5 -> self#debug
+      | v -> log#f v
 
     (** The program will not function after that. *)
     method critical : 'a. ('a, unit, string, unit) format4 -> 'a =

--- a/src/core/tools/utils.ml
+++ b/src/core/tools/utils.ml
@@ -25,8 +25,8 @@
    as severe otherwise. Backtrace should be captured as early
    as possible. *)
 let log_exception ~(log : Log.t) ~bt msg =
-  if log#active 4 (* info *) then log#info "%s\n%s" msg bt
-  else log#severe "%s" msg
+  log#severe "%s" msg;
+  if log#active 4 (* info *) then log#info "%s" bt
 
 (* Force locale to C *)
 external force_locale : unit -> unit = "liquidsoap_set_locale" [@@noalloc]

--- a/src/lang/parser.mly
+++ b/src/lang/parser.mly
@@ -111,6 +111,9 @@ open Parser_helper
 %start time_predicate
 %type <Term.t> time_predicate
 
+%start plain_encoder_params
+%type <Parser_helper.encoder_param list> plain_encoder_params
+
 %type <Parser_helper.let_decoration> _let
 %type <string> annotate_key
 %type <(string * string) list> annotate_metadata
@@ -546,6 +549,9 @@ encoder_params:
   |                                    { [] }
   | encoder_param                      { [$1] }
   | encoder_param COMMA encoder_params { $1::$3 }
+
+plain_encoder_params:
+  | LPAR encoder_params RPAR { $2 }
 
 record:
   | VAR GETS expr {

--- a/src/libs/externals.liq
+++ b/src/libs/externals.liq
@@ -180,7 +180,7 @@ def enable_external_flac_decoder() =
   if file.which(metaflac) != null() then
     log(label="decoder.external","Enabling EXTERNAL_FLAC metadata \
                 resolver.")
-    def flac_meta(fname)
+    def flac_meta(~metadata=_, fname)
       ret = process.read.lines("#{metaflac} --export-tags-to=- \
                    #{process.quote(fname)}")
       ret = list.map(r/=/.split, ret)
@@ -273,7 +273,7 @@ def enable_external_faad_decoder() =
     end
     decoder.oblivious.add(name="EXTERNAL_FAAD",description="Decode files using \
                           the faad binary.", test=test_faad, faad_p)
-    def faad_meta(file) =
+    def faad_meta(~metadata=_, file) =
       if faad_test(file) then
         ret = process.read.lines("#{faad} -i #{process.quote(file)} 2>&1")
         # Yea, this is ugly programming (again)!

--- a/src/libs/replaygain.liq
+++ b/src/libs/replaygain.liq
@@ -51,7 +51,7 @@ end
 # `replaygain:` protocol.
 # @category Liquidsoap
 def enable_replaygain_metadata()
-  def replaygain_metadata(fname)
+  def replaygain_metadata(~metadata=_, fname)
     gain = file.replaygain(fname)
     if null.defined(gain) then
       [("replaygain_track_gain","#{null.get(gain)} dB")]

--- a/src/runtime/main.ml
+++ b/src/runtime/main.ml
@@ -187,7 +187,9 @@ let process_request s =
         begin
           try
             Printf.printf "%.2f s\n"
-              (Request.duration (Option.get (Request.get_filename req)))
+              (Request.duration
+                 ~metadata:(Request.get_all_metadata req)
+                 (Option.get (Request.get_filename req)))
           with Not_found -> Printf.printf "failed\n"
         end;
         Request.destroy req

--- a/tests/harbor/dune.inc
+++ b/tests/harbor/dune.inc
@@ -4,7 +4,6 @@
  (package liquidsoap)
  (deps
   http3.liq
-  ../media/all_media_files
   ../../src/bin/liquidsoap.exe
   (package liquidsoap)
   (:stdlib ../../src/libs/stdlib.liq)
@@ -17,7 +16,6 @@
  (package liquidsoap)
  (deps
   http2.liq
-  ../media/all_media_files
   ../../src/bin/liquidsoap.exe
   (package liquidsoap)
   (:stdlib ../../src/libs/stdlib.liq)
@@ -30,7 +28,6 @@
  (package liquidsoap)
  (deps
   http.liq
-  ../media/all_media_files
   ../../src/bin/liquidsoap.exe
   (package liquidsoap)
   (:stdlib ../../src/libs/stdlib.liq)
@@ -43,7 +40,6 @@
  (package liquidsoap)
  (deps
   put.liq
-  ../media/all_media_files
   ../../src/bin/liquidsoap.exe
   (package liquidsoap)
   (:stdlib ../../src/libs/stdlib.liq)
@@ -56,7 +52,6 @@
  (package liquidsoap)
  (deps
   post.liq
-  ../media/all_media_files
   ../../src/bin/liquidsoap.exe
   (package liquidsoap)
   (:stdlib ../../src/libs/stdlib.liq)

--- a/tests/language/dune.inc
+++ b/tests/language/dune.inc
@@ -4,7 +4,6 @@
  (package liquidsoap)
  (deps
   rec.liq
-  ../media/all_media_files
   ../../src/bin/liquidsoap.exe
   (package liquidsoap)
   (:stdlib ../../src/libs/stdlib.liq)
@@ -17,7 +16,6 @@
  (package liquidsoap)
  (deps
   loop.liq
-  ../media/all_media_files
   ../../src/bin/liquidsoap.exe
   (package liquidsoap)
   (:stdlib ../../src/libs/stdlib.liq)
@@ -30,7 +28,6 @@
  (package liquidsoap)
  (deps
   type_errors.liq
-  ../media/all_media_files
   ../../src/bin/liquidsoap.exe
   (package liquidsoap)
   (:stdlib ../../src/libs/stdlib.liq)
@@ -43,7 +40,6 @@
  (package liquidsoap)
  (deps
   thread.liq
-  ../media/all_media_files
   ../../src/bin/liquidsoap.exe
   (package liquidsoap)
   (:stdlib ../../src/libs/stdlib.liq)
@@ -56,7 +52,6 @@
  (package liquidsoap)
  (deps
   process.liq
-  ../media/all_media_files
   ../../src/bin/liquidsoap.exe
   (package liquidsoap)
   (:stdlib ../../src/libs/stdlib.liq)
@@ -69,7 +64,6 @@
  (package liquidsoap)
  (deps
   ref.liq
-  ../media/all_media_files
   ../../src/bin/liquidsoap.exe
   (package liquidsoap)
   (:stdlib ../../src/libs/stdlib.liq)
@@ -82,7 +76,6 @@
  (package liquidsoap)
  (deps
   conversions.liq
-  ../media/all_media_files
   ../../src/bin/liquidsoap.exe
   (package liquidsoap)
   (:stdlib ../../src/libs/stdlib.liq)
@@ -95,7 +88,6 @@
  (package liquidsoap)
  (deps
   regexp.liq
-  ../media/all_media_files
   ../../src/bin/liquidsoap.exe
   (package liquidsoap)
   (:stdlib ../../src/libs/stdlib.liq)
@@ -108,7 +100,6 @@
  (package liquidsoap)
  (deps
   null.liq
-  ../media/all_media_files
   ../../src/bin/liquidsoap.exe
   (package liquidsoap)
   (:stdlib ../../src/libs/stdlib.liq)
@@ -121,7 +112,6 @@
  (package liquidsoap)
  (deps
   math.liq
-  ../media/all_media_files
   ../../src/bin/liquidsoap.exe
   (package liquidsoap)
   (:stdlib ../../src/libs/stdlib.liq)
@@ -134,7 +124,6 @@
  (package liquidsoap)
  (deps
   socket.liq
-  ../media/all_media_files
   ../../src/bin/liquidsoap.exe
   (package liquidsoap)
   (:stdlib ../../src/libs/stdlib.liq)
@@ -147,7 +136,6 @@
  (package liquidsoap)
  (deps
   pp.liq
-  ../media/all_media_files
   ../../src/bin/liquidsoap.exe
   (package liquidsoap)
   (:stdlib ../../src/libs/stdlib.liq)
@@ -160,7 +148,6 @@
  (package liquidsoap)
  (deps
   error.liq
-  ../media/all_media_files
   ../../src/bin/liquidsoap.exe
   (package liquidsoap)
   (:stdlib ../../src/libs/stdlib.liq)
@@ -173,7 +160,6 @@
  (package liquidsoap)
  (deps
   string.liq
-  ../media/all_media_files
   ../../src/bin/liquidsoap.exe
   (package liquidsoap)
   (:stdlib ../../src/libs/stdlib.liq)
@@ -186,7 +172,6 @@
  (package liquidsoap)
  (deps
   stdlib.liq
-  ../media/all_media_files
   ../../src/bin/liquidsoap.exe
   (package liquidsoap)
   (:stdlib ../../src/libs/stdlib.liq)
@@ -199,7 +184,6 @@
  (package liquidsoap)
  (deps
   yaml.liq
-  ../media/all_media_files
   ../../src/bin/liquidsoap.exe
   (package liquidsoap)
   (:stdlib ../../src/libs/stdlib.liq)
@@ -212,7 +196,6 @@
  (package liquidsoap)
  (deps
   argsof.liq
-  ../media/all_media_files
   ../../src/bin/liquidsoap.exe
   (package liquidsoap)
   (:stdlib ../../src/libs/stdlib.liq)
@@ -225,7 +208,6 @@
  (package liquidsoap)
  (deps
   file.watch.liq
-  ../media/all_media_files
   ../../src/bin/liquidsoap.exe
   (package liquidsoap)
   (:stdlib ../../src/libs/stdlib.liq)
@@ -238,7 +220,6 @@
  (package liquidsoap)
  (deps
   interactive.liq
-  ../media/all_media_files
   ../../src/bin/liquidsoap.exe
   (package liquidsoap)
   (:stdlib ../../src/libs/stdlib.liq)
@@ -251,7 +232,6 @@
  (package liquidsoap)
  (deps
   predicate.liq
-  ../media/all_media_files
   ../../src/bin/liquidsoap.exe
   (package liquidsoap)
   (:stdlib ../../src/libs/stdlib.liq)
@@ -264,7 +244,6 @@
  (package liquidsoap)
  (deps
   file.liq
-  ../media/all_media_files
   ../../src/bin/liquidsoap.exe
   (package liquidsoap)
   (:stdlib ../../src/libs/stdlib.liq)
@@ -277,7 +256,6 @@
  (package liquidsoap)
  (deps
   getter.liq
-  ../media/all_media_files
   ../../src/bin/liquidsoap.exe
   (package liquidsoap)
   (:stdlib ../../src/libs/stdlib.liq)
@@ -290,7 +268,6 @@
  (package liquidsoap)
  (deps
   comments.liq
-  ../media/all_media_files
   ../../src/bin/liquidsoap.exe
   (package liquidsoap)
   (:stdlib ../../src/libs/stdlib.liq)
@@ -303,7 +280,6 @@
  (package liquidsoap)
  (deps
   pattern.liq
-  ../media/all_media_files
   ../../src/bin/liquidsoap.exe
   (package liquidsoap)
   (:stdlib ../../src/libs/stdlib.liq)
@@ -316,7 +292,6 @@
  (package liquidsoap)
  (deps
   list.liq
-  ../media/all_media_files
   ../../src/bin/liquidsoap.exe
   (package liquidsoap)
   (:stdlib ../../src/libs/stdlib.liq)
@@ -329,7 +304,6 @@
  (package liquidsoap)
  (deps
   mem_usage.liq
-  ../media/all_media_files
   ../../src/bin/liquidsoap.exe
   (package liquidsoap)
   (:stdlib ../../src/libs/stdlib.liq)
@@ -342,7 +316,6 @@
  (package liquidsoap)
  (deps
   metadata.liq
-  ../media/all_media_files
   ../../src/bin/liquidsoap.exe
   (package liquidsoap)
   (:stdlib ../../src/libs/stdlib.liq)
@@ -355,7 +328,6 @@
  (package liquidsoap)
  (deps
   file.watch2.liq
-  ../media/all_media_files
   ../../src/bin/liquidsoap.exe
   (package liquidsoap)
   (:stdlib ../../src/libs/stdlib.liq)
@@ -368,7 +340,6 @@
  (package liquidsoap)
  (deps
   functions.liq
-  ../media/all_media_files
   ../../src/bin/liquidsoap.exe
   (package liquidsoap)
   (:stdlib ../../src/libs/stdlib.liq)
@@ -381,7 +352,6 @@
  (package liquidsoap)
  (deps
   record.liq
-  ../media/all_media_files
   ../../src/bin/liquidsoap.exe
   (package liquidsoap)
   (:stdlib ../../src/libs/stdlib.liq)
@@ -394,7 +364,6 @@
  (package liquidsoap)
  (deps
   osc.liq
-  ../media/all_media_files
   ../../src/bin/liquidsoap.exe
   (package liquidsoap)
   (:stdlib ../../src/libs/stdlib.liq)
@@ -407,7 +376,6 @@
  (package liquidsoap)
  (deps
   file_protocol.liq
-  ../media/all_media_files
   ../../src/bin/liquidsoap.exe
   (package liquidsoap)
   (:stdlib ../../src/libs/stdlib.liq)
@@ -420,7 +388,6 @@
  (package liquidsoap)
  (deps
   eval.liq
-  ../media/all_media_files
   ../../src/bin/liquidsoap.exe
   (package liquidsoap)
   (:stdlib ../../src/libs/stdlib.liq)
@@ -433,7 +400,6 @@
  (package liquidsoap)
  (deps
   bool.liq
-  ../media/all_media_files
   ../../src/bin/liquidsoap.exe
   (package liquidsoap)
   (:stdlib ../../src/libs/stdlib.liq)
@@ -446,7 +412,6 @@
  (package liquidsoap)
  (deps
   json.liq
-  ../media/all_media_files
   ../../src/bin/liquidsoap.exe
   (package liquidsoap)
   (:stdlib ../../src/libs/stdlib.liq)
@@ -459,7 +424,6 @@
  (package liquidsoap)
  (deps
   encoders.liq
-  ../media/all_media_files
   ../../src/bin/liquidsoap.exe
   (package liquidsoap)
   (:stdlib ../../src/libs/stdlib.liq)
@@ -472,7 +436,6 @@
  (package liquidsoap)
  (deps
   doc.liq
-  ../media/all_media_files
   ../../src/bin/liquidsoap.exe
   (package liquidsoap)
   (:stdlib ../../src/libs/stdlib.liq)
@@ -485,7 +448,6 @@
  (package liquidsoap)
  (deps
   typing.liq
-  ../media/all_media_files
   ../../src/bin/liquidsoap.exe
   (package liquidsoap)
   (:stdlib ../../src/libs/stdlib.liq)
@@ -498,7 +460,6 @@
  (package liquidsoap)
  (deps
   time.liq
-  ../media/all_media_files
   ../../src/bin/liquidsoap.exe
   (package liquidsoap)
   (:stdlib ../../src/libs/stdlib.liq)

--- a/tests/regression/dune
+++ b/tests/regression/dune
@@ -10,12 +10,16 @@
  (action
   (with-stdout-to
    dune.inc.gen
-   (run ../gen_dune.exe))))
+   (run ./gen_dune.exe))))
 
 (rule
  (alias gendune)
  (action
   (diff dune.inc dune.inc.gen)))
+
+(executable
+ (name gen_dune)
+ (modules gen_dune))
 
 (rule
  (alias citest)

--- a/tests/regression/gen_dune.ml
+++ b/tests/regression/gen_dune.ml
@@ -14,6 +14,7 @@ let () =
  (package liquidsoap)
  (deps
   %s
+  ../media/all_media_files
   ../../src/bin/liquidsoap.exe
   (package liquidsoap)
   (:stdlib ../../src/libs/stdlib.liq)

--- a/tests/streams/dune
+++ b/tests/streams/dune
@@ -25,37 +25,103 @@
  (alias citest)
  (target file1.mp3)
  (action
-  (run ffmpeg -f lavfi -i "sine=frequency=220:duration=5" -ac 2 %{target})))
+  (run
+   ffmpeg
+   -hide_banner
+   -loglevel
+   error
+   -f
+   lavfi
+   -i
+   "sine=frequency=220:duration=5"
+   -ac
+   2
+   %{target})))
 
 (rule
  (alias citest)
  (target file2.mp3)
  (action
-  (run ffmpeg -f lavfi -i "sine=frequency=440:duration=5" -ac 2 %{target})))
+  (run
+   ffmpeg
+   -hide_banner
+   -loglevel
+   error
+   -f
+   lavfi
+   -i
+   "sine=frequency=440:duration=5"
+   -ac
+   2
+   %{target})))
 
 (rule
  (alias citest)
  (target file3.mp3)
  (action
-  (run ffmpeg -f lavfi -i "sine=frequency=880:duration=5" -ac 2 %{target})))
+  (run
+   ffmpeg
+   -hide_banner
+   -loglevel
+   error
+   -f
+   lavfi
+   -i
+   "sine=frequency=880:duration=5"
+   -ac
+   2
+   %{target})))
 
 (rule
  (alias citest)
  (target jingle1.mp3)
  (action
-  (run ffmpeg -f lavfi -i "sine=frequency=220:duration=2" -ac 2 %{target})))
+  (run
+   ffmpeg
+   -hide_banner
+   -loglevel
+   error
+   -f
+   lavfi
+   -i
+   "sine=frequency=220:duration=2"
+   -ac
+   2
+   %{target})))
 
 (rule
  (alias citest)
  (target jingle2.mp3)
  (action
-  (run ffmpeg -f lavfi -i "sine=frequency=440:duration=2" -ac 2 %{target})))
+  (run
+   ffmpeg
+   -hide_banner
+   -loglevel
+   error
+   -f
+   lavfi
+   -i
+   "sine=frequency=440:duration=2"
+   -ac
+   2
+   %{target})))
 
 (rule
  (alias citest)
  (target jingle3.mp3)
  (action
-  (run ffmpeg -f lavfi -i "sine=frequency=880:duration=2" -ac 2 %{target})))
+  (run
+   ffmpeg
+   -hide_banner
+   -loglevel
+   error
+   -f
+   lavfi
+   -i
+   "sine=frequency=880:duration=2"
+   -ac
+   2
+   %{target})))
 
 (rule
  (alias citest)
@@ -63,6 +129,9 @@
  (action
   (run
    ffmpeg
+   -hide_banner
+   -loglevel
+   error
    -f
    lavfi
    -i
@@ -79,6 +148,9 @@
  (action
   (run
    ffmpeg
+   -hide_banner
+   -loglevel
+   error
    -f
    lavfi
    -i

--- a/tests/streams/dune.inc
+++ b/tests/streams/dune.inc
@@ -348,6 +348,29 @@
  (alias citest)
  (package liquidsoap)
  (deps
+  srt_raw_pcm.liq
+  ./file1.mp3
+  ./file2.mp3
+  ./file3.mp3
+  ./jingle1.mp3
+  ./jingle2.mp3
+  ./jingle3.mp3
+  ./file1.png
+  ./file2.png
+  ./jingles
+  ./playlist
+  ./huge_playlist
+  ../media/all_media_files
+  ../../src/bin/liquidsoap.exe
+  (package liquidsoap)
+  (:test_liq ../test.liq)
+  (:run_test ../run_test.exe))
+ (action (run %{run_test} srt_raw_pcm.liq liquidsoap %{test_liq} srt_raw_pcm.liq)))
+
+(rule
+ (alias citest)
+ (package liquidsoap)
+ (deps
   random.liq
   ./file1.mp3
   ./file2.mp3

--- a/tests/streams/dune.inc
+++ b/tests/streams/dune.inc
@@ -15,7 +15,6 @@
   ./jingles
   ./playlist
   ./huge_playlist
-  ../media/all_media_files
   ../../src/bin/liquidsoap.exe
   (package liquidsoap)
   (:test_liq ../test.liq)
@@ -38,7 +37,6 @@
   ./jingles
   ./playlist
   ./huge_playlist
-  ../media/all_media_files
   ../../src/bin/liquidsoap.exe
   (package liquidsoap)
   (:test_liq ../test.liq)
@@ -61,7 +59,6 @@
   ./jingles
   ./playlist
   ./huge_playlist
-  ../media/all_media_files
   ../../src/bin/liquidsoap.exe
   (package liquidsoap)
   (:test_liq ../test.liq)
@@ -84,7 +81,6 @@
   ./jingles
   ./playlist
   ./huge_playlist
-  ../media/all_media_files
   ../../src/bin/liquidsoap.exe
   (package liquidsoap)
   (:test_liq ../test.liq)
@@ -107,7 +103,6 @@
   ./jingles
   ./playlist
   ./huge_playlist
-  ../media/all_media_files
   ../../src/bin/liquidsoap.exe
   (package liquidsoap)
   (:test_liq ../test.liq)
@@ -130,7 +125,6 @@
   ./jingles
   ./playlist
   ./huge_playlist
-  ../media/all_media_files
   ../../src/bin/liquidsoap.exe
   (package liquidsoap)
   (:test_liq ../test.liq)
@@ -153,7 +147,6 @@
   ./jingles
   ./playlist
   ./huge_playlist
-  ../media/all_media_files
   ../../src/bin/liquidsoap.exe
   (package liquidsoap)
   (:test_liq ../test.liq)
@@ -176,7 +169,6 @@
   ./jingles
   ./playlist
   ./huge_playlist
-  ../media/all_media_files
   ../../src/bin/liquidsoap.exe
   (package liquidsoap)
   (:test_liq ../test.liq)
@@ -199,7 +191,6 @@
   ./jingles
   ./playlist
   ./huge_playlist
-  ../media/all_media_files
   ../../src/bin/liquidsoap.exe
   (package liquidsoap)
   (:test_liq ../test.liq)
@@ -222,7 +213,6 @@
   ./jingles
   ./playlist
   ./huge_playlist
-  ../media/all_media_files
   ../../src/bin/liquidsoap.exe
   (package liquidsoap)
   (:test_liq ../test.liq)
@@ -245,7 +235,6 @@
   ./jingles
   ./playlist
   ./huge_playlist
-  ../media/all_media_files
   ../../src/bin/liquidsoap.exe
   (package liquidsoap)
   (:test_liq ../test.liq)
@@ -268,7 +257,6 @@
   ./jingles
   ./playlist
   ./huge_playlist
-  ../media/all_media_files
   ../../src/bin/liquidsoap.exe
   (package liquidsoap)
   (:test_liq ../test.liq)
@@ -291,7 +279,6 @@
   ./jingles
   ./playlist
   ./huge_playlist
-  ../media/all_media_files
   ../../src/bin/liquidsoap.exe
   (package liquidsoap)
   (:test_liq ../test.liq)
@@ -314,7 +301,6 @@
   ./jingles
   ./playlist
   ./huge_playlist
-  ../media/all_media_files
   ../../src/bin/liquidsoap.exe
   (package liquidsoap)
   (:test_liq ../test.liq)
@@ -337,7 +323,6 @@
   ./jingles
   ./playlist
   ./huge_playlist
-  ../media/all_media_files
   ../../src/bin/liquidsoap.exe
   (package liquidsoap)
   (:test_liq ../test.liq)
@@ -360,7 +345,6 @@
   ./jingles
   ./playlist
   ./huge_playlist
-  ../media/all_media_files
   ../../src/bin/liquidsoap.exe
   (package liquidsoap)
   (:test_liq ../test.liq)
@@ -383,7 +367,6 @@
   ./jingles
   ./playlist
   ./huge_playlist
-  ../media/all_media_files
   ../../src/bin/liquidsoap.exe
   (package liquidsoap)
   (:test_liq ../test.liq)
@@ -406,7 +389,6 @@
   ./jingles
   ./playlist
   ./huge_playlist
-  ../media/all_media_files
   ../../src/bin/liquidsoap.exe
   (package liquidsoap)
   (:test_liq ../test.liq)
@@ -429,7 +411,6 @@
   ./jingles
   ./playlist
   ./huge_playlist
-  ../media/all_media_files
   ../../src/bin/liquidsoap.exe
   (package liquidsoap)
   (:test_liq ../test.liq)
@@ -452,7 +433,6 @@
   ./jingles
   ./playlist
   ./huge_playlist
-  ../media/all_media_files
   ../../src/bin/liquidsoap.exe
   (package liquidsoap)
   (:test_liq ../test.liq)
@@ -475,7 +455,6 @@
   ./jingles
   ./playlist
   ./huge_playlist
-  ../media/all_media_files
   ../../src/bin/liquidsoap.exe
   (package liquidsoap)
   (:test_liq ../test.liq)
@@ -498,7 +477,6 @@
   ./jingles
   ./playlist
   ./huge_playlist
-  ../media/all_media_files
   ../../src/bin/liquidsoap.exe
   (package liquidsoap)
   (:test_liq ../test.liq)
@@ -521,7 +499,6 @@
   ./jingles
   ./playlist
   ./huge_playlist
-  ../media/all_media_files
   ../../src/bin/liquidsoap.exe
   (package liquidsoap)
   (:test_liq ../test.liq)
@@ -544,7 +521,6 @@
   ./jingles
   ./playlist
   ./huge_playlist
-  ../media/all_media_files
   ../../src/bin/liquidsoap.exe
   (package liquidsoap)
   (:test_liq ../test.liq)
@@ -567,7 +543,6 @@
   ./jingles
   ./playlist
   ./huge_playlist
-  ../media/all_media_files
   ../../src/bin/liquidsoap.exe
   (package liquidsoap)
   (:test_liq ../test.liq)
@@ -590,7 +565,6 @@
   ./jingles
   ./playlist
   ./huge_playlist
-  ../media/all_media_files
   ../../src/bin/liquidsoap.exe
   (package liquidsoap)
   (:test_liq ../test.liq)
@@ -613,7 +587,6 @@
   ./jingles
   ./playlist
   ./huge_playlist
-  ../media/all_media_files
   ../../src/bin/liquidsoap.exe
   (package liquidsoap)
   (:test_liq ../test.liq)
@@ -636,7 +609,6 @@
   ./jingles
   ./playlist
   ./huge_playlist
-  ../media/all_media_files
   ../../src/bin/liquidsoap.exe
   (package liquidsoap)
   (:test_liq ../test.liq)
@@ -659,7 +631,6 @@
   ./jingles
   ./playlist
   ./huge_playlist
-  ../media/all_media_files
   ../../src/bin/liquidsoap.exe
   (package liquidsoap)
   (:test_liq ../test.liq)
@@ -682,7 +653,6 @@
   ./jingles
   ./playlist
   ./huge_playlist
-  ../media/all_media_files
   ../../src/bin/liquidsoap.exe
   (package liquidsoap)
   (:test_liq ../test.liq)
@@ -705,7 +675,6 @@
   ./jingles
   ./playlist
   ./huge_playlist
-  ../media/all_media_files
   ../../src/bin/liquidsoap.exe
   (package liquidsoap)
   (:test_liq ../test.liq)
@@ -728,7 +697,6 @@
   ./jingles
   ./playlist
   ./huge_playlist
-  ../media/all_media_files
   ../../src/bin/liquidsoap.exe
   (package liquidsoap)
   (:test_liq ../test.liq)
@@ -751,7 +719,6 @@
   ./jingles
   ./playlist
   ./huge_playlist
-  ../media/all_media_files
   ../../src/bin/liquidsoap.exe
   (package liquidsoap)
   (:test_liq ../test.liq)
@@ -774,7 +741,6 @@
   ./jingles
   ./playlist
   ./huge_playlist
-  ../media/all_media_files
   ../../src/bin/liquidsoap.exe
   (package liquidsoap)
   (:test_liq ../test.liq)
@@ -797,7 +763,6 @@
   ./jingles
   ./playlist
   ./huge_playlist
-  ../media/all_media_files
   ../../src/bin/liquidsoap.exe
   (package liquidsoap)
   (:test_liq ../test.liq)
@@ -820,7 +785,6 @@
   ./jingles
   ./playlist
   ./huge_playlist
-  ../media/all_media_files
   ../../src/bin/liquidsoap.exe
   (package liquidsoap)
   (:test_liq ../test.liq)
@@ -843,7 +807,6 @@
   ./jingles
   ./playlist
   ./huge_playlist
-  ../media/all_media_files
   ../../src/bin/liquidsoap.exe
   (package liquidsoap)
   (:test_liq ../test.liq)
@@ -866,7 +829,6 @@
   ./jingles
   ./playlist
   ./huge_playlist
-  ../media/all_media_files
   ../../src/bin/liquidsoap.exe
   (package liquidsoap)
   (:test_liq ../test.liq)
@@ -889,7 +851,6 @@
   ./jingles
   ./playlist
   ./huge_playlist
-  ../media/all_media_files
   ../../src/bin/liquidsoap.exe
   (package liquidsoap)
   (:test_liq ../test.liq)
@@ -912,7 +873,6 @@
   ./jingles
   ./playlist
   ./huge_playlist
-  ../media/all_media_files
   ../../src/bin/liquidsoap.exe
   (package liquidsoap)
   (:test_liq ../test.liq)
@@ -935,7 +895,6 @@
   ./jingles
   ./playlist
   ./huge_playlist
-  ../media/all_media_files
   ../../src/bin/liquidsoap.exe
   (package liquidsoap)
   (:test_liq ../test.liq)
@@ -958,7 +917,6 @@
   ./jingles
   ./playlist
   ./huge_playlist
-  ../media/all_media_files
   ../../src/bin/liquidsoap.exe
   (package liquidsoap)
   (:test_liq ../test.liq)

--- a/tests/streams/gen_dune.ml
+++ b/tests/streams/gen_dune.ml
@@ -25,7 +25,6 @@ let () =
   ./jingles
   ./playlist
   ./huge_playlist
-  ../media/all_media_files
   ../../src/bin/liquidsoap.exe
   (package liquidsoap)
   (:test_liq ../test.liq)

--- a/tests/streams/request.liq
+++ b/tests/streams/request.liq
@@ -4,6 +4,11 @@ settings.log.level.set(4)
 
 test.check(fun () ->
   begin
+    if request.duration("file1.mp3") != 5.06 then
+      print("Invalid duration!")
+      test.fail()
+    end
+
     r = request.dynamic(prefetch=1, fun () -> request.create("invalid"))
 
     if not r.add(request.create("file2.mp3")) then

--- a/tests/streams/srt_raw_pcm.liq
+++ b/tests/streams/srt_raw_pcm.liq
@@ -1,0 +1,28 @@
+log.level := 4
+
+port = random.int(min=8000, max=10000)
+
+s = input.srt(
+ port=port,
+ content_type = "application/ffmpeg;format=s16le,ch_layout=mono,sample_rate=48000"
+)
+
+s = source.on_track(s, fun (_) -> test.pass())
+
+output.dummy(fallible=true, s)
+
+enc = %ffmpeg(
+  format="s16le",
+  %audio(
+    codec="pcm_s16le",
+    ac=1,
+    ar=48000
+  )
+)
+
+output.srt(
+  fallible=true,
+  port=port,
+  enc,
+  sine()
+)


### PR DESCRIPTION
This PR adds support for decoder arguments in the FFmpeg decoder. This makes it possible to decoder streams and files that require specific input arguments such as raw PCM data.

The convention is to use a special mime type for streams: `application/ffmpeg;<arguments>`. For files, the convention is to use the `ffmpeg_options` metadata, for instance: `annotate:ffmpeg_options='<arguments>':/path/to/file.raw`