### PR TITLE
Stricter white space

### DIFF
--- a/src/lang/lexer.ml
+++ b/src/lang/lexer.ml
@@ -73,7 +73,8 @@ let parse_time t =
       None;
     ]
 
-let skipped = [%sedlex.regexp? Sub (white_space, '\n') | '\r' | '\t']
+let white_space = [%sedlex.regexp? Sub (white_space, '\n')]
+let skipped = [%sedlex.regexp? white_space | '\r' | '\t']
 let decimal_digit = [%sedlex.regexp? '0' .. '9']
 
 let decimal_literal =

--- a/tests/regression/GH3093.liq
+++ b/tests/regression/GH3093.liq
@@ -1,0 +1,8 @@
+x = false
+
+ignore(x)
+
+#
+x = true
+
+if x then test.pass() else test.fail () end

--- a/tests/regression/GH3093.liq
+++ b/tests/regression/GH3093.liq
@@ -1,8 +1,12 @@
-x = false
+def f() =
+  x = false
 
-ignore(x)
+  ignore(x)
 
 #
-x = true
+  x = true
 
-if x then test.pass() else test.fail () end
+  if x then test.pass() else test.fail () end
+end
+
+test.check(f)

--- a/tests/regression/dune.inc
+++ b/tests/regression/dune.inc
@@ -354,6 +354,19 @@
  (alias citest)
  (package liquidsoap)
  (deps
+  GH3093.liq
+  ../media/all_media_files
+  ../../src/bin/liquidsoap.exe
+  (package liquidsoap)
+  (:stdlib ../../src/libs/stdlib.liq)
+  (:test_liq ../test.liq)
+  (:run_test ../run_test.exe))
+ (action (run %{run_test} GH3093.liq liquidsoap %{test_liq} GH3093.liq)))
+
+(rule
+ (alias citest)
+ (package liquidsoap)
+ (deps
   GH2602.liq
   ../media/all_media_files
   ../../src/bin/liquidsoap.exe


### PR DESCRIPTION
Interestingly, white space unicode characters do include line break characters (see: https://en.wikipedia.org/wiki/Whitespace_character) but, in our parser, we want to differentiate between the two.

This PR does just that and should fix #3093