### PR TITLE
Optims

### DIFF
--- a/.github/scripts/build-posix.sh
+++ b/.github/scripts/build-posix.sh
@@ -80,7 +80,7 @@ OCAMLPATH="$(cat .ocamlpath)"
 export OCAMLPATH
 
 cd /tmp/liquidsoap-full/liquidsoap
-dune build
+dune build --profile=release
 
 echo "::endgroup::"
 

--- a/src/core/builtins/builtins_source.ml
+++ b/src/core/builtins/builtins_source.ml
@@ -239,6 +239,7 @@ let _ =
       o#get_ready [s];
       log#info "Start dropping source.";
       while s#is_ready do
+        o#before_output;
         o#output;
         o#after_output
       done;

--- a/src/core/dune
+++ b/src/core/dune
@@ -1,4 +1,6 @@
 (env
+ (release
+  (ocamlopt_flags (:standard -w -9 -alert --deprecated -O2)))
  (_
   (flags
    (:standard -w -9 -alert --deprecated))))

--- a/src/core/operators/accelerate.ml
+++ b/src/core/operators/accelerate.ml
@@ -90,13 +90,9 @@ class accelerate ~ratio ~randomize source_val =
       filled <- filled + (after - before);
       self#child_tick
 
-    method! before_output =
-      super#before_output;
-      child_support#before_output
-
-    method! after_output =
-      super#after_output;
-      child_support#after_output
+    initializer
+      self#on_before_output (fun () -> child_support#child_before_output);
+      self#on_after_output (fun () -> child_support#child_after_output)
   end
 
 let _ =

--- a/src/core/operators/cuepoint.ml
+++ b/src/core/operators/cuepoint.ml
@@ -39,7 +39,7 @@ type state = [ `Idle | `No_cue_out | `Cue_out of int * int ]
 class cue_cut ~m_cue_in ~m_cue_out ~on_cue_in ~on_cue_out source_val =
   let source = Lang.to_source source_val in
   object (self)
-    inherit operator ~name:"cue_cut" [source] as super
+    inherit operator ~name:"cue_cut" [source]
 
     inherit!
       Child_support.base ~check_self_sync:true [source_val] as child_support
@@ -60,13 +60,9 @@ class cue_cut ~m_cue_in ~m_cue_out ~on_cue_in ~on_cue_out source_val =
             if source_remaining = -1 then target
             else min source#remaining target
 
-    method! before_output =
-      super#before_output;
-      child_support#before_output
-
-    method! after_output =
-      super#after_output;
-      child_support#after_output
+    initializer
+      self#on_before_output (fun () -> child_support#child_before_output);
+      self#on_after_output (fun () -> child_support#child_after_output)
 
     method private get_cue_points buf pos =
       match Frame.get_metadata buf pos with

--- a/src/core/operators/max_duration.ml
+++ b/src/core/operators/max_duration.ml
@@ -26,7 +26,7 @@
  *  stack of sources. *)
 class max_duration ~override_meta ~duration source =
   object (self)
-    inherit Source.operator ~name:"max_duration" [] as super
+    inherit Source.operator ~name:"max_duration" []
     val mutable remaining = duration
     val mutable s : Source.source = source
     method self_sync = source#self_sync
@@ -75,9 +75,9 @@ class max_duration ~override_meta ~duration source =
         s <- Debug_sources.empty ();
         s#get_ready [(self :> Source.source)])
 
-    method! after_output =
-      super#after_output;
-      s#after_output
+    initializer
+      self#on_before_output (fun () -> s#before_output);
+      self#on_after_output (fun () -> s#after_output)
   end
 
 let _ =

--- a/src/core/operators/muxer.ml
+++ b/src/core/operators/muxer.ml
@@ -40,7 +40,7 @@ class muxer tracks =
     List.iter (fun (_, frame) -> Frame.clear frame) !track_frames
   in
   object (self)
-    inherit Source.operator ~name:"source" sources as super
+    inherit Source.operator ~name:"source" sources
     method stype = stype
 
     method self_sync =
@@ -132,10 +132,10 @@ class muxer tracks =
       self#feed ~force:true buf;
       Generator.fill self#buffer buf
 
-    method! advance =
-      super#advance;
-      clear_track_frames ();
-      Frame.clear self#buffer
+    initializer
+      self#on_after_output (fun () ->
+          clear_track_frames ();
+          Frame.clear self#buffer)
   end
 
 let source =

--- a/src/core/operators/pipe.ml
+++ b/src/core/operators/pipe.ml
@@ -276,14 +276,11 @@ class pipe ~replay_delay ~data_len ~process ~bufferize ~max ~restart
           with Process_handler.Finished -> ())
         ()
 
-    method! before_output =
-      super#before_output;
-      child_support#before_output
-
-    method! after_output =
-      super#after_output;
-      (* As long as we have a process, we let it drive the child source entirely. *)
-      if handler = None then child_support#after_output
+    initializer
+      self#on_before_output (fun () -> child_support#child_before_output);
+      self#on_after_output (fun () ->
+          (* As long as we have a process, we let it drive the child source entirely. *)
+          if handler = None then child_support#child_after_output)
   end
 
 let _ =

--- a/src/core/operators/resample.ml
+++ b/src/core/operators/resample.ml
@@ -60,13 +60,9 @@ class resample ~field ~ratio source =
       converter <- Some (Audio_converter.Samplerate.create self#audio_channels);
       write_frame_ref := self#write_frame
 
-    method! before_output =
-      super#before_output;
-      child_support#before_output
-
-    method! after_output =
-      super#after_output;
-      child_support#after_output
+    initializer
+      self#on_before_output (fun () -> child_support#child_before_output);
+      self#on_after_output (fun () -> child_support#child_after_output)
 
     method private write_frame =
       function `Frame frame -> self#process_frame frame | `Flush -> ()

--- a/src/core/operators/soundtouch_op.ml
+++ b/src/core/operators/soundtouch_op.ml
@@ -94,13 +94,9 @@ class soundtouch source_val rate tempo pitch =
         (Soundtouch.get_version_string (Option.get st));
       write_frame_ref := self#write_frame
 
-    method! before_output =
-      super#before_output;
-      child_support#before_output
-
-    method! private after_output =
-      super#after_output;
-      child_support#after_output
+    initializer
+      self#on_before_output (fun () -> child_support#child_before_output);
+      self#on_after_output (fun () -> child_support#child_after_output)
   end
 
 let _ =

--- a/src/core/operators/track_map.ml
+++ b/src/core/operators/track_map.ml
@@ -24,7 +24,7 @@ open Source
 
 class track_map ~name ~field ~fn s =
   object (self)
-    inherit operator ~name [s] as super
+    inherit operator ~name [s]
     method stype = s#stype
     method remaining = s#remaining
     method abort_track = s#abort_track
@@ -60,9 +60,7 @@ class track_map ~name ~field ~fn s =
         (Frame.get_all_metadata tmp_frame);
       Frame.add_break buf end_pos
 
-    method! advance =
-      super#advance;
-      Frame.clear self#tmp_frame
+    initializer self#on_after_output (fun () -> Frame.clear self#tmp_frame)
   end
 
 let _ =

--- a/src/core/outputs/output.ml
+++ b/src/core/outputs/output.ml
@@ -52,7 +52,7 @@ class virtual output ~output_kind ?(name = "") ~infallible
         raise (Error.Invalid_value (val_source, "That source is fallible"))
 
     initializer Typing.(source#frame_type <: self#frame_type)
-    inherit active_operator ~name:output_kind [source] as super
+    inherit active_operator ~name:output_kind [source]
     inherit Start_stop.base ~on_start ~on_stop as start_stop
     method virtual private start : unit
     method virtual private stop : unit
@@ -173,15 +173,13 @@ class virtual output ~output_kind ?(name = "") ~infallible
           self#log#important "Source failed (no more tracks) stopping output...";
           self#transition_to `Idle))
 
-    method! after_output =
-      (* Let [memo] be cleared and signal propagated *)
-      super#after_output;
-
-      (* Perform skip if needed *)
-      if skip then (
-        self#log#important "Performing user-requested skip";
-        skip <- false;
-        self#abort_track)
+    initializer
+      self#on_after_output (fun () ->
+          (* Perform skip if needed *)
+          if skip then (
+            self#log#important "Performing user-requested skip";
+            skip <- false;
+            self#abort_track))
   end
 
 class dummy ~infallible ~on_start ~on_stop ~autostart source =

--- a/src/core/source.mli
+++ b/src/core/source.mli
@@ -201,13 +201,17 @@ class virtual source :
 
        method is_active : bool
 
+       (* Register callback to be executed on #before_output. *)
+       method on_before_output : (unit -> unit) -> unit
+
        (** Prepare for output round. *)
        method before_output : unit
 
+       (* Register callback to be executed on #after_output. *)
+       method on_after_output : (unit -> unit) -> unit
+
        (** Cleanup after output round. *)
        method after_output : unit
-
-       method advance : unit
 
        (** {1 Utilities} *)
 

--- a/src/core/stream/content_base.ml
+++ b/src/core/stream/content_base.ml
@@ -324,12 +324,12 @@ module MkContentBase (C : ContentSpecs) :
       C.blit data offset buf pos length;
       pos + length
     in
-    fun d ->
+    fun ?(force = false) d ->
       match (length d, d.chunks) with
         | 0, _ ->
             d.chunks <- [];
             d
-        | _, [{ offset = 0; length = None }] -> d
+        | _, [{ offset = 0; length = None }] when not force -> d
         | length, _ ->
             let buf = C.make ~length d.params in
             ignore (List.fold_left (consolidate_chunk ~buf) 0 d.chunks);
@@ -342,7 +342,8 @@ module MkContentBase (C : ContentSpecs) :
     dst.params <- src.params;
     let dst_len = length dst in
     dst.chunks <-
-      (sub dst 0 dst_pos).chunks @ (copy (sub src src_pos len)).chunks
+      (sub dst 0 dst_pos).chunks
+      @ (consolidate_chunks ~force:true (sub src src_pos len)).chunks
       @ (sub dst (dst_pos + len) (dst_len - len - dst_pos)).chunks;
     assert (dst_len = length dst)
 

--- a/src/core/tools/child_support.ml
+++ b/src/core/tools/child_support.ml
@@ -68,6 +68,7 @@ class virtual base ?(create_known_clock = true) ~check_self_sync children_val =
       Gc.finalise (finalise_child_clock self#child_clock) self
 
     method private child_tick =
+      List.iter (fun c -> c#before_output) children;
       (Clock.get self#child_clock)#end_tick;
       List.iter (fun c -> c#after_output) children;
       needs_tick <- false
@@ -79,6 +80,6 @@ class virtual base ?(create_known_clock = true) ~check_self_sync children_val =
        expect the source to make a decision about executing a child clock
        tick as part of its [#get_frame] implementation. See [cross.ml] or
        [soundtouch.ml] as examples. *)
-    method before_output = needs_tick <- true
-    method after_output = if needs_tick then self#child_tick
+    method child_before_output = needs_tick <- true
+    method child_after_output = if needs_tick then self#child_tick
   end

--- a/src/core/tools/producer_consumer.ml
+++ b/src/core/tools/producer_consumer.ml
@@ -129,13 +129,9 @@ class producer ?create_known_clock ~check_self_sync ~consumers ~name () =
         let cur_pos = Frame.position buf in
         Frame.set_breaks buf (b @ [cur_pos]))
 
-    method! before_output =
-      super#before_output;
-      child_support#before_output
-
-    method! after_output =
-      super#after_output;
-      child_support#after_output
+    initializer
+      self#on_before_output (fun () -> child_support#child_before_output);
+      self#on_after_output (fun () -> child_support#child_after_output)
 
     method abort_track =
       Generator.add_track_mark self#buffer;

--- a/src/lang/dune
+++ b/src/lang/dune
@@ -1,4 +1,6 @@
 (env
+ (release
+  (ocamlopt_flags (:standard -O2)))
  (dev
   (flags
    (:standard -w -9))))


### PR DESCRIPTION
This PR implements some optimizations found after running the code using the script provided by `pranza` on the ML:

<details>
<summary>Script</summary>
<pre>
mishke = single(id="mishke", "/tmp/bla.m4a")
planetanons = single(id="planetanons", "/tmp/bla.m4a")

pirmad09 = playlist(id="pirmad09", mode="normal", "/tmp/pl", reload_mode="watch")
pirmad12 = playlist(id="pirmad12", mode="normal", "/tmp/pl", reload_mode="watch")
pirmad13 = playlist(id="pirmad13", mode="normal", "/tmp/pl", reload_mode="watch")
pirmad14 = playlist(id="pirmad14", mode="normal", "/tmp/pl", reload_mode="watch")
pirmad15 = playlist(id="pirmad15", mode="normal", "/tmp/pl", reload_mode="watch")
pirmad16 = playlist(id="pirmad16", mode="normal", "/tmp/pl", reload_mode="watch")
pirmad17 = playlist(id="pirmad17", mode="normal", "/tmp/pl", reload_mode="watch")
pirmad18 = playlist(id="pirmad18", mode="normal", "/tmp/pl", reload_mode="watch")
pirmad19 = playlist(id="pirmad19", mode="normal", "/tmp/pl", reload_mode="watch")
pirmad20 = playlist(id="pirmad20", mode="normal", "/tmp/pl", reload_mode="watch")
pirmad21 = playlist(id="pirmad21", mode="normal", "/tmp/pl", reload_mode="watch")
pirmad22 = playlist(id="pirmad22", mode="normal", "/tmp/pl", reload_mode="watch")

antrad09 = playlist(id="antrad09", mode="normal", "/tmp/pl", reload_mode="watch")
antrad12 = playlist(id="antrad12", mode="normal", "/tmp/pl", reload_mode="watch")
antrad13 = playlist(id="antrad13", mode="normal", "/tmp/pl", reload_mode="watch")
antrad14 = playlist(id="antrad14", mode="normal", "/tmp/pl", reload_mode="watch")
antrad15 = playlist(id="antrad15", mode="normal", "/tmp/pl", reload_mode="watch")
antrad16 = playlist(id="antrad16", mode="normal", "/tmp/pl", reload_mode="watch")
antrad17 = playlist(id="antrad17", mode="normal", "/tmp/pl", reload_mode="watch")
antrad18 = playlist(id="antrad18", mode="normal", "/tmp/pl", reload_mode="watch")
antrad19 = playlist(id="antrad19", mode="normal", "/tmp/pl", reload_mode="watch")
antrad20 = playlist(id="antrad20", mode="normal", "/tmp/pl", reload_mode="watch")
antrad21 = playlist(id="antrad21", mode="normal", "/tmp/pl", reload_mode="watch")
antrad22 = playlist(id="antrad22", mode="normal", "/tmp/pl", reload_mode="watch")

trechiad09 = playlist(id="trechiad09", mode="normal", "/tmp/pl", reload_mode="watch")
trechiad12 = playlist(id="trechiad12", mode="normal", "/tmp/pl", reload_mode="watch")
trechiad13 = playlist(id="trechiad13", mode="normal", "/tmp/pl", reload_mode="watch")
trechiad14 = playlist(id="trechiad14", mode="normal", "/tmp/pl", reload_mode="watch")
trechiad15 = playlist(id="trechiad15", mode="normal", "/tmp/pl", reload_mode="watch")
trechiad16 = playlist(id="trechiad16", mode="normal", "/tmp/pl", reload_mode="watch")
trechiad17 = playlist(id="trechiad17", mode="normal", "/tmp/pl", reload_mode="watch")
trechiad18 = playlist(id="trechiad18", mode="normal", "/tmp/pl", reload_mode="watch")
trechiad19 = playlist(id="trechiad19", mode="normal", "/tmp/pl", reload_mode="watch")
trechiad20 = playlist(id="trechiad20", mode="normal", "/tmp/pl", reload_mode="watch")
trechiad21 = playlist(id="trechiad21", mode="normal", "/tmp/pl", reload_mode="watch")
trechiad22 = playlist(id="trechiad22", mode="normal", "/tmp/pl", reload_mode="watch")

ketvirtad09 = playlist(id="ketvirtad09", mode="normal", "/tmp/pl", reload_mode="watch")
ketvirtad12 = playlist(id="ketvirtad12", mode="normal", "/tmp/pl", reload_mode="watch")
ketvirtad13 = playlist(id="ketvirtad13", mode="normal", "/tmp/pl", reload_mode="watch")
ketvirtad14 = playlist(id="ketvirtad14", mode="normal", "/tmp/pl", reload_mode="watch")
ketvirtad15 = playlist(id="ketvirtad15", mode="normal", "/tmp/pl", reload_mode="watch")
ketvirtad16 = playlist(id="ketvirtad16", mode="normal", "/tmp/pl", reload_mode="watch")
ketvirtad17 = playlist(id="ketvirtad17", mode="normal", "/tmp/pl", reload_mode="watch")
ketvirtad18 = playlist(id="ketvirtad18", mode="normal", "/tmp/pl", reload_mode="watch")
ketvirtad19 = playlist(id="ketvirtad19", mode="normal", "/tmp/pl", reload_mode="watch")
ketvirtad20 = playlist(id="ketvirtad20", mode="normal", "/tmp/pl", reload_mode="watch")
ketvirtad21 = playlist(id="ketvirtad21", mode="normal", "/tmp/pl", reload_mode="watch")
ketvirtad22 = playlist(id="ketvirtad22", mode="normal", "/tmp/pl", reload_mode="watch")

penktad09 = playlist(id="penktad09", mode="normal", "/tmp/pl", reload_mode="watch")
penktad12 = playlist(id="penktad12", mode="normal", "/tmp/pl", reload_mode="watch")
penktad13 = playlist(id="penktad13", mode="normal", "/tmp/pl", reload_mode="watch")
penktad14 = playlist(id="penktad14", mode="normal", "/tmp/pl", reload_mode="watch")
penktad15 = playlist(id="penktad15", mode="normal", "/tmp/pl", reload_mode="watch")
penktad16 = playlist(id="penktad16", mode="normal", "/tmp/pl", reload_mode="watch")
penktad17 = playlist(id="penktad17", mode="normal", "/tmp/pl", reload_mode="watch")
penktad18 = playlist(id="penktad18", mode="normal", "/tmp/pl", reload_mode="watch")
penktad19 = playlist(id="penktad19", mode="normal", "/tmp/pl", reload_mode="watch")
penktad20 = playlist(id="penktad20", mode="normal", "/tmp/pl", reload_mode="watch")
penktad21 = playlist(id="penktad21", mode="normal", "/tmp/pl", reload_mode="watch")
penktad22 = playlist(id="penktad22", mode="normal", "/tmp/pl", reload_mode="watch")
penktad23 = playlist(id="penktad23", mode="normal", "/tmp/pl", reload_mode="watch")

sheshtad00 = playlist(id="sheshtad00", mode="normal", "/tmp/pl", reload_mode="watch")
sheshtad01 = playlist(id="sheshtad01", mode="normal", "/tmp/pl", reload_mode="watch")
sheshtad02 = playlist(id="sheshtad02", mode="normal", "/tmp/pl", reload_mode="watch")
sheshtad09 = playlist(id="sheshtad09", mode="normal", "/tmp/pl", reload_mode="watch")
sheshtad12 = playlist(id="sheshtad12", mode="normal", "/tmp/pl", reload_mode="watch")
sheshtad13 = playlist(id="sheshtad13", mode="normal", "/tmp/pl", reload_mode="watch")
sheshtad14 = playlist(id="sheshtad14", mode="normal", "/tmp/pl", reload_mode="watch")
sheshtad15 = playlist(id="sheshtad15", mode="normal", "/tmp/pl", reload_mode="watch")
sheshtad16 = playlist(id="sheshtad16", mode="normal", "/tmp/pl", reload_mode="watch")
sheshtad17 = playlist(id="sheshtad17", mode="normal", "/tmp/pl", reload_mode="watch")
sheshtad18 = playlist(id="sheshtad18", mode="normal", "/tmp/pl", reload_mode="watch")
sheshtad19 = playlist(id="sheshtad19", mode="normal", "/tmp/pl", reload_mode="watch")
sheshtad20 = playlist(id="sheshtad20", mode="normal", "/tmp/pl", reload_mode="watch")
sheshtad21 = playlist(id="sheshtad21", mode="normal", "/tmp/pl", reload_mode="watch")
sheshtad22 = playlist(id="sheshtad22", mode="normal", "/tmp/pl", reload_mode="watch")
sheshtad23 = playlist(id="sheshtad23", mode="normal", "/tmp/pl", reload_mode="watch")

sekmad00 = playlist(id="sekmad00", mode="normal", "/tmp/pl", reload_mode="watch")
sekmad01 = playlist(id="sekmad01", mode="normal", "/tmp/pl", reload_mode="watch")
sekmad02 = playlist(id="sekmad02", mode="normal", "/tmp/pl", reload_mode="watch")
sekmad09 = playlist(id="sekmad09", mode="normal", "/tmp/pl", reload_mode="watch")
sekmad12 = playlist(id="sekmad12", mode="normal", "/tmp/pl", reload_mode="watch")
sekmad13 = playlist(id="sekmad13", mode="normal", "/tmp/pl", reload_mode="watch")
sekmad14 = playlist(id="sekmad14", mode="normal", "/tmp/pl", reload_mode="watch")
sekmad15 = playlist(id="sekmad15", mode="normal", "/tmp/pl", reload_mode="watch")
sekmad16 = playlist(id="sekmad16", mode="normal", "/tmp/pl", reload_mode="watch")
sekmad17 = playlist(id="sekmad17", mode="normal", "/tmp/pl", reload_mode="watch")
sekmad18 = playlist(id="sekmad18", mode="normal", "/tmp/pl", reload_mode="watch")
sekmad19 = playlist(id="sekmad19", mode="normal", "/tmp/pl", reload_mode="watch")
sekmad20 = playlist(id="sekmad20", mode="normal", "/tmp/pl", reload_mode="watch")
sekmad21 = playlist(id="sekmad21", mode="normal", "/tmp/pl", reload_mode="watch")
sekmad22 = playlist(id="sekmad22", mode="normal", "/tmp/pl", reload_mode="watch")

reklama = playlist(id="vinjetes", mode="random", reload_mode="watch", "/tmp/pl")
def reklamos_metadata(m) =  [("artist", ""),("title","")]
end
reklama=metadata.map(reklamos_metadata, reklama)


vinjetes = playlist(id="vinjetes", mode="random", reload_mode="watch", "/tmp/pl")
def vinjetes_metadata(m) =  [("artist", ""),("title","")]
end
vinjetes=metadata.map(vinjetes_metadata, vinjetes)


#def alist_request_function() =
#  result = process.read("curl http://localhost:3000/api/v1/playlists/manalist/nextsong?format=text")
#  log("next a-list chuek "^result)
#  request.create(result)
#end

#alist = request.dynamic(alist_request_function)
alist = playlist(id="alist", mode="normal", reload_mode="watch", "/tmp/pl")
def alist_metadata(m) =  artist = m["artist"]
	[("artist", "Laikas eina per miestą: #{artist}")]
end
alist=metadata.map(alist_metadata, alist)

def avant_request_function() =
  resultt = process.read("curl http://localhost:3000/api/v1/playlists/manavant/nextsong?format=text")
  log("next avant chuek "^resultt)
  request.create(resultt)
end

avant = request.dynamic(avant_request_function)
def avant_metadata(m) =  artist = m["artist"]
	[("artist", "Laikas eina per miestą: #{artist}")]
end
avant=metadata.map(avant_metadata, avant)

def classic_request_function() =
  resulttt = process.read("curl http://localhost:3000/api/v1/playlists/manclassic/nextsong?format=text")
  log("next classic chuek "^resulttt)
  request.create(resulttt)
end

classic = request.dynamic(classic_request_function)
def classic_metadata(m) =  artist = m["artist"]
	[("artist", "Laikas eina per miestą: #{artist}")]
end
classic=metadata.map(classic_metadata, classic)

def recurrent_request_function() =
  resultttt = process.read("curl http://localhost:3000/api/v1/playlists/manrecurrent/nextsong?format=text")
  log("next recurrent chuek "^resultttt)
  request.create(resultttt)
end

recurrent = request.dynamic(recurrent_request_function)
def recurrent_metadata(m) =  artist = m["artist"]
	[("artist", "Laikas eina per miestą: #{artist}")]
end
recurrent=metadata.map(recurrent_metadata, recurrent)

patreonas = single(id="padre", "/tmp/bla.m4a")

def jazz_request_function() =
  resulttttt = process.read("curl http://localhost:3000/api/v1/playlists/manjazz/nextsong?format=text")
  log("next jazz chuek "^resulttttt)
  request.create(resulttttt)
end

jazz = request.dynamic(jazz_request_function)
def jazz_metadata(m) =  artist = m["artist"]
	[("artist", "Jazz Power Shower: #{artist}")]
end
jazz=metadata.map(jazz_metadata, jazz)
jazz = rotate (weights = [5, 1], [jazz, patreonas])
jazz=mksafe(jazz)

def planetos_request_function() =
  resultttttt = process.read("curl http://localhost:3000/api/v1/playlists/manplanetos/nextsong?format=text")
  log("next planetos chuek "^resultttttt)
  request.create(resultttttt)
end

planetos = request.dynamic(planetos_request_function)
def planetos_metadata(m) =  [("artist", "Lietuviškos muzikos archyvai"),("title","„Sukasi planetos“")]
end
planetos=metadata.map(planetos_metadata, planetos)
planetos = rotate (weights = [5, 1], [planetos, patreonas])
planetos = rotate (weights = [5, 1], [planetos, planetanons])

planetos  = smooth_add(
        normal= planetos,
        p=0.70,
        special=switch([
        ( { 0m0s }, planetanons )
        ])
)

planetos=mksafe(planetos)

muzonas = rotate (weights = [1, 1, 1, 1], [alist, avant, classic, recurrent])
plejlist = rotate (weights = [2, 7, 1, 6, 1], [vinjetes, muzonas, patreonas, muzonas, reklama])
plejlist = mksafe(plejlist)


# external sources
studija = input.harbor(id="studija", "studija", port=8117, password="")
studija = buffer(fallible=true,buffer=15.,studija)
output.file(%wav(stereo=true, channels=2, samplesize=16, header=false), {time.string("/tmp/radioVilnius-%Y-%m-%d-%H-%M.wav")}, studija, fallible=true)
#studija = merge_tracks(studija)




def chik(jingle,old,new) =
  # Fade out old source
  old = fade.out(old)
  # Superpose the jingle
  radio = add([jingle,old])
  # Compose this in sequence with
  # the new source
  sequence([radio,new])
end

def crossfade_1s(a,b)
    faded = add(normalize=false, [
        fade.in(duration=1., type="exp", b),
        amplify(mkfade(duration=1., start=1., stop=0., type="exp", a) ,a)
    ])
    thread.run.recurrent(delay=3., { source.skip(a) ; -1.})
    faded
end


# fallback system
radio = fallback(track_sensitive=false, [studija,
switch(track_sensitive=true,[
			({ 1w and 09h-09h19 }, pirmad09),
			({ 1w and 12h-12h19 }, pirmad12),
			({ 1w and 13h-13h19 }, pirmad13),
			({ 1w and 14h-14h19 }, pirmad14),
			({ 1w and 15h-15h19 }, pirmad15),
			({ 1w and 16h-16h19 }, pirmad16),
			({ 1w and 17h-17h19 }, pirmad17),
			({ 1w and 18h-18h19 }, pirmad18),
			({ 1w and 19h-19h19 }, pirmad19),
			({ 1w and 20h-20h19 }, pirmad20),
			({ 1w and 21h-21h19 }, pirmad21),
			({ 1w and 22h-22h19 }, pirmad22),

			({ 2w and 09h-09h19 }, antrad09),
			({ 2w and 12h-12h19 }, antrad12),
			({ 2w and 13h-13h19 }, antrad13),
			({ 2w and 14h-14h19 }, antrad14),
			({ 2w and 15h-15h19 }, antrad15),
			({ 2w and 16h-16h19 }, antrad16),
			({ 2w and 17h-17h19 }, antrad17),
			({ 2w and 18h-18h19 }, antrad18),
			({ 2w and 19h-19h19 }, antrad19),
			({ 2w and 20h-20h19 }, antrad20),
			({ 2w and 21h-21h19 }, antrad21),
			({ 2w and 22h-22h19 }, antrad22),

			({ 3w and 09h-09h19 }, trechiad09),
			({ 3w and 12h-12h19 }, trechiad12),
			({ 3w and 13h-13h19 }, trechiad13),
			({ 3w and 14h-14h19 }, trechiad14),
			({ 3w and 15h-15h19 }, trechiad15),
			({ 3w and 16h-16h19 }, trechiad16),
			({ 3w and 17h-17h19 }, trechiad17),
			({ 3w and 18h-18h19 }, trechiad18),
			({ 3w and 19h-19h19 }, trechiad19),
			({ 3w and 20h-20h19 }, trechiad20),
			({ 3w and 21h-21h19 }, trechiad21),
			({ 3w and 22h-22h19 }, trechiad22),

			({ 4w and 09h-09h19 }, ketvirtad09),
			({ 4w and 12h-12h19 }, ketvirtad12),
			({ 4w and 13h-13h19 }, ketvirtad13),
			({ 4w and 14h-14h19 }, ketvirtad14),
			({ 4w and 15h-15h19 }, ketvirtad15),
			({ 4w and 16h-16h19 }, ketvirtad16),
			({ 4w and 17h-17h19 }, ketvirtad17),
			({ 4w and 18h-18h19 }, ketvirtad18),
			({ 4w and 19h-19h19 }, ketvirtad19),
			({ 4w and 20h-20h19 }, ketvirtad20),
			({ 4w and 21h-21h19 }, ketvirtad21),
			({ 4w and 22h-22h19 }, ketvirtad22),

			({ 5w and 09h-09h19 }, penktad09),
			({ 5w and 12h-12h19 }, penktad12),
			({ 5w and 13h-13h19 }, penktad13),
			({ 5w and 14h-14h19 }, penktad14),
			({ 5w and 15h-15h19 }, penktad15),
			({ 5w and 16h-16h19 }, penktad16),
			({ 5w and 17h-17h19 }, penktad17),
			({ 5w and 18h-18h19 }, penktad18),
			({ 5w and 19h-19h19 }, penktad19),
			({ 5w and 20h-20h19 }, penktad20),
			({ 5w and 21h-21h19 }, penktad21),
			({ 5w and 22h-22h19 }, penktad22),
			({ 5w and 23h-23h19 }, penktad23),

			({ 6w and 00h-00h19 }, sheshtad00),
			({ 6w and 01h-01h19 }, sheshtad01),
			({ 6w and 02h-02h19 }, sheshtad02),
			({ 6w and 09h-09h19 }, sheshtad09),
			({ 6w and 12h-12h19 }, sheshtad12),
			({ 6w and 13h-13h19 }, sheshtad13),
			({ 6w and 14h-14h19 }, sheshtad14),
			({ 6w and 15h-15h19 }, sheshtad15),
			({ 6w and 16h-16h19 }, sheshtad16),
			({ 6w and 17h-17h19 }, sheshtad17),
			({ 6w and 18h-18h19 }, sheshtad18),
			({ 6w and 19h-19h19 }, sheshtad19),
			({ 6w and 20h-20h19 }, sheshtad20),
			({ 6w and 21h-21h19 }, sheshtad21),
			({ 6w and 22h-22h19 }, sheshtad22),
			({ 6w and 23h-23h19 }, sheshtad23),

			({ 7w and 00h-00h19 }, sekmad00),
			({ 7w and 01h-01h19 }, sekmad01),
			({ 7w and 02h-02h19 }, sekmad02),
			({ 7w and 09h-09h19 }, sekmad09),
			({ 7w and 12h-12h19 }, sekmad12),
			({ 7w and 13h-13h19 }, sekmad13),
			({ 7w and 14h-14h19 }, sekmad14),
			({ 7w and 15h-15h19 }, sekmad15),
			({ 7w and 16h-16h19 }, sekmad16),
			({ 7w and 17h-17h19 }, sekmad17),
			({ 7w and 18h-18h19 }, sekmad18),
			({ 7w and 19h-19h19 }, sekmad19),
			({ 7w and 20h-20h19 }, sekmad20),
			({ 7w and 21h-21h19 }, sekmad21),
			({ 7w and 22h-22h19 }, sekmad22),
			({ 6h00-6h16 }, mishke)]),

		switch(track_sensitive=false,[
			({ 1w and 07h-09h00 }, jazz),
			({ 1w and 11h-12h00 }, planetos),
			({ 2w and 07h-09h00 }, jazz),
			({ 2w and 11h-12h00 }, planetos),
			({ 3w and 07h-09h00 }, jazz),
			({ 3w and 11h-12h00 }, planetos),
			({ 4w and 07h-09h00 }, jazz),
			({ 4w and 11h-12h00 }, planetos),
			({ 5w and 07h-09h00 }, jazz),
			({ 5w and 11h-12h00 }, planetos),
			({ 6w and 07h-09h00 }, jazz),
			({ 6w and 11h-12h00 }, planetos),
			({ 7w and 07h-09h00 }, jazz),
			({ 7w and 11h-12h00 }, planetos)]),
			plejlist], transitions=[crossfade_1s, crossfade_1s])


def normalize_music(s)
amplify(0.6, normalize(gain_max = 27.0, gain_min = -18.0, target=-15.0, threshold=-40.0, window=10.0, s))
end

def loudnesswar(s)
# 3-band crossover
low = fun (s) -> filter.iir.eq.low(frequency = 300., s)
mh = fun (s) -> filter.iir.eq.high(frequency = 180., s)
mid = fun (s) -> filter.iir.eq.low(frequency = 1800., s)
high = fun (s) -> filter.iir.eq.high(frequency = 1366., s)

# Add back
compressed = add(normalize = false,
[ compress(attack = 100., release = 200., threshold = -20.,
ratio = 2.8, gain = 8.0, knee = 9.0,
low(s)),
compress(attack = 100., release = 200., threshold = -24.,
ratio = 2.0, gain = 9.0, knee = 9.0,
mid(mh(s))),
compress(attack = 100., release = 200., threshold = -20.,
ratio = 2.4, gain = 6.0, knee = 9.0,
high(s))
])
limit(attack=0.01, release=5000., threshold=-2., compressed)
#ladspa.fastlookaheadlimiter(limit=-1.0, release_time=0.08, compressed)
end

radio = loudnesswar(normalize_music(radio))


# output
out = output.icecast(
   %ffmpeg(format = "mp3", %audio(codec = "libmp3lame", b = "192k")), host = "localhost", port = 8000, password = "hackme",
   mount = "radiovilnius-mp3", name = "Radio Vilnius", description = "", genre = "3",
   url = "", fallible = true, encoding = "UTF-8",
   radio )
</pre>
</details>

The most important optimization is around `{before,after}_output`. These functions are used to do some house keeping around streaming cycle, most notably to clear cached data between rounds. Because sources can be shared, these functions might be called several times and we were not doing anything to optimize it.

With the introduction of tracks, this ended up being even more problematic as sources may not appear for each of their track in the muxer, which resulted in a significant CPU usage increase (about 3x, consistent with audio/metadata/track marks).

With this PR, we now mark the source as being inside a streaming round and prevent multiple calls accordingly. This requires a stricter streaming discipline, which seems to have been chased down, thanks to our test suite.

Lastly, to prevent sub-classing those methods, which would override the optimization, everything relying on these events has been moved to a callback API, which makes things arguably more readable too.

With this, CPU usage is now reduced again to levels comparable to `v2.1.4`. `memtrace` indicates a high amount of memory allocation around data bliting/copying which should eventually go away when we switch to immutable content in `v2.3.x`!

Memory footprint is still about double in `v2.2.x` compares to `v2.1.4`. This seems to be traceable to the standard library and will hopefully be addressed when we start optimizing this side of things.