### PR TITLE
Cleanup shutdown

### DIFF
--- a/.github/scripts/build-details.sh
+++ b/.github/scripts/build-details.sh
@@ -54,6 +54,14 @@ else
   IS_ROLLING_RELEASE=
 fi
 
+if [ "${IS_FORK}" != "true" ] && [ "${IS_RELEASE}" != "true" ] && [ "${IS_ROLLING_RELEASE}" != "true" ]; then
+  echo "Save tests traces"
+  SAVE_TRACES=true
+else
+  echo "Disable tests traces upload"
+  SAVE_TRACES=
+fi
+
 MINIMAL_EXCLUDE_DEPS="alsa ao bjack camlimages dssi faad fdkaac flac frei0r gd graphics gstreamer imagelib irc-client-unix ladspa lame lastfm lilv lo mad magic ogg opus osc-unix portaudio pulseaudio samplerate shine soundtouch speex srt taglib tls theora tsdl vorbis"
 
 {
@@ -68,4 +76,5 @@ MINIMAL_EXCLUDE_DEPS="alsa ao bjack camlimages dssi faad fdkaac flac frei0r gd g
   echo "s3-artifact-basepath=s3://liquidsoap-artifacts/${GITHUB_WORKFLOW}/${GITHUB_RUN_NUMBER}"
   echo "is_fork=${IS_FORK}"
   echo "minimal_exclude_deps=${MINIMAL_EXCLUDE_DEPS}"
+  echo "save_traces=${SAVE_TRACES}"
 } >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,7 @@ jobs:
       docker_release: ${{ steps.build_details.outputs.docker_release }}
       s3-artifact-basepath: ${{ steps.build_details.outputs.s3-artifact-basepath }}
       minimal_exclude_deps: ${{ steps.build_details.outputs.minimal_exclude_deps }}
+      save_traces: ${{ steps.build_details.outputs.save_traces }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -202,11 +203,22 @@ jobs:
         run: |
           cd /tmp/liquidsoap-full/liquidsoap
           sudo -u opam -E ./.github/scripts/test-posix.sh ${{ matrix.target }}
-      - name: Export potential core dumps
-        if: ${{ failure() }}
+      - name: Save traces
+        if: (success() || failure()) && ${{ needs.build_details.outputs.save_traces == 'true' }}
+        run: |
+          mkdir -p /tmp/${{ github.run_number }}/traces/${{ matrix.target }}
+          cd /tmp/liquidsoap-full/liquidsoap
+          find _build/default/tests | grep '\.trace$' | while read i; do mv "$i" /tmp/${{ github.run_number }}/traces/${{ matrix.target }}; done
+      - name: Upload traces
+        if: (success() || failure()) && ${{ needs.build_details.outputs.save_traces == 'true' }}
         uses: actions/upload-artifact@v3
         with:
-          name: core-dump-${{ matrix.os }}-${{ matrix.platform }}
+          name: traces-${{ matrix.target }}
+          path: ${{ github.workspace }}/${{ github.run_number }}/traces/${{ matrix.target }}
+      - name: Export potential core dumps
+        uses: actions/upload-artifact@v3
+        with:
+          name: core-dump-${{ matrix.os }}-${{ matrix.platform }}-${{ matrix.target }}
           path: ${{ github.workspace }}/${{ github.run_number }}/core
       - name: Cleanup
         if: ${{ always() }}

--- a/src/core/builtins/builtins_settings.ml
+++ b/src/core/builtins/builtins_settings.ml
@@ -117,17 +117,7 @@ let settings_module =
              Printf.sprintf "Entry for configuration key %s" label ))
          conf#subs
      in
-     let log_t = get_type Dtools.Log.conf in
-     let init_t = get_type Dtools.Init.conf in
-     let settings_t =
-       get_type
-         ~sub:
-           [
-             ("init", ([], init_t), "Daemon settings");
-             ("log", ([], log_t), "Logging settings");
-           ]
-         Configure.conf
-     in
+     let settings_t = get_type Configure.conf in
      let get_v fn conv_to conv_from conf =
        let get =
          Lang.val_fun [] (fun _ ->
@@ -178,9 +168,7 @@ let settings_module =
            (Utils.normalize_parameter_string label, v))
          conf#subs
      in
-     let init = get_value Dtools.Init.conf in
-     let log = get_value Dtools.Log.conf in
-     settings := get_value ~sub:[("log", log); ("init", init)] Configure.conf;
+     settings := get_value Configure.conf;
      ignore
        (Lang.add_builtin_value ~category:`Settings "settings"
           ~descr:"All settings." ~flags:[`Hidden] !settings settings_t))

--- a/src/core/builtins/builtins_thread.ml
+++ b/src/core/builtins/builtins_thread.ml
@@ -72,10 +72,8 @@ let _ =
               if delay >= 0. then [task delay] else []);
         }
       in
-      if not (Tutils.has_started ()) then
-        Lifecycle.after_start (fun () ->
-            Duppy.Task.add Tutils.scheduler (task delay))
-      else Duppy.Task.add Tutils.scheduler (task delay);
+      Lifecycle.after_start (fun () ->
+          Duppy.Task.add Tutils.scheduler (task delay));
       Lang.unit)
 
 let _ =

--- a/src/core/configure.ml
+++ b/src/core/configure.ml
@@ -46,7 +46,10 @@ let path () =
 let () = conf#plug "log" Dtools.Log.conf
 
 let conf_init =
-  Dtools.Conf.void ~p:(conf#plug "init") "Initialization configuration"
+  if not Sys.win32 then (
+    conf#plug "init" Dtools.Init.conf;
+    Dtools.Init.conf)
+  else Dtools.Conf.void ~p:(conf#plug "init") "Initialization configuration"
 
 let conf_console =
   Dtools.Conf.void ~p:(conf#plug "console") "Console configuration"

--- a/src/core/configure.ml
+++ b/src/core/configure.ml
@@ -43,6 +43,11 @@ let path () =
   let s = try Sys.getenv "PATH" with Not_found -> "" in
   bin_dir () :: Str.split (Str.regexp_string ":") s
 
+let () = conf#plug "log" Dtools.Log.conf
+
+let conf_init =
+  Dtools.Conf.void ~p:(conf#plug "init") "Initialization configuration"
+
 let conf_console =
   Dtools.Conf.void ~p:(conf#plug "console") "Console configuration"
 

--- a/src/core/configure.mli
+++ b/src/core/configure.mli
@@ -1,6 +1,7 @@
 (** Constants describing configuration options of liquidsoap. *)
 
 val conf : Dtools.Conf.ut
+val conf_init : Dtools.Conf.ut
 val conf_debug : bool Dtools.Conf.t
 val conf_debug_errors : bool Dtools.Conf.t
 

--- a/src/core/stream/frame.ml
+++ b/src/core/stream/frame.ml
@@ -42,7 +42,7 @@ let string_of_fields fn fields =
 let string_of_content_type = string_of_fields string_of_format
 
 module S = Set.Make (struct
-  type t = Fields.key
+  type t = Fields.field
 
   let compare = Stdlib.compare
 end)

--- a/src/core/stream/frame.mli
+++ b/src/core/stream/frame.mli
@@ -25,9 +25,11 @@
 (** {2 Frame definitions} *)
 
 module Fields : sig
-  type field = Frame_base.Fields.field
+  include module type of Liquidsoap_lang.Methods
 
-  include Map.S with type key := field and type 'a t = 'a Frame_base.Fields.t
+  type field = Frame_base.Fields.field
+  type 'a typ = (field, 'a) t
+  type 'a t = 'a typ
 
   val metadata : field
   val track_marks : field

--- a/src/core/stream/frame_base.ml
+++ b/src/core/stream/frame_base.ml
@@ -34,13 +34,11 @@ module FieldNames = Hashtbl.Make (struct
 end)
 
 module Fields = struct
-  include Map.Make (struct
-    type t = int
+  include Liquidsoap_lang.Methods
 
-    let compare (x : int) (y : int) = x - y [@@inline always]
-  end)
-
-  type field = key
+  type field = int
+  type 'a typ = (field, 'a) t
+  type 'a t = 'a typ
 
   let field_names = FieldNames.create 0
   let name_fields = Hashtbl.create 0

--- a/src/core/tools/lifecycle.mli
+++ b/src/core/tools/lifecycle.mli
@@ -32,7 +32,7 @@
 
 (** {2 Init start} *)
 
-val init_atom : Dtools.Init.t
+val init : unit -> unit
 val before_init : (unit -> unit) -> unit
 val on_init : (unit -> unit) -> unit
 val after_init : (unit -> unit) -> unit
@@ -49,8 +49,11 @@ val before_start : (unit -> unit) -> unit
 val on_start : (unit -> unit) -> unit
 val after_start : (unit -> unit) -> unit
 
-(** {2 Set application main loop} *)
-val main_loop : (unit -> unit) -> unit
+(** {2 Application main loop} *)
+val before_main_loop : (unit -> unit) -> unit
+
+val on_main_loop : (unit -> unit) -> unit
+val after_main_loop : (unit -> unit) -> unit
 
 (** {1 Shutdown} *)
 
@@ -77,9 +80,3 @@ val after_scheduler_shutdown : (unit -> unit) -> unit
 val before_final_cleanup : (unit -> unit) -> unit
 val on_final_cleanup : (unit -> unit) -> unit
 val after_final_cleanup : (unit -> unit) -> unit
-
-(** {2 Stop} *)
-
-val before_stop : (unit -> unit) -> unit
-val on_stop : (unit -> unit) -> unit
-val after_stop : (unit -> unit) -> unit

--- a/src/core/tools/tutils.ml
+++ b/src/core/tools/tutils.ml
@@ -386,7 +386,8 @@ let run = Atomic.make running
 
 let main () =
   wait no_problem lock (fun () ->
-      Atomic.get run <> running || Atomic.get uncaught <> None)
+      Atomic.get run <> running || Atomic.get uncaught <> None);
+  log#important "Main loop exited"
 
 let shutdown code =
   if Atomic.compare_and_set run running (`Exit code) then

--- a/src/core/tools/tutils.ml
+++ b/src/core/tools/tutils.ml
@@ -269,67 +269,6 @@ let start () =
   done;
   mutexify started_m (fun () -> started := true) ()
 
-(** Replace stdout/err by a pipe, and install a Duppy task that pulls data
-  * out of that pipe and logs it.
-  * Never use that when logging to stdout: it would just loop! *)
-let start_forwarding () =
-  let reopen fd =
-    let i, o = Unix.pipe ~cloexec:true () in
-    Unix.dup2 ~cloexec:true o fd;
-    Unix.close o;
-    Unix.set_close_on_exec i;
-    i
-  in
-  let in_stdout = reopen Unix.stdout in
-  let in_stderr = reopen Unix.stderr in
-  (* Without the eta-expansion, the timestamp is computed once for all. *)
-  let log_stdout =
-    let log = Log.make ["stdout"] in
-    fun s -> log#important "%s" s
-  in
-  let log_stderr =
-    let log = Log.make ["stderr"] in
-    fun s -> log#important "%s" s
-  in
-  let forward fd log =
-    let task ~priority f =
-      { Duppy.Task.priority; events = [`Read fd]; handler = f }
-    in
-    let len = Utils.pagesize in
-    let buffer = Bytes.create len in
-    let rec f (acc : string list) _ =
-      let n = Unix.read fd buffer 0 len in
-      let buffer = Bytes.unsafe_to_string buffer in
-      let rec split acc i =
-        match
-          try Some (String.index_from buffer i '\n') with Not_found -> None
-        with
-          | Some j when j < n ->
-              let line =
-                List.fold_left
-                  (fun s l -> l ^ s)
-                  (String.sub buffer i (j - i))
-                  acc
-              in
-              (* This _could_ be blocking! *)
-              log line;
-              split [] (j + 1)
-          | _ -> String.sub buffer i (n - i) :: acc
-      in
-      [task ~priority:`Non_blocking (f (split acc 0))]
-    in
-    Duppy.Task.add scheduler (task ~priority:`Maybe_blocking (f []))
-  in
-  forward in_stdout log_stdout;
-  forward in_stderr log_stderr
-
-let () =
-  ignore
-    (Dtools.Init.at_start (fun () ->
-         if Dtools.Init.conf_daemon#get then (
-           Dtools.Log.conf_stdout#set false;
-           start_forwarding ())))
-
 (** Waits for [f()] to become true on condition [c]. *)
 let wait c m f =
   mutexify m

--- a/src/lang/dune
+++ b/src/lang/dune
@@ -117,6 +117,7 @@
   lang_regexp
   lang_string
   lexer
+  methods
   modules
   parser
   parser_helper

--- a/src/lang/methods.ml
+++ b/src/lang/methods.ml
@@ -1,0 +1,41 @@
+(*****************************************************************************
+
+  Liquidsoap, a programmable audio stream generator.
+  Copyright 2003-2023 Savonet team
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details, fully stated in the COPYING
+  file at the root of the liquidsoap distribution.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA
+
+ *****************************************************************************)
+
+(* Immutable fast hash *)
+
+type ('a, 'b) t = ('a * 'b) list
+
+let is_empty h = h = []
+let bindings h = h
+let empty = []
+let cardinal = List.length
+let fold fn h r = List.fold_left (fun r (k, v) -> fn k v r) r h
+let find = List.assoc
+let find_opt = List.assoc_opt
+let mem = List.mem_assoc
+let mapi fn = List.map (fun (k, v) -> (k, fn k v))
+let map fn = List.map (fun (k, v) -> (k, fn v))
+let filter fn = List.filter (fun (k, v) -> fn k v)
+let add k v h = (k, v) :: List.remove_assoc k h
+let iter fn = List.iter (fun (k, v) -> fn k v)
+let for_all fn = List.for_all (fun (k, v) -> fn k v)
+let exists fn = List.exists (fun (k, v) -> fn k v)

--- a/src/lang/methods.mli
+++ b/src/lang/methods.mli
@@ -1,0 +1,41 @@
+(*****************************************************************************
+
+  Liquidsoap, a programmable audio stream generator.
+  Copyright 2003-2023 Savonet team
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details, fully stated in the COPYING
+  file at the root of the liquidsoap distribution.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA
+
+ *****************************************************************************)
+
+(* Immutable fast hash *)
+
+type ('a, 'b) t
+
+val is_empty : ('a, 'b) t -> bool
+val empty : ('a, 'b) t
+val cardinal : ('a, 'b) t -> int
+val fold : ('a -> 'b -> 'c -> 'c) -> ('a, 'b) t -> 'c -> 'c
+val bindings : ('a, 'b) t -> ('a * 'b) list
+val find : 'a -> ('a, 'b) t -> 'b
+val find_opt : 'a -> ('a, 'b) t -> 'b option
+val mem : 'a -> ('a, 'b) t -> bool
+val add : 'a -> 'b -> ('a, 'b) t -> ('a, 'b) t
+val mapi : ('a -> 'b -> 'c) -> ('a, 'b) t -> ('a, 'c) t
+val map : ('b -> 'c) -> ('a, 'b) t -> ('a, 'c) t
+val filter : ('a -> 'b -> bool) -> ('a, 'b) t -> ('a, 'b) t
+val for_all : ('a -> 'b -> bool) -> ('a, 'b) t -> bool
+val exists : ('a -> 'b -> bool) -> ('a, 'b) t -> bool
+val iter : ('a -> 'b -> unit) -> ('a, 'b) t -> unit

--- a/src/lang/term.ml
+++ b/src/lang/term.ml
@@ -184,11 +184,12 @@ module MkGround (D : GroundDef) = struct
       { Ground.typ = D.typ; to_json; compare; descr }
 end
 
-module Methods = Map.Make (struct
-  type t = string
+module Methods = struct
+  include Methods
 
-  let compare (x : string) (y : string) = Stdlib.compare x y [@@inline always]
-end)
+  type 'a typ = (string, 'a) t
+  type 'a t = 'a typ
+end
 
 type t = { mutable t : Type.t; term : in_term; methods : t Methods.t }
 

--- a/src/lang/term.mli
+++ b/src/lang/term.mli
@@ -117,52 +117,10 @@ module MkGround : functor (D : GroundDef) -> sig
 end
 
 module Methods : sig
-  type key = string
-  type +!'a t
+  include module type of Methods
 
-  val empty : 'a t
-  val is_empty : 'a t -> bool
-  val mem : key -> 'a t -> bool
-  val add : key -> 'a -> 'a t -> 'a t
-  val update : key -> ('a option -> 'a option) -> 'a t -> 'a t
-  val singleton : key -> 'a -> 'a t
-  val remove : key -> 'a t -> 'a t
-
-  val merge :
-    (key -> 'a option -> 'b option -> 'c option) -> 'a t -> 'b t -> 'c t
-
-  val union : (key -> 'a -> 'a -> 'a option) -> 'a t -> 'a t -> 'a t
-  val compare : ('a -> 'a -> int) -> 'a t -> 'a t -> int
-  val equal : ('a -> 'a -> bool) -> 'a t -> 'a t -> bool
-  val iter : (key -> 'a -> unit) -> 'a t -> unit
-  val fold : (key -> 'a -> 'b -> 'b) -> 'a t -> 'b -> 'b
-  val for_all : (key -> 'a -> bool) -> 'a t -> bool
-  val exists : (key -> 'a -> bool) -> 'a t -> bool
-  val filter : (key -> 'a -> bool) -> 'a t -> 'a t
-  val filter_map : (key -> 'a -> 'b option) -> 'a t -> 'b t
-  val partition : (key -> 'a -> bool) -> 'a t -> 'a t * 'a t
-  val cardinal : 'a t -> int
-  val bindings : 'a t -> (key * 'a) list
-  val min_binding : 'a t -> key * 'a
-  val min_binding_opt : 'a t -> (key * 'a) option
-  val max_binding : 'a t -> key * 'a
-  val max_binding_opt : 'a t -> (key * 'a) option
-  val choose : 'a t -> key * 'a
-  val choose_opt : 'a t -> (key * 'a) option
-  val split : key -> 'a t -> 'a t * 'a option * 'a t
-  val find : key -> 'a t -> 'a
-  val find_opt : key -> 'a t -> 'a option
-  val find_first : (key -> bool) -> 'a t -> key * 'a
-  val find_first_opt : (key -> bool) -> 'a t -> (key * 'a) option
-  val find_last : (key -> bool) -> 'a t -> key * 'a
-  val find_last_opt : (key -> bool) -> 'a t -> (key * 'a) option
-  val map : ('a -> 'b) -> 'a t -> 'b t
-  val mapi : (key -> 'a -> 'b) -> 'a t -> 'b t
-  val to_seq : 'a t -> (key * 'a) Seq.t
-  val to_rev_seq : 'a t -> (key * 'a) Seq.t
-  val to_seq_from : key -> 'a t -> (key * 'a) Seq.t
-  val add_seq : (key * 'a) Seq.t -> 'a t -> 'a t
-  val of_seq : (key * 'a) Seq.t -> 'a t
+  type 'a typ = (string, 'a) t
+  type 'a t = 'a typ
 end
 
 type t = private { mutable t : Type.t; term : in_term; methods : t Methods.t }

--- a/src/runtime/main.ml
+++ b/src/runtime/main.ml
@@ -590,11 +590,9 @@ let () =
         Sys.set_signal Sys.sigpipe Sys.Signal_ignore;
         ignore (Unix.sigprocmask Unix.SIG_BLOCK [Sys.sigpipe]));
 
-      (* On Windows we need to initiate shutdown ourselves by catching INT
-         since dtools doesn't do it. *)
-      if Sys.win32 then
-        Sys.set_signal Sys.sigint
-          (Sys.Signal_handle (fun _ -> Tutils.shutdown 0));
+      Sys.set_signal Sys.sigterm
+        (Sys.Signal_handle (fun _ -> Tutils.shutdown 0));
+      Sys.set_signal Sys.sigint (Sys.Signal_handle (fun _ -> Tutils.shutdown 0));
 
       Dtools.Init.exec Dtools.Log.start;
 

--- a/src/runtime/main.ml
+++ b/src/runtime/main.ml
@@ -582,6 +582,13 @@ let reopen_in inchan filename =
   Unix.dup2 fd2 fd1;
   Unix.close fd2
 
+let () =
+  Dtools.Init.conf_daemon#on_change (fun v ->
+      if v then
+        log#important
+          "Script-base daemonization is DEPRECATED! Please use a modern \
+           daemonization facility such as `systemd` or `launchd` instead.")
+
 let daemonize () =
   Dtools.Log.conf_stdout#set false;
   (* Change user.. *)

--- a/tests/regression/GH2585.liq
+++ b/tests/regression/GH2585.liq
@@ -1,4 +1,7 @@
-settings.log.level.set(6)
+settings.log.level.set(4)
 s = playlist(reload_mode='watch', "../media/all_media_files")
 output.dummy(fallible = true, s)
-thread.run(delay=3., fun () -> process.run("kill -s INT #{process.pid()}"))
+thread.run(delay=3., fun () -> begin
+  print("sending kill -s INT #{process.pid()}")
+  process.run("kill -s INT #{process.pid()}")
+end)

--- a/tests/run_test.ml
+++ b/tests/run_test.ml
@@ -67,6 +67,7 @@ let run () =
          on_timeout ())
        ());
 
+  Unix.putenv "MEMTRACE" (Printf.sprintf "%s.trace" test);
   let pid = Unix.create_process cmd args stdin stdout stdout in
 
   match Unix.waitpid [] pid with

--- a/tests/streams/197.liq
+++ b/tests/streams/197.liq
@@ -1,3 +1,5 @@
+log.level.set(3)
+
 first = ref("")
 def filter(r)
   m = request.metadata(r)


### PR DESCRIPTION
I started looking at the lifecycle/application start and shutdown logic and it still didn't make sense.

Firstly, the `Dtools.Init` atom mechanism is confusing and impossible to track. Our initialization sequence did not make sense.

Also, `Dtools.Init` was running its own waiting loop while `Tutils` was doing the same..

One source of confusion is that the `Dtools.Init` facilities for daemonization really do not fit our needs. They're a patchwork of windows/non windows stuff but, most importantly, we need a finer grained control of when we go into daemon mode.

This is because the script code need to be allowed to change settings before we execute so, we need to do all the initialization until after script parsing in non-daemon mode.

In fact, I almost removed the daemon entirely because, the way we're setup, we cannot really prevent things like socket being opened while evaluating the script. If going into daemon mode afterward, the daemon user could potentially inherit sockets and file descriptors that they are not allowed to access..

However, this felt a little too radical so instead:
* The whole `Dtools.Init.init` is bypassed
* Daemonization code is backported to `main.ml`. Daemonization configuration settings are remove on windows
* `Dtools.Init` atoms are removed and replaced by sequentialized calls:
```ocaml
let () =
  after_init script_parse;
  after_script_parse start;
  after_start main_loop;
  after_main_loop core_shutdown;
  after_core_shutdown scheduler_shutdown;
  after_scheduler_shutdown final_cleanup
```
🤩
* The main loops is now `Tutils.main` and we install our custom event handlers to trigger `Tutils.shutdown` when needed.

![giphy](https://github.com/savonet/liquidsoap/assets/871060/340de688-3e4e-4204-8c67-05140349746a)
