### PR TITLE
Add support for never type.

### DIFF
--- a/src/core/hooks_implementations.ml
+++ b/src/core/hooks_implementations.ml
@@ -104,7 +104,7 @@ let mk_field_t ~pos (kind, params) =
           raise (Term.Parse_error (pos, "Unknown type constructor: " ^ t ^ "."))
         )
 
-let mk_source_ty ~pos name args =
+let mk_source_ty ~pos ~extensible name args =
   if name <> "source" then
     raise (Term.Parse_error (pos, "Unknown type constructor: " ^ name ^ "."));
 
@@ -121,8 +121,9 @@ let mk_source_ty ~pos name args =
                 (mk_field_t ~pos k) fields)
             Frame.Fields.empty args
         in
+        let base = if extensible then Lang.univ_t () else Lang.unit_t in
 
-        Lang_source.source_t (Frame_type.make Lang.unit_t fields)
+        Lang_source.source_t (Frame_type.make base fields)
 
 let register () =
   Hooks.liq_libs_dir := Configure.liq_libs_dir;

--- a/src/lang/hooks.ml
+++ b/src/lang/hooks.ml
@@ -52,6 +52,6 @@ let log name =
   end
 
 let eval_check = ref (fun ~env:_ ~tm:_ _ -> ())
-let mk_source_ty = ref (fun ~pos:_ _ _ -> assert false)
+let mk_source_ty = ref (fun ~pos:_ ~extensible:_ _ _ -> assert false)
 let source_methods_t = ref (fun _ -> assert false)
 let getpwnam = Lang_string.getpwnam

--- a/src/lang/hooks.mli
+++ b/src/lang/hooks.mli
@@ -32,6 +32,7 @@ val collect_after : ((unit -> Value.t) -> Value.t) ref
 
 val mk_source_ty :
   (pos:Pos.t ->
+  extensible:bool ->
   string ->
   (string * (string * (string * string) list)) list ->
   Type.t)

--- a/src/lang/parser.mly
+++ b/src/lang/parser.mly
@@ -164,7 +164,7 @@ open Parser_helper
 %type <Parser_helper.ty_content_arg> ty_content_arg
 %type <Parser_helper.ty_content_args> ty_content_args
 %type <Type.t> ty_source
-%type <(string * Parser_helper.ty_content) list> ty_source_params
+%type <bool * (string * Parser_helper.ty_content) list> ty_source_params
 %type <Type.t list> ty_tuple
 %type <Term.pattern> var_pattern
 %type <Parser_helper.varlist> varlist
@@ -324,12 +324,13 @@ meth_ty:
          | _ -> raise (Parse_error ($loc, "Invalid type constructor")) }
 
 ty_source:
-  | VARLPAR RPAR                  { mk_source_ty ~pos:$loc ~extensible:true $1 [] }
-  | VARLPAR ty_source_params RPAR { mk_source_ty ~pos:$loc ~extensible:true $1 $2 }
+  | VARLPAR RPAR                  { mk_source_ty ~pos:$loc ~extensible:false $1 [] }
+  | VARLPAR ty_source_params RPAR { mk_source_ty ~pos:$loc ~extensible:(fst $2) $1 (snd $2) }
 
 ty_source_params:
-  | VAR GETS ty_content { [$1,$3] }
-  | VAR GETS ty_content COMMA ty_source_params { ($1,$3)::$5 }
+  | VAR GETS ty_content { false, [$1,$3] }
+  | DOTDOTDOT { true, [] }
+  | VAR GETS ty_content COMMA ty_source_params { fst $5, (($1,$3)::(snd $5)) }
 
 ty_content:
   | VAR                           { $1, [] }

--- a/src/lang/parser.mly
+++ b/src/lang/parser.mly
@@ -324,8 +324,8 @@ meth_ty:
          | _ -> raise (Parse_error ($loc, "Invalid type constructor")) }
 
 ty_source:
-  | VARLPAR RPAR                  { mk_source_ty ~pos:$loc $1 [] }
-  | VARLPAR ty_source_params RPAR { mk_source_ty ~pos:$loc $1 $2 }
+  | VARLPAR RPAR                  { mk_source_ty ~pos:$loc ~extensible:true $1 [] }
+  | VARLPAR ty_source_params RPAR { mk_source_ty ~pos:$loc ~extensible:true $1 $2 }
 
 ty_source_params:
   | VAR GETS ty_content { [$1,$3] }

--- a/src/lang/parser_helper.ml
+++ b/src/lang/parser_helper.ml
@@ -549,7 +549,7 @@ let mk_ty ~pos name =
     | "float" -> Type.make Type.Ground.float
     | "string" -> Type.make Type.Ground.string
     | "ref" -> Type.reference (Type.var ())
-    | "source" -> mk_source_ty ~pos "source" []
+    | "source" -> mk_source_ty ~pos ~extensible:true "source" []
     | "source_methods" -> !Hooks.source_methods_t ()
     | name -> (
         match Type.find_type_opt name with

--- a/src/lang/parser_helper.ml
+++ b/src/lang/parser_helper.ml
@@ -543,6 +543,7 @@ let mk_ty ~pos name =
   match name with
     | "_" -> Type.var ()
     | "unit" -> Type.make Type.unit
+    | "never" -> Type.make Type.Ground.never
     | "bool" -> Type.make Type.Ground.bool
     | "int" -> Type.make Type.Ground.int
     | "float" -> Type.make Type.Ground.float

--- a/src/lang/typing.ml
+++ b/src/lang/typing.ml
@@ -595,7 +595,8 @@ and ( <: ) a b =
                           },
                           var () ));
                 a <: b
-            | _ when optional -> a <: hide_meth l c
+            | _ when optional || Ground_type.Never.is_descr (deref t2).descr ->
+                a <: hide_meth l c
             | _ ->
                 raise
                   (Error

--- a/tests/language/typing.liq
+++ b/tests/language/typing.liq
@@ -188,6 +188,11 @@ def f() =
   ([({}:{foo?:int}), (), {foo = 123}]:[{foo?:int}])
   ([(), {foo = 123}]:[{foo?:int}])
 
+  # This one is more subtle than it seems because we have no field video on the
+  # left and a video:never field on the right when testing for the subtyping,
+  # see #3210.
+  s = (sine():source(video=none))
+
   test.pass()
 end
 

--- a/tests/language/typing.liq
+++ b/tests/language/typing.liq
@@ -192,6 +192,7 @@ def f() =
   # left and a video:never field on the right when testing for the subtyping,
   # see #3210.
   s = (sine():source(video=none))
+  s = (sine():source(video=none,...))
 
   test.pass()
 end


### PR DESCRIPTION
Source types are now extensible by default, i.e. we specify an open record rather than a closed one. I think that this is reasonable because most of the time you want to ensure that a track has a specific type (e.g. audio is in `pcm` format) rather than want to specify all the track types (most of the time we want to have a metadata track but don't want to have to write this down).

In order to have the following example pass
```
s = (sine():source(video=none))
output(s)
```
I needed to slightly modify the subtyping algorithm since `sine()` has no field `video` whereas we want it to be a subtype of a record with a `never` field.

Fixes #3203.