### PR TITLE
Enhance start.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -86,6 +86,8 @@ Changed:
   `"liq_fade_in"`, `"liq_cross_duration"` and `"liq_fade_type"` now all reset on
   new tracks. Use `persist_overrides` to revert to previous behavior
   (`persist_override` for `cross`/`crossfade`) (#2488).
+- Allow running as root by default when docker container can be detected using
+  the presence of a `/.dockerenv` file.
 - Moved HLS outputs stream info as optional methods on their respective encoder.
 - Changed `self_sync` in `input.ffmpeg` to be a boolean getter, changed `self_sync`
   in `input.http` to be a nullable boolean getter. Set `self_sync` to `true` in

--- a/src/core/builtins/builtins_thread.ml
+++ b/src/core/builtins/builtins_thread.ml
@@ -72,7 +72,8 @@ let _ =
               if delay >= 0. then [task delay] else []);
         }
       in
-      Duppy.Task.add Tutils.scheduler (task delay);
+      Lifecycle.after_start (fun () ->
+          Duppy.Task.add Tutils.scheduler (task delay));
       Lang.unit)
 
 let _ =

--- a/src/core/tools/lifecycle.ml
+++ b/src/core/tools/lifecycle.ml
@@ -23,12 +23,26 @@
 let log = Log.make ["lifecycle"]
 
 let make_action ?(before = []) ?(after = []) name =
-  let on_actions = ref [(fun () -> log#debug "At stage: %S" name)] in
+  let is_done = ref false in
+  let on_actions =
+    ref
+      [
+        (fun () ->
+          is_done := true;
+          log#debug "At stage: %S" name);
+      ]
+  in
   let on_action () = List.iter (fun fn -> fn ()) !on_actions in
   let atom = Dtools.Init.make ~before ~after ~name on_action in
-  let before_action f = ignore (Dtools.Init.make ~before:[atom] f) in
-  let on_action fn = on_actions := !on_actions @ [fn] in
-  let after_action f = ignore (Dtools.Init.make ~after:[atom] f) in
+  let before_action f =
+    if !is_done then f () else ignore (Dtools.Init.make ~before:[atom] f)
+  in
+  let on_action fn =
+    if !is_done then fn () else on_actions := !on_actions @ [fn]
+  in
+  let after_action f =
+    if !is_done then f () else ignore (Dtools.Init.make ~after:[atom] f)
+  in
   (atom, before_action, on_action, after_action)
 
 (* This atom is explicitly triggered in [Main] *)
@@ -39,8 +53,40 @@ let script_parse_atom, before_script_parse, on_script_parse, after_script_parse
     =
   make_action ~after:[init_atom] "Liquidsoap script parse"
 
-let _, before_start, on_start, after_start =
+let start_atom, before_start, on_start, after_start =
   make_action ~after:[script_parse_atom] "Liquidsoap application start"
+
+(* Should we allow to run as root? *)
+let allow_root =
+  Dtools.Conf.bool
+    ~p:(Dtools.Init.conf#plug "allow_root")
+    ~d:false "Allow liquidsoap to run as root"
+    ~comments:
+      [
+        "This should be reserved for advanced dynamic uses of liquidsoap ";
+        "such as running inside an isolated environment like docker.";
+      ]
+
+let main_loop_ref = ref (fun () -> assert false)
+let main_loop fn = main_loop_ref := fn
+
+let _ =
+  Dtools.Init.make ~after:[start_atom] (fun () ->
+      let fn = !main_loop_ref in
+      let msg_of_err = function
+        | `User -> "root euid (user)"
+        | `Group -> "root guid (group)"
+        | `Both -> "root euid & guid (user & group)"
+      in
+      let on_error e =
+        Printf.eprintf
+          "init: security exit, %s. Override with \
+           settings.init.allow_root.set(true)\n"
+          (msg_of_err e);
+        exit (-1)
+      in
+      try Dtools.Init.init ~prohibit_root:(not allow_root#get) fn
+      with Dtools.Init.Root_prohibited e -> on_error e)
 
 let ( final_cleanup_atom,
       before_final_cleanup,

--- a/src/core/tools/lifecycle.mli
+++ b/src/core/tools/lifecycle.mli
@@ -49,6 +49,9 @@ val before_start : (unit -> unit) -> unit
 val on_start : (unit -> unit) -> unit
 val after_start : (unit -> unit) -> unit
 
+(** {2 Set application main loop} *)
+val main_loop : (unit -> unit) -> unit
+
 (** {1 Shutdown} *)
 
 (** Shutdown proceeds in 3 phases:

--- a/src/runtime/main.ml
+++ b/src/runtime/main.ml
@@ -58,8 +58,7 @@ let force_start =
 let allow_root =
   Dtools.Conf.bool
     ~p:(Dtools.Init.conf#plug "allow_root")
-    ~d:(try Sys.file_exists "/.dockerenv" with _ -> false)
-    "Allow liquidsoap to run as root"
+    ~d:false "Allow liquidsoap to run as root"
     ~comments:
       [
         "This should be reserved for advanced dynamic uses of liquidsoap ";
@@ -560,6 +559,7 @@ To change it, add the following to your script:
     check_dir Dtools.Init.conf_daemon_pidfile_path "PID"
 
 let () =
+  Lifecycle.on_start Tutils.start;
   Lifecycle.main_loop (fun () ->
       let main () =
         (* See http://caml.inria.fr/mantis/print_bug_page.php?bug_id=4640 for
@@ -582,7 +582,6 @@ let () =
            default at least). *)
         Server.start ();
         Clock.start ();
-        Tutils.start ();
         Tutils.main ()
       in
       if !run_streams then


### PR DESCRIPTION
1. Fix start lifecycle callbacks logic:
 
The current lifecycle main loop callback do block the application start atom main task. This is a problem as some of the code calling `Lifecycle.{on,after}_start` won't get called if is registered after the main loop.

Instead, create a main loop atom and execute the main loop there.

`Tutils.start` is moved to `on_start` to be executed first so that we can assume that the scheduler is running after start, which is the point where threads can register they task. The rest of the runtime is the same, in particular we want `Server.start` to be executed after checking for root user to prevent opening ports as root even for a short time.

2. Make lifecycle callbacks registration execution immediate if the atom has already been executed.
3. Register thread actions after start to make sure that `Tutils.main` is running.
4. Allow running as root as default when inside a docker container, detected via the presence of a `/.dockerenv` file