### PR TITLE
String recoding improvements.

### DIFF
--- a/doc/content/strings_encoding.md
+++ b/doc/content/strings_encoding.md
@@ -1,0 +1,18 @@
+# Strings encoding
+
+Liquidsoap operates internally using the UTF-8 string encoding. Most strings inside the application are converted
+to UTF-8 whenever possible. Conversion is done using [camomile](https://github.com/ocaml-community/camomile) automatic
+string encoding detection. If the conversion fails, the string is kept as-is. The list of encodings used for automatic
+detection is set via [settings.charset.encodings](settings.html#list-of-encodings-to-try-for-automatic-encoding-detection.)
+
+There are some exceptions, however. For instance, filenames and paths are not converted: if your system expects paths
+to be in a different encoding than UTF-8 then we do need to keep strings representing files and paths in this encoding
+to prevent errors.
+
+In general, you are advised to set the string encoding to UTF-8 on all systems running liquidsoap scripts for consistency
+and clarity.
+
+However, if for some reasons you need to tweak string encoding, these settings can be of use:
+
+- `settings.log.recode` and `settings.log.recode.encoding`: set the first one to `true` and the second one to the string encoding you would like log entries to be converted into.
+- `settings.metadata.recode`: set to `false` to prevent metadata from being converted to UTF-8.

--- a/src/core/clock.ml
+++ b/src/core/clock.ml
@@ -355,7 +355,7 @@ module MkClock (Time : Liq_time.T) = struct
         List.iter (fun fn -> fn ()) todo
 
       method start_outputs f =
-        let f s = Tutils.running () && f s in
+        let f s = (not (Tutils.finished ())) && f s in
         (* Extract the list of outputs to start, mark them as Starting
          * so they are not managed by a nested call of start_outputs
          * (triggered by collect, which can be triggered by the

--- a/src/core/configure.ml
+++ b/src/core/configure.ml
@@ -1,5 +1,3 @@
-let add_subst = Utils.add_subst
-
 open Liquidsoap_lang
 include Build_config
 include Liquidsoap_paths
@@ -27,11 +25,6 @@ let libs_versions () =
          if version = "?" then name else name ^ "=" ^ version)
   |> String.concat " "
 
-let () =
-  Lifecycle.before_init (fun () ->
-      add_subst "<sysrundir>" (rundir ());
-      add_subst "<syslogdir>" (logdir ()))
-
 let restart = ref false
 
 let vendor =
@@ -47,30 +40,6 @@ let () = conf#plug "log" Dtools.Log.conf
 let conf_init =
   conf#plug "init" Dtools.Init.conf;
   Dtools.Init.conf
-
-let conf_console =
-  Dtools.Conf.void ~p:(conf#plug "console") "Console configuration"
-
-let conf_colorize =
-  Dtools.Conf.string
-    ~p:(conf_console#plug "colorize")
-    ~d:
-      (match !Console.color_conf with
-        | `Auto -> "auto"
-        | `Always -> "always"
-        | `Never -> "never")
-    "Use color in console output when available. One of: \"always\", \"never\" \
-     or \"auto\"."
-
-let () =
-  let log = Log.make ["console"] in
-  conf_colorize#on_change (function
-    | "auto" -> Console.color_conf := `Auto
-    | "always" -> Console.color_conf := `Always
-    | "never" -> Console.color_conf := `Never
-    | _ ->
-        log#important "Invalid color configuration, using default \"auto\"";
-        Console.color_conf := `Auto)
 
 let conf_debug =
   Dtools.Conf.bool ~p:(conf#plug "debug") ~d:!Term.conf_debug

--- a/src/core/dune
+++ b/src/core/dune
@@ -61,6 +61,7 @@
   avi_format
   biquad_filter
   blank
+  charset_base
   charset
   child_support
   chord

--- a/src/core/tools/charset.ml
+++ b/src/core/tools/charset.ml
@@ -20,50 +20,9 @@
 
   *****************************************************************************)
 
-let conf_camomile =
-  Dtools.Conf.void
-    ~p:(Configure.conf#plug "camomile")
-    "Settings related to camomile library (for charset conversion)."
+include Charset_base
 
-let conf_path =
-  Dtools.Conf.string
-    ~p:(conf_camomile#plug "path")
-    ~d:(Liquidsoap_paths.camomile_dir ())
-    "Directory where camomile files are to be found."
-
-let conf_encoding =
-  Dtools.Conf.list
-    ~p:(conf_camomile#plug "encodings")
-    ~d:["UTF-8"; "ISO-8859-1"; "UTF-16"]
-    "List of encodings to try for automatic encoding detection."
-
-module C = CamomileLib.CharEncoding.Configure (struct
-  let basedir = conf_path#get
-  let datadir = Filename.concat basedir "database"
-  let localedir = Filename.concat basedir "locales"
-  let charmapdir = Filename.concat basedir "charmaps"
-  let unimapdir = Filename.concat basedir "mappings"
-end)
-
-include C
-
-exception Unknown_encoding of string
-exception Unsupported_encoding of t
-
-let of_string s = try C.of_name s with Not_found -> raise (Unknown_encoding s)
-let to_string = C.name_of
-let custom_encoding = ref None
-
-let automatic_encoding () =
-  match !custom_encoding with
-    | Some e -> e
-    | None ->
-        let encs = conf_encoding#get in
-        let e = C.automatic "auto" (List.map of_string encs) C.utf8 in
-        custom_encoding := Some e;
-        e
-
-let log = Log.make ["camomile"]
+let log = Log.make ["charset"]
 
 let recode_string ~fail ~in_enc ~out_enc s =
   try

--- a/src/core/tools/charset_base.ml
+++ b/src/core/tools/charset_base.ml
@@ -1,0 +1,63 @@
+(*****************************************************************************
+
+    Liquidsoap, a programmable audio stream generator.
+    Copyright 2003-2023 Savonet team
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details, fully stated in the COPYING
+    file at the root of the liquidsoap distribution.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA
+
+  *****************************************************************************)
+
+let conf_charset =
+  Dtools.Conf.void
+    ~p:(Configure.conf#plug "charset")
+    "Settings related to charset conversion."
+
+let conf_path =
+  Dtools.Conf.string ~p:(conf_charset#plug "path")
+    ~d:(Liquidsoap_paths.camomile_dir ())
+    "Directory where charset files are to be found."
+
+let conf_encoding =
+  Dtools.Conf.list
+    ~p:(conf_charset#plug "encodings")
+    ~d:["UTF-8"; "ISO-8859-1"; "UTF-16"]
+    "List of encodings to try for automatic encoding detection."
+
+module C = CamomileLib.CharEncoding.Configure (struct
+  let basedir = conf_path#get
+  let datadir = Filename.concat basedir "database"
+  let localedir = Filename.concat basedir "locales"
+  let charmapdir = Filename.concat basedir "charmaps"
+  let unimapdir = Filename.concat basedir "mappings"
+end)
+
+include C
+
+exception Unknown_encoding of string
+exception Unsupported_encoding of t
+
+let of_string s = try C.of_name s with Not_found -> raise (Unknown_encoding s)
+let to_string = C.name_of
+let custom_encoding = ref None
+
+let automatic_encoding () =
+  match !custom_encoding with
+    | Some e -> e
+    | None ->
+        let encs = conf_encoding#get in
+        let e = C.automatic "auto" (List.map of_string encs) C.utf8 in
+        custom_encoding := Some e;
+        e

--- a/src/core/tools/log.ml
+++ b/src/core/tools/log.ml
@@ -22,6 +22,20 @@
 
 (** Logging functions. *)
 
+let conf_recode =
+  Dtools.Conf.bool
+    ~p:(Dtools.Log.conf#plug "recode")
+    ~d:false
+    "Recode log entries. Source encoding is set using \
+     `settings.charset.encodings`."
+
+let conf_encoding =
+  Dtools.Conf.string
+    ~p:(conf_recode#plug "encoding")
+    ~d:"UTF-8" "Encoding to recode log entries to."
+
+let recode = ref (fun s -> s)
+
 type t =
   < active : int -> bool
   ; f : 'a. int -> ('a, unit, string, unit) format4 -> 'a
@@ -35,11 +49,12 @@ type t =
 
 let make path : t =
   let colorize colors { Dtools.Log.time; label; level; log } =
+    let recode = !recode in
     {
       Dtools.Log.time;
-      label = Option.map (Console.colorize [`green]) label;
+      label = Option.map (fun s -> Console.colorize [`green] (recode s)) label;
       level;
-      log = Console.colorize colors log;
+      log = Console.colorize colors (recode log);
     }
   in
   let log = Dtools.Log.make path in
@@ -85,3 +100,48 @@ let make path : t =
     method set_level lvl =
       (Dtools.Conf.as_int (Dtools.Log.conf_level#ut#path log#path))#set lvl
   end
+
+let () =
+  let log = make ["log"] in
+  let set_recode () =
+    recode :=
+      match Charset_base.of_string conf_encoding#get with
+        | out_enc -> (
+            fun s ->
+              let in_enc = Charset_base.automatic_encoding () in
+              try Charset_base.recode_string ~in_enc ~out_enc s
+              with exn ->
+                log#important "Failed to convert %S: unknown error %s" s
+                  (Printexc.to_string exn);
+                s)
+        | exception _ ->
+            log#severe "Invalid target encoding for log conversion: %s"
+              conf_encoding#get;
+            fun s -> s
+  in
+  conf_recode#on_change (fun recode -> if recode then set_recode ());
+  conf_encoding#on_change (fun _ -> if conf_recode#get then set_recode ())
+
+let conf_console =
+  Dtools.Conf.void ~p:(Configure.conf#plug "console") "Console configuration"
+
+let conf_colorize =
+  Dtools.Conf.string
+    ~p:(conf_console#plug "colorize")
+    ~d:
+      (match !Console.color_conf with
+        | `Auto -> "auto"
+        | `Always -> "always"
+        | `Never -> "never")
+    "Use color in console output when available. One of: \"always\", \"never\" \
+     or \"auto\"."
+
+let () =
+  let log = make ["console"] in
+  conf_colorize#on_change (function
+    | "auto" -> Console.color_conf := `Auto
+    | "always" -> Console.color_conf := `Always
+    | "never" -> Console.color_conf := `Never
+    | _ ->
+        log#important "Invalid color configuration, using default \"auto\"";
+        Console.color_conf := `Auto)

--- a/src/core/tools/tutils.ml
+++ b/src/core/tools/tutils.ml
@@ -49,7 +49,8 @@ type state = [ `Idle | `Starting | `Running | `Done of exit_status ]
 
 let internal_error_code = 128
 let state : state Atomic.t = Atomic.make `Idle
-let running () = match Atomic.get state with `Done _ -> false | _ -> true
+let running () = match Atomic.get state with `Running -> true | _ -> false
+let finished () = match Atomic.get state with `Done _ -> true | _ -> false
 
 let exit_code () =
   match Atomic.get state with

--- a/src/core/tools/tutils.mli
+++ b/src/core/tools/tutils.mli
@@ -37,6 +37,7 @@ val create : ('a -> unit) -> 'a -> string -> Thread.t
 val main : unit -> unit
 val start : unit -> unit
 val running : unit -> bool
+val finished : unit -> bool
 val shutdown : int -> unit
 val cleanup : unit -> unit
 val exit_code : unit -> int

--- a/src/runtime/main.ml
+++ b/src/runtime/main.ml
@@ -456,6 +456,9 @@ let () =
       Dtools.Init.conf_daemon_pidfile_path#set_d
         (Some "<sysrundir>/<script>.pid");
 
+      Utils.add_subst "<sysrundir>" (Liquidsoap_paths.rundir ());
+      Utils.add_subst "<syslogdir>" (Liquidsoap_paths.logdir ());
+
       log#important "Liquidsoap %s" Configure.version;
       log#important "Using: %s" (Configure.libs_versions ());
       if Configure.git_snapshot then

--- a/tests/media/ffmpeg_audio_decoder.liq
+++ b/tests/media/ffmpeg_audio_decoder.liq
@@ -11,27 +11,29 @@ end
 
 s = single(fname)
 
-s = once(s)
+s = sequence([s, s, once(s)])
 
 clock.assign_new(sync='none',[s])
 
 def on_done () =
-  j = process.read("ffprobe -v quiet -print_format json -show_streams #{process.quote(out)}")
+  thread.run(delay=0.2, fun () -> begin
+    j = process.read("ffprobe -v quiet -print_format json -show_streams #{process.quote(out)}")
 
-  let json.parse ( parsed: {
-    streams: [{
-      channels: int,
-      sample_rate: string
-    }]
-  }) = j
+    let json.parse ( parsed: {
+      streams: [{
+        channels: int,
+        sample_rate: string
+      }]
+    }) = j
 
-  let [stream] = parsed.streams
+    let [stream] = parsed.streams
 
-  if stream.channels == 1 and stream.sample_rate == "48000" then
-    test.pass()
-  else
-    test.fail()
-  end
+    if stream.channels == 1 and stream.sample_rate == "48000" then
+      test.pass()
+    else
+      test.fail()
+    end
+  end)
 end
 
 output.file(fallible=true, on_stop=on_done, %wav(mono), out, s)

--- a/tests/media/ffmpeg_inline_encode_decode_video.liq
+++ b/tests/media/ffmpeg_inline_encode_decode_video.liq
@@ -12,36 +12,40 @@ if file.exists(out_encode) then
   file.remove(out_encode)
 end
 
-s = once(blank(duration=10.))
+v = video.fill(color=0xff0000, blank())
+a = sine(duration=10.)
+s = source.mux.video(video=v, a)
 
 todo = ref(2)
 
 def on_done () =
-  def check(out) =
-    j = process.read("ffprobe -v quiet -print_format json -show_streams #{process.quote(out)}")
+  thread.run(delay=1., fun () -> begin
+    def check(out) =
+      j = process.read("ffprobe -v quiet -print_format json -show_streams #{process.quote(out)}")
 
-    let json.parse ( parsed : {
-      streams: [{
-        codec_name: string,
-        pix_fmt: string
-      }]
-    }) = j
+      let json.parse ( parsed : {
+        streams: [{
+          codec_name: string,
+          pix_fmt: string
+        }]
+      }) = j
 
-   let [stream] = parsed.streams
+      let [stream] = parsed.streams
 
-    stream.codec_name == "h264" and
-    stream.pix_fmt == "yuv420p"
-  end
-
-  todo := !todo - 1
-
-  if !todo == 0 then
-    if check(out_copy) and check(out_encode) then
-      test.pass()
-    else
-      test.fail()
+      stream.codec_name == "h264" and
+      stream.pix_fmt == "yuv420p"
     end
-  end
+
+    todo := !todo - 1
+
+    if !todo == 0 then
+      if check(out_copy) and check(out_encode) then
+        test.pass()
+      else
+        test.fail()
+      end
+    end
+  end)
 end
 
 s = ffmpeg.encode.video(

--- a/tests/media/ffmpeg_raw_and_encode_decoder.liq
+++ b/tests/media/ffmpeg_raw_and_encode_decoder.liq
@@ -10,36 +10,38 @@ end
 
 s = single(fname)
 
-s = once(s)
+s = sequence([s, s, once(s)])
 
 clock.assign_new(sync='none',[s])
 
 def on_done () =
-  j = process.read("ffprobe -v quiet -print_format json -show_streams #{process.quote(out)}")
+  thread.run(delay=0.2, fun () -> begin
+    j = process.read("ffprobe -v quiet -print_format json -show_streams #{process.quote(out)}")
 
-  let json.parse ( parsed : {
-    streams: [{
-      channel_layout: string?,
-      sample_rate: string?,
-      sample_fmt: string?,
-      codec_name: string?,
-      pix_fmt: string?
-    }]
-  }) = j
+    let json.parse ( parsed : {
+      streams: [{
+        channel_layout: string?,
+        sample_rate: string?,
+        sample_fmt: string?,
+        codec_name: string?,
+        pix_fmt: string?
+      }]
+    }) = j
 
-  video_stream = list.find((fun (stream) -> null.defined(stream.pix_fmt)), parsed.streams)
-  audio_stream = list.find((fun (stream) -> null.defined(stream.sample_rate)), parsed.streams)
+    video_stream = list.find((fun (stream) -> null.defined(stream.pix_fmt)), parsed.streams)
+    audio_stream = list.find((fun (stream) -> null.defined(stream.sample_rate)), parsed.streams)
 
-  if null.get(video_stream.codec_name) == "h264" and
-     null.get(video_stream.pix_fmt) == "yuv420p" and
-     null.get(audio_stream.channel_layout) == "stereo" and
-     null.get(audio_stream.codec_name) == "aac" and
-     null.get(audio_stream.sample_fmt) == "fltp" and
-     null.get(audio_stream.sample_rate) == "44100" then
-    test.pass()
-  else
-    test.fail()
-  end
+    if null.get(video_stream.codec_name) == "h264" and
+       null.get(video_stream.pix_fmt) == "yuv420p" and
+       null.get(audio_stream.channel_layout) == "stereo" and
+       null.get(audio_stream.codec_name) == "aac" and
+       null.get(audio_stream.sample_fmt) == "fltp" and
+       null.get(audio_stream.sample_rate) == "44100" then
+      test.pass()
+    else
+      test.fail()
+    end
+  end)
 end
 
 output.file(fallible=true, on_stop=on_done, %ffmpeg(format="mkv",%audio(codec="aac"),%video.raw(codec="libx264")), out, s)

--- a/tests/media/mono.liq
+++ b/tests/media/mono.liq
@@ -11,27 +11,29 @@ end
 
 s = single(fname)
 
-s = once(s)
+s = sequence([s, s, once(s)])
 
 clock.assign_new(sync='none',[s])
 
 def on_done () =
-  j = process.read("ffprobe -v quiet -print_format json -show_streams #{process.quote(out)}")
+  thread.run(delay=0.2, fun () -> begin
+    j = process.read("ffprobe -v quiet -print_format json -show_streams #{process.quote(out)}")
 
-  let json.parse ( parsed: {
-    streams: [{
-      channels: int,
-      sample_rate: string
-    }]
-  }) = j
+    let json.parse ( parsed: {
+      streams: [{
+        channels: int,
+        sample_rate: string
+      }]
+    }) = j
 
-  let [stream] = parsed.streams
+    let [stream] = parsed.streams
 
-  if stream.channels == 1 and stream.sample_rate == "48000" then
-    test.pass()
-  else
-    test.fail()
-  end
+    if stream.channels == 1 and stream.sample_rate == "48000" then
+      test.pass()
+    else
+      test.fail()
+    end
+  end)
 end
 
 output.file(fallible=true, on_stop=on_done, %wav(mono), out, s)

--- a/tests/media/stereo.liq
+++ b/tests/media/stereo.liq
@@ -11,27 +11,29 @@ end
 
 s = single(fname)
 
-s = once(s)
+s = sequence([s, s, once(s)])
 
 clock.assign_new(sync='none',[s])
 
 def on_done () =
-  j = process.read("ffprobe -v quiet -print_format json -show_streams #{process.quote(out)}")
+  thread.run(delay=0.2, fun () -> begin
+    j = process.read("ffprobe -v quiet -print_format json -show_streams #{process.quote(out)}")
 
-  let json.parse ( parsed: {
-    streams: [{
-      channels: int,
-      sample_rate: string
-    }]
-  }) = j
+    let json.parse ( parsed: {
+      streams: [{
+        channels: int,
+        sample_rate: string
+      }]
+    }) = j
 
-  let [stream] = parsed.streams
+    let [stream] = parsed.streams
 
-  if stream.channels == 2 and stream.sample_rate == "48000" then
-    test.pass()
-  else
-    test.fail()
-  end
+    if stream.channels == 2 and stream.sample_rate == "48000" then
+      test.pass()
+    else
+      test.fail()
+    end
+  end)
 end
 
 output.file(fallible=true, on_stop=on_done, %wav(stereo), out, s)

--- a/tests/regression/GH2585.liq
+++ b/tests/regression/GH2585.liq
@@ -1,6 +1,16 @@
 settings.log.level.set(4)
+
 output.dummy(fallible = true, sine())
-thread.run(delay=3., {
-  print("sending kill -s INT #{process.pid()}")
-  process.run("kill -s INT #{process.pid()}")
+
+count = ref(0)
+
+thread.run.recurrent({
+  if count() == 5 then begin
+    print("sending kill -s INT #{process.pid()}")
+    process.run("kill -s INT #{process.pid()}")
+    (-1.)
+  end else begin
+    count := count()+1
+    1.
+  end end
 })

--- a/tests/regression/GH2871.liq
+++ b/tests/regression/GH2871.liq
@@ -1,9 +1,15 @@
 def f() =
   s = metronome()
   s = bpm(s)
-  clock.assign_new(sync="none",[s])
   output.dummy(fallible=true, s)
-  thread.run(delay=0.2, {if s.bpm() != 0. then test.pass() else test.fail () end})
+  thread.run.recurrent({
+    if s.bpm() != 0. then begin
+      test.pass()
+      (-1.)
+    end else
+      1.
+    end
+  })
 end
 
 test.check(f)

--- a/tests/streams/icecast_tls.liq
+++ b/tests/streams/icecast_tls.liq
@@ -7,14 +7,17 @@ transport = http.transport.tls(
 
 port = random.int(min=8000, max=10000)
 
-s = sine()
+thread.run(delay=1., fun () -> begin
+  s = sine()
 
-output.icecast(
-  port=port,
-  mount="tls_test",
-  transport=transport,
-  %vorbis,
-  s)
+  output.icecast(
+    port=port,
+    mount="tls_test",
+    transport=transport,
+    %vorbis,
+    s
+  )
+end)
 
 i = input.harbor(
   buffer=2.,


### PR DESCRIPTION
* Add `settings.log.recode` and `settings.log.recode.encoding` to record log strings. This is opt-in to prevent performances impact.
* Add `settings.metadata.recode` to recode metadata into `UTF-8`. This is opt-out as we are expecting UTF-8 strings internally and metadata can come from a wide range of encodings.

Fixes: #3231