### PR TITLE
Improve `harbor.http.static`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -53,6 +53,7 @@ New:
 - Added `--unsafe` option (#3113). This makes the startup much faster but
   disables some guarantees (and might even make the script crash...).
 - Added `string.split.first` (#3146).
+- Added `string.getter.single` (#3125).
 
 Changed:
 

--- a/src/libs/http.liq
+++ b/src/libs/http.liq
@@ -403,53 +403,60 @@ def harbor.http.static.base(serve,~content_type,~basepath,~headers,~browse,direc
       basepath
     end
   basepath =
-    if string.sub(basepath,start=string.length(basepath)-1,length=1) != "/" then
-      basepath^"/"
+    if string.sub(basepath,start=string.length(basepath)-1,length=1) == "/" then
+      string.sub(basepath,start=0,length=string.length(basepath)-1)
     else
       basepath
     end
-  basepath = "#{basepath}.*"
-  directory = path.home.unrelate(directory)
 
   def handler(request, response)
     response.headers(headers)
 
-    fname = path.concat(directory, request.path)
-    log.debug("Serving static file: #{fname}")
-    if not file.exists(fname) then
+    rpath = string.residual(prefix=basepath, request.path)
+    if not null.defined(rpath) then
       response.status_code(404)
     else
-      if file.is_directory(fname) then
-        if not browse then
-          response.status_code(403)
-        else
-          page = ref("")
-          def add(s)
-            page := page() ^ s ^ "\n"
-          end
-          def add_file(f)
-            add("<li><a href=\"#{request.path}/#{url.encode(f)}\">#{f}</a></li>")
-          end
-          add("<html><body><ul>")
-          list.iter(add_file, file.ls(sorted=true, fname))
-          add("</ul></body>")
-          response.content_type("text/html; charset=UTF-8")
-          response.data(page)
-        end
+      rpath = null.get(rpath)
+      rpath = (rpath == "") ? "/" : rpath
+      fname = path.concat(directory, rpath)
+      log.debug("Serving static file: #{fname}")
+      if not file.exists(fname) then
+        response.status_code(404)
       else
-        mime = content_type(fname)
+        if file.is_directory(fname) then
+          if not browse then
+            response.status_code(403)
+          else
+            page = ref("")
+            def add(s)
+              page := page() ^ s ^ "\n"
+            end
+            def add_file(f)
+              add("<li><a href=\"#{request.path}/#{url.encode(f)}\">#{f}</a></li>")
+            end
+            add("<html><body><ul>")
+            list.iter(add_file, file.ls(sorted=true, fname))
+            add("</ul></body>")
+            response.content_type("text/html; charset=UTF-8")
+            response.data(page)
+          end
+        else
+          mime = content_type(fname)
 
-        if null.defined(mime) then
-          response.content_type(null.get(mime))
-        end
+          if null.defined(mime) then
+            response.content_type(null.get(mime))
+          end
 
-        if request.method == "GET" then
-          response.data(file.read(fname))
+          if request.method == "GET" then
+            response.data(file.read(fname))
+          end
         end
       end
     end
   end
 
+  basepath = "#{basepath}/.*"
+  directory = path.home.unrelate(directory)
   def register(method)
     serve(method=method, basepath, handler)
   end

--- a/src/libs/http.liq
+++ b/src/libs/http.liq
@@ -437,7 +437,7 @@ def harbor.http.static.base(serve,~content_type,~basepath,~headers,~browse,direc
             list.iter(add_file, file.ls(sorted=true, fname))
             add("</ul></body>")
             response.content_type("text/html; charset=UTF-8")
-            response.data(page)
+            response.data(string.getter.single(page()))
           end
         else
           mime = content_type(fname)

--- a/src/libs/http.liq
+++ b/src/libs/http.liq
@@ -417,7 +417,6 @@ def harbor.http.static.base(serve,~content_type,~basepath,~headers,~browse,direc
       response.status_code(404)
     else
       rpath = null.get(rpath)
-      rpath = (rpath == "") ? "/" : rpath
       fname = path.concat(directory, rpath)
       log.debug("Serving static file: #{fname}")
       if not file.exists(fname) then

--- a/src/libs/http.liq
+++ b/src/libs/http.liq
@@ -403,8 +403,8 @@ def harbor.http.static.base(serve,~content_type,~basepath,~headers,~browse,direc
       basepath
     end
   basepath =
-    if string.sub(basepath,start=string.length(basepath)-1,length=1) == "/" then
-      string.sub(basepath,start=0,length=string.length(basepath)-1)
+    if string.sub(basepath,start=string.length(basepath)-1,length=1) != "/" then
+      basepath^"/"
     else
       basepath
     end
@@ -455,7 +455,7 @@ def harbor.http.static.base(serve,~content_type,~basepath,~headers,~browse,direc
     end
   end
 
-  basepath = "#{basepath}/.*"
+  basepath = "#{basepath}.*"
   directory = path.home.unrelate(directory)
   def register(method)
     serve(method=method, basepath, handler)

--- a/src/libs/http.liq
+++ b/src/libs/http.liq
@@ -431,7 +431,7 @@ def harbor.http.static.base(serve,~content_type,~basepath,~headers,~browse,direc
               page := page() ^ s ^ "\n"
             end
             def add_file(f)
-              add("<li><a href=\"#{request.path}/#{url.encode(f)}\">#{f}</a></li>")
+              add("<li><a href=\"#{request.path}#{url.encode(f)}\">#{f}</a></li>")
             end
             add("<html><body><ul>")
             list.iter(add_file, file.ls(sorted=true, fname))

--- a/src/libs/string.liq
+++ b/src/libs/string.liq
@@ -235,6 +235,21 @@ end
 
 let string.getter = ()
 
+# Create a string getter which will return once the given string and then the
+# empty string.
+# @category String
+def string.getter.single(s)
+  first = ref(true)
+  fun () -> begin
+    if first() then
+      first := false
+      s
+    else
+      ""
+    end
+  end
+end
+
 # Flush all values from a string getter and return
 # the concatenated result. If the getter is constant,
 # return the constant string. Otherwise, call the getter


### PR DESCRIPTION
When we serve directory `/dir` on path `/path` on the url `http://.../dir/a` we want to serve the file `/path/a` not `/path/dir/a` as it was the case before.

We also avoid an infinite serving loop for static file due to the use of a string getter instead of a string...