### PR TITLE
Better encoder errors.

### DIFF
--- a/src/core/dune
+++ b/src/core/dune
@@ -200,6 +200,7 @@
   playlist_parser
   plug
   pool
+  pos
   ppm_decoder
   prepend
   process_handler

--- a/src/core/encoder/encoder.ml
+++ b/src/core/encoder/encoder.ml
@@ -284,7 +284,8 @@ type encoder = {
   stop : unit -> Strings.t;
 }
 
-type factory = string -> Meta_format.export_metadata -> encoder
+type factory =
+  pos:Pos.t option -> string -> Meta_format.export_metadata -> encoder
 
 (** A plugin might or might not accept a given format.
     If it accepts it, it gives a function creating suitable encoders. *)
@@ -302,8 +303,10 @@ let get_factory fmt =
         match f fmt with Some factory -> raise (Found factory) | None -> ());
     raise Not_found
   with Found factory ->
-    fun name m ->
-      let { insert_metadata; hls; encode; stop; header } = factory name m in
+    fun ~pos name m ->
+      let { insert_metadata; hls; encode; stop; header } =
+        factory ~pos name m
+      in
       (* Protect all functions with a mutex. *)
       let m = Mutex.create () in
       let insert_metadata = Tutils.mutexify m insert_metadata in

--- a/src/core/encoder/encoder.mli
+++ b/src/core/encoder/encoder.mli
@@ -110,7 +110,8 @@ type encoder = {
   stop : unit -> Strings.t;
 }
 
-type factory = string -> Meta_format.export_metadata -> encoder
+type factory =
+  pos:Pos.t option -> string -> Meta_format.export_metadata -> encoder
 
 (** A plugin might or might not accept a given format.
   * If it accepts it, it gives a function creating suitable encoders. *)

--- a/src/core/encoder/encoders/avi_encoder.ml
+++ b/src/core/encoder/encoders/avi_encoder.ml
@@ -91,7 +91,7 @@ let encode_frame ~channels ~samplerate ~width ~height ~converter frame start len
   in
   Strings.add video audio
 
-let encoder avi =
+let encoder ~pos:_ avi =
   let channels = avi.channels in
   let samplerate = Lazy.force avi.samplerate in
   let converter = Audio_converter.Samplerate.create channels in
@@ -131,5 +131,5 @@ let encoder avi =
 
 let () =
   Plug.register Encoder.plug "avi" ~doc:"Native avi encoder." (function
-    | Encoder.AVI avi -> Some (fun _ _ -> encoder avi)
+    | Encoder.AVI avi -> Some (fun ~pos _ _ -> encoder ~pos avi)
     | _ -> None)

--- a/src/core/encoder/encoders/external_encoder.ml
+++ b/src/core/encoder/encoders/external_encoder.ml
@@ -26,7 +26,7 @@ open Mm
 
 open External_encoder_format
 
-let encoder id ext =
+let encoder ~pos:_ id ext =
   let log = Log.make [id] in
   let is_metadata_restart = ref false in
   let is_stop = ref false in
@@ -185,5 +185,5 @@ let encoder id ext =
 let () =
   Plug.register Encoder.plug "external" ~doc:"Encode using external programs."
     (function
-    | Encoder.External m -> Some (fun s _ -> encoder s m)
+    | Encoder.External m -> Some (fun ~pos s _ -> encoder ~pos s m)
     | _ -> None)

--- a/src/core/encoder/encoders/ffmpeg_copy_encoder.ml
+++ b/src/core/encoder/encoders/ffmpeg_copy_encoder.ml
@@ -27,7 +27,8 @@ open Ffmpeg_encoder_common
 
 let log = Log.make ["ffmpeg"; "copy"; "encoder"]
 
-let mk_stream_copy ~get_stream ~remove_stream ~keyframe_opt ~field output =
+let mk_stream_copy ~pos:_ ~get_stream ~remove_stream ~keyframe_opt ~field output
+    =
   let stream = ref None in
   let video_size_ref = ref None in
   let codec_attr = ref None in

--- a/src/core/encoder/encoders/ffmpeg_encoder.ml
+++ b/src/core/encoder/encoders/ffmpeg_encoder.ml
@@ -28,7 +28,7 @@ let () =
   Plug.register Encoder.plug "ffmpeg" ~doc:"" (function
     | Encoder.Ffmpeg m ->
         Some
-          (fun _ ->
+          (fun ~pos _ ->
             let copy_count =
               List.fold_left
                 (fun cur (_, c) -> match c with `Copy _ -> cur + 1 | _ -> cur)
@@ -41,10 +41,10 @@ let () =
                   Frame.Fields.add field
                     (match stream with
                       | `Copy keyframe_opt ->
-                          Ffmpeg_copy_encoder.mk_stream_copy ~get_stream
+                          Ffmpeg_copy_encoder.mk_stream_copy ~pos ~get_stream
                             ~remove_stream ~keyframe_opt ~field output
                       | `Encode Ffmpeg_format.{ codec = None } ->
-                          Lang_encoder.raise_error ~pos:None
+                          Lang_encoder.raise_error ~pos
                             (Printf.sprintf
                                "Codec unspecified for %%ffmpeg stream %%%s!"
                                (Frame.Fields.string_of_field field))
@@ -56,7 +56,7 @@ let () =
                               options = `Audio params;
                               opts = options;
                             } ->
-                          Ffmpeg_internal_encoder.mk_audio ~mode ~params
+                          Ffmpeg_internal_encoder.mk_audio ~pos ~mode ~params
                             ~options ~codec ~field output
                       | `Encode
                           Ffmpeg_format.
@@ -66,10 +66,10 @@ let () =
                               options = `Video params;
                               opts = options;
                             } ->
-                          Ffmpeg_internal_encoder.mk_video ~mode ~params
+                          Ffmpeg_internal_encoder.mk_video ~pos ~mode ~params
                             ~options ~codec ~field output)
                     streams)
                 Frame.Fields.empty m.streams
             in
-            encoder ~mk_streams m)
+            encoder ~pos ~mk_streams m)
     | _ -> None)

--- a/src/core/encoder/encoders/ffmpeg_encoder_common.ml
+++ b/src/core/encoder/encoders/ffmpeg_encoder_common.ml
@@ -112,7 +112,7 @@ let convert_options opts =
     | `String layout -> `Int64 Avutil.Channel_layout.(get_id (find layout))
     | _ -> assert false)
 
-let encoder ~mk_streams ffmpeg meta =
+let encoder ~pos ~mk_streams ffmpeg meta =
   let buf = Strings.Mutable.empty () in
   let make () =
     let options = Hashtbl.copy ffmpeg.Ffmpeg_format.opts in
@@ -127,9 +127,9 @@ let encoder ~mk_streams ffmpeg meta =
         | `Stream ->
             if format = None then (
               match ffmpeg.Ffmpeg_format.format with
-                | None -> failwith "Format is required!"
+                | None -> Lang_encoder.raise_error ~pos "Format is required!"
                 | Some fmt ->
-                    failwith
+                    Lang_encoder.raise_error ~pos
                       (Printf.sprintf
                          "No ffmpeg format could be guessed for format=%S" fmt));
             Av.open_output_stream ~opts:options write (Option.get format)
@@ -137,7 +137,7 @@ let encoder ~mk_streams ffmpeg meta =
     in
     let streams = mk_streams output in
     if Hashtbl.length options > 0 then
-      failwith
+      Lang_encoder.raise_error ~pos
         (Printf.sprintf "Unrecognized options: %s"
            (Ffmpeg_format.string_of_options options));
     { output; streams; started = false }

--- a/src/core/encoder/encoders/flac_encoder.ml
+++ b/src/core/encoder/encoders/flac_encoder.ml
@@ -24,7 +24,7 @@ open Mm
 
 (** FLAC encoder *)
 
-let encoder flac meta =
+let encoder ~pos:_ flac meta =
   let comments = Utils.list_of_metadata (Meta_format.to_metadata meta) in
   let channels = flac.Flac_format.channels in
   let samplerate_converter = Audio_converter.Samplerate.create channels in
@@ -82,5 +82,5 @@ let encoder flac meta =
 
 let () =
   Plug.register Encoder.plug "flac" ~doc:"Flac encoder." (function
-    | Encoder.Flac m -> Some (fun _ -> encoder m)
+    | Encoder.Flac m -> Some (fun ~pos _ -> encoder ~pos m)
     | _ -> None)

--- a/src/core/encoder/encoders/lame_encoder.ml
+++ b/src/core/encoder/encoders/lame_encoder.ml
@@ -75,7 +75,7 @@ let () =
     Lame.init_params enc;
     enc
   in
-  let mp3_encoder mp3 metadata =
+  let mp3_encoder ~pos:_ mp3 metadata =
     let enc = create_encoder mp3 in
     let channels = if mp3.Mp3_format.stereo then 2 else 1 in
     (* Lame accepts data of a fixed length.. *)
@@ -129,5 +129,5 @@ let () =
     }
   in
   Plug.register Encoder.plug "lame" ~doc:"LAME mp3 encoder." (function
-    | Encoder.MP3 mp3 -> Some (fun _ meta -> mp3_encoder mp3 meta)
+    | Encoder.MP3 mp3 -> Some (fun ~pos _ meta -> mp3_encoder ~pos mp3 meta)
     | _ -> None)

--- a/src/core/encoder/encoders/ogg_encoder.ml
+++ b/src/core/encoder/encoders/ogg_encoder.ml
@@ -71,21 +71,21 @@ let encoder_name = function
   | Ogg_format.Flac _ -> "flac"
   | Ogg_format.Speex _ -> "speex"
 
-let get_encoder name =
+let get_encoder ~pos name =
   try Hashtbl.find audio_encoders name
   with Not_found ->
-    Ogg_muxer.log#important "Could not find any %s encoder." name;
-    raise Not_found
+    Lang_encoder.raise_error ~pos
+      (Printf.sprintf "Could not find any %s encoder." name)
 
-let encoder { Ogg_format.audio; video } =
-  ignore (Option.map (fun p -> get_encoder (encoder_name p)) audio);
+let encoder ~pos { Ogg_format.audio; video } =
+  ignore (Option.map (fun p -> get_encoder ~pos (encoder_name p)) audio);
   ignore (Option.map (fun _ -> assert (!theora_encoder <> None)) video);
   fun name meta ->
     let tracks = [] in
     let tracks =
       match audio with
         | Some params ->
-            let enc = get_encoder (encoder_name params) in
+            let enc = get_encoder ~pos (encoder_name params) in
             enc params :: tracks
         | None -> tracks
     in

--- a/src/core/encoder/encoders/shine_encoder.ml
+++ b/src/core/encoder/encoders/shine_encoder.ml
@@ -27,7 +27,7 @@ open Shine_format
 let create_encoder ~samplerate ~bitrate ~channels =
   Shine.create { Shine.channels; samplerate; bitrate }
 
-let encoder shine =
+let encoder ~pos:_ shine =
   let channels = shine.channels in
   let samplerate = Lazy.force shine.samplerate in
   let enc = create_encoder ~samplerate ~bitrate:shine.bitrate ~channels in
@@ -84,5 +84,5 @@ let encoder shine =
 let () =
   Plug.register Encoder.plug "shine" ~doc:"SHINE fixed-point mp3 encoder."
     (function
-    | Encoder.Shine m -> Some (fun _ _ -> encoder m)
+    | Encoder.Shine m -> Some (fun ~pos _ _ -> encoder ~pos m)
     | _ -> None)

--- a/src/core/encoder/encoders/wav_encoder.ml
+++ b/src/core/encoder/encoders/wav_encoder.ml
@@ -26,7 +26,7 @@ open Mm
 
 open Wav_format
 
-let encoder wav =
+let encoder ~pos wav =
   let channels = wav.channels in
   let sample_rate = Lazy.force wav.samplerate in
   let sample_size = wav.samplesize in
@@ -60,7 +60,7 @@ let encoder wav =
         | 24 -> fun buf s off -> Audio.S24LE.of_audio buf s off
         | 16 -> Audio.S16LE.of_audio
         | 8 -> fun buf s off -> Audio.U8.of_audio buf s off
-        | _ -> failwith "unsupported sample size"
+        | _ -> Lang_encoder.raise_error ~pos "Unsupported sample size"
     in
     of_audio b start s 0 len;
     let s = Bytes.unsafe_to_string s in
@@ -88,5 +88,5 @@ let encoder wav =
 
 let () =
   Plug.register Encoder.plug "wav" ~doc:"Native wav encoder." (function
-    | Encoder.WAV w -> Some (fun _ _ -> encoder w)
+    | Encoder.WAV w -> Some (fun ~pos _ _ -> encoder ~pos w)
     | _ -> None)

--- a/src/core/encoder/lang_encoder.ml
+++ b/src/core/encoder/lang_encoder.ml
@@ -133,7 +133,7 @@ let make_encoder ~pos t ((e, p) : Hooks.encoder) =
   try
     let e = (find_encoder e).make p in
     let (_ : Encoder.factory) = Encoder.get_factory e in
-    V.to_value e
+    V.to_value ?pos e
   with Not_found ->
     raise_error ~pos
       (Printf.sprintf "unsupported format: %s" (Term.to_string t))

--- a/src/core/io/srt_io.ml
+++ b/src/core/io/srt_io.ml
@@ -1076,7 +1076,7 @@ let _ =
       let format_val = Lang.assoc "" 1 p in
       let format = Lang.to_format format_val in
       let encoder_factory =
-        try Encoder.get_factory format
+        try (Encoder.get_factory format) ~pos:format_val.Value.pos
         with Not_found ->
           raise
             (Error.Invalid_value

--- a/src/core/io/udp_io.ml
+++ b/src/core/io/udp_io.ml
@@ -221,7 +221,7 @@ let _ =
       let hostname = Lang.to_string (List.assoc "host" p) in
       let fmt =
         let fmt = Lang.assoc "" 1 p in
-        try Encoder.get_factory (Lang.to_format fmt)
+        try (Encoder.get_factory (Lang.to_format fmt)) ~pos:fmt.Value.pos
         with Not_found ->
           raise
             (Error.Invalid_value

--- a/src/core/lang.ml
+++ b/src/core/lang.ml
@@ -68,4 +68,4 @@ let http_transport_t = HttpTransport.t
 let http_transport_base_t = HttpTransport.base_t
 let to_http_transport = HttpTransport.of_value
 let http_transport = HttpTransport.to_value
-let base_http_transport = HttpTransport.to_base_value
+let base_http_transport = HttpTransport.to_base_value ?pos:None

--- a/src/core/lang_source.ml
+++ b/src/core/lang_source.ml
@@ -283,7 +283,7 @@ let source_methods ~base s =
   meth base (List.map (fun (name, _, _, fn) -> (name, fn s)) source_methods)
 
 let source s = source_methods ~base:(Source_val.to_value s) s
-let track = Track.to_value
+let track = Track.to_value ?pos:None
 let to_source = Source_val.of_value
 let to_source_list l = List.map to_source (to_list l)
 let to_track = Track.of_value

--- a/src/core/outputs/hls_output.ml
+++ b/src/core/outputs/hls_output.ml
@@ -311,16 +311,18 @@ class hls_output p =
   in
   let mk_streams, streams =
     let f s =
-      let name, fmt = Lang.to_product s in
-      let stream_info, fmt = Lang.split_meths fmt in
+      let name, fmt_val = Lang.to_product s in
+      let stream_info, fmt = Lang.split_meths fmt_val in
       let name = Lang.to_string name in
       let format = Lang.to_format fmt in
       let encoder_factory =
         try Encoder.get_factory format
         with Not_found ->
-          raise (Error.Invalid_value (fmt, "Unsupported format"))
+          raise (Error.Invalid_value (fmt_val, "Unsupported format"))
       in
-      let encoder = encoder_factory name Meta_format.empty_metadata in
+      let encoder =
+        encoder_factory ~pos:fmt_val.Value.pos name Meta_format.empty_metadata
+      in
       let bandwidth, codecs, extname, video_size =
         let bandwidth =
           lazy

--- a/src/core/outputs/pipe_output.ml
+++ b/src/core/outputs/pipe_output.ml
@@ -28,7 +28,7 @@ let encoder_factory ?format format_val =
   let format =
     match format with Some f -> f | None -> Lang.to_format format_val
   in
-  try Encoder.get_factory format
+  try (Encoder.get_factory format) ~pos:format_val.Value.pos
   with Not_found ->
     raise (Error.Invalid_value (format_val, "Unsupported encoding format"))
 
@@ -53,7 +53,9 @@ class virtual base ~source ~name p =
 
     val mutable encoder = None
     val mutable current_metadata = None
-    method virtual private encoder_factory : Encoder.factory
+
+    method virtual private encoder_factory
+        : string -> Meta_format.export_metadata -> Encoder.encoder
 
     method start =
       let enc = self#encoder_factory self#id in

--- a/src/core/pos.ml
+++ b/src/core/pos.ml
@@ -1,0 +1,1 @@
+include Liquidsoap_lang.Pos

--- a/src/core/tools/icecast_utils.ml
+++ b/src/core/tools/icecast_utils.ml
@@ -198,5 +198,5 @@ module Icecast_v (M : Icecast_t) = struct
                    ( Lang.assoc "" 1 p,
                      "No format (mime) found, please specify one." )))
     in
-    { factory = encoder_factory; format; info }
+    { factory = encoder_factory ~pos:v.Value.pos; format; info }
 end

--- a/src/core/track.mli
+++ b/src/core/track.mli
@@ -22,6 +22,6 @@
 
 type content = Frame.field * Source.source
 
-val to_value : content -> Value.t
+val to_value : ?pos:Pos.t -> content -> Value.t
 val of_value : Value.t -> content
 val is_value : Value.t -> bool

--- a/src/lang/lang_regexp.ml
+++ b/src/lang/lang_regexp.ml
@@ -2,7 +2,7 @@ type regexp = Builtins_regexp.regexp
 
 let regexp_t = Builtins_regexp.RegExp.t
 let to_regexp = Builtins_regexp.RegExp.of_value
-let regexp = Builtins_regexp.RegExp.to_value
+let regexp = Builtins_regexp.RegExp.to_value ?pos:None
 let descr_of_regexp { Builtins_regexp.descr; _ } = descr
 let string_of_regexp = Builtins_regexp.string_of_regexp
 

--- a/src/lang/value.ml
+++ b/src/lang/value.ml
@@ -187,7 +187,7 @@ let compare a b =
 module type Abstract = sig
   include Term.Abstract
 
-  val to_value : content -> t
+  val to_value : ?pos:Pos.t -> content -> t
   val of_value : t -> content
   val is_value : t -> bool
 end
@@ -197,8 +197,8 @@ module type AbstractDef = Term.AbstractDef
 module MkAbstractFromTerm (Term : Term.Abstract) = struct
   include Term
 
-  let to_value c =
-    { pos = None; value = Ground (to_ground c); methods = Methods.empty }
+  let to_value ?pos c =
+    { pos; value = Ground (to_ground c); methods = Methods.empty }
 
   let of_value t =
     match t.value with

--- a/src/runtime/build_config.ml
+++ b/src/runtime/build_config.ml
@@ -49,6 +49,8 @@ let build_config =
    - Ffmpeg            : %{Ffmpeg_option.detected}
    - MP3               : %{Lame_option.detected}
    - MP3 (fixed-point) : %{Shine_option.detected}
+   - Flac (native)     : %{Flac_option.detected}
+   - Flac (ogg)        : %{Ogg_flac_option.detected}
    - Opus              : %{Opus_option.detected}
    - Speex             : %{Speex_option.detected}
    - Theora            : %{Theora_option.detected}

--- a/tests/core/stream_decoder_test.ml
+++ b/tests/core/stream_decoder_test.ml
@@ -31,7 +31,9 @@ let () =
   let buffer = Decoder.mk_buffer ~ctype generator in
   let mp3_format = Lang_mp3.mp3_base_defaults () in
   let create_encoder = Encoder.get_factory (Encoder.MP3 mp3_format) in
-  let encoder = create_encoder "test stream" Meta_format.empty_metadata in
+  let encoder =
+    create_encoder ~pos:None "test stream" Meta_format.empty_metadata
+  in
   write encoder.Encoder.header;
   try
     while true do


### PR DESCRIPTION
* Add position to custom value extensions
* Pass position to encoder factory
* Have encoders raise standard error with position for better error reporting

Before:

<img width="1115" alt="Screenshot 2023-06-17 at 12 14 39 PM" src="https://github.com/savonet/liquidsoap/assets/871060/1e14bb02-a5de-403c-af3e-b63321b7d994">

After:

<img width="369" alt="Screenshot 2023-06-17 at 12 14 16 PM" src="https://github.com/savonet/liquidsoap/assets/871060/92f9b156-f33a-4be2-8397-1366f1e06b81">


