### PR TITLE
Add defer operator.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,6 +22,7 @@ New:
 - Added support for unit interactive variables: those call a handler when their
   value is set.
 - Added support for id3v2 `v2.2.0` frames and pictures.
+- Added `track.audio.defer` to be used to buffer large amount of audio data (#3136)
 - Added `source.drop` to animate a source as fast as possible..
 - Added in house replaygain computation:
   - `source.replaygain.compute` to compute replaygain of a source

--- a/src/core/dune
+++ b/src/core/dune
@@ -43,7 +43,7 @@
    (-> liqmagic.disabled.ml)))
  (foreign_stubs
   (language c)
-  (names unix_c))
+  (names unix_c defer_c))
  (wrapped false)
  (library_flags -linkall)
  (modules
@@ -86,6 +86,7 @@
   debug_sources
   decoder
   decoder_utils
+  defer
   delay
   delay_line
   doc

--- a/src/core/operators/defer.ml
+++ b/src/core/operators/defer.ml
@@ -1,0 +1,180 @@
+(*****************************************************************************
+
+  Liquidsoap, a programmable audio stream generator.
+  Copyright 2003-2023 Savonet team
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details, fully stated in the COPYING
+  file at the root of the liquidsoap distribution.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA
+
+ *****************************************************************************)
+
+external alloc_managed_int16_ba :
+  int -> (int, Bigarray.int16_signed_elt, Bigarray.c_layout) Bigarray.Array1.t
+  = "liquidsoap_alloc_managed_int16_ba"
+
+external cleanup_managed_int16_ba :
+  (int, Bigarray.int16_signed_elt, Bigarray.c_layout) Bigarray.Array1.t -> unit
+  = "liquidsoap_cleanup_managed_int16_ba"
+
+(* For this to work, we need to make sure that we are never holding onto
+   any view on the array.. *)
+let alloc_managed_int16_ba len =
+  let ba = alloc_managed_int16_ba len in
+  Gc.finalise cleanup_managed_int16_ba ba;
+  ba
+
+type state = { offset : int; position : int }
+
+class defer ~delay ~overhead ~field source =
+  let overhead =
+    match overhead with
+      | None -> Lazy.force Frame.size
+      | Some v -> Frame.main_of_seconds v
+  in
+  let delay = Frame.main_of_seconds delay in
+  object (self)
+    inherit Source.operator ~name:"defer" [source]
+    method stype = `Fallible
+    method remaining = source#remaining
+    method abort_track = source#abort_track
+    method seek = source#seek
+    method self_sync = source#self_sync
+    val mutable state = { offset = 0; position = 0 }
+    val mutable deferred = true
+    val mutable generator = None
+    val mutable data = None
+    val mutable tmp_frame = None
+
+    method private data =
+      match data with
+        | Some d -> d
+        | None ->
+            let make_chunk len =
+              Array.init self#audio_channels (fun _ ->
+                  alloc_managed_int16_ba (Frame.audio_of_main len))
+            in
+            let d = [| make_chunk delay; make_chunk overhead |] in
+            data <- Some d;
+            d
+
+    method private generator =
+      match generator with
+        | Some g -> g
+        | None ->
+            let gen =
+              Generator.create ~max_length:(delay + overhead) self#content_type
+            in
+            generator <- Some gen;
+            gen
+
+    method private tmp_frame =
+      match tmp_frame with
+        | Some tmp_frame -> tmp_frame
+        | None ->
+            let frame = Frame.create source#content_type in
+            tmp_frame <- Some frame;
+            frame
+
+    method private buffer_data =
+      let { offset; position } = state in
+      let data = self#data.(position) in
+      let chunk_len = Content_pcm_base.length data in
+      let data_rem = chunk_len - offset in
+
+      let tmp_frame = self#tmp_frame in
+      Frame.clear tmp_frame;
+
+      while Frame.is_partial tmp_frame && source#is_ready do
+        source#get tmp_frame
+      done;
+      let gen_len = Frame.position tmp_frame in
+
+      let gen = self#generator in
+      let buffered = Generator.length gen + offset in
+
+      List.iter
+        (fun (pos, m) ->
+          if pos < gen_len then
+            Generator.add_metadata ~pos:(pos + buffered) gen m)
+        (Frame.get_all_metadata tmp_frame);
+      List.iter
+        (fun pos ->
+          if pos < gen_len then
+            Generator.add_track_mark ~pos:(pos + buffered) gen)
+        (Frame.breaks tmp_frame);
+
+      let frame_content = Frame.get tmp_frame field in
+      let frame_pcm = Content_pcm_s16.get_data frame_content in
+      let blit_len = min data_rem gen_len in
+      Content_pcm_base.blit frame_pcm 0 data offset blit_len;
+
+      if offset + blit_len < chunk_len then (
+        assert (gen_len = blit_len);
+        state <- { offset = offset + blit_len; position })
+      else (
+        assert (offset + data_rem = chunk_len);
+        deferred <- false;
+        let position = (position + 1) mod 2 in
+        let offset = gen_len - blit_len in
+        Generator.put gen field (Content_pcm_s16.lift_data data);
+        Content_pcm_base.blit frame_pcm blit_len self#data.(position) 0 offset;
+        state <- { offset; position })
+
+    val mutable should_queue = false
+
+    method private queue_output =
+      let clock = Source.Clock_variables.get self#clock in
+      clock#on_output (fun () ->
+          if source#is_ready then self#buffer_data;
+          if should_queue then
+            clock#on_before_output (fun () -> self#queue_output))
+
+    initializer
+      self#on_wake_up (fun () ->
+          should_queue <- true;
+          self#queue_output);
+      self#on_sleep (fun () -> should_queue <- false)
+
+    method is_ready = (not deferred) && Generator.length self#generator > 0
+    method private get_frame buf = Generator.fill self#generator buf
+  end
+
+let _ =
+  let frame_t = Format_type.audio ~pcm_kind:Content_pcm_s16.kind () in
+  Lang.add_track_operator ~base:Modules.track_audio "defer"
+    [
+      ("delay", Lang.float_t, None, Some "Duration of the delay, in seconds.");
+      ( "overhead",
+        Lang.(nullable_t float_t),
+        Some Lang.null,
+        Some
+          "Duration of the delay overhead, in seconds. Defaults to frame size."
+      );
+      ("", frame_t, None, Some "Track to delay.");
+    ]
+    ~category:`Track
+    ~descr:
+      "Defer an audio track by a given amount of time. Track will be available \
+       when the given `delay` has been fully buffered. Use this operator \
+       instead of `buffer` when buffering large amount of data as initial \
+       delay."
+    ~return_t:frame_t
+    (fun p ->
+      let delay = Lang.to_float (List.assoc "delay" p) in
+      let overhead =
+        Lang.to_valued_option Lang.to_float (List.assoc "overhead" p)
+      in
+      let field, s = Lang.to_track (List.assoc "" p) in
+      (field, new defer ~delay ~overhead ~field s))

--- a/src/core/operators/defer_c.c
+++ b/src/core/operators/defer_c.c
@@ -1,0 +1,23 @@
+#define CAML_INTERNALS 1
+
+#include <caml/bigarray.h>
+#include <caml/fail.h>
+#include <caml/memory.h>
+
+// Single bigarray not registered with the GC.
+CAMLprim value liquidsoap_alloc_managed_int16_ba(value _len) {
+  CAMLparam0();
+  intnat out_size = Int_val(_len);
+  void *data = malloc(out_size * caml_ba_element_size[CAML_BA_SINT16]);
+  if (!data)
+    caml_raise_out_of_memory();
+
+  CAMLreturn(
+      caml_ba_alloc(CAML_BA_C_LAYOUT | CAML_BA_SINT16, 1, data, &out_size));
+}
+
+CAMLprim value liquidsoap_cleanup_managed_int16_ba(value _ba) {
+  CAMLparam1(_ba);
+  free(Caml_ba_data_val(_ba));
+  CAMLreturn(Val_unit);
+}

--- a/src/core/source.ml
+++ b/src/core/source.ml
@@ -690,6 +690,8 @@ class virtual operator ?(name = "src") sources =
       List.iter (fun fn -> fn ()) on_before_output;
       in_output <- true
 
+    val mutable on_output = []
+    method on_output fn = on_output <- fn :: on_output
     val mutable on_after_output = []
     method on_after_output fn = on_after_output <- fn :: on_after_output
 
@@ -708,7 +710,9 @@ class virtual operator ?(name = "src") sources =
         in_output <- true;
         self#before_output;
         match deref clock with
-          | Known c -> c#on_after_output (fun () -> self#after_output)
+          | Known c ->
+              c#on_output (fun () -> List.iter (fun fn -> fn ()) on_output);
+              c#on_after_output (fun () -> self#after_output)
           | _ -> assert false)
 
     (* [#get buf] completes the frame with the next data in the stream.

--- a/src/core/source.mli
+++ b/src/core/source.mli
@@ -207,6 +207,9 @@ class virtual source :
        (* Register callback to be executed on #before_output. *)
        method on_before_output : (unit -> unit) -> unit
 
+       (* Register callback to be executed on #output. *)
+       method on_output : (unit -> unit) -> unit
+
        (* Register callback to be executed on #after_output. *)
        method on_after_output : (unit -> unit) -> unit
        method private has_ticked : unit

--- a/src/core/stream/content_pcm_base.ml
+++ b/src/core/stream/content_pcm_base.ml
@@ -73,30 +73,6 @@ let length = function
 let clear_content ~v b ofs len =
   Array.iter (fun c -> Bigarray.Array1.fill (Bigarray.Array1.sub c ofs len) v) b
 
-let from_audio ~to_value ~fmt c =
-  Array.map
-    (fun c ->
-      Bigarray.Array1.init fmt Bigarray.c_layout (Array.length c) (fun pos ->
-          to_value c.(pos)))
-    c
-
-let to_audio ~of_value c =
-  Array.map
-    (fun c ->
-      Array.init (Bigarray.Array1.dim c) (fun pos ->
-          of_value (Bigarray.Array1.unsafe_get c pos)))
-    c
-
-let blit_audio ~to_value src src_ofs dst dst_ofs len =
-  Array.iter2
-    (fun src dst ->
-      Array.iteri
-        (fun pos v ->
-          if src_ofs <= pos && pos < len then
-            Bigarray.Array1.set dst (dst_ofs + (pos - src_ofs)) (to_value v))
-        src)
-    src dst
-
 let channels_of_format ~get_params p =
   Content_audio.Specs.(
     channels_of_param (Lazy.force (get_params p).channel_layout))

--- a/src/core/stream/content_pcm_f32.ml
+++ b/src/core/stream/content_pcm_f32.ml
@@ -42,9 +42,11 @@ include MkContentBase (Specs)
 
 let kind = lift_kind `Pcm_f32
 let clear = Content_pcm_base.clear_content ~v:0.
-let to_value (v : float) = v [@@inline always]
-let of_value (v : float) = v [@@inline always]
-let from_audio = Content_pcm_base.from_audio ~to_value ~fmt:Bigarray.float32
-let to_audio = Content_pcm_base.to_audio ~of_value
-let blit_audio = Content_pcm_base.blit_audio ~to_value
+let from_audio c = Mm.Audio.to_ba c 0 (Mm.Audio.length c)
+let to_audio = Mm.Audio.of_ba
+
+let blit_audio src src_ofs dst dst_ofs len =
+  Mm.Audio.copy_to_ba src src_ofs len
+    (Array.map (fun dst -> Bigarray.Array1.sub dst dst_ofs len) dst)
+
 let channels_of_format = Content_pcm_base.channels_of_format ~get_params

--- a/src/core/stream/content_pcm_s16.ml
+++ b/src/core/stream/content_pcm_s16.ml
@@ -42,13 +42,11 @@ include MkContentBase (Specs)
 
 let kind = lift_kind `Pcm_s16
 let clear = Content_pcm_base.clear_content ~v:0
-let max_int16 = 32767.
-let to_value v = int_of_float (v *. max_int16)
-let of_value v = float v /. max_int16
+let from_audio c = Mm.Audio.to_int16_ba c 0 (Mm.Audio.length c)
+let to_audio = Mm.Audio.of_int16_ba
 
-let from_audio =
-  Content_pcm_base.from_audio ~to_value ~fmt:Bigarray.int16_signed
+let blit_audio src src_ofs dst dst_ofs len =
+  Mm.Audio.copy_to_int16_ba src src_ofs len
+    (Array.map (fun dst -> Bigarray.Array1.sub dst dst_ofs len) dst)
 
-let to_audio = Content_pcm_base.to_audio ~of_value
-let blit_audio = Content_pcm_base.blit_audio ~to_value
 let channels_of_format = Content_pcm_base.channels_of_format ~get_params


### PR DESCRIPTION
This PR adds a `track.audio.defer` operator that can be used to buffer large amount of audio data, following the issues outlined in https://github.com/savonet/liquidsoap/issues/2998

The underlying problem to do this is that the OCaml compiler will accelerate its garbage collection rate in the presence of declared large amount of external memory being held up by an OCaml value (see: https://github.com/ocaml/ocaml/issues/12228). This results in high CPU usage when intentionally holding up a large amount of audio data.

The only solution at the moment seems to be a user-managed external memory which is undeclared to the GC and needs to be manually collected. This is also the approach taken in reference-counting based processing stacks such as FFmpeg.

However, our current media data is designed to hold views on immutable chunks of data with offset/length and was designed to rely on the GC to collect them. Tracking references and manually cleaning up content memory would be impractical.

Thus, the implementation for this operator uses a big array with its external memory undeclared to the GC and a custom finalization function registered with it. This should work fine as long as we're not holding onto views on the arrays, which seems to be the case at the moment in the `Content_pcm_s16` implementation.

The trick to ensure strict memory limits in the implementation is to limit ourselves to a single allocated buffer (technically one per channel) and use it as a ringbuffer. A small overhead is added to allow the stream an extra buffer between consumer and producer.

The overhead was tricky to setup but it seems to be working fine. It can also be adjusted.

Another trick in the implementation is the use of clock callback. This allows the producing source to be attached to the same clock as the consuming source, as opposed to the `buffer` operator.

Previously, this would be achieved by placing the producing source in a dummy output attached to the source with a shared generator. This results in more complexity and issues that are harder to track. Hopefully, this new implementation should give a good blueprint for the future rewrite of the clock implementation.