### PR TITLE
HLS segment reopen improvements

### DIFF
--- a/doc/content/hls_output.md
+++ b/doc/content/hls_output.md
@@ -33,7 +33,7 @@ streams = [("aac_lofi",aac_lofi),
            ("aac_hifi", aac_hifi)]
 
 def segment_name(~position,~extname,stream_name) =
-  timestamp = int_of_float(gettimeofday())
+  timestamp = int_of_float(time())
   duration = 2
   "#{stream_name}_#{duration}_#{timestamp}_#{position}.#{extname}"
 end

--- a/src/core/encoder/formats/meta_format.ml
+++ b/src/core/encoder/formats/meta_format.ml
@@ -32,6 +32,7 @@ let export_metadata m =
   ret
 
 let to_metadata m = m
+let to_metadata_list m = Utils.list_of_metadata m
 let empty_metadata = Hashtbl.create 0
 let is_empty m = Hashtbl.length m == 0
 

--- a/src/core/encoder/formats/meta_format.mli
+++ b/src/core/encoder/formats/meta_format.mli
@@ -24,6 +24,7 @@ type export_metadata
 
 val export_metadata : Frame.metadata -> export_metadata
 val to_metadata : export_metadata -> Frame.metadata
+val to_metadata_list : export_metadata -> (string * string) list
 val empty_metadata : export_metadata
 val is_empty : export_metadata -> bool
 val to_string : export_metadata -> string

--- a/src/core/tools/utils.ml
+++ b/src/core/tools/utils.ml
@@ -57,7 +57,7 @@ let hashtbl_of_list l =
 
 let list_of_metadata m =
   let f x y l = (x, y) :: l in
-  Hashtbl.fold f m []
+  List.sort (fun (k, _) (k', _) -> Stdlib.compare k k') (Hashtbl.fold f m [])
 
 let hashtbl_get : ('a, 'b) Hashtbl.t -> 'a -> 'b option =
  fun h k -> try Some (Hashtbl.find h k) with Not_found -> None


### PR DESCRIPTION
* Don't mark metadata as to be inserted if they match the last inserted ones.
* Log segment reopen reasons.