### PR TITLE
Use a single context for all incoming SSL connections from a given transport. 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,6 +165,7 @@ jobs:
       image: savonet/liquidsoap-ci:debian_bullseye_amd64
       options: --user root --privileged --ulimit core=-1 --security-opt seccomp=unconfined -v ${{ github.workspace }}/${{ github.run_number }}:/tmp/${{ github.run_number }}
     strategy:
+      fail-fast: false
       matrix:
         target: ["@citest", "@mediatest"]
     env:

--- a/tests/harbor/http.liq
+++ b/tests/harbor/http.liq
@@ -231,7 +231,15 @@ def f() =
   test.equals("#{resp}", "")
 
   # transport conflict
-  transport = http.transport.ssl(certificate="foo", key="bla")
+  certificate = file.temp("cert", "pem")
+  file.write(data="foo", certificate)
+  on_shutdown({file.remove(certificate)})
+
+  key = file.temp("cert", "key")
+  file.write(data="foo", key)
+  on_shutdown({file.remove(key)})
+
+  transport = http.transport.ssl(certificate=certificate, key=key)
   try
     harbor.http.register("/default", transport=transport, port=3456, fun (_, _) -> ())
     test.fail()


### PR DESCRIPTION
This might a fd leak from `libssl` but this should mitigate most issues.

Fixes: #3067