### PR TITLE
Optionally register source for cleanup.

### DIFF
--- a/src/core/builtins/builtins_ffmpeg_filters.ml
+++ b/src/core/builtins/builtins_ffmpeg_filters.ml
@@ -94,9 +94,7 @@ let is_ready graph =
   (not graph.failed)
   && Queue.fold (fun cur s -> cur && s#is_ready) true graph.graph_inputs
 
-let pull graph =
-  (Clock.get (Queue.peek graph.graph_inputs)#clock)#end_tick;
-  Queue.iter (fun s -> s#after_output) graph.graph_inputs
+let pull graph = (Clock.get (Queue.peek graph.graph_inputs)#clock)#end_tick
 
 let self_sync_type graph =
   Lazy.from_fun (fun () ->

--- a/src/core/builtins/builtins_source.ml
+++ b/src/core/builtins/builtins_source.ml
@@ -195,11 +195,12 @@ let _ =
       let s = Lang.to_source (Lang.assoc "" 3 p) in
       let p = (("id", Lang.string "source_dumper") :: p) @ proto in
       let fo = Pipe_output.new_file_output p in
+      let clock = Clock.clock ~start:false "source_dumper" in
+      Clock.unify s#clock (Clock.create_known clock);
       fo#get_ready [s];
       log#info "Start dumping source.";
       while s#is_ready do
-        fo#output;
-        fo#after_output
+        clock#end_tick
       done;
       log#info "Source dumped.";
       fo#leave s;
@@ -221,12 +222,12 @@ let _ =
           ~on_stop:(fun () -> ())
           ~autostart:true (Lang.source s)
       in
+      let clock = Clock.clock ~start:false "source_dropper" in
+      Clock.unify s#clock (Clock.create_known clock);
       o#get_ready [s];
       log#info "Start dropping source.";
       while s#is_ready do
-        o#before_output;
-        o#output;
-        o#after_output
+        clock#end_tick
       done;
       log#info "Source dropped.";
       o#leave s;

--- a/src/core/clock.ml
+++ b/src/core/clock.ml
@@ -279,6 +279,8 @@ module MkClock (Time : Liq_time.T) = struct
       val thread_name = "clock_" ^ id
       val mutable on_before_output = []
       method on_before_output fn = on_before_output <- fn :: on_before_output
+      val mutable on_output = []
+      method on_output fn = on_output <- fn :: on_output
       val mutable on_after_output = []
       method on_after_output fn = on_after_output <- fn :: on_after_output
 
@@ -323,6 +325,8 @@ module MkClock (Time : Liq_time.T) = struct
                       e))
             [] active
         in
+        List.iter (fun fn -> fn ()) on_output;
+        on_output <- [];
         if error <> [] then (
           Tutils.mutexify lock
             (fun () ->

--- a/src/core/clock.mli
+++ b/src/core/clock.mli
@@ -79,7 +79,7 @@
  *   duration of each frame.
  *
  * About dependent clocks:
- * - The following is mostly implemented in [Child_resource] for reference.
+ * - The following is mostly implemented in [Child_support] for reference.
  * - In some operators such as [cross], [cue_cut], [soundtouch] and etc, the main
  *   operator wants full control over the children's clock.
  * - In this case, the children's source must all be statically non [self_sync]
@@ -99,7 +99,7 @@
  * - However, one should remember that the children clock needs to be eventually
  *   animated in order to allow the children outputs to detect source failure,
  *   trigger [on_stop] events and etc.
- * - Thus, the convention proposed in [Child_resource] is that, if the main source
+ * - Thus, the convention proposed in [Child_support] is that, if the main source
  *   is not available, it should always call [#end_tick] on each of the main clock
  *   tick. This is implemented by using a [needs_tick] that is always set to [true]
  *   on each [#after_output]. If [true], a [#end_tick] is executed on the children

--- a/src/core/operators/accelerate.ml
+++ b/src/core/operators/accelerate.ml
@@ -26,10 +26,7 @@ class accelerate ~ratio ~randomize source_val =
   let source = Lang.to_source source_val in
   object (self)
     inherit operator ~name:"accelerate" [source] as super
-
-    inherit!
-      Child_support.base ~check_self_sync:true [source_val] as child_support
-
+    inherit! Child_support.base ~check_self_sync:true [source_val]
     method self_sync = source#self_sync
     method stype = source#stype
     method seek = source#seek
@@ -89,10 +86,6 @@ class accelerate ~ratio ~randomize source_val =
       let after = Frame.position frame in
       filled <- filled + (after - before);
       self#child_tick
-
-    initializer
-      self#on_before_output (fun () -> child_support#child_before_output);
-      self#on_after_output (fun () -> child_support#child_after_output)
   end
 
 let _ =

--- a/src/core/operators/cross.ml
+++ b/src/core/operators/cross.ml
@@ -30,7 +30,7 @@ let finalise_child_clock child_clock source =
   * [cross_length] is in ticks (like #remaining estimations).
   * We are assuming a fixed audio kind -- at least for now. *)
 class cross val_source ~duration_getter ~override_duration ~persist_override
-  ~rms_width ~minimum_length ~conservative ~active transition =
+  ~rms_width ~minimum_length ~conservative transition =
   let s = Lang.to_source val_source in
   let original_duration_getter = duration_getter in
   object (self)
@@ -147,34 +147,12 @@ class cross val_source ~duration_getter ~override_duration ~persist_override
         transition;
       self#cleanup_transition_source
 
-    method! private set_clock =
-      child_support#set_clock;
-      Lang.iter_sources
-        (fun s -> Clock.unify self#child_clock s#clock)
-        transition
-
-    val mutable main_time = 0
-    val mutable last_child_tick = 0
-
     (* in main time *)
     val mutable status = `Idle
 
     method! private child_tick =
       child_support#child_tick;
-      Frame.clear self#buf_frame;
-      last_child_tick <- (Clock.get self#clock)#get_tick
-
-    initializer
-      self#on_before_output (fun () -> child_support#child_before_output);
-      self#on_after_output (fun () ->
-          let main_clock = Clock.get self#clock in
-          (* Is it really a new tick? *)
-          if main_time <> main_clock#get_tick then (
-            (* Did the child clock tick during this instant? *)
-            if active && last_child_tick <> main_time then (
-              self#child_tick;
-              last_child_tick <- main_time);
-            main_time <- main_clock#get_tick))
+      Frame.clear self#buf_frame
 
     method private save_last_metadata mode buf_frame =
       let compare x y = -compare (fst x) (fst y) in
@@ -204,13 +182,13 @@ class cross val_source ~duration_getter ~override_duration ~persist_override
       self#set_cross_length
 
     method private get_frame frame =
-      let buf_frame = self#buf_frame in
       match status with
         | `Idle ->
             let rem = source#remaining in
             if conservative || (0 <= rem && rem <= cross_length) then (
               self#log#info "Buffering end of track...";
               status <- `Before;
+              let buf_frame = self#buf_frame in
               Frame.set_breaks buf_frame [Frame.position frame];
               Frame.set_all_metadata buf_frame [];
               self#buffering cross_length;
@@ -221,8 +199,7 @@ class cross val_source ~duration_getter ~override_duration ~persist_override
               let p = Frame.position frame in
               source#get frame;
               self#save_last_metadata `Before frame;
-              self#update_cross_length frame p;
-              needs_tick <- true)
+              self#update_cross_length frame p)
         | `Before ->
             (* We started buffering but the track didn't end.
              * Play the beginning of the buffer while filling it more. *)
@@ -244,7 +221,6 @@ class cross val_source ~duration_getter ~override_duration ~persist_override
               Frame.add_break frame (Frame.position frame)
         | `After when (Option.get transition_source)#is_ready ->
             (Option.get transition_source)#get frame;
-            needs_tick <- true;
             if Generator.length pending_after = 0 && Frame.is_partial frame then (
               status <- `Idle;
               self#cleanup_transition_source;
@@ -479,15 +455,6 @@ let _ =
           "Do not trust remaining time estimations, always buffering data in \
            advance. This avoids being tricked by skips, either manual or \
            caused by blank.skip()." );
-      ( "active",
-        Lang.bool_t,
-        Some (Lang.bool false),
-        Some
-          "The active behavior is to keep ticking the child's clock when the \
-           operator is not streaming. Otherwise the child's clock is strictly \
-           based on what is streamed off the child source, which results in \
-           time-dependent active sources to be frozen when that source is \
-           stopped." );
       ( "",
         Lang.fun_t
           [(false, "", transition_arg); (false, "", transition_arg)]
@@ -525,8 +492,7 @@ let _ =
       let rms_width = Frame.audio_of_seconds rms_width in
       let transition = Lang.assoc "" 1 p in
       let conservative = Lang.to_bool (List.assoc "conservative" p) in
-      let active = Lang.to_bool (List.assoc "active" p) in
       let source = Lang.assoc "" 2 p in
       new cross
-        source transition ~conservative ~active ~duration_getter ~rms_width
+        source transition ~conservative ~duration_getter ~rms_width
         ~minimum_length ~override_duration ~persist_override)

--- a/src/core/operators/cross.ml
+++ b/src/core/operators/cross.ml
@@ -121,7 +121,6 @@ class cross val_source ~duration_getter ~override_duration ~persist_override
       let s = (s :> source) in
       s#get_ready ~dynamic:true [(self :> source)];
       Clock.unify source#clock s#clock;
-      s#before_output;
       transition_source <- Some s
 
     method cleanup_transition_source =
@@ -166,13 +165,8 @@ class cross val_source ~duration_getter ~override_duration ~persist_override
       last_child_tick <- (Clock.get self#clock)#get_tick
 
     initializer
-      self#on_before_output (fun () ->
-          source#before_output;
-          ignore (Option.map (fun s -> s#before_output) transition_source);
-          child_support#child_before_output);
+      self#on_before_output (fun () -> child_support#child_before_output);
       self#on_after_output (fun () ->
-          source#after_output;
-          ignore (Option.map (fun s -> s#after_output) transition_source);
           let main_clock = Clock.get self#clock in
           (* Is it really a new tick? *)
           if main_time <> main_clock#get_tick then (

--- a/src/core/operators/cuepoint.ml
+++ b/src/core/operators/cuepoint.ml
@@ -40,10 +40,7 @@ class cue_cut ~m_cue_in ~m_cue_out ~on_cue_in ~on_cue_out source_val =
   let source = Lang.to_source source_val in
   object (self)
     inherit operator ~name:"cue_cut" [source]
-
-    inherit!
-      Child_support.base ~check_self_sync:true [source_val] as child_support
-
+    inherit! Child_support.base ~check_self_sync:true [source_val]
     val mutable track_state : state = `Idle
     method stype = source#stype
     method is_ready = source#is_ready
@@ -59,10 +56,6 @@ class cue_cut ~m_cue_in ~m_cue_out ~on_cue_in ~on_cue_out source_val =
             let target = cue_out - elapsed in
             if source_remaining = -1 then target
             else min source#remaining target
-
-    initializer
-      self#on_before_output (fun () -> child_support#child_before_output);
-      self#on_after_output (fun () -> child_support#child_after_output)
 
     method private get_cue_points buf pos =
       match Frame.get_metadata buf pos with

--- a/src/core/operators/max_duration.ml
+++ b/src/core/operators/max_duration.ml
@@ -74,10 +74,6 @@ class max_duration ~override_meta ~duration source =
         s#leave (self :> Source.source);
         s <- Debug_sources.empty ();
         s#get_ready [(self :> Source.source)])
-
-    initializer
-      self#on_before_output (fun () -> s#before_output);
-      self#on_after_output (fun () -> s#after_output)
   end
 
 let _ =

--- a/src/core/operators/pipe.ml
+++ b/src/core/operators/pipe.ml
@@ -57,9 +57,7 @@ class pipe ~replay_delay ~data_len ~process ~bufferize ~max ~restart
     inherit source ~name:"pipe" () as super
 
     (* We are expecting real-rate with a couple of hickups.. *)
-    inherit!
-      Child_support.base ~check_self_sync:false [source_val] as child_support
-
+    inherit! Child_support.base ~check_self_sync:false [source_val]
     inherit Generated.source ~empty_on_abort:false ~bufferize ()
     val mutable samplesize = 16
     val mutable samplerate = Frame.audio_of_seconds 1.
@@ -275,12 +273,6 @@ class pipe ~replay_delay ~data_len ~process ~bufferize ~max ~restart
             handler <- None
           with Process_handler.Finished -> ())
         ()
-
-    initializer
-      self#on_before_output (fun () -> child_support#child_before_output);
-      self#on_after_output (fun () ->
-          (* As long as we have a process, we let it drive the child source entirely. *)
-          if handler = None then child_support#child_after_output)
   end
 
 let _ =

--- a/src/core/operators/resample.ml
+++ b/src/core/operators/resample.ml
@@ -34,10 +34,7 @@ class resample ~field ~ratio source =
   let () = Typing.(consumer#frame_type <: source#frame_type) in
   object (self)
     inherit operator ~name:"stretch" [(consumer :> Source.source)] as super
-
-    inherit!
-      Child_support.base ~check_self_sync:true [source_val] as child_support
-
+    inherit! Child_support.base ~check_self_sync:true [source_val]
     method self_sync = source#self_sync
     method stype = source#stype
 
@@ -59,10 +56,6 @@ class resample ~field ~ratio source =
       super#wake_up a;
       converter <- Some (Audio_converter.Samplerate.create self#audio_channels);
       write_frame_ref := self#write_frame
-
-    initializer
-      self#on_before_output (fun () -> child_support#child_before_output);
-      self#on_after_output (fun () -> child_support#child_after_output)
 
     method private write_frame =
       function `Frame frame -> self#process_frame frame | `Flush -> ()

--- a/src/core/operators/soundtouch_op.ml
+++ b/src/core/operators/soundtouch_op.ml
@@ -37,10 +37,7 @@ class soundtouch source_val rate tempo pitch =
   in
   object (self)
     inherit operator ~name:"soundtouch" [(consumer :> Source.source)] as super
-
-    inherit!
-      Child_support.base ~check_self_sync:true [source_val] as child_support
-
+    inherit! Child_support.base ~check_self_sync:true [source_val]
     val mutable st = None
     method stype = source#stype
     method self_sync = source#self_sync
@@ -93,10 +90,6 @@ class soundtouch source_val rate tempo pitch =
       self#log#important "Using soundtouch %s."
         (Soundtouch.get_version_string (Option.get st));
       write_frame_ref := self#write_frame
-
-    initializer
-      self#on_before_output (fun () -> child_support#child_before_output);
-      self#on_after_output (fun () -> child_support#child_after_output)
   end
 
 let _ =

--- a/src/core/outputs/output.ml
+++ b/src/core/outputs/output.ml
@@ -151,6 +151,7 @@ class virtual output ~output_kind ?(name = "") ~infallible
     method private get_frame buf = if Frame.is_partial buf then source#get buf
 
     method private output =
+      self#has_ticked;
       if self#is_ready && state <> `Stopped then
         start_stop#transition_to `Started;
       if start_stop#state = `Started then (

--- a/src/core/source.ml
+++ b/src/core/source.ml
@@ -98,7 +98,8 @@ class type ['a, 'b] proto_clock =
     method detach_clock : 'b -> unit
     method sub_clocks : 'b list
     method start_outputs : ('a -> bool) -> unit -> 'a list
-    method on_after_output : int -> (unit -> unit) -> unit
+    method on_before_output : (unit -> unit) -> unit
+    method on_after_output : (unit -> unit) -> unit
     method get_tick : int
     method end_tick : unit
   end
@@ -705,8 +706,7 @@ class virtual operator ?(name = "src") sources =
         in_output <- true;
         self#before_output;
         match deref clock with
-          | Known c ->
-              c#on_after_output (Obj.magic self) (fun () -> self#after_output)
+          | Known c -> c#on_after_output (fun () -> self#after_output)
           | _ -> assert false)
 
     (* [#get buf] completes the frame with the next data in the stream.
@@ -835,7 +835,8 @@ class type clock =
     method detach_clock : clock_variable -> unit
     method sub_clocks : clock_variable list
     method start_outputs : (active_source -> bool) -> unit -> active_source list
-    method on_after_output : int -> (unit -> unit) -> unit
+    method on_before_output : (unit -> unit) -> unit
+    method on_after_output : (unit -> unit) -> unit
     method get_tick : int
     method end_tick : unit
   end

--- a/src/core/source.ml
+++ b/src/core/source.ml
@@ -99,6 +99,7 @@ class type ['a, 'b] proto_clock =
     method sub_clocks : 'b list
     method start_outputs : ('a -> bool) -> unit -> 'a list
     method on_before_output : (unit -> unit) -> unit
+    method on_output : (unit -> unit) -> unit
     method on_after_output : (unit -> unit) -> unit
     method get_tick : int
     method end_tick : unit
@@ -836,6 +837,7 @@ class type clock =
     method sub_clocks : clock_variable list
     method start_outputs : (active_source -> bool) -> unit -> active_source list
     method on_before_output : (unit -> unit) -> unit
+    method on_output : (unit -> unit) -> unit
     method on_after_output : (unit -> unit) -> unit
     method get_tick : int
     method end_tick : unit

--- a/src/core/source.ml
+++ b/src/core/source.ml
@@ -98,6 +98,7 @@ class type ['a, 'b] proto_clock =
     method detach_clock : 'b -> unit
     method sub_clocks : 'b list
     method start_outputs : ('a -> bool) -> unit -> 'a list
+    method on_after_output : int -> (unit -> unit) -> unit
     method get_tick : int
     method end_tick : unit
   end
@@ -672,6 +673,42 @@ class virtual operator ?(name = "src") sources =
           w.get_frame ~start_time ~start_position ~end_time ~end_position
             ~is_partial ~metadata)
 
+    (* Set to [true] when we're inside an output cycle. *)
+    val mutable in_output = false
+    val mutable on_before_output = []
+    method on_before_output fn = on_before_output <- fn :: on_before_output
+
+    initializer
+      self#on_before_output (fun () ->
+          self#iter_watchers (fun w -> w.before_output ()))
+
+    (* Prepare for output round. *)
+    method private before_output =
+      List.iter (fun fn -> fn ()) on_before_output;
+      in_output <- true
+
+    val mutable on_after_output = []
+    method on_after_output fn = on_after_output <- fn :: on_after_output
+
+    initializer
+      self#on_after_output (fun () -> Frame.clear self#memo);
+      self#on_after_output (fun () ->
+          self#iter_watchers (fun w -> w.after_output ()))
+
+    (* Cleanup after output round. *)
+    method private after_output =
+      List.iter (fun fn -> fn ()) on_after_output;
+      in_output <- false
+
+    method private has_ticked =
+      if not in_output then (
+        in_output <- true;
+        self#before_output;
+        match deref clock with
+          | Known c ->
+              c#on_after_output (Obj.magic self) (fun () -> self#after_output)
+          | _ -> assert false)
+
     (* [#get buf] completes the frame with the next data in the stream.
        Depending on whether caching is enabled or not,
        it calls [#get_frame] directly or tries to get data from the cache frame,
@@ -681,6 +718,7 @@ class virtual operator ?(name = "src") sources =
        round ([#after_output]). *)
     method get buf =
       assert (Frame.is_partial buf);
+      self#has_ticked;
 
       (* In some cases we can't avoid #get being called on a non-ready
          source, for example:
@@ -735,41 +773,6 @@ class virtual operator ?(name = "src") sources =
        It cannot be called directly, but [#get] should be used instead, for
        dealing with caching if needed. *)
     method virtual private get_frame : Frame.t -> unit
-
-    (* Set to [true] when we're inside an output cycle. *)
-    val mutable in_output = false
-    val mutable on_before_output = []
-    method on_before_output fn = on_before_output <- fn :: on_before_output
-
-    initializer
-      List.iter
-        (fun s -> self#on_before_output (fun () -> s#before_output))
-        sources;
-      self#on_before_output (fun () ->
-          self#iter_watchers (fun w -> w.before_output ()))
-
-    (* Prepare for output round. *)
-    method before_output =
-      if not in_output then (
-        List.iter (fun fn -> fn ()) on_before_output;
-        in_output <- true)
-
-    val mutable on_after_output = []
-    method on_after_output fn = on_after_output <- fn :: on_after_output
-
-    initializer
-      self#on_after_output (fun () -> Frame.clear self#memo);
-      List.iter
-        (fun s -> self#on_after_output (fun () -> s#after_output))
-        sources;
-      self#on_after_output (fun () ->
-          self#iter_watchers (fun w -> w.after_output ()))
-
-    (* Cleanup after output round. *)
-    method after_output =
-      if in_output then (
-        List.iter (fun fn -> fn ()) on_after_output;
-        in_output <- false)
   end
 
 (** Entry-point sources, which need to actively perform some task. *)
@@ -832,6 +835,7 @@ class type clock =
     method detach_clock : clock_variable -> unit
     method sub_clocks : clock_variable list
     method start_outputs : (active_source -> bool) -> unit -> active_source list
+    method on_after_output : int -> (unit -> unit) -> unit
     method get_tick : int
     method end_tick : unit
   end

--- a/src/core/source.mli
+++ b/src/core/source.mli
@@ -288,6 +288,7 @@ class type clock =
 
     method start_outputs : (active_source -> bool) -> unit -> active_source list
     method on_before_output : (unit -> unit) -> unit
+    method on_output : (unit -> unit) -> unit
     method on_after_output : (unit -> unit) -> unit
     method get_tick : int
     method end_tick : unit

--- a/src/core/source.mli
+++ b/src/core/source.mli
@@ -205,14 +205,9 @@ class virtual source :
        (* Register callback to be executed on #before_output. *)
        method on_before_output : (unit -> unit) -> unit
 
-       (** Prepare for output round. *)
-       method before_output : unit
-
        (* Register callback to be executed on #after_output. *)
        method on_after_output : (unit -> unit) -> unit
-
-       (** Cleanup after output round. *)
-       method after_output : unit
+       method private has_ticked : unit
 
        (** {1 Utilities} *)
 
@@ -292,6 +287,7 @@ class type clock =
     (** Streaming *)
 
     method start_outputs : (active_source -> bool) -> unit -> active_source list
+    method on_after_output : int -> (unit -> unit) -> unit
     method get_tick : int
     method end_tick : unit
   end

--- a/src/core/source.mli
+++ b/src/core/source.mli
@@ -287,7 +287,8 @@ class type clock =
     (** Streaming *)
 
     method start_outputs : (active_source -> bool) -> unit -> active_source list
-    method on_after_output : int -> (unit -> unit) -> unit
+    method on_before_output : (unit -> unit) -> unit
+    method on_after_output : (unit -> unit) -> unit
     method get_tick : int
     method end_tick : unit
   end

--- a/src/core/tools/child_support.ml
+++ b/src/core/tools/child_support.ml
@@ -27,7 +27,16 @@ let finalise_child_clock child_clock source =
   Clock.forget source#clock child_clock
 
 class virtual base ?(create_known_clock = true) ~check_self_sync children_val =
-  let children = List.map Lang.to_source children_val in
+  let children =
+    List.map
+      (fun s ->
+        new Output.dummy
+          ~infallible:false
+          ~on_start:(fun () -> ())
+          ~on_stop:(fun () -> ())
+          ~autostart:true s)
+      children_val
+  in
   let create_child_clock id =
     if create_known_clock then
       Clock.create_known

--- a/src/core/tools/child_support.ml
+++ b/src/core/tools/child_support.ml
@@ -68,9 +68,7 @@ class virtual base ?(create_known_clock = true) ~check_self_sync children_val =
       Gc.finalise (finalise_child_clock self#child_clock) self
 
     method private child_tick =
-      List.iter (fun c -> c#before_output) children;
       (Clock.get self#child_clock)#end_tick;
-      List.iter (fun c -> c#after_output) children;
       needs_tick <- false
 
     (* This methods always set [need_tick] to true. If the source is not

--- a/src/core/tools/producer_consumer.ml
+++ b/src/core/tools/producer_consumer.ml
@@ -74,7 +74,7 @@ class producer ?create_known_clock ~check_self_sync ~consumers ~name () =
     inherit!
       Child_support.base
         ?create_known_clock ~check_self_sync
-        (List.map (fun s -> Lang.source (s :> Source.source)) consumers) as child_support
+        (List.map (fun s -> Lang.source (s :> Source.source)) consumers)
 
     method self_sync =
       ( Lazy.force self_sync_type,
@@ -128,10 +128,6 @@ class producer ?create_known_clock ~check_self_sync ~consumers ~name () =
       if List.length b + 1 <> List.length (Frame.breaks buf) then (
         let cur_pos = Frame.position buf in
         Frame.set_breaks buf (b @ [cur_pos]))
-
-    initializer
-      self#on_before_output (fun () -> child_support#child_before_output);
-      self#on_after_output (fun () -> child_support#child_after_output)
 
     method abort_track =
       Generator.add_track_mark self#buffer;

--- a/tests/core/output_test.ml
+++ b/tests/core/output_test.ml
@@ -29,6 +29,8 @@ let () =
   let on_start () = started := true in
   let failed = new failed in
   let o = new dummy ~on_start ~autostart:true failed in
+  let clock = Clock.clock ~start:false "source" in
+  Clock.unify o#clock (Clock.create_known clock);
   assert (not o#is_ready);
   o#content_type_computation_allowed;
   o#test_wake_up;

--- a/tests/media/ffmpeg_inline_encode_decode_audio.liq
+++ b/tests/media/ffmpeg_inline_encode_decode_audio.liq
@@ -12,7 +12,9 @@ if file.exists(out_encode) then
   file.remove(out_encode)
 end
 
-s = once(blank(id="blank", duration=10.))
+s = once(blank(duration=10.))
+
+todo = ref(2)
 
 def on_done () =
   def check(out) =
@@ -35,27 +37,27 @@ def on_done () =
     stream.sample_rate == "44100"
   end
 
-  if check(out_copy) and check(out_encode) then
-    test.pass()
-  else
-    test.fail()
+  todo := !todo - 1
+
+  if !todo == 0 then
+    if check(out_copy) and check(out_encode) then
+      test.pass()
+    else
+      test.fail()
+    end
   end
 end
 
 s = ffmpeg.encode.audio(
-  id="ffmpeg.encode.audio",
   %ffmpeg(
     %audio(codec="aac")
   ),
   s
 )
 
-# This output might stop when the top-level
-# output stops because it is not pulled anymore
-# We'll have to see how we can make this better.
-encoded_output = output.file(
-  id="output.file",
+output.file(
   fallible=true,
+  on_stop=on_done,
   %ffmpeg(
     %audio.copy,
   ),
@@ -63,17 +65,13 @@ encoded_output = output.file(
   s
 )
 
-s = ffmpeg.decode.audio(id="ffmpeg.decode.audio", s)
+s = ffmpeg.decode.audio(s)
 
 clock.assign_new(sync='none',[s])
 
 output.file(
-  id="output.file_2",
   fallible=true,
-  on_stop=fun () -> begin
-    encoded_output.stop()
-    on_done()
-  end,
+  on_stop=on_done,
   %ffmpeg(
     %audio(codec="aac")
   ),

--- a/tests/media/ffmpeg_inline_encode_decode_audio.liq
+++ b/tests/media/ffmpeg_inline_encode_decode_audio.liq
@@ -12,9 +12,7 @@ if file.exists(out_encode) then
   file.remove(out_encode)
 end
 
-s = once(blank(duration=10.))
-
-todo = ref(2)
+s = once(blank(id="blank", duration=10.))
 
 def on_done () =
   def check(out) =
@@ -37,27 +35,27 @@ def on_done () =
     stream.sample_rate == "44100"
   end
 
-  todo := !todo - 1
-
-  if !todo == 0 then
-    if check(out_copy) and check(out_encode) then
-      test.pass()
-    else
-      test.fail()
-    end
+  if check(out_copy) and check(out_encode) then
+    test.pass()
+  else
+    test.fail()
   end
 end
 
 s = ffmpeg.encode.audio(
+  id="ffmpeg.encode.audio",
   %ffmpeg(
     %audio(codec="aac")
   ),
   s
 )
 
-output.file(
+# This output might stop when the top-level
+# output stops because it is not pulled anymore
+# We'll have to see how we can make this better.
+encoded_output = output.file(
+  id="output.file",
   fallible=true,
-  on_stop=on_done,
   %ffmpeg(
     %audio.copy,
   ),
@@ -65,13 +63,17 @@ output.file(
   s
 )
 
-s = ffmpeg.decode.audio(s)
+s = ffmpeg.decode.audio(id="ffmpeg.decode.audio", s)
 
 clock.assign_new(sync='none',[s])
 
 output.file(
+  id="output.file_2",
   fallible=true,
-  on_stop=on_done,
+  on_stop=fun () -> begin
+    encoded_output.stop()
+    on_done()
+  end,
   %ffmpeg(
     %audio(codec="aac")
   ),


### PR DESCRIPTION
This PR addresses some performance issues as well as a bug reported with `input.harbor` related to the new `source()` muxer operator.

The streaming cycle consists of 3 calls on sources:
* `before_output`
* `output`
* `after_output`

The top-level calls from the clock executes these callback only on active sources (output and live sources that need to be constantly animated such as `input.http` etc).

In the current code, we propagate calls to `before_output` and `after_output` from those top-level sources down to their dependent sources (for instance the list of sources in a `sequence`).

This has two issues:
1. This is not robust. A source can be missed in the descending calls and this is pretty hard to catch
2. This is not efficient. If you have say 12,000 sources in a switch, _all_ sources in the switch will see their `before_output` and `after_output` executed.

This gets even more trickier because `after_output` is tasked with clearing the cache for shared sources so, if it is not called, the source will produce the same frame on the next round and possibly the following if it keeps happening. Furthermore, the new `source()` muxer will also enter an infinite loop when its `#get_frame` is called in such case. This is the source of the reported bugs in `input.harbor`.

This PR inverts the mechanism to make sure that only sources that have been effectively used during a streaming cycle have their `before_output` and `after_output` called.

This is done by registering `after_callback` on the source's clock. If a source's `#get` or `#output` is called, on the first call, we execute their `#before_output` then register a call to their `#after_output` with the clock. Once the clock has done its round, it executes the registered `#after_output` only.

This has the fortunate/unfortunate effect of coupling sources with clocks so now sources are expecting to always have a clock attached to them. This also tightens up the requirements for executing source's `#get` and `#output` function. This is not necessarily a bad thing, being too lax on these can lead to many issues.

The changes worked well across the board except for `cross` which was, indeed, not adhering to this logic properly and calling `#get` in its source outside of the expected `before_output`/`output`/`after_output`, the reason being that `cross` wants to catch a source right when it has finished a track so it needs a tighter control on when to call `#get`.

The solution for this one was to create another `on_output` callback that is called after the round of `#output` but before the cache is wiped during `#after_output`, at which point it is safe to call the crossfaded source to get its current content.

This seems to work just fine! `cross` got cleaned up a little in the process. Next step: rewrite all this to make it make sense. But for now, this will do! 

