### PR TITLE
Use TLS1.3.

### DIFF
--- a/src/core/builtins/builtins_ssl.ml
+++ b/src/core/builtins/builtins_ssl.ml
@@ -51,7 +51,7 @@ let ssl_socket transport ssl =
   end
 
 let server ~read_timeout ~write_timeout ~password ~certificate ~key transport =
-  let context = Ssl.create_context Ssl.SSLv23 Ssl.Server_context in
+  let context = Ssl.create_context Ssl.TLSv1_3 Ssl.Server_context in
   let () =
     ignore
       (Option.map
@@ -83,7 +83,7 @@ let transport ~read_timeout ~write_timeout ~password ~certificate ~key () =
 
     method connect ?bind_address ?timeout host port =
       try
-        let ctx = Ssl.create_context Ssl.SSLv23 Ssl.Client_context in
+        let ctx = Ssl.create_context Ssl.TLSv1_3 Ssl.Client_context in
         (* TODO: add option.. *)
         Ssl.set_verify ctx [] (Some Ssl.client_verify_callback);
         (* Add certificate from transport if passed. *)

--- a/src/core/builtins/builtins_ssl.ml
+++ b/src/core/builtins/builtins_ssl.ml
@@ -140,8 +140,8 @@ let _ =
         Some Lang.null,
         Some "SSL certificate password" );
       ( "protocol",
-        Lang.nullable_t Lang.string_t,
-        Some Lang.null,
+        Lang.string_t,
+        Some (Lang.string "tls.1.3"),
         Some
           {|Accepted SSL protocol. One of: `"ssl.2.3"`, `"ssl.3"`, `"tls.1"`, `"tls.1.1"`, `"tls.1.2"` or `"tls.1.3"`|}
       );

--- a/src/core/builtins/builtins_ssl.ml
+++ b/src/core/builtins/builtins_ssl.ml
@@ -178,7 +178,7 @@ let _ =
               Ssl.SSLv23 [@alert "-deprecated"]
           | "ssl.3" ->
               log#severe
-                "ssl.3 protocol was deprecated in June 2015 by RFC 7568";
+                "ssl.3 protocol was deprecated in June 2015 by RFC 7568.";
               Ssl.SSLv3 [@alert "-deprecated"]
           | "tls.1" ->
               log#severe

--- a/src/core/builtins/builtins_ssl.ml
+++ b/src/core/builtins/builtins_ssl.ml
@@ -25,6 +25,8 @@ let set_socket_default ~read_timeout ~write_timeout fd =
   ignore (Option.map (Unix.setsockopt_float fd Unix.SO_RCVTIMEO) read_timeout);
   ignore (Option.map (Unix.setsockopt_float fd Unix.SO_SNDTIMEO) write_timeout)
 
+let log = Log.make ["ssl"]
+
 let ssl_socket transport ssl =
   object
     method typ = "ssl"
@@ -50,8 +52,9 @@ let ssl_socket transport ssl =
         (fun () -> ignore (Ssl.close_notify ssl))
   end
 
-let server ~read_timeout ~write_timeout ~password ~certificate ~key transport =
-  let context = Ssl.create_context Ssl.TLSv1_3 Ssl.Server_context in
+let server ~protocol ~read_timeout ~write_timeout ~password ~certificate ~key
+    transport =
+  let context = Ssl.create_context protocol Ssl.Server_context in
   let () =
     ignore
       (Option.map
@@ -75,7 +78,8 @@ let server ~read_timeout ~write_timeout ~password ~certificate ~key transport =
         Printexc.raise_with_backtrace exn bt
   end
 
-let transport ~read_timeout ~write_timeout ~password ~certificate ~key () =
+let transport ~protocol ~read_timeout ~write_timeout ~password ~certificate ~key
+    () =
   object (self)
     method name = "ssl"
     method protocol = "https"
@@ -83,7 +87,7 @@ let transport ~read_timeout ~write_timeout ~password ~certificate ~key () =
 
     method connect ?bind_address ?timeout host port =
       try
-        let ctx = Ssl.create_context Ssl.TLSv1_3 Ssl.Client_context in
+        let ctx = Ssl.create_context protocol Ssl.Client_context in
         (* TODO: add option.. *)
         Ssl.set_verify ctx [] (Some Ssl.client_verify_callback);
         (* Add certificate from transport if passed. *)
@@ -115,7 +119,8 @@ let transport ~read_timeout ~write_timeout ~password ~certificate ~key () =
         Lang.raise_as_runtime ~bt ~kind:"ssl" exn
 
     method server =
-      server ~read_timeout ~write_timeout ~password ~certificate ~key self
+      server ~protocol ~read_timeout ~write_timeout ~password ~certificate ~key
+        self
   end
 
 let _ =
@@ -134,6 +139,12 @@ let _ =
         Lang.nullable_t Lang.string_t,
         Some Lang.null,
         Some "SSL certificate password" );
+      ( "protocol",
+        Lang.nullable_t Lang.string_t,
+        Some Lang.null,
+        Some
+          {|Accepted SSL protocol. One of: `"ssl.2.3"`, `"ssl.3"`, `"tls.1"`, `"tls.1.1"`, `"tls.1.2"` or `"tls.1.3"`|}
+      );
       ( "certificate",
         Lang.nullable_t Lang.string_t,
         Some Lang.null,
@@ -159,6 +170,29 @@ let _ =
       let password =
         Lang.to_valued_option Lang.to_string (List.assoc "password" p)
       in
+      let protocol_val = List.assoc "protocol" p in
+      let protocol =
+        match Lang.to_string protocol_val with
+          | "ssl.2.3" ->
+              log#severe "ssl.2.3 protocol was deprecated in 2011 by RFC 6176.";
+              Ssl.SSLv23 [@alert "-deprecated"]
+          | "ssl.3" ->
+              log#severe
+                "ssl.3 protocol was deprecated in June 2015 by RFC 7568";
+              Ssl.SSLv3 [@alert "-deprecated"]
+          | "tls.1" ->
+              log#severe
+                "tls.1 protocol was deprecated in RFC8996 in March 2021.";
+              Ssl.TLSv1 [@alert "-deprecated"]
+          | "tls.1.1" ->
+              log#severe
+                "tls.1.1 protocol was deprecated in RFC8996 in March 2021.";
+              Ssl.TLSv1_1 [@alert "-deprecated"]
+          | "tls.1.2" -> Ssl.TLSv1_2
+          | "tls.1.3" -> Ssl.TLSv1_3
+          | _ ->
+              raise (Error.Invalid_value (protocol_val, "Invalid SSL protocol"))
+      in
       let find name () =
         match Lang.to_valued_option Lang.to_string (List.assoc name p) with
           | None ->
@@ -169,4 +203,5 @@ let _ =
       let certificate = find "certificate" in
       let key = find "key" in
       Lang.http_transport
-        (transport ~read_timeout ~write_timeout ~password ~certificate ~key ()))
+        (transport ~protocol ~read_timeout ~write_timeout ~password ~certificate
+           ~key ()))


### PR DESCRIPTION
This avoid the following (justified) warning:
```
Alert deprecated: SSLv23
SSL 2.0 was deprecated in 2011 by RFC 6176.
```