### PR TITLE
[2.2] feat: Enhance data value set in http.response.json

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,8 @@ Changed:
 - BREAKING: on HLS outputs, `on_file_change` events are
   now `"created"`, `"updated"` and `"deleted"`, to better
   reflect the new atomic file operations (#3284)
+- Added `compact` argument to the `http.response.json` function. `http.response.json` will produce minified JSON by
+  default. Added a newline symbol to the end of the JSON data produced by `http.response.json`. (#3299)
 
 Fixed:
 

--- a/src/libs/http.liq
+++ b/src/libs/http.liq
@@ -194,12 +194,12 @@ def http.response(~http_version="1.1",
     header("Location", location)
   end
 
-  def json(v) =
+  def json(~compact=true, v) =
     if headers_sent() then
       error.raise(error.invalid, "HTTP response has already been sent for this value!")
     end
     content_type := "application/json; charset=utf-8"
-    data := json.stringify(v)
+    data := json.stringify(v, compact=compact) ^ "\n"
   end
 
   def html(d) =


### PR DESCRIPTION
## Summary
- Add the `compact` named argument, set to `true` by default, into `http.response.json`.
- Forward the `compact` named argument from `http.response.json` into `json.stringify` to produce minified JSON by default.
- Add a newline symbol to the end of the JSON string sent by `http.response.json`.

Backport of #3298.