### PR TITLE
POC: import/export.

### DIFF
--- a/src/lang/dune
+++ b/src/lang/dune
@@ -104,6 +104,7 @@
   extralib
   ground_type
   hooks
+  import
   json_base
   json_lexer
   json_parser

--- a/src/lang/import.ml
+++ b/src/lang/import.ml
@@ -1,0 +1,63 @@
+(*****************************************************************************
+
+  Liquidsoap, a programmable audio stream generator.
+  Copyright 2003-2023 Savonet team
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details, fully stated in the COPYING
+  file at the root of the liquidsoap distribution.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA
+
+ *****************************************************************************)
+
+let rec append_exported ~pos tm =
+  match tm.Term.term with
+    | Term.(Let ({ body } as let_t)) ->
+        Term.
+          { tm with term = Let { let_t with body = append_exported ~pos body } }
+    | _ ->
+        Parser_helper.(
+          mk_let ~pos
+            (let_args ~pat:(PVar ["_"]) ~def:tm ())
+            (mk ~pos (Var "_export_")))
+
+let import fname =
+  let dir = !Hooks.liq_libs_dir () in
+  let file = Filename.concat dir fname in
+  let fd = open_in_bin file in
+  let lexbuf = Sedlexing.Utf8.from_channel fd in
+  Fun.protect
+    ~finally:(fun () -> close_in_noerr fd)
+    (fun () ->
+      let processor =
+        MenhirLib.Convert.Simplified.traditional2revised Parser.program
+      in
+      let tokenizer = Preprocessor.mk_tokenizer ~fname ~pwd:dir lexbuf in
+      let term = processor tokenizer in
+      let pos =
+        Option.value
+          ~default:(Lexing.dummy_pos, Lexing.dummy_pos)
+          term.Term.t.Type.pos
+      in
+      let term =
+        Parser_helper.(
+          mk_let ~pos
+            (let_args ~pat:(PVar ["_export_"]) ~def:(mk ~pos (Tuple [])) ())
+            term)
+      in
+      let term = append_exported ~pos term in
+      Typechecking.check ~throw:(fun exn -> raise exn) ~ignored:true term;
+      Term.check_unused ~throw:(fun exn -> raise exn) ~lib:false term;
+      term)
+
+let () = Parser_helper.import := import

--- a/src/lang/lexer.ml
+++ b/src/lang/lexer.ml
@@ -205,12 +205,15 @@ let rec token lexbuf =
     | eof -> EOF
     | "def", Plus skipped, "rec", Plus skipped -> PP_DEF `Recursive
     | "def", Plus skipped, "replaces", Plus skipped -> PP_DEF `Replaces
+    | "def", Plus skipped, "export", Plus skipped -> PP_DEF `Export
     | "def" -> PP_DEF `None
     | "try" -> TRY
     | "catch" -> CATCH
     | "do" -> DO
     | "let", Plus skipped, "replaces", Plus skipped -> LET `Replaces
     | "let", Plus skipped, "eval", Plus skipped -> LET `Eval
+    | "let", Plus skipped, "export", Plus skipped -> LET `Export
+    | "let", Plus skipped, "import", Plus skipped -> LET `Import
     | "let", Plus skipped, "json.parse", Star skipped, '[' ->
         LETLBRA `Json_parse
     | "let", Plus skipped, "json.parse", Plus skipped -> LET `Json_parse

--- a/src/lang/parser.mly
+++ b/src/lang/parser.mly
@@ -479,7 +479,7 @@ _let:
         | _ -> raise (Parse_error ($loc, "Invalid let constructor")) }
 
 binding:
-  | optvar GETS expr         { Parser_helper.let_args ~decoration:`None ~pat:(PVar [$1]) ~def:$3 () }
+  | optvar GETS expr         { Parser_helper.let_args ~pat:(PVar [$1]) ~def:$3 () }
   | _let pattern GETS expr   { Parser_helper.let_args ~decoration:$1 ~pat:$2 ~def:$4 () }
   | _let LPAR pattern COLON ty RPAR GETS expr
                              { Parser_helper.let_args ~decoration:$1 ~pat:$3 ~def:$8 ~cast:$5 () }

--- a/src/libs/error.liq
+++ b/src/libs/error.liq
@@ -8,20 +8,21 @@ let error.not_found = error.register("not_found")
 let error.output = error.register("output")
 let error.socket = error.register("socket")
 let error.string = error.register("string")
+let error.failure = error.register("failure")
+
+let export error = error
 
 # Ensure that a condition is satisfied (raise `error.assertion` exception
 # otherwise).
 # @category Programming
 # @param c Condition which should be satisfied.
-def assert(c)
+def export assert(c)
   if not c then error.raise(error.assertion, "Assertion failed.") end
 end
-
-let error.failure = error.register("failure")
 
 # Major failure.
 # @category Programming
 # @param msg Explanation about the failure.
-def failwith(msg)
+def export failwith(msg)
   error.raise(error.failure, msg)
 end

--- a/src/libs/stdlib.liq
+++ b/src/libs/stdlib.liq
@@ -1,4 +1,5 @@
-%include "error.liq"
+let import {error, assert, failwith} = "error.liq"
+
 %include "null.liq"
 %include "ref.liq"
 %include "list.liq"


### PR DESCRIPTION
This is a first stab at a proper module import/export.

Syntax:

Export `"module.liq"`
```liquidsoap
let export foo = "123"
def export bla() =
  print("bla")
end
```

Import:
```liquidsoap
let import { foo, bla } = "module.liq"
```

The implementation works by replacing `"module.liq"` in the import statement with the type-checked term:

```liquidsoap
let _export_ = ()

let _export_.foo = "123"

def _export_.bla() =
  print("bla")
end

_export_
```

Based on this, it should be possible to cache the result of the evaluation of `"module.liq"` to speed up future executions.

