### PR TITLE
Add flushing API to ffmpeg video with FPS filter

### DIFF
--- a/src/core/decoder/aac_decoder.ml
+++ b/src/core/decoder/aac_decoder.ml
@@ -114,6 +114,7 @@ let create_decoder input =
   in
   {
     Decoder.seek;
+    eof = (fun _ -> ());
     decode =
       (fun buffer ->
         let len = input.Decoder.read aacbuf 0 aacbuflen in
@@ -220,7 +221,7 @@ let create_decoder input =
       ended := true;
       0
   in
-  { Decoder.decode; seek }
+  { Decoder.decode; seek; eof = (fun _ -> ()) }
 
 (* Get the number of channels of audio in an MP4 file. *)
 let file_type ~metadata:_ ~ctype:_ filename =

--- a/src/core/decoder/decoder.ml
+++ b/src/core/decoder/decoder.ml
@@ -67,6 +67,7 @@ type buffer = {
 
 type decoder = {
   decode : buffer -> unit;
+  eof : buffer -> unit;
   (* [seek x]: Skip [x] main ticks. Returns the number of ticks atcually
      skipped. *)
   seek : int -> int;
@@ -505,6 +506,11 @@ let mk_decoder ~filename ~close ~remaining ~buffer decoder =
     remaining ()
     + Generator.length buffer.generator
     + Frame.position frame - offset
+  in
+
+  let close () =
+    decoder.eof buffer;
+    close ()
   in
 
   let fill frame =

--- a/src/core/decoder/decoder.mli
+++ b/src/core/decoder/decoder.mli
@@ -55,6 +55,7 @@ type buffer = {
 
 type decoder = {
   decode : buffer -> unit;
+  eof : buffer -> unit;
   (* [seek x]: Skip [x] main ticks.
    * Returns the number of ticks atcually skipped. *)
   seek : int -> int;

--- a/src/core/decoder/ffmpeg_internal_decoder.mli
+++ b/src/core/decoder/ffmpeg_internal_decoder.mli
@@ -27,7 +27,7 @@ val mk_audio_decoder :
   pcm_kind:Content.kind ->
   Avutil.audio Avcodec.params ->
   buffer:Decoder.buffer ->
-  Avutil.audio Avutil.Frame.t ->
+  [ `Frame of Avutil.audio Avutil.Frame.t | `Flush ] ->
   unit
 
 val mk_video_decoder :
@@ -37,5 +37,5 @@ val mk_video_decoder :
   field:Frame.field ->
   Avutil.video Avcodec.params ->
   buffer:Decoder.buffer ->
-  [ `Video ] Avutil.Frame.t ->
+  [ `Frame of Avutil.video Avutil.Frame.t | `Flush ] ->
   unit

--- a/src/core/decoder/ffmpeg_raw_decoder.mli
+++ b/src/core/decoder/ffmpeg_raw_decoder.mli
@@ -27,7 +27,7 @@ val mk_audio_decoder :
   field:Frame.field ->
   Avutil.audio Avcodec.params ->
   buffer:Decoder.buffer ->
-  Avutil.audio Avutil.Frame.t ->
+  [ `Frame of Avutil.audio Avutil.Frame.t | `Flush ] ->
   unit
 
 val mk_video_decoder :
@@ -37,5 +37,5 @@ val mk_video_decoder :
   field:Frame.field ->
   Avutil.video Avcodec.params ->
   buffer:Decoder.buffer ->
-  Avutil.video Avutil.Frame.t ->
+  [ `Frame of Avutil.video Avutil.Frame.t | `Flush ] ->
   unit

--- a/src/core/decoder/liq_flac_decoder.ml
+++ b/src/core/decoder/liq_flac_decoder.ml
@@ -88,6 +88,7 @@ let create_decoder input =
           | `Read_frame ->
               Flac.Decoder.process decoder c
           | _ -> raise End_of_stream);
+    eof = (fun _ -> ());
   }
 
 (** Configuration keys for flac. *)

--- a/src/core/decoder/liq_ogg_decoder.ml
+++ b/src/core/decoder/liq_ogg_decoder.ml
@@ -225,7 +225,7 @@ let create_decoder ?(merge_tracks = false) source input =
       log#info "End of track reached while seeking!";
       0
   in
-  { Decoder.decode; seek }
+  { Decoder.decode; seek; eof = (fun _ -> ()) }
 
 (** File decoder *)
 

--- a/src/core/decoder/mad_decoder.ml
+++ b/src/core/decoder/mad_decoder.ml
@@ -102,6 +102,7 @@ let create_decoder input =
         let data = get_data () in
         let { Mad.samplerate } = get_info () in
         buffer.Decoder.put_pcm ~samplerate data);
+    eof = (fun _ -> ());
   }
 
 (** Configuration keys for mad. *)

--- a/src/core/decoder/raw_audio_decoder.ml
+++ b/src/core/decoder/raw_audio_decoder.ml
@@ -98,7 +98,7 @@ let create ~format input =
   in
   (* TODO *)
   let seek _ = 0 in
-  { Decoder.decode = decoder; seek }
+  { Decoder.decode = decoder; seek; eof = (fun _ -> ()) }
 
 (* The mime types are inspired of GStreamer's convention. See
    http://gstreamer.freedesktop.org/data/doc/gstreamer/head/pwg/html/section-types-definitions.html

--- a/src/core/decoder/wav_aiff_decoder.ml
+++ b/src/core/decoder/wav_aiff_decoder.ml
@@ -112,7 +112,11 @@ let create ?header input =
           with _ -> 0)
       | _, _, _ -> 0
   in
-  { Decoder.decode = (fun buffer -> !decoder ~buffer); seek }
+  {
+    Decoder.decode = (fun buffer -> !decoder ~buffer);
+    seek;
+    eof = (fun _ -> ());
+  }
 
 (* File decoding *)
 

--- a/src/core/encoder/ffmpeg_copy_encoder.ml
+++ b/src/core/encoder/ffmpeg_copy_encoder.ml
@@ -188,6 +188,7 @@ let mk_stream_copy ~get_stream ~remove_stream ~keyframe_opt ~field output =
     Ffmpeg_encoder_common.mk_stream;
     can_split;
     encode;
+    flush = (fun () -> ());
     codec_attr;
     bitrate;
     video_size;

--- a/src/core/encoder/ffmpeg_internal_encoder.ml
+++ b/src/core/encoder/ffmpeg_internal_encoder.ml
@@ -128,7 +128,7 @@ let write_audio_frame ~time_base ~sample_rate ~channel_layout ~sample_format
         let add_filter_frame_pts = add_frame_pts () in
         fun frame ->
           add_filter_frame_pts frame;
-          Avfilter.Utils.convert_audio converter write_frame frame
+          Avfilter.Utils.convert_audio converter write_frame (`Frame frame)
 
 let mk_audio ~mode ~codec ~params ~options ~field output =
   let internal_resampler =

--- a/src/core/encoder/ffmpeg_internal_encoder.ml
+++ b/src/core/encoder/ffmpeg_internal_encoder.ml
@@ -298,6 +298,7 @@ let mk_audio ~mode ~codec ~params ~options ~field output =
     Ffmpeg_encoder_common.mk_stream;
     can_split = can_split stream;
     encode;
+    flush = (fun () -> ());
     codec_attr;
     bitrate;
     video_size;
@@ -389,6 +390,19 @@ let mk_video ~mode ~codec ~params ~options ~field output =
 
   let stream_time_base = Av.get_time_base stream in
 
+  let write_frame ~time_base frame =
+    let frame_pts =
+      Option.map
+        (fun pts ->
+          Ffmpeg_utils.convert_time_base ~src:time_base ~dst:stream_time_base
+            pts)
+        (Avutil.Frame.pts frame)
+    in
+    Avutil.Frame.set_pts frame frame_pts;
+    start_pts := Int64.succ !start_pts;
+    Av.write_frame stream frame
+  in
+
   let fps_converter ~stream_idx ~time_base frame =
     let converter =
       get_converter ~time_base ~stream_idx
@@ -396,17 +410,15 @@ let mk_video ~mode ~codec ~params ~options ~field output =
         ()
     in
     let time_base = Ffmpeg_avfilter_utils.Fps.time_base converter in
-    Ffmpeg_avfilter_utils.Fps.convert converter frame (fun frame ->
-        let frame_pts =
-          Option.map
-            (fun pts ->
-              Ffmpeg_utils.convert_time_base ~src:time_base
-                ~dst:stream_time_base pts)
-            (Avutil.Frame.pts frame)
-        in
-        Avutil.Frame.set_pts frame frame_pts;
-        start_pts := Int64.succ !start_pts;
-        Av.write_frame stream frame)
+    Ffmpeg_avfilter_utils.Fps.convert converter frame (write_frame ~time_base)
+  in
+
+  let flush () =
+    match !converter with
+      | None -> ()
+      | Some (_, _, _, converter) ->
+          let time_base = Ffmpeg_avfilter_utils.Fps.time_base converter in
+          Ffmpeg_avfilter_utils.Fps.eof converter (write_frame ~time_base)
   in
 
   let internal_converter cb =
@@ -420,6 +432,7 @@ let mk_video ~mode ~codec ~params ~options ~field output =
     let nb_frames = ref 0L in
     let time_base = Ffmpeg_utils.liq_video_sample_time_base () in
     let stream_idx = 1L in
+
     fun frame start len ->
       let vstart = Frame.video_of_main start in
       let vstop = Frame.video_of_main (start + len) in
@@ -491,6 +504,7 @@ let mk_video ~mode ~codec ~params ~options ~field output =
     Ffmpeg_encoder_common.mk_stream;
     can_split = can_split stream;
     encode;
+    flush;
     codec_attr;
     bitrate;
     video_size;

--- a/src/core/io/ffmpeg_filter_io.ml
+++ b/src/core/io/ffmpeg_filter_io.ml
@@ -93,7 +93,9 @@ class virtual ['a] base_output ~pass_metadata ~name ~frame_t ~field source =
         self#frame_type <: frame_t;
         source#frame_type <: self#frame_type)
 
-    val mutable input = fun _ -> ()
+    val mutable input : [ `Frame of 'a Avutil.frame | `Flush ] -> unit =
+      fun _ -> ()
+
     method set_input fn = input <- fn
     val mutable init : 'a Avutil.frame -> unit = fun _ -> assert false
     method set_init v = init <- v
@@ -148,7 +150,7 @@ class virtual ['a] base_output ~pass_metadata ~name ~frame_t ~field source =
                       in
                       if metadata <> [] then
                         Avutil.Frame.set_metadata frame metadata);
-                    input frame)
+                    input (`Frame frame))
                   frames)
         frames
   end

--- a/src/core/tools/ffmpeg_avfilter_utils.ml
+++ b/src/core/tools/ffmpeg_avfilter_utils.ml
@@ -33,8 +33,8 @@ module Fps = struct
     | `Filter { time_base } -> time_base
     | `Pass_through time_base -> time_base
 
-  let init ?(start_pts = 0L) ~width ~height ~pixel_format ~time_base
-      ?pixel_aspect ?source_fps ~target_fps () =
+  let init ?start_pts ~width ~height ~pixel_format ~time_base ?pixel_aspect
+      ?source_fps ~target_fps () =
     let config = Avfilter.init () in
     let _buffer =
       let args =
@@ -57,19 +57,12 @@ module Fps = struct
       in
       Avfilter.attach ~name:"buffer" ~args Avfilter.buffer config
     in
-    let fps =
-      match
-        List.find_opt (fun { Avfilter.name } -> name = "fps") Avfilter.filters
-      with
-        | Some fps -> fps
-        | None -> failwith "Could not find fps ffmpeg filter!"
-    in
-    let fps =
-      let args =
-        [`Pair ("fps", `Rational { Avutil.num = target_fps; den = 1 })]
-      in
-      Avfilter.attach ~name:"fps" ~args fps config
-    in
+    (* There are two use-case:
+       - Decoder assumes no `start_pts` and want to keep negative
+         STARTPTS (to be skipped) but re-align positive STARTPTS
+         in case the file is a partial copy dump.
+       - Encoder wants to apply `start_pts` all the time and realign
+         all PTS accordingly. *)
     let setpts =
       match
         List.find_opt
@@ -81,21 +74,43 @@ module Fps = struct
     in
     let setpts =
       let args =
-        [`Pair ("expr", `String (Printf.sprintf "%Ld+PTS-STARTPTS" start_pts))]
+        match start_pts with
+          | Some start_pts ->
+              [
+                `Pair
+                  ("expr", `String (Printf.sprintf "%Ld+PTS-STARTPTS" start_pts));
+              ]
+          | None -> [`Pair ("expr", `String "PTS-min(STARTPTS, 0)")]
       in
       Avfilter.attach ~name:"setpts" ~args setpts config
+    in
+    let fps =
+      match
+        List.find_opt (fun { Avfilter.name } -> name = "fps") Avfilter.filters
+      with
+        | Some fps -> fps
+        | None -> failwith "Could not find fps ffmpeg filter!"
+    in
+    let fps =
+      let args =
+        [`Pair ("fps", `Rational { Avutil.num = target_fps; den = 1 })]
+      in
+      let args =
+        if start_pts = None then `Pair ("start_time", `Int 0) :: args else args
+      in
+      Avfilter.attach ~name:"fps" ~args fps config
     in
     let _buffersink =
       Avfilter.attach ~name:"buffersink" Avfilter.buffersink config
     in
     Avfilter.link
       (List.hd Avfilter.(_buffer.io.outputs.video))
-      (List.hd Avfilter.(fps.io.inputs.video));
-    Avfilter.link
-      (List.hd Avfilter.(fps.io.outputs.video))
       (List.hd Avfilter.(setpts.io.inputs.video));
     Avfilter.link
       (List.hd Avfilter.(setpts.io.outputs.video))
+      (List.hd Avfilter.(fps.io.inputs.video));
+    Avfilter.link
+      (List.hd Avfilter.(fps.io.outputs.video))
       (List.hd Avfilter.(_buffersink.io.inputs.video));
     let graph = Avfilter.launch config in
     let _, input = List.hd Avfilter.(graph.inputs.video) in

--- a/src/core/tools/ffmpeg_avfilter_utils.mli
+++ b/src/core/tools/ffmpeg_avfilter_utils.mli
@@ -39,4 +39,6 @@ module Fps : sig
 
   val convert :
     t -> [ `Video ] Avutil.frame -> ([ `Video ] Avutil.frame -> unit) -> unit
+
+  val eof : t -> ([ `Video ] Avutil.frame -> unit) -> unit
 end


### PR DESCRIPTION
This PR adds various API to allow proper flushing of residual data when finishing decoding and encoding. This is primarily driven by the fact that ffmpeg decoder and encoder uses a FPS avfilter which may still hold data at the time of closing.