### PR TITLE
Add id3v2 export to HLS output.

### DIFF
--- a/doc/content/hls_output.md
+++ b/doc/content/hls_output.md
@@ -69,6 +69,48 @@ Liquidsoap also provides `output.harbor.hls` which allows to serve HLS streams d
 liquidsoap. Their options should be the same as `output.file.hls`, except for harbor-specifc options `port` and `path`. It is
 not recommended for listener-facing setup but can be useful to sync up with a caching system such as cloudfront.
 
+## Metadata
+
+HLS outputs supports metadata in two ways:
+
+- Through a `timed_id3` metadata logical stream with `mpegts` and `mp4` formats
+- Through regular ID3 frames, as requested by the [HLS specifications](https://datatracker.ietf.org/doc/html/rfc8216#section-3.4) for `adts`, `mp3`, `ac3` and `eac3` formats.
+
+Metadata parameters are passed through the record methods of the streams' encoders. Here's an example
+
+```liquidsoap
+output.file.hls(
+  "/path/to/directory",
+  [
+   ("aac",
+      %ffmpeg(format="adts", %audio(codec="aac")).{
+        id3_version = 3
+       }),
+   ("ts-with-meta",
+      %ffmpeg(format="mpegts", %audio(codec="aac")).{
+        id3_version = 4
+     }),
+   ("ts",
+      %ffmpeg(format="mpegts", %audio(codec="aac")).{
+        id3 = false
+      }),
+   ("mp3",
+      %ffmpeg(format="mp3", %audio(codec="libmp3lame")).{
+        replay_id3 = false
+      })
+  ],
+  source
+)
+```
+
+Parameters are:
+
+- `id3`: Set to `false` to deactivate metadata on the streams. Defaults to `true`.
+- `id3_version`: Set the `id3v2` version used to export metadata
+- `replay_id3`: By default, the latest metadata is inserted at the beginning of each segment to make sure new listeners always get the latest metadata. Set to `false` to disable it.
+
+Metadata for these formats are activated by default. If you are experiencing any issues with them, you can disable them by setting `id3` to `false`.
+
 ## Mp4 format
 
 `mp4` container is supported by requires specific parameters. Here's an example that mixes `aac` and `flac` audio, The parameters

--- a/doc/content/hls_output.md
+++ b/doc/content/hls_output.md
@@ -73,8 +73,9 @@ not recommended for listener-facing setup but can be useful to sync up with a ca
 
 HLS outputs supports metadata in two ways:
 
-- Through a `timed_id3` metadata logical stream with `mpegts` and `mp4` formats
+- Through a `timed_id3` metadata logical stream with the `mpegts` format.
 - Through regular ID3 frames, as requested by the [HLS specifications](https://datatracker.ietf.org/doc/html/rfc8216#section-3.4) for `adts`, `mp3`, `ac3` and `eac3` formats.
+- There is currently no support for in-stream metadata for the `mp4` format.
 
 Metadata parameters are passed through the record methods of the streams' encoders. Here's an example
 

--- a/src/core/builtins/builtins_metadata.ml
+++ b/src/core/builtins/builtins_metadata.ml
@@ -1,0 +1,38 @@
+(*****************************************************************************
+
+  Liquidsoap, a programmable audio stream generator.
+  Copyright 2003-2023 Savonet team
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details, fully stated in the COPYING
+  file at the root of the liquidsoap distribution.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA
+
+ *****************************************************************************)
+
+let _ =
+  Lang.add_builtin ~base:Liquidsoap_lang.Builtins_string.string "id3v2"
+    ~category:`String
+    ~descr:"Return a string representation of a id3v2 metadata tag"
+    [
+      ("", Lang.metadata_t, None, None);
+      ( "version",
+        Lang.int_t,
+        Some (Lang.int 3),
+        Some "Tag version. One of: 3 or 4" );
+    ]
+    Lang.string_t
+    (fun p ->
+      let m = Utils.list_of_metadata (Lang.to_metadata (List.assoc "" p)) in
+      let version = Lang.to_int (List.assoc "version" p) in
+      Lang.string (Utils.id3v2_of_metadata ~version m))

--- a/src/core/dune
+++ b/src/core/dune
@@ -279,6 +279,7 @@
   builtins_files
   builtins_harbor
   builtins_http
+  builtins_metadata
   builtins_process
   builtins_request
   builtins_resolvers

--- a/src/core/encoder/encoder.mli
+++ b/src/core/encoder/encoder.mli
@@ -90,14 +90,23 @@ type split_result =
 exception Not_enough_data
 
 type hls = {
+  (* Returns true if id3 is enabled. *)
+  init : ?id3_enabled:bool -> ?id3_version:int -> unit -> bool;
   (* Returns (init_segment, first_bytes) *)
   init_encode : Frame.t -> int -> int -> Strings.t option * Strings.t;
   split_encode : Frame.t -> int -> int -> split_result;
   codec_attrs : unit -> string option;
+  insert_id3 :
+    frame_position:int ->
+    sample_position:int ->
+    (string * string) list ->
+    string option;
   bitrate : unit -> int option;
   (* width x height *)
   video_size : unit -> (int * int) option;
 }
+
+val dummy_hls : (Generator.t -> int -> int -> Strings.t) -> hls
 
 type encoder = {
   insert_metadata : Meta_format.export_metadata -> unit;

--- a/src/core/encoder/encoders/avi_encoder.ml
+++ b/src/core/encoder/encoders/avi_encoder.ml
@@ -112,18 +112,9 @@ let encoder ~pos:_ avi =
       Strings.dda header ans)
     else ans
   in
-  let hls =
-    {
-      Encoder.init_encode = (fun f o l -> (None, encode f o l));
-      split_encode = (fun f o l -> `Ok (Strings.empty, encode f o l));
-      codec_attrs = (fun () -> None);
-      bitrate = (fun () -> None);
-      video_size = (fun () -> None);
-    }
-  in
   {
     Encoder.insert_metadata = (fun _ -> ());
-    hls;
+    hls = Encoder.dummy_hls encode;
     encode;
     header = Strings.of_string header;
     stop = (fun () -> Strings.empty);

--- a/src/core/encoder/encoders/external_encoder.ml
+++ b/src/core/encoder/encoders/external_encoder.ml
@@ -162,22 +162,13 @@ let encoder ~pos:_ id ext =
         Condition.wait condition mutex;
         Strings.Mutable.flush buf)
   in
-  let hls =
-    {
-      Encoder.init_encode = (fun f o l -> (None, encode f o l));
-      split_encode = (fun f o l -> `Ok (Strings.empty, encode f o l));
-      codec_attrs = (fun () -> None);
-      bitrate = (fun () -> None);
-      video_size = (fun () -> None);
-    }
-  in
   {
     Encoder.insert_metadata;
     (* External encoders do not support
      * headers for now. They will probably
      * never do.. *)
     header = Strings.empty;
-    hls;
+    hls = Encoder.dummy_hls encode;
     encode;
     stop;
   }

--- a/src/core/encoder/encoders/fdkaac_encoder.ml
+++ b/src/core/encoder/encoders/fdkaac_encoder.ml
@@ -108,19 +108,10 @@ let encoder ~pos aac =
     Strings.Mutable.add rem (Fdkaac.Encoder.flush enc);
     Strings.Mutable.to_strings rem
   in
-  let hls =
-    {
-      Encoder.init_encode = (fun f o l -> (None, encode f o l));
-      split_encode = (fun f o l -> `Ok (Strings.empty, encode f o l));
-      codec_attrs = (fun () -> None);
-      bitrate = (fun () -> None);
-      video_size = (fun () -> None);
-    }
-  in
   {
     Encoder.insert_metadata = (fun _ -> ());
     header = Strings.empty;
-    hls;
+    hls = Encoder.dummy_hls encode;
     encode;
     stop;
   }

--- a/src/core/encoder/encoders/ffmpeg_encoder_common.ml
+++ b/src/core/encoder/encoders/ffmpeg_encoder_common.ml
@@ -221,17 +221,18 @@ let encoder ~pos ~mk_streams ffmpeg meta =
             in
             encoder.insert_id3 <-
               (fun ~frame_position ~sample_position m ->
-                let tag = Utils.id3v2_of_metadata ~version:id3_version m in
-                let packet = Avcodec.Packet.create tag in
-                let position =
-                  Int64.of_int
-                    (Frame.audio_of_main
-                       ((frame_position * Lazy.force Frame.size)
-                       + sample_position))
-                in
-                Avcodec.Packet.set_pts packet (Some position);
-                Avcodec.Packet.set_dts packet (Some position);
-                Av.write_packet stream time_base packet;
+                if encoder.started then (
+                  let tag = Utils.id3v2_of_metadata ~version:id3_version m in
+                  let packet = Avcodec.Packet.create tag in
+                  let position =
+                    Int64.of_int
+                      (Frame.audio_of_main
+                         ((frame_position * Lazy.force Frame.size)
+                         + sample_position))
+                  in
+                  Avcodec.Packet.set_pts packet (Some position);
+                  Avcodec.Packet.set_dts packet (Some position);
+                  Av.write_packet stream time_base packet);
                 None);
             true)
           else false

--- a/src/core/encoder/encoders/ffmpeg_encoder_common.ml
+++ b/src/core/encoder/encoders/ffmpeg_encoder_common.ml
@@ -212,8 +212,8 @@ let encoder ~pos ~mk_streams ffmpeg meta =
   let init ?id3_enabled ?id3_version () =
     let encoder = !encoder in
     match Option.map Av.Format.get_output_name encoder.format with
-      | Some "mpegts" | Some "mp4" ->
-          if id3_enabled = Some true then (
+      | Some "mpegts" ->
+          if id3_enabled <> Some false then (
             let id3_version = Option.value ~default:3 id3_version in
             let time_base = Ffmpeg_utils.liq_audio_sample_time_base () in
             let stream =

--- a/src/core/encoder/encoders/flac_encoder.ml
+++ b/src/core/encoder/encoders/flac_encoder.ml
@@ -61,21 +61,12 @@ let encoder ~pos:_ flac meta =
     Flac.Encoder.finish !enc cb;
     Strings.Mutable.flush buf
   in
-  let hls =
-    {
-      Encoder.init_encode = (fun f o l -> (None, encode f o l));
-      split_encode = (fun f o l -> `Ok (Strings.empty, encode f o l));
-      codec_attrs = (fun () -> None);
-      bitrate = (fun () -> None);
-      video_size = (fun () -> None);
-    }
-  in
   {
     Encoder.insert_metadata = (fun _ -> ());
     (* Flac encoder do not support header
      * for now. It will probably never do.. *)
     header = Strings.empty;
-    hls;
+    hls = Encoder.dummy_hls encode;
     encode;
     stop;
   }

--- a/src/core/encoder/encoders/gstreamer_encoder.ml
+++ b/src/core/encoder/encoders/gstreamer_encoder.ml
@@ -189,16 +189,13 @@ let encoder ext =
       decr_samples ();
       Strings.of_string ans)
   in
-  let hls =
-    {
-      Encoder.init_encode = (fun f o l -> (None, encode f o l));
-      split_encode = (fun f o l -> `Ok (Strings.empty, encode f o l));
-      codec_attrs = (fun () -> None);
-      bitrate = (fun () -> None);
-      video_size = (fun () -> None);
-    }
-  in
-  { Encoder.insert_metadata; header = Strings.empty; hls; encode; stop }
+  {
+    Encoder.insert_metadata;
+    header = Strings.empty;
+    hls = Encoder.dummy_hls encode;
+    encode;
+    stop;
+  }
 
 let () =
   Plug.register Encoder.plug "gstreamer" ~doc:"" (function

--- a/src/core/encoder/encoders/lame_encoder.ml
+++ b/src/core/encoder/encoders/lame_encoder.ml
@@ -111,18 +111,9 @@ let () =
       Strings.Mutable.flush encoded
     in
     let stop () = Strings.of_string (Lame.encode_flush enc) in
-    let hls =
-      {
-        Encoder.init_encode = (fun f o l -> (None, encode f o l));
-        split_encode = (fun f o l -> `Ok (Strings.empty, encode f o l));
-        codec_attrs = (fun () -> None);
-        bitrate = (fun () -> None);
-        video_size = (fun () -> None);
-      }
-    in
     {
       insert_metadata = (fun _ -> ());
-      hls;
+      hls = Encoder.dummy_hls encode;
       encode;
       header = Strings.empty;
       stop;

--- a/src/core/encoder/encoders/ogg_encoder.ml
+++ b/src/core/encoder/encoders/ogg_encoder.ml
@@ -101,7 +101,13 @@ let encoder ~pos { Ogg_format.audio; video } =
     let skeleton = List.length tracks > 1 in
     let ogg_enc = Ogg_muxer.create ~skeleton name in
     let rec enc =
-      { Encoder.insert_metadata; hls; encode; header = Strings.empty; stop }
+      {
+        Encoder.insert_metadata;
+        hls = Encoder.dummy_hls (fun _ _ -> assert false);
+        encode;
+        header = Strings.empty;
+        stop;
+      }
     and streams_start () =
       let f track =
         match track.id with
@@ -122,14 +128,6 @@ let encoder ~pos { Ogg_format.audio; video } =
       in
       List.iter f tracks;
       Ogg_muxer.get_data ogg_enc
-    and hls =
-      {
-        Encoder.init_encode = (fun f o l -> (None, encode f o l));
-        split_encode = (fun f o l -> `Ok (Strings.empty, encode f o l));
-        codec_attrs = (fun () -> None);
-        bitrate = (fun () -> None);
-        video_size = (fun () -> None);
-      }
     and ogg_stop () =
       let f track = track.id <- None in
       List.iter f tracks;
@@ -146,7 +144,7 @@ let encoder ~pos { Ogg_format.audio; video } =
       List.iter f tracks;
       enc.Encoder.header <- Ogg_muxer.get_header ogg_enc
     in
-    enc
+    { enc with hls = Encoder.dummy_hls encode }
 
 let () =
   Plug.register Encoder.plug "ogg" ~doc:"ogg encoder." (function

--- a/src/core/encoder/encoders/shine_encoder.ml
+++ b/src/core/encoder/encoders/shine_encoder.ml
@@ -64,19 +64,10 @@ let encoder ~pos:_ shine =
     Strings.Mutable.flush encoded
   in
   let stop () = Strings.of_string (Shine.flush enc) in
-  let hls =
-    {
-      Encoder.init_encode = (fun f o l -> (None, encode f o l));
-      split_encode = (fun f o l -> `Ok (Strings.empty, encode f o l));
-      codec_attrs = (fun () -> None);
-      bitrate = (fun () -> None);
-      video_size = (fun () -> None);
-    }
-  in
   {
     Encoder.insert_metadata = (fun _ -> ());
     header = Strings.empty;
-    hls;
+    hls = Encoder.dummy_hls encode;
     encode;
     stop;
   }

--- a/src/core/encoder/encoders/wav_encoder.ml
+++ b/src/core/encoder/encoders/wav_encoder.ml
@@ -69,18 +69,9 @@ let encoder ~pos wav =
       Strings.of_list [header; s])
     else Strings.of_string s
   in
-  let hls =
-    {
-      Encoder.init_encode = (fun f o l -> (None, encode f o l));
-      split_encode = (fun f o l -> `Ok (Strings.empty, encode f o l));
-      codec_attrs = (fun () -> None);
-      bitrate = (fun () -> None);
-      video_size = (fun () -> None);
-    }
-  in
   {
     Encoder.insert_metadata = (fun _ -> ());
-    hls;
+    hls = Encoder.dummy_hls encode;
     encode;
     header = Strings.of_string header;
     stop = (fun () -> Strings.empty);

--- a/src/core/lang.mli
+++ b/src/core/lang.mli
@@ -308,6 +308,8 @@ val pos : env -> Liquidsoap_lang.Pos.t list
 (** Convert a metadata packet to a list associating strings to strings. *)
 val metadata : Frame.metadata -> value
 
+val metadata_list : (string * string) list -> value
+
 (** Raise an error. *)
 val raise_error :
   ?bt:Printexc.raw_backtrace ->

--- a/src/core/lang_source.ml
+++ b/src/core/lang_source.ml
@@ -38,6 +38,9 @@ let to_metadata t =
   List.iter (fun (a, b) -> Hashtbl.add metas a b) t;
   metas
 
+let metadata_list m =
+  list (List.map (fun (k, v) -> product (string k) (string v)) m)
+
 let metadata m =
   list (Hashtbl.fold (fun k v l -> product (string k) (string v) :: l) m [])
 

--- a/src/core/stream/frame.mli
+++ b/src/core/stream/frame.mli
@@ -35,6 +35,8 @@ module Fields : sig
   val audio_n : int -> field
   val video : field
   val video_n : int -> field
+  val data : field
+  val data_n : int -> field
   val midi : field
   val register : string -> field
   val make : ?audio:'a -> ?video:'a -> ?midi:'a -> unit -> 'a t

--- a/src/core/stream/frame_base.ml
+++ b/src/core/stream/frame_base.ml
@@ -59,6 +59,7 @@ module Fields = struct
   let track_marks = register "track_marks"
   let audio = register "audio"
   let video = register "video"
+  let data = register "data"
   let midi = register "midi"
 
   let audio_n = function
@@ -68,6 +69,10 @@ module Fields = struct
   let video_n = function
     | 0 -> video
     | n -> register (Printf.sprintf "video_%d" (n + 1))
+
+  let data_n = function
+    | 0 -> data
+    | n -> register (Printf.sprintf "data_%d" (n + 1))
 
   let make =
     let audio_f = audio in

--- a/src/core/tools/utils.ml
+++ b/src/core/tools/utils.ml
@@ -490,3 +490,116 @@ let write_all fd b =
 
 (* Stdlib.abs_float is not inlined!. *)
 let abs_float (f : float) = if f < 0. then -.f else f [@@inline always]
+
+let frame_id_of_string = function
+  | "comment" -> Some `COMM
+  | "album" -> Some `TALB
+  | "bpm" -> Some `TBPM
+  | "composer" -> Some `TCOM
+  | "content" -> Some `TCON
+  | "copyright" -> Some `TCOP
+  | "date" -> Some `TDAT
+  | "encoder" -> Some `TENC
+  | "title" -> Some `TIT2
+  | "language" -> Some `TLAN
+  | "length" -> Some `TLEN
+  | "performer" -> Some `TOPE
+  | "artist" -> Some `TPE1
+  | "band" -> Some `TPE2
+  | "publisher" -> Some `TPUB
+  | "tracknumber" -> Some `TRCK
+  | "year" -> Some `TYER
+  | "url" -> Some `WXXX
+  | "AENC" -> Some `AENC
+  | "APIC" -> Some `APIC
+  | "COMM" -> Some `COMM
+  | "COMR" -> Some `COMR
+  | "ENCR" -> Some `ENCR
+  | "EQUA" -> Some `EQUA
+  | "ETCO" -> Some `ETCO
+  | "GEOB" -> Some `GEOB
+  | "GRID" -> Some `GRID
+  | "IPLS" -> Some `IPLS
+  | "LINK" -> Some `LINK
+  | "MCDI" -> Some `MCDI
+  | "MLLT" -> Some `MLLT
+  | "OWNE" -> Some `OWNE
+  | "PRIV" -> Some `PRIV
+  | "PCNT" -> Some `PCNT
+  | "POPM" -> Some `POPM
+  | "POSS" -> Some `POSS
+  | "RBUF" -> Some `RBUF
+  | "RVAD" -> Some `RVAD
+  | "RVRB" -> Some `RVRB
+  | "SYLT" -> Some `SYLT
+  | "SYTC" -> Some `SYTC
+  | "TALB" -> Some `TALB
+  | "TBPM" -> Some `TBPM
+  | "TCOM" -> Some `TCOM
+  | "TCON" -> Some `TCON
+  | "TCOP" -> Some `TCOP
+  | "TDAT" -> Some `TDAT
+  | "TDLY" -> Some `TDLY
+  | "TENC" -> Some `TENC
+  | "TEXT" -> Some `TEXT
+  | "TFLT" -> Some `TFLT
+  | "TIME" -> Some `TIME
+  | "TIT1" -> Some `TIT1
+  | "TIT2" -> Some `TIT2
+  | "TIT3" -> Some `TIT3
+  | "TKEY" -> Some `TKEY
+  | "TLAN" -> Some `TLAN
+  | "TLEN" -> Some `TLEN
+  | "TMED" -> Some `TMED
+  | "TOAL" -> Some `TOAL
+  | "TOFN" -> Some `TOFN
+  | "TOLY" -> Some `TOLY
+  | "TOPE" -> Some `TOPE
+  | "TORY" -> Some `TORY
+  | "TOWN" -> Some `TOWN
+  | "TPE1" -> Some `TPE1
+  | "TPE2" -> Some `TPE2
+  | "TPE3" -> Some `TPE3
+  | "TPE4" -> Some `TPE4
+  | "TPOS" -> Some `TPOS
+  | "TPUB" -> Some `TPUB
+  | "TRCK" -> Some `TRCK
+  | "TRDA" -> Some `TRDA
+  | "TRSN" -> Some `TRSN
+  | "TRSO" -> Some `TRSO
+  | "TSIZ" -> Some `TSIZ
+  | "TSRC" -> Some `TSRC
+  | "TSSE" -> Some `TSSE
+  | "TYER" -> Some `TYER
+  | "TXXX" -> Some `TXXX
+  | "UFID" -> Some `UFID
+  | "USER" -> Some `USER
+  | "USLT" -> Some `USLT
+  | "WCOM" -> Some `WCOM
+  | "WCOP" -> Some `WCOP
+  | "WOAF" -> Some `WOAF
+  | "WOAR" -> Some `WOAR
+  | "WOAS" -> Some `WOAS
+  (* codespell 💩 *)
+  | x when x = "W" ^ "ORS" -> Some `WORS
+  | "WPAY" -> Some `WPAY
+  | "WPUB" -> Some `WPUB
+  | "WXXX" -> Some `WXXX
+  | _ -> None
+
+let id3v2_of_metadata ~version m =
+  let frames =
+    List.fold_left
+      (fun frames (k, v) ->
+        match frame_id_of_string k with
+          | Some id ->
+              {
+                Metadata.ID3v2.id;
+                data = `Text (`UTF_8, v);
+                flags = Metadata.ID3v2.default_flags id;
+              }
+              :: frames
+          | None -> frames)
+      [] m
+  in
+  Metadata.ID3v2.make ~version frames

--- a/tests/streams/dune.inc
+++ b/tests/streams/dune.inc
@@ -355,6 +355,28 @@
  (alias citest)
  (package liquidsoap)
  (deps
+  hls_id3v2.liq
+  ./file1.mp3
+  ./file2.mp3
+  ./file3.mp3
+  ./jingle1.mp3
+  ./jingle2.mp3
+  ./jingle3.mp3
+  ./file1.png
+  ./file2.png
+  ./jingles
+  ./playlist
+  ./huge_playlist
+  ../../src/bin/liquidsoap.exe
+  (package liquidsoap)
+  (:test_liq ../test.liq)
+  (:run_test ../run_test.exe))
+ (action (run %{run_test} hls_id3v2.liq liquidsoap %{test_liq} hls_id3v2.liq)))
+
+(rule
+ (alias citest)
+ (package liquidsoap)
+ (deps
   huge-playlist.liq
   ./file1.mp3
   ./file2.mp3

--- a/tests/streams/hls_id3v2.liq
+++ b/tests/streams/hls_id3v2.liq
@@ -1,0 +1,80 @@
+s = sine()
+
+s = insert_metadata(s)
+
+def f() =
+  s.insert_metadata([("title", "test title"), ("album","foolol")])
+end
+
+thread.run(every=2., f)
+
+s = mksafe(s)
+
+tmp_dir = file.temp_dir("tmp")
+on_shutdown({file.rmdir(tmp_dir)})
+
+output.file.hls(
+  tmp_dir,
+  [
+   ("aac", %ffmpeg(format="adts",%audio(codec="aac")).{id3_version = 3}),
+   ("ts_with_meta", %ffmpeg(format="mpegts",%audio(codec="aac")).{id3 = true, id3_version = 4}),
+   ("ts", %ffmpeg(format="mpegts",%audio(codec="aac")))
+  ],
+  s
+)
+
+to_check = ref({
+  aac = null(),
+  ts_with_meta = null(),
+  ts = null()
+})
+
+def check_done() =
+  let { aac, ts_with_meta, ts } = to_check()
+
+  if null.defined(ts) then test.fail("ts shouldn't have metadata!") end
+
+  if null.defined(aac) and null.defined(ts_with_meta) then
+    aac = null.get(aac)
+    ts_with_meta = null.get(ts_with_meta)
+    if aac["title"] == "test title" and ts_with_meta["title"] == "test title" and
+       aac["album"] == "foolol" and ts_with_meta["album"] == "foolol" then
+      test.pass()
+    end
+  end
+end
+
+aac = input.hls("#{tmp_dir}/aac.m3u8")
+
+aac = source.on_metadata(aac, fun (m) -> begin
+  if m["title"] != "" then
+    to_check := to_check().{ aac = m }
+  end
+  check_done()
+end)
+
+output.dummy(fallible=true, aac)
+
+ts_with_meta = input.hls("#{tmp_dir}/ts_with_meta.m3u8")
+
+ts_with_meta = source.on_metadata(ts_with_meta, fun (m) -> begin
+  if m["title"] != "" then
+    to_check := to_check().{ ts_with_meta = m }
+  end
+  check_done()
+end)
+
+output.dummy(fallible=true, ts_with_meta)
+
+ts = input.hls("#{tmp_dir}/ts.m3u8")
+
+ts = source.on_metadata(ts, fun (m) -> begin
+  if m["title"] != "" then
+    to_check := to_check().{ ts = m }
+  end
+  check_done()
+end)
+
+output.dummy(fallible=true, ts)
+
+clock.assign_new(sync="none",[s, aac, ts_with_meta, ts])

--- a/tests/streams/hls_id3v2.liq
+++ b/tests/streams/hls_id3v2.liq
@@ -17,8 +17,9 @@ output.file.hls(
   tmp_dir,
   [
    ("aac", %ffmpeg(format="adts",%audio(codec="aac")).{id3_version = 3}),
-   ("ts_with_meta", %ffmpeg(format="mpegts",%audio(codec="aac")).{id3 = true, id3_version = 4}),
-   ("ts", %ffmpeg(format="mpegts",%audio(codec="aac")))
+   ("ts_with_meta", %ffmpeg(format="mpegts",%audio(codec="aac")).{id3_version = 4}),
+   ("ts", %ffmpeg(format="mpegts",%audio(codec="aac")).{ id3=false }),
+   ("mp4", %ffmpeg(format="mp4",frag_duration=10,movflags="+dash+skip_sidx+skip_trailer+frag_custom",%audio(codec="aac")))
   ],
   s
 )
@@ -26,19 +27,21 @@ output.file.hls(
 to_check = ref({
   aac = null(),
   ts_with_meta = null(),
-  ts = null()
+  ts = null(),
+  mp4 = null()
 })
 
 def check_done() =
-  let { aac, ts_with_meta, ts } = to_check()
+  let { aac, ts_with_meta, ts, mp4 } = to_check()
 
   if null.defined(ts) then test.fail("ts shouldn't have metadata!") end
+  if null.defined(mp4) then test.fail("mp4 should have metadata but it's not supported by the demuxer yet.") end
 
   if null.defined(aac) and null.defined(ts_with_meta) then
     aac = null.get(aac)
     ts_with_meta = null.get(ts_with_meta)
-    if aac["title"] == "test title" and ts_with_meta["title"] == "test title" and
-       aac["album"] == "foolol" and ts_with_meta["album"] == "foolol" then
+    if aac["title"] == "test title" and aac["album"] == "foolol" and
+       ts_with_meta["title"] == "test title" and ts_with_meta["album"] == "foolol" then
       test.pass()
     end
   end
@@ -77,4 +80,15 @@ end)
 
 output.dummy(fallible=true, ts)
 
-clock.assign_new(sync="none",[s, aac, ts_with_meta, ts])
+mp4 = input.hls("#{tmp_dir}/mp4.m3u8")
+
+mp4 = source.on_metadata(mp4, fun (m) -> begin
+  if m["title"] != "" then
+    to_check := to_check().{ mp4 = m }
+  end
+  check_done()
+end)
+
+output.dummy(fallible=true, mp4)
+
+clock.assign_new(sync="none",[s, aac, ts_with_meta, ts, mp4])

--- a/tests/test.liq
+++ b/tests/test.liq
@@ -9,8 +9,9 @@ def test.pass()
 end
 
 # End test with a failure.
-def test.fail()
-  print("Test failed!")
+def test.fail(reason = null())
+  reason = if null.defined(reason) then ": #{null.get(reason)}" else "!" end
+  print("Test failed#{reason}")
   exit(1)
 end
 


### PR DESCRIPTION
This PR implements support for ID3 metadata for HLS output.

From the doc:

## Metadata

HLS outputs supports metadata in two ways:

- Through a `timed_id3` metadata logical stream with the `mpegts` format.
- Through regular ID3 frames, as requested by the [HLS specifications](https://datatracker.ietf.org/doc/html/rfc8216#section-3.4) for `adts`, `mp3`, `ac3` and `eac3` formats.
- There is currently no support for in-stream metadata for the `mp4` format.

Metadata parameters are passed through the record methods of the streams' encoders. Here's an example

```liquidsoap
output.file.hls(
  "/path/to/directory",
  [
   ("aac",
      %ffmpeg(format="adts", %audio(codec="aac")).{
        id3_version = 3
       }),
   ("ts-with-meta",
      %ffmpeg(format="mpegts", %audio(codec="aac")).{
        id3_version = 4
     }),
   ("ts",
      %ffmpeg(format="mpegts", %audio(codec="aac")).{
        id3 = false
      }),
   ("mp3",
      %ffmpeg(format="mp3", %audio(codec="libmp3lame")).{
        replay_id3 = false
      })
  ],
  source
)
```

Parameters are:

- `id3`: Set to `false` to deactivate metadata on the streams. Defaults to `true`.
- `id3_version`: Set the `id3v2` version used to export metadata
- `replay_id3`: By default, the latest metadata is inserted at the beginning of each segment to make sure new listeners always get the latest metadata. Set to `false` to disable it.

Metadata for these formats are activated by default. If you are experiencing any issues with them, you can disable them by setting `id3` to `false`.



Fixes: #3153