### PR TITLE
Cleanup init.

### DIFF
--- a/src/core/builtins/builtins_prometheus.ml
+++ b/src/core/builtins/builtins_prometheus.ml
@@ -165,11 +165,11 @@ let source_monitor ~prefix ~label_names ~labels ~window s =
   let last_start_time = ref 0. in
   let last_end_time = ref 0. in
   let last_data = Gauge.labels (get_last_data ~label_names) labels in
-  let get_ready ~stype:_ ~is_active:_ ~id:_ ~ctype:_ ~clock_id:_
+  let wake_up ~stype:_ ~is_active:_ ~id:_ ~ctype:_ ~clock_id:_
       ~clock_sync_mode:_ =
     ()
   in
-  let leave () = () in
+  let sleep () = () in
   let get_frame ~start_time ~end_time ~start_position ~end_position
       ~is_partial:_ ~metadata:_ =
     last_start_time := start_time;
@@ -186,8 +186,8 @@ let source_monitor ~prefix ~label_names ~labels ~window s =
   in
   let watcher =
     {
-      Source.get_ready;
-      leave;
+      Source.wake_up;
+      sleep;
       get_frame;
       before_output = (fun _ -> ());
       after_output;

--- a/src/core/builtins/builtins_source.ml
+++ b/src/core/builtins/builtins_source.ml
@@ -137,7 +137,7 @@ let _ =
       Lang.float (frame_position +. in_frame_position))
 
 let _ =
-  Lang.add_builtin ~base:source "on_leave" ~category:(`Source `Liquidsoap)
+  Lang.add_builtin ~base:source "on_shutdown" ~category:(`Source `Liquidsoap)
     [
       ("", Lang.source_t (Lang.univ_t ()), None, None);
       ("", Lang.fun_t [] Lang.unit_t, None, None);
@@ -150,22 +150,7 @@ let _ =
       let s = Lang.to_source (Lang.assoc "" 1 p) in
       let f = Lang.assoc "" 2 p in
       let wrap_f () = ignore (Lang.apply f []) in
-      s#on_leave wrap_f;
-      Lang.unit)
-
-let _ =
-  Lang.add_builtin ~base:source "on_shutdown" ~category:(`Source `Liquidsoap)
-    [
-      ("", Lang.source_t (Lang.univ_t ()), None, None);
-      ("", Lang.fun_t [] Lang.unit_t, None, None);
-    ]
-    Lang.unit_t
-    ~descr:"Register a function to be called when source shuts down."
-    (fun p ->
-      let s = Lang.to_source (Lang.assoc "" 1 p) in
-      let f = Lang.assoc "" 2 p in
-      let wrap_f () = ignore (Lang.apply f []) in
-      s#on_shutdown wrap_f;
+      s#on_sleep wrap_f;
       Lang.unit)
 
 let _ =

--- a/src/core/lang_source.ml
+++ b/src/core/lang_source.ml
@@ -102,7 +102,7 @@ let source_methods =
             let f = assoc "" 1 p in
             s#on_metadata (fun m -> ignore (apply f [("", metadata m)]));
             unit) );
-    ( "on_get_ready",
+    ( "on_wake_up",
       ([], fun_t [(false, "", fun_t [] unit_t)] unit_t),
       "Register a function to be called after the source is asked to get \
        ready. This is when, for instance, the source's final ID is set.",
@@ -111,7 +111,7 @@ let source_methods =
           [("", "", None)]
           (fun p ->
             let f = assoc "" 1 p in
-            s#on_get_ready (fun () -> ignore (apply f []));
+            s#on_wake_up (fun () -> ignore (apply f []));
             unit) );
     ( "on_shutdown",
       ([], fun_t [(false, "", fun_t [] unit_t)] unit_t),
@@ -121,18 +121,7 @@ let source_methods =
           [("", "", None)]
           (fun p ->
             let f = assoc "" 1 p in
-            s#on_shutdown (fun () -> ignore (apply f []));
-            unit) );
-    ( "on_leave",
-      ([], fun_t [(false, "", fun_t [] unit_t)] unit_t),
-      "Register a function to be called when source is not used anymore by \
-       another source.",
-      fun s ->
-        val_fun
-          [("", "", None)]
-          (fun p ->
-            let f = assoc "" 1 p in
-            s#on_leave (fun () -> ignore (apply f []));
+            s#on_sleep (fun () -> ignore (apply f []));
             unit) );
     ( "on_track",
       ([], fun_t [(false, "", fun_t [(false, "", metadata_t)] unit_t)] unit_t),

--- a/src/libs/request.liq
+++ b/src/libs/request.liq
@@ -60,7 +60,7 @@ def request.queue(~id=null(), ~interactive=true, ~prefetch=1, ~native=false, ~qu
       push(r)
       "#{request.id(r)}"
     end
-    s.on_get_ready(memoize({
+    s.on_wake_up(memoize({
       begin
         server.register(namespace=source.id(s), description="Flush the queue and skip the current track",
                         "flush_and_skip", fun (_) -> try

--- a/src/libs/telnet.liq
+++ b/src/libs/telnet.liq
@@ -2,7 +2,7 @@
 def replaces request.dynamic(%argsof(request.dynamic), fn) =
   s = request.dynamic(%argsof(request.dynamic), fn)
 
-  s.on_get_ready(memoize({
+  s.on_wake_up(memoize({
     server.register(namespace=source.id(s), description="Flush the queue and skip the current track",
                     "flush_and_skip", fun (_) -> try
                       s.set_queue([])
@@ -21,7 +21,7 @@ end
 def replaces input.gstreamer.audio_video(%argsof(input.gstreamer.audio_video)) =
   s = input.gstreamer.audio_video(%argsof(input.gstreamer.audio_video))
 
-  s.on_get_ready(memoize({
+  s.on_wake_up(memoize({
     begin
       server.register(namespace=source.id(s), description="Set gstreamer pipeline state to play",
                       "play", fun (_) -> try
@@ -57,7 +57,7 @@ end
 def replaces blank.strip(%argsof(blank.strip), s) =
   s = blank.strip(%argsof(blank.strip), s)
 
-  s.on_get_ready(memoize({
+  s.on_wake_up(memoize({
     server.register(namespace=source.id(s), description="Check if the source is stripping.",
                     "is_stripping", fun (_) -> begin
                       "#{s.is_blank()}"
@@ -71,7 +71,7 @@ end
 def replaces output.external(%argsof(output.external), f, p, s) =
   s = output.external(%argsof(output.external), f, p, s)
 
-  s.on_get_ready(memoize({
+  s.on_wake_up(memoize({
     server.register(namespace=s.id(), description="Re-open the output.",
                     "reopen", fun (_) -> begin
                       s.reopen()
@@ -86,7 +86,7 @@ end
 def replaces input.external.avi(%argsof(input.external.avi), s) =
   s = input.external.avi(%argsof(input.external.avi), s)
 
-  s.on_get_ready(memoize({
+  s.on_wake_up(memoize({
     server.register(namespace=source.id(s), description="Show internal buffer length (in seconds).",
                     "buffer_length", fun (_) -> begin
                       buffered = s.buffered()
@@ -104,7 +104,7 @@ end
 def replaces input.harbor(%argsof(input.harbor), s) =
   s = input.harbor(%argsof(input.harbor), s)
 
-  s.on_get_ready(memoize({
+  s.on_wake_up(memoize({
     begin
       server.register(namespace=source.id(s), description="Stop current source client, if connected.",
                      "stop", fun (_) -> begin
@@ -132,7 +132,7 @@ end
 def replaces input.http(%argsof(input.http), s) =
   s = input.http(%argsof(input.http), s)
 
-  s.on_get_ready(memoize({
+  s.on_wake_up(memoize({
     begin
       server.register(namespace=source.id(s), description="Start the source, if needed.",
                       "start", fun (_) -> begin


### PR DESCRIPTION
This PR cleans up the init phase the same way we did for `{before,after}_output` in https://github.com/savonet/liquidsoap/pull/3079, making sure that we execute the init callbacks only once per source.