### PR TITLE
Cleanup append operator.

### DIFF
--- a/src/libs/extra/source.liq
+++ b/src/libs/extra/source.liq
@@ -142,6 +142,7 @@ def source.say_metadata =
       end
     say_metadata = "#{artist_predicate}#{title}"
     say_metadata = r/:/g.replace(fun (_) -> '$(colon)', say_metadata)
+    say_metadata = say_metadata == "" ? "Sorry, I do not know what this song title was" : say_metadata
     "say:#{say_metadata}"
   end
   fun (~id=null("source.say_metadata"), ~pattern=pattern, s) ->


### PR DESCRIPTION
This PR simplifies the `append` operator logic, removing the notion of pre-loaded append source. Practically, metadata are almost always timed with track marks and this logic makes thing much more complex to understand. The changes also tighten up some details related to `is_ready` which could lead to the append source being called while not ready.