### PR TITLE
feat: Enhance data value set in http.response.json

### DIFF
--- a/src/libs/http.liq
+++ b/src/libs/http.liq
@@ -194,12 +194,12 @@ def http.response(~http_version="1.1",
     header("Location", location)
   end
 
-  def json(v) =
+  def json(~compact=true, v) =
     if headers_sent() then
       error.raise(error.invalid, "HTTP response has already been sent for this value!")
     end
     content_type := "application/json; charset=utf-8"
-    data := json.stringify(v)
+    data := json.stringify(v, compact=compact) ^ "\n"
   end
 
   def html(d) =


### PR DESCRIPTION
## Summary
- Add the `compact` named argument, set to `true` by default, into `http.response.json`.
- Forward the `compact` named argument from `http.response.json` into `json.stringify` to produce minified JSON by default.
- Add a newline symbol to the end of the JSON string sent by `http.response.json`.

Closes #3296.