### PR TITLE
Don't use locks for all generator read operations.

### DIFF
--- a/src/core/stream/generator.ml
+++ b/src/core/stream/generator.ml
@@ -26,8 +26,8 @@ type t = {
   lock : Mutex.t;
   log : string -> unit;
   content_type : Frame_base.content_type;
-  mutable max_length : int option;
-  mutable content : Content.data Frame_base.Fields.t;
+  max_length : int option Atomic.t;
+  content : Content.data Frame_base.Fields.t Atomic.t;
 }
 
 let add_timed_content content =
@@ -37,116 +37,112 @@ let add_timed_content content =
        (Content.make Content.Metadata.format)
        content)
 
+let make_content ?length content_type =
+  add_timed_content (Frame_base.Fields.map (Content.make ?length) content_type)
+
 let create ?(log = fun s -> log#info "%s" s) ?max_length ?length content_type =
   {
     lock = Mutex.create ();
-    max_length;
+    max_length = Atomic.make max_length;
     log;
     content_type;
-    content =
-      add_timed_content
-        (Frame_base.Fields.map (Content.make ?length) content_type);
+    content = Atomic.make (make_content ?length content_type);
   }
 
-let get_field gen =
-  Tutils.mutexify gen.lock (fun field ->
-      Frame_base.Fields.find field gen.content)
+let get_field gen field = Frame_base.Fields.find field (Atomic.get gen.content)
 
-let set_field gen field =
-  Tutils.mutexify gen.lock (fun content ->
-      gen.content <- Frame_base.Fields.add field content gen.content)
+let set_field =
+  let add_field gen field content () =
+    Atomic.set gen.content
+      (Frame_base.Fields.add field content (Atomic.get gen.content))
+  in
+  fun gen field content ->
+    Tutils.mutexify gen.lock (add_field gen field content) ()
 
-let max_length gen = Tutils.mutexify gen.lock (fun () -> gen.max_length) ()
-let content_type gen = Tutils.mutexify gen.lock (fun () -> gen.content_type) ()
+let max_length { max_length } = Atomic.get max_length
+let content_type { content_type } = content_type
+let set_max_length gen max_length = Atomic.set gen.max_length max_length
 
-let set_max_length gen =
-  Tutils.mutexify gen.lock (fun max_length -> gen.max_length <- max_length)
+let field_length { content } field =
+  Content.length (Frame_base.Fields.find field (Atomic.get content))
 
-let field_length { lock; content } =
-  Tutils.mutexify lock (fun field ->
-      Content.length (Frame_base.Fields.find field content))
-
-let _media_content { content } =
+let media_content { content } =
   Frame_base.Fields.filter
     (fun f _ ->
       f <> Frame_base.Fields.metadata && f <> Frame_base.Fields.track_marks)
-    content
+    (Atomic.get content)
 
-let _length gen =
+let length gen =
   Option.value ~default:0
     (Frame_base.Fields.fold
        (fun _ c -> function
          | None -> Some (Content.length c)
          | Some l' -> Some (min (Content.length c) l'))
-       (_media_content gen) None)
+       (media_content gen) None)
 
-let _buffered_length gen =
+let buffered_length gen =
   Option.value ~default:0
     (Frame_base.Fields.fold
        (fun _ c -> function
          | None -> Some (Content.length c)
          | Some l' -> Some (max (Content.length c) l'))
-       (_media_content gen) None)
+       (media_content gen) None)
 
-let buffered_length gen =
-  Tutils.mutexify gen.lock (fun () -> _buffered_length gen) ()
-
-let length gen = Tutils.mutexify gen.lock (fun () -> _length gen) ()
-
-let _remaining gen =
+let remaining gen =
   match
     Content.Track_marks.get_data
-      (Frame_base.Fields.find Frame_base.Fields.track_marks gen.content)
+      (Frame_base.Fields.find Frame_base.Fields.track_marks
+         (Atomic.get gen.content))
   with
-    | p :: _ when p <= _length gen -> p
+    | p :: _ when p <= length gen -> p
     | _ -> -1
 
-let remaining gen = Tutils.mutexify gen.lock (fun () -> _remaining gen) ()
-
 let _truncate gen len =
-  gen.content <-
-    Frame_base.Fields.map
-      (fun content -> Content.truncate content len)
-      gen.content
+  Atomic.set gen.content
+    (Frame_base.Fields.map
+       (fun content -> Content.truncate content len)
+       (Atomic.get gen.content))
 
 let truncate gen = Tutils.mutexify gen.lock (_truncate gen)
 
 let clear gen =
   Tutils.mutexify gen.lock
     (fun () ->
-      gen.content <-
-        Frame_base.Fields.map
-          (fun c -> Content.make ~length:0 (Content.format c))
-          gen.content)
+      Atomic.set gen.content
+        (Frame_base.Fields.map
+           (fun c -> Content.make ~length:0 (Content.format c))
+           (Atomic.get gen.content)))
     ()
 
 let _set_metadata gen =
   Content.Metadata.set_data
-    (Frame_base.Fields.find Frame_base.Fields.metadata gen.content)
+    (Frame_base.Fields.find Frame_base.Fields.metadata (Atomic.get gen.content))
 
-let _get_metadata gen =
+let get_metadata gen =
   Content.Metadata.get_data
-    (Frame_base.Fields.find Frame_base.Fields.metadata gen.content)
+    (Frame_base.Fields.find Frame_base.Fields.metadata (Atomic.get gen.content))
 
-let _default_pos gen = function Some pos -> pos | None -> _length gen
+let default_pos gen = function Some pos -> pos | None -> length gen
 
 let _add_metadata ?pos gen m =
-  let pos = _default_pos gen pos in
-  _set_metadata gen ((pos, m) :: _get_metadata gen)
+  let pos = default_pos gen pos in
+  _set_metadata gen ((pos, m) :: get_metadata gen)
 
 let add_metadata ?pos gen = Tutils.mutexify gen.lock (_add_metadata ?pos gen)
 
 let _set_track_marks gen =
   Content.Track_marks.set_data
-    (Frame_base.Fields.find Frame_base.Fields.track_marks gen.content)
+    (Frame_base.Fields.find Frame_base.Fields.track_marks
+       (Atomic.get gen.content))
 
-let _get_track_marks gen =
+let get_track_marks gen =
   Content.Track_marks.get_data
-    (Frame_base.Fields.find Frame_base.Fields.track_marks gen.content)
+    (Frame_base.Fields.find Frame_base.Fields.track_marks
+       (Atomic.get gen.content))
 
 let _add_track_mark ?pos gen =
-  let pos = _default_pos gen pos in
-  _set_track_marks gen (pos :: _get_track_marks gen)
+  let pos = default_pos gen pos in
+  _set_track_marks gen (pos :: get_track_marks gen)
 
 let add_track_mark ?pos gen =
   Tutils.mutexify gen.lock (fun () -> _add_track_mark ?pos gen) ()
@@ -162,15 +158,15 @@ let _put gen field content =
           (fun (pos, m) -> _add_metadata ~pos gen m)
           (Content.Metadata.get_data content)
     | _ ->
-        gen.content <-
-          Frame_base.Fields.add field
-            (Content.append
-               (Frame_base.Fields.find field gen.content)
-               (Content.copy content))
-            gen.content);
+        Atomic.set gen.content
+          (Frame_base.Fields.add field
+             (Content.append
+                (Frame_base.Fields.find field (Atomic.get gen.content))
+                content)
+             (Atomic.get gen.content)));
 
-  let l = _buffered_length gen in
-  match gen.max_length with
+  let l = buffered_length gen in
+  match Atomic.get gen.max_length with
     | Some l' when l' < l ->
         let drop = l - l' in
         gen.log
@@ -184,76 +180,87 @@ let _put gen field content =
 let put gen field =
   Tutils.mutexify gen.lock (fun content -> _put gen field content)
 
-let _get ?length gen =
-  let length = Option.value ~default:(_length gen) length in
-  if _length gen < length then
-    failwith "Requested length is greater than buffer length!";
-  let content =
-    Frame_base.Fields.map (fun c -> Content.sub c 0 length) gen.content
-  in
-  gen.content <-
-    Frame_base.Fields.map (fun c -> Content.truncate c length) gen.content;
-  content
+let _get =
+  let len = length in
+  fun ?length gen ->
+    let length = Option.value ~default:(len gen) length in
+    if len gen < length then
+      failwith "Requested length is greater than buffer length!";
+    let content =
+      Frame_base.Fields.map
+        (fun c -> Content.sub c 0 length)
+        (Atomic.get gen.content)
+    in
+    Atomic.set gen.content
+      (Frame_base.Fields.map
+         (fun c -> Content.truncate c length)
+         (Atomic.get gen.content));
+    content
 
 let get ?length gen = Tutils.mutexify gen.lock (fun () -> _get ?length gen) ()
-let peek gen = Tutils.mutexify gen.lock (fun () -> gen.content) ()
-let peek_media gen = Tutils.mutexify gen.lock (fun () -> _media_content gen) ()
+let peek gen = Atomic.get gen.content
+let peek_media gen = media_content gen
 
 (* The following is frame-specific and should hopefully go away when
    we switch to immutable content. *)
 
-let _frame_position frame =
+let frame_position frame =
   match
     List.rev
       (Content.Track_marks.get_data
-         (Frame_base.Fields.find Frame_base.Fields.track_marks frame.content))
+         (Frame_base.Fields.find Frame_base.Fields.track_marks
+            (Atomic.get frame.content)))
   with
     | p :: _ -> p
     | _ -> 0
 
-let _frame_remaining frame =
-  Lazy.force Frame_settings.size - _frame_position frame
+let frame_remaining frame =
+  Lazy.force Frame_settings.size - frame_position frame
 
 let feed ?offset ?length ?fields gen =
   Tutils.mutexify gen.lock (fun frame ->
       Tutils.mutexify frame.lock
         (fun () ->
           let offset = Option.value ~default:0 offset in
-          let length = Option.value ~default:(_frame_position frame) length in
+          let length = Option.value ~default:(frame_position frame) length in
+
+          let gen_content = Atomic.get gen.content in
+          let frame_content = Atomic.get frame.content in
+
           let fields =
             Option.value
-              ~default:(List.map fst (Frame_base.Fields.bindings gen.content))
+              ~default:(List.map fst (Frame_base.Fields.bindings gen_content))
               fields
           in
 
-          gen.content <-
-            List.fold_left
-              (fun content field ->
-                match field with
-                  (* The current use of generators is to explicitly add track marks via `Generator.add_track_mark`.
-                     This will be changed when we switch to immutable content. *)
-                  | f when f = Frame_base.Fields.track_marks -> content
-                  | f when f = Frame_base.Fields.metadata ->
-                      let gen_content =
-                        Frame_base.Fields.find field gen.content
-                      in
-                      let frame_content =
-                        Frame_base.Fields.find field frame.content
-                      in
-                      Content.Metadata.set_data gen_content
-                        (Content.Metadata.get_data gen_content
-                        @ Content.Metadata.get_data frame_content);
-                      content
-                  | _ ->
-                      Frame_base.Fields.add field
-                        (Content.append
-                           (Frame_base.Fields.find field gen.content)
-                           (Content.copy
-                              (Content.sub
-                                 (Frame_base.Fields.find field frame.content)
-                                 offset length)))
-                        content)
-              gen.content fields)
+          Atomic.set gen.content
+            (List.fold_left
+               (fun content field ->
+                 match field with
+                   (* The current use of generators is to explicitly add track marks via `Generator.add_track_mark`.
+                      This will be changed when we switch to immutable content. *)
+                   | f when f = Frame_base.Fields.track_marks -> content
+                   | f when f = Frame_base.Fields.metadata ->
+                       let gen_content =
+                         Frame_base.Fields.find field gen_content
+                       in
+                       let frame_content =
+                         Frame_base.Fields.find field frame_content
+                       in
+                       Content.Metadata.set_data gen_content
+                         (Content.Metadata.get_data gen_content
+                         @ Content.Metadata.get_data frame_content);
+                       content
+                   | _ ->
+                       Frame_base.Fields.add field
+                         (Content.append
+                            (Frame_base.Fields.find field gen_content)
+                            (Content.copy
+                               (Content.sub
+                                  (Frame_base.Fields.find field frame_content)
+                                  offset length)))
+                         content)
+               gen_content fields))
         ())
 
 let fill gen =
@@ -261,46 +268,50 @@ let fill gen =
       Tutils.mutexify frame.lock
         (fun () ->
           let available =
-            match _remaining gen with -1 -> _length gen | l -> l
+            match remaining gen with -1 -> length gen | l -> l
           in
-          let len = min (_frame_remaining frame) available in
-          let pos = _frame_position frame in
+          let len = min (frame_remaining frame) available in
+          let pos = frame_position frame in
           let new_pos = pos + len in
-          gen.content <-
-            Frame_base.Fields.mapi
-              (fun field content ->
-                let rem =
-                  Content.sub content len (Content.length content - len)
-                in
-                (* TODO: make this append after after switch to immutable content. *)
-                (match field with
-                  (* Remove the track mark if it is was used to compute remaining and it's not
-                     at frame boundaries. *)
-                  | f when f = Frame_base.Fields.track_marks -> (
-                      match Content.Track_marks.get_data rem with
-                        | 0 :: d when new_pos <> Lazy.force Frame_settings.size
-                          ->
-                            Content.Track_marks.set_data rem d
-                        | _ -> ())
-                  | f when f = Frame_base.Fields.metadata ->
-                      (* For metadata, it is expected that we only add new metadata and do not replace
-                         exiting ones. *)
-                      let frame_content =
-                        Frame_base.Fields.find field frame.content
-                      in
-                      let content =
-                        Content.Metadata.get_data (Content.sub content 0 len)
-                      in
-                      let content =
-                        List.map (fun (p, m) -> (pos + p, m)) content
-                      in
-                      Content.Metadata.set_data frame_content
-                        (Content.Metadata.get_data frame_content @ content)
-                  | f ->
-                      Content.blit content 0
-                        (Frame_base.Fields.find f frame.content)
-                        pos len);
-                rem)
-              gen.content;
+
+          let gen_content = Atomic.get gen.content in
+          let frame_content = Atomic.get frame.content in
+
+          Atomic.set gen.content
+            (Frame_base.Fields.mapi
+               (fun field content ->
+                 let rem =
+                   Content.sub content len (Content.length content - len)
+                 in
+                 (* TODO: make this append after after switch to immutable content. *)
+                 (match field with
+                   (* Remove the track mark if it is was used to compute remaining and it's not
+                      at frame boundaries. *)
+                   | f when f = Frame_base.Fields.track_marks -> (
+                       match Content.Track_marks.get_data rem with
+                         | 0 :: d when new_pos <> Lazy.force Frame_settings.size
+                           ->
+                             Content.Track_marks.set_data rem d
+                         | _ -> ())
+                   | f when f = Frame_base.Fields.metadata ->
+                       (* For metadata, it is expected that we only add new metadata and do not replace
+                          exiting ones. *)
+                       let frame_content =
+                         Frame_base.Fields.find field frame_content
+                       in
+                       let content =
+                         Content.Metadata.get_data (Content.sub content 0 len)
+                       in
+                       let content =
+                         List.map (fun (p, m) -> (pos + p, m)) content
+                       in
+                       Content.Metadata.set_data frame_content
+                         (Content.Metadata.get_data frame_content @ content)
+                   | f ->
+                       Content.blit content 0
+                         (Frame_base.Fields.find f frame_content)
+                         pos len);
+                 rem)
+               gen_content);
           _add_track_mark ~pos:new_pos frame)
         ())


### PR DESCRIPTION
This is another slice of https://github.com/savonet/liquidsoap/pull/3079 this time making use of `Atomic` to prevent generator from using locks in read operations, saving the memory and CPU overhead for repeated streaming operations.

When we switch to OCaml 5, we could even use a busy-wait loop via `Domain.cpu_relax` and avoid locks altogether!