### PR TITLE
Add univ_descr to constraints to describe them when they're the only one on their type.

### DIFF
--- a/src/core/builtins/builtins_settings.ml
+++ b/src/core/builtins/builtins_settings.ml
@@ -32,6 +32,7 @@ let dtools_constr =
   {
     t = Dtools;
     constr_descr = "unit, bool, int, float, string or [string]";
+    univ_descr = None;
     satisfied =
       (fun ~subtype ~satisfies:_ b ->
         let b = demeth b in

--- a/src/core/types/format_type.ml
+++ b/src/core/types/format_type.ml
@@ -197,13 +197,14 @@ let is_format f m =
   let module Content = (val m : Content) in
   Content.is_format f
 
-let check_track ~t modules =
+let check_track ?univ_descr ~t modules =
   {
     Type.t;
     constr_descr =
       Printf.sprintf "a track of type: %s"
         (Utils.concat_with_last ~last:"or" ", "
            (List.map string_of_kind modules));
+    univ_descr;
     satisfied =
       (fun ~subtype:_ ~satisfies b ->
         let b = Type.demeth b in
@@ -219,13 +220,14 @@ let check_track ~t modules =
           | _ -> raise Type.Unsatisfied_constraint);
   }
 
-let pcm_audio = check_track ~t:PcmAudio pcm_modules
+let pcm_audio = check_track ~univ_descr:"pcm*" ~t:PcmAudio pcm_modules
 let internal_track = check_track ~t:InternalTrack internal_modules
 
 let internal_tracks =
   {
     Type.t = InternalTracks;
     constr_descr = "a set of internal tracks";
+    univ_descr = None;
     satisfied =
       (fun ~subtype:_ ~satisfies b ->
         let meths, base_type = Type.split_meths b in
@@ -253,7 +255,8 @@ let internal_tracks =
 let track =
   {
     Type.t = Track;
-    constr_descr = "a source track";
+    constr_descr = "a track";
+    univ_descr = None;
     satisfied =
       (fun ~subtype:_ ~satisfies b ->
         let b = Type.demeth b in
@@ -270,6 +273,7 @@ let muxed_tracks =
   {
     Type.t = MuxedTracks;
     constr_descr = "a set of tracks to be muxed into a source";
+    univ_descr = None;
     satisfied =
       (fun ~subtype:_ ~satisfies b ->
         let meths, base_type = Type.split_meths b in

--- a/src/lang/repr.ml
+++ b/src/lang/repr.ml
@@ -377,6 +377,12 @@ let print f t =
         let vars = print ~par:false vars t in
         Format.fprintf f "}";
         vars
+    | (`EVar (_, c) | `UVar (_, c))
+      when Constraints.cardinal c = 1
+           && (Constraints.choose c).univ_descr <> None ->
+        let constr = Constraints.choose c in
+        Format.fprintf f "%s" (Option.get constr.univ_descr);
+        vars
     | `EVar (name, c) | `UVar (name, c) ->
         Format.fprintf f "%s" name;
         if not (Constraints.is_empty c) then DS.add (name, c) vars else vars

--- a/src/lang/type.ml
+++ b/src/lang/type.ml
@@ -28,6 +28,7 @@ let num_constr =
   {
     t = Num;
     constr_descr = "a number type";
+    univ_descr = None;
     satisfied =
       (fun ~subtype:_ ~satisfies:_ b ->
         let b = demeth b in
@@ -43,6 +44,7 @@ let ord_constr =
   {
     t = Ord;
     constr_descr = "an orderable type";
+    univ_descr = None;
     satisfied =
       (fun ~subtype:_ ~satisfies b ->
         let m, b = split_meths b in

--- a/src/lang/type.mli
+++ b/src/lang/type.mli
@@ -35,6 +35,7 @@ type constr_t += Num | Ord
 type constr = Type_base.constr = {
   t : constr_t;
   constr_descr : string;
+  univ_descr : string option;
   satisfied : subtype:(t -> t -> unit) -> satisfies:(t -> unit) -> t -> unit;
 }
 

--- a/src/lang/types/type_base.ml
+++ b/src/lang/types/type_base.ml
@@ -62,6 +62,7 @@ type constr_t += Num | Ord
 type constr = {
   t : constr_t;
   constr_descr : string;
+  univ_descr : string option;
   satisfied : subtype:(t -> t -> unit) -> satisfies:(t -> unit) -> t -> unit;
 }
 


### PR DESCRIPTION
It's only used for pcm track type but could definitely be useful in other cases.

<img width="629" alt="Screenshot 2023-07-13 at 8 28 54 AM" src="https://github.com/savonet/liquidsoap/assets/871060/9699bfd2-c66e-417a-9542-cc5fa3681b04">

