### PR TITLE
Revert "Only fill content when filling up frames. (#3226)"

### DIFF
--- a/src/core/stream/generator.ml
+++ b/src/core/stream/generator.ml
@@ -313,7 +313,7 @@ let fill gen =
                        Content.Metadata.set_data frame_content
                          (Content.Metadata.get_data frame_content @ content)
                    | f ->
-                       Content.fill content 0
+                       Content.blit content 0
                          (Frame_base.Fields.find f frame_content)
                          pos len);
                  rem)


### PR DESCRIPTION
This reverts commit 4898d18b0a4ea9be8910045a82818bef1c5e23a9.