### PR TITLE
Allow trailing commas in record definitions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,8 @@
-# 2.2.1 (unreleased)
+# 2.3.0 (unreleased)
 
 New:
+
+- Allow trailing commas in record definition (#3300)
 
 Changed:
 

--- a/src/lang/parser.mly
+++ b/src/lang/parser.mly
@@ -219,11 +219,12 @@ expr:
   | ENCODER encoder_opt              { mk_encoder ~pos:$loc $1 $2 }
   | LPAR RPAR                        { mk ~pos:$loc (`Tuple []) }
   | LPAR inner_tuple RPAR            { mk ~pos:$loc (`Tuple $2) }
-  | expr DOT LCUR record RCUR        { $4 ~pos:$loc $1 }
+  | expr DOT LCUR record optional_comma RCUR
+                                     { $4 ~pos:$loc $1 }
   | LCUR DOTDOTDOT expr RCUR         { $3 }
   | LCUR record COMMA DOTDOTDOT expr RCUR
                                      { $2 ~pos:$loc $5 }
-  | LCUR record RCUR                 { $2 ~pos:$loc (mk ~pos:$loc (`Tuple [])) }
+  | LCUR record optional_comma RCUR  { $2 ~pos:$loc (mk ~pos:$loc (`Tuple [])) }
   | LCUR RCUR                        { mk ~pos:$loc (`Tuple []) }
   | expr QUESTION DOT invoke         { mk ~pos:$loc (`Invoke { invoked = $1; meth = $4; default = Some (mk ~pos:$loc `Null) }) }
   | expr DOT invoke                  { mk ~pos:$loc (`Invoke { invoked = $1; meth = $3; default = None }) }
@@ -556,6 +557,10 @@ encoder_params:
 
 plain_encoder_params:
   | LPAR encoder_params RPAR { $2 }
+
+optional_comma:
+  |       {}
+  | COMMA {}
 
 record:
   | VAR GETS expr {

--- a/tests/language/record.liq
+++ b/tests/language/record.liq
@@ -229,6 +229,10 @@ def f() =
   end
   g({blo="bla"})
 
+  # Allow optional trailing comma
+  x = { foo = "bar", gni = 123, }
+  x = "aabb".{ foo = "bar", gni = 123, }
+
   test.pass()
 end
 


### PR DESCRIPTION
Fixes: #3300