### PR TITLE
Add suport for jemalloc

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -79,6 +79,7 @@
     imagelib
     inotify
     irc-client-unix
+    jemalloc
     ladspa
     lame
     lastfm

--- a/liquidsoap-core.opam
+++ b/liquidsoap-core.opam
@@ -44,6 +44,7 @@ depopts: [
   "imagelib"
   "inotify"
   "irc-client-unix"
+  "jemalloc"
   "ladspa"
   "lame"
   "lastfm"

--- a/src/config/jemalloc_option.disabled.ml
+++ b/src/config/jemalloc_option.disabled.ml
@@ -1,0 +1,1 @@
+noop.disabled.ml

--- a/src/config/jemalloc_option.enabled.ml
+++ b/src/config/jemalloc_option.enabled.ml
@@ -1,0 +1,1 @@
+noop.enabled.ml

--- a/src/core/builtins/builtins_jemalloc.ml
+++ b/src/core/builtins/builtins_jemalloc.ml
@@ -1,0 +1,136 @@
+(*****************************************************************************
+
+  Liquidsoap, a programmable audio stream generator.
+  Copyright 2003-2023 Savonet team
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details, fully stated in the COPYING
+  file at the root of the liquidsoap distribution.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA
+
+ *****************************************************************************)
+
+let jemalloc = Lang.add_module ~base:Modules.runtime "jemalloc"
+let mallctl = Lang.add_module ~base:jemalloc "mallctl"
+
+let _ =
+  Lang.add_builtin ~base:jemalloc "epoch" ~category:`System
+    ~descr:"Refresh the epoch counter for statistics" [] Lang.unit_t (fun _ ->
+      Jemalloc.epoch ();
+      Lang.unit)
+
+let () =
+  let register (name, typ, cmd, from_val, to_val) =
+    let get_t =
+      Lang.method_t (Lang.fun_t [] typ)
+        [
+          ( "set",
+            ([], Lang.fun_t [(false, "", typ)] Lang.unit_t),
+            "Set option value" );
+        ]
+    in
+    ignore
+      (Lang.add_builtin ~base:mallctl name ~category:`System
+         ~descr:
+           ("Get an option of type " ^ name
+          ^ " using mallctl. Returned value has the same type as a reference.")
+         [("", Lang.string_t, None, Some "Option name")]
+         get_t
+         (fun p ->
+           let name = Lang.to_string (List.assoc "" p) in
+           let cmd value =
+             try to_val (cmd name value)
+             with Jemalloc.Invalid_property name ->
+               Runtime_error.raise ~pos:(Lang.pos p)
+                 ~message:
+                   (if value = None then "Invalid property: " ^ name
+                    else "Failed to set value on property " ^ name)
+                 "invalid"
+           in
+           let get = Lang.val_fun [] (fun _ -> cmd None) in
+           Lang.meth get
+             [
+               ( "set",
+                 Lang.val_fun
+                   [("", "", None)]
+                   (fun p ->
+                     let value = from_val (List.assoc "" p) in
+                     ignore (cmd (Some value));
+                     Lang.unit) );
+             ]))
+  in
+  register ("bool", Lang.bool_t, Jemalloc.mallctl_bool, Lang.to_bool, Lang.bool);
+  register ("int", Lang.int_t, Jemalloc.mallctl_int, Lang.to_int, Lang.int);
+  register
+    ( "string",
+      Lang.string_t,
+      Jemalloc.mallctl_string,
+      Lang.to_string,
+      Lang.string );
+  ignore
+    (Lang.add_builtin ~base:mallctl "flag" ~category:`System
+       ~descr:"Set an option flag"
+       [("", Lang.string_t, None, Some "Flag name")]
+       Lang.unit_t
+       (fun p ->
+         let name = Lang.to_string (List.assoc "" p) in
+         (try Jemalloc.mallctl_unit name
+          with Jemalloc.Invalid_property name ->
+            Runtime_error.raise ~pos:(Lang.pos p)
+              ~message:("Invalid property: " ^ name)
+              "invalid");
+         Lang.unit))
+
+let _ =
+  let stat_t =
+    Lang.record_t
+      [
+        ("active", Lang.int_t);
+        ("resident", Lang.int_t);
+        ("allocated", Lang.int_t);
+        ("mapped", Lang.int_t);
+      ]
+  in
+  let stat () =
+    let { Jemalloc.active; resident; allocated; mapped } =
+      Jemalloc.get_memory_stats ()
+    in
+    Lang.record
+      [
+        ("active", Lang.int active);
+        ("resident", Lang.int resident);
+        ("allocated", Lang.int allocated);
+        ("mapped", Lang.int mapped);
+      ]
+  in
+  Lang.add_builtin ~base:jemalloc "memory_stats" ~category:`System
+    ~descr:"Return memory allocation stats from `jemalloc`." [] stat_t (fun _ ->
+      stat ())
+
+let _ =
+  Lang.add_builtin ~base:jemalloc "version" ~category:`System
+    ~descr:"Jemalloc version information" []
+    (Lang.method_t Lang.string_t
+       [
+         ("major", ([], Lang.int_t), "Major version");
+         ("minor", ([], Lang.int_t), "Minor version");
+         ("git_version", ([], Lang.string_t), "Git version");
+       ])
+    (fun _ ->
+      let version, major, minor, git = Jemalloc.version () in
+      Lang.meth (Lang.string version)
+        [
+          ("major", Lang.int major);
+          ("minor", Lang.int minor);
+          ("git", Lang.string git);
+        ])

--- a/src/core/builtins/builtins_mem_usage.ml
+++ b/src/core/builtins/builtins_mem_usage.ml
@@ -52,13 +52,12 @@ let _ =
       ]
   in
   let runtime_mem_usage =
-    Lang.add_builtin ~base:Modules.runtime "mem_usage" ~category:`Liquidsoap
+    Lang.add_builtin ~base:Modules.runtime "mem_usage" ~category:`System
       ~flags:[`Hidden]
       ~descr:"Return stats about the system and process memory." [] mem_usage_t
       (fun _ -> mem_usage (Mem_usage.info ()))
   in
-  Lang.add_builtin ~base:runtime_mem_usage "prettify_bytes"
-    ~category:`Liquidsoap
+  Lang.add_builtin ~base:runtime_mem_usage "prettify_bytes" ~category:`String
     ~descr:"Returns a human-redable description of an amount of bytes."
     [
       ( "float_printer",

--- a/src/core/builtins/builtins_runtime.ml
+++ b/src/core/builtins/builtins_runtime.ml
@@ -91,13 +91,13 @@ let _ =
       ]
   in
   ignore
-    (Lang.add_builtin ~base:runtime_gc "stat" ~category:`Liquidsoap
+    (Lang.add_builtin ~base:runtime_gc "stat" ~category:`System
        ~descr:
          "Return the current values of the memory management counters. This \
           function examines every heap block to get the statistics." [] stat_t
        (fun _ -> stat (Gc.stat ())));
 
-  Lang.add_builtin ~base:runtime_gc "quick_stat" ~category:`Liquidsoap
+  Lang.add_builtin ~base:runtime_gc "quick_stat" ~category:`System
     ~descr:
       "Same as stat except that `live_words`, `live_blocks`, `free_words`, \
        `free_blocks`, `largest_free`, and `fragments` are set to `0`. This \
@@ -105,7 +105,7 @@ let _ =
        through the heap." [] stat_t (fun _ -> stat (Gc.quick_stat ()))
 
 let _ =
-  Lang.add_builtin ~base:runtime_gc "print_stat" ~category:`Liquidsoap
+  Lang.add_builtin ~base:runtime_gc "print_stat" ~category:`System
     ~descr:
       "Print the current values of the memory management counters in \
        human-readable form." [] Lang.unit_t (fun _ ->
@@ -176,11 +176,11 @@ let _ =
     }
   in
   ignore
-    (Lang.add_builtin ~base:runtime_gc "get" ~category:`Liquidsoap
+    (Lang.add_builtin ~base:runtime_gc "get" ~category:`System
        ~descr:"Return the current values of the GC parameters" [] control_t
        (fun _ -> control (Gc.get ())));
 
-  Lang.add_builtin ~base:runtime_gc "set" ~category:`Liquidsoap
+  Lang.add_builtin ~base:runtime_gc "set" ~category:`System
     ~descr:"Set the GC parameters."
     [("", control_t, None, None)]
     Lang.unit_t
@@ -192,7 +192,7 @@ let _ =
 let runtime_sys = Lang.add_module ~base:runtime "sys"
 
 let _ =
-  Lang.add_builtin_base ~category:`Liquidsoap
+  Lang.add_builtin_base ~category:`System
     ~descr:
       "Size of one word on the machine currently executing the program, in \
        bits. Either `32` or `64`."

--- a/src/core/dune
+++ b/src/core/dune
@@ -471,6 +471,14 @@
  (modules builtins_irc))
 
 (library
+ (name liquidsoap_jemalloc)
+ (libraries jemalloc liquidsoap_core)
+ (library_flags -linkall)
+ (wrapped false)
+ (optional)
+ (modules builtins_jemalloc))
+
+(library
  (name liquidsoap_ladspa)
  (libraries ladspa liquidsoap_core)
  (library_flags -linkall)
@@ -748,6 +756,7 @@
   imagelib_option
   inotify_option
   irc_option
+  jemalloc_option
   ladspa_option
   lame_option
   lastfm_option
@@ -862,6 +871,11 @@
    from
    (liquidsoap_irc -> irc_option.enabled.ml)
    (-> irc_option.disabled.ml))
+  (select
+   jemalloc_option.ml
+   from
+   (liquidsoap_jemalloc -> jemalloc_option.enabled.ml)
+   (-> jemalloc_option.disabled.ml))
   (select
    ladspa_option.ml
    from

--- a/src/runtime/build_config.ml
+++ b/src/runtime/build_config.ml
@@ -99,6 +99,7 @@ let build_config =
    - FFmpeg devices    : %{Ffmpeg_option.detected}
    - inotify           : %{Inotify_option.detected}
    - irc               : %{Irc_option.detected}
+   - jemalloc          : %{Jemalloc_option.detected}
    - lastfm            : %{Lastfm_option.detected}
    - lo                : %{Lo_option.detected}
    - magic             : %{Magic_option.detected}


### PR DESCRIPTION
[jemalloc](https://github.com/jemalloc/jemalloc) is a user-land memory allocator that:
> emphasizes fragmentation avoidance and scalable concurrency support.

The memory profile on macos seems radically different:

<details>
  <summary>Script</summary>
  
```liquidsoap
def hflip(s) =
  let {audio,video} = source.tracks(s)
  def mkfilter(graph) =
    video = ffmpeg.filter.video.input(graph, video)
    video = ffmpeg.filter.hflip(graph, video)
    video = ffmpeg.filter.hflip(graph, video)

    audio = ffmpeg.filter.audio.input(graph, audio)
    audio = ffmpeg.filter.acopy(graph, audio)

    video = ffmpeg.filter.video.output(graph, video)
    audio = ffmpeg.filter.audio.output(graph, audio)

    source({
      audio = audio,
      video = video,
      metadata = track.metadata(audio),
      track_marks = track.track_marks(audio)
    })
  end

  ffmpeg.filter.create(mkfilter)
end

s1 = hflip(playlist("/tmp/pl"))
s2 = hflip(playlist("/tmp/pl"))
s3 = hflip(playlist("/tmp/pl"))
s4 = hflip(playlist("/tmp/pl"))
s5 = hflip(playlist("/tmp/pl"))
s6 = hflip(playlist("/tmp/pl"))
s7 = hflip(playlist("/tmp/pl"))
s8 = hflip(playlist("/tmp/pl"))
s9 = hflip(playlist("/tmp/pl"))
s10 = hflip(playlist("/tmp/pl"))


s = fallback([s1,s2,s3,s4,s5,s6,s7,s8,s9,s10])

aac_lofi = %ffmpeg(format="mp4",
                   movflags="+dash+skip_sidx+skip_trailer+frag_custom",
                   frag_duration=10,
                   %video.raw(codec="libx264"),
                   %audio.raw(
                     codec="aac",
                     channels=2,
                     ar=44100,
                     b="192k"
                   ))

flac_hifi = %ffmpeg(format="mp4",
                    movflags="+dash+skip_sidx+skip_trailer+frag_custom",
                    frag_duration=10,
                    strict="-2",
                    %video.raw(codec="libx264"),
                    %audio.raw(
                      codec="flac",
                      channels=2,
                      ar=44100
                    ))

flac_hires = %ffmpeg(format="mp4",
                     movflags="+dash+skip_sidx+skip_trailer+frag_custom",
                     frag_duration=10,
                     strict="-2",
                     %video.raw(codec="libx264"),
                     %audio.raw(
                       codec="flac",
                       channels=2,
                       ar=48000
                     ))

streams = [("aac_lofi", aac_lofi),
           ("flac_hifi", flac_hifi),
           ("flac_hires", flac_hires)]

output.file.hls(playlist="live.m3u8",
                fallible=true,
                "/tmp/hls",
                streams,
                s)
```
</details>

Without it:
<img width="1275" alt="Screenshot 2023-06-25 at 10 39 34 AM" src="https://github.com/savonet/liquidsoap/assets/871060/632816e7-4146-4016-a0c5-de0ef4500ac5">

With it:
<img width="1286" alt="Screenshot 2023-06-25 at 10 42 35 AM" src="https://github.com/savonet/liquidsoap/assets/871060/85f745d2-2c0e-4e1d-9203-f47f328039c9">
