### PR TITLE
Trim runtime types before starting the application.

### DIFF
--- a/.github/scripts/build-details.sh
+++ b/.github/scripts/build-details.sh
@@ -37,8 +37,8 @@ else
 
   echo "Building on amd64 only"
   BUILD_OS='["debian_trixie", "debian_bookworm", "ubuntu_jammy", "ubuntu_lunar", "alpine"]'
-  BUILD_PLATFORM='["amd64"]'
-  BUILD_INCLUDE='[{"platform": "amd64", "runs-on": "ubuntu-latest", "alpine-arch": "x86_64", "docker-platform": "linux/amd64"}]'
+  BUILD_PLATFORM='["amd64", "arm64"]'
+  BUILD_INCLUDE='[{"platform": "amd64", "runs-on": "ubuntu-latest", "alpine-arch": "x86_64", "docker-platform": "linux/amd64"}, {"platform": "arm64", "runs-on": "self-hosted", "alpine-arch": "aarch64", "docker-platform": "linux/arm64"}]'
 
   echo "Not enabling opam build"
   echo "Branch does not have a docker release"

--- a/.github/scripts/build-details.sh
+++ b/.github/scripts/build-details.sh
@@ -37,8 +37,8 @@ else
 
   echo "Building on amd64 only"
   BUILD_OS='["debian_trixie", "debian_bookworm", "ubuntu_jammy", "ubuntu_lunar", "alpine"]'
-  BUILD_PLATFORM='["amd64", "arm64"]'
-  BUILD_INCLUDE='[{"platform": "amd64", "runs-on": "ubuntu-latest", "alpine-arch": "x86_64", "docker-platform": "linux/amd64"}, {"platform": "arm64", "runs-on": "self-hosted", "alpine-arch": "aarch64", "docker-platform": "linux/arm64"}]'
+  BUILD_PLATFORM='["amd64"]'
+  BUILD_INCLUDE='[{"platform": "amd64", "runs-on": "ubuntu-latest", "alpine-arch": "x86_64", "docker-platform": "linux/amd64"}]'
 
   echo "Not enabling opam build"
   echo "Branch does not have a docker release"

--- a/src/core/builtins/builtins_sys.ml
+++ b/src/core/builtins/builtins_sys.ml
@@ -46,6 +46,20 @@ let () =
 let log = Lang.log
 let encoder = Modules.encoder
 
+let conf_runtime =
+  Dtools.Conf.void ~p:(Configure.conf#plug "runtime") "Runtime configuration."
+
+let conf_strip_types_types =
+  Dtools.Conf.bool
+    ~p:(conf_runtime#plug "strip_types")
+    ~d:true "Strip runtime types whenever possible to optimize memory usage."
+
+let () =
+  Lifecycle.before_start (fun () ->
+      if conf_strip_types_types#get then (
+        Liquidsoap_lang.Term.trim_runtime_types ();
+        Gc.full_major ()))
+
 let _ =
   let kind = Lang.univ_t () in
   Lang.add_builtin ~category:`Liquidsoap ~base:encoder "content_type"

--- a/src/lang/term.mli
+++ b/src/lang/term.mli
@@ -165,7 +165,7 @@ module Methods : sig
   val of_seq : (key * 'a) Seq.t -> 'a t
 end
 
-type t = private { t : Type.t; term : in_term; methods : t Methods.t }
+type t = private { mutable t : Type.t; term : in_term; methods : t Methods.t }
 and doc = Doc.Value.t
 
 and let_t = {
@@ -210,6 +210,7 @@ val is_ground : t -> bool
 val string_of_pat : pattern -> string
 val to_string : t -> string
 val make : ?pos:Pos.t -> ?t:Type.t -> ?methods:term Methods.t -> in_term -> t
+val trim_runtime_types : unit -> unit
 val free_vars_pat : pattern -> Vars.t
 val bound_vars_pat : pattern -> Vars.t
 val free_vars : ?bound:Vars.elt list -> t -> Vars.t

--- a/src/lang/type.mli
+++ b/src/lang/type.mli
@@ -107,6 +107,7 @@ module Vars = Type_base.Vars
 val make : ?pos:Pos.t -> descr -> t
 val deref : t -> t
 val demeth : t -> t
+val deep_demeth : t -> t
 val remeth : t -> t -> t
 val invoke : t -> string -> scheme
 val has_meth : t -> string -> bool

--- a/src/lang/types/type_base.ml
+++ b/src/lang/types/type_base.ml
@@ -232,7 +232,7 @@ let rec deep_demeth t =
           { t with descr = Tuple (List.map deep_demeth l) }
       | { descr = Nullable t' } as t ->
           { t with descr = Nullable (deep_demeth t') }
-      | { descr = Meth (_, t) } -> t
+      | { descr = Meth (_, t) } -> deep_demeth t
       | { descr = Arrow (l, t') } as t ->
           {
             t with


### PR DESCRIPTION
Some early `2.2.x` users have reported high memory usage under this version. The source of it seems to be the type data structure for methods.

While we could probably enhance the actual typing format, for now this PR addresses the problem by trimming down types retained at runtime.

The only types that we require at runtime are for sources to carry expected media/track content at runtime. This is a new feature from `2.2.x`, before that, no types were required.

The code that carries types at runtime to inform sources of their expected content-type explicitly removes methods before passing the type to the source, thus it is safe to assume that we do not need to carry term type's methods at runtime.

```ocaml
(* For source eval check there are cases of:
     source('a) <: (source('a).{ source methods })?
   b/c of source.dynamic so we want to dig deeper
   than the regular demeth. *)
let rec deep_demeth t =
  match Type.demeth t with
    | Type.{ descr = Nullable t } -> deep_demeth t
    | t -> t

let eval_check ~env:_ ~tm v =
  if Lang_source.Source_val.is_value v then (
    let s = Lang_source.Source_val.of_value v in
    if not s#has_content_type then (
      let scheme = Typing.generalize ~level:(-1) (deep_demeth tm.Term.t) in
      let ty = Typing.instantiate ~level:(-1) scheme in
      Typing.(Lang_source.source_t ~methods:false s#frame_type <: ty);
      s#content_type_computation_allowed))
  else if Track.is_value v then (
    let field, source = Lang_source.to_track v in
    if not source#has_content_type then (
      match field with
        | _ when field = Frame.Fields.metadata -> ()
        | _ when field = Frame.Fields.track_marks -> ()
        | _ ->
            let scheme =
              Typing.generalize ~level:(-1) (deep_demeth tm.Term.t)
            in
            let ty = Typing.instantiate ~level:(-1) scheme in
            let frame_t =
              Frame_type.make (Lang.univ_t ())
                (Frame.Fields.add field ty Frame.Fields.empty)
            in
            Typing.(source#frame_type <: frame_t)))
```

This PR, therefore, tracks terms that are still in memory via a weak hash and, before running the application, strips all these terms' types of their methods. This results in a massive memory cleanup that brings the application back to the `2.1.4` memory usage on the initial run of a simple `output.dummy(blank())`. There is a slight increase in memory usage afterward, but nothing like the ~100mb that we were seeing before.

This optimization is controlled via `settings.runtime.strip_types` and can be turned off if needed.

### Comparison with `2.1.4` (`liquidsoap.exe` is `2.2.x`):
<img width="377" alt="Screenshot 2023-07-05 at 9 26 04 AM" 
src="https://github.com/savonet/liquidsoap/assets/871060/4a767a63-7cee-45e1-a4fd-2ee9ccea0647">

### Memtrace:
<img width="530" alt="Screenshot 2023-07-05 at 9 26 49 AM" src="https://github.com/savonet/liquidsoap/assets/871060/e3f3b071-39b7-4d37-ae05-0fe94ac2ec5f">


