### PR TITLE
Add string interpolation to parsed terms.

### DIFF
--- a/src/lang/parser.mly
+++ b/src/lang/parser.mly
@@ -71,6 +71,8 @@ open Parser_helper
 %token ARGS_OF
 %token PP_IFENCODER PP_IFNENCODER PP_ELSE PP_ENDIF
 %token PP_ENDL PP_DEFINE
+%token BEGIN_INTERPOLATION END_INTERPOLATION
+%token <string> INTERPOLATED_STRING
 %token <Parsed_term.inc> INCLUDE
 %token WHILE FOR TO
 
@@ -210,6 +212,7 @@ expr:
   | BOOL                             { mk ~pos:$loc (`Ground (Bool $1)) }
   | FLOAT                            { mk ~pos:$loc (`Ground (Float  $1)) }
   | STRING                           { mk ~pos:$loc (`Ground (String $1)) }
+  | string_interpolation             { mk ~pos:$loc (`String_interpolation $1) }
   | VAR                              { mk ~pos:$loc (`Var $1) }
   | varlist                          { mk ~pos:$loc (`List $1) }
   | GET expr                         { mk ~pos:$loc (`Get $2) }
@@ -572,6 +575,18 @@ record:
         let tm = $1 ~pos e in
         mk ~pos:$loc ~t:tm.Term.t ~methods:(Methods.add $3 $5 tm.methods) tm.Term.term
   }
+
+string_interpolation:
+  | BEGIN_INTERPOLATION string_interpolation_elems END_INTERPOLATION { $2 }
+
+string_interpolation_elem:
+  | INTERPOLATED_STRING  { `String $1 }
+  | expr                 { `Term $1 }
+
+string_interpolation_elems:
+  | string_interpolation_elem { [$1] }
+  | string_interpolation_elem string_interpolation_elems
+                              { $1::$2 }
 
 annotate:
   | annotate_metadata COLON { $1 }

--- a/src/lang/term/parsed_term.ml
+++ b/src/lang/term/parsed_term.ml
@@ -142,10 +142,12 @@ and parsed_ast =
   | `Bool of t * string * t
   | `Coalesce of t * t
   | `Simple_fun of t
+  | `String_interpolation of string_interpolation list
   | `Include of inc
   | t ast ]
 
 and t = parsed_ast term
+and string_interpolation = [ `String of string | `Term of t ]
 
 type encoder_params = t ast_encoder_params
 
@@ -225,6 +227,8 @@ let rec iter_term fn ({ term; methods } as tm) =
         iter_term fn tm;
         iter_term fn tm'
     | `Var _ -> ()
+    | `String_interpolation l ->
+        List.iter (function `String _ -> () | `Term tm -> iter_term fn tm) l
     | `Seq (tm, tm') ->
         iter_term fn tm;
         iter_term fn tm'

--- a/src/tooling/json_dump.ml
+++ b/src/tooling/json_dump.ml
@@ -12,5 +12,6 @@ let parse_content content =
 let () =
   let content = read_stdin () in
   let term = parse_content content in
+  Parser_helper.attach_comments ~pos:(Option.get term.Term.t.Type.pos) term;
   let json = Liquidsoap_tooling.Parsed_json.to_json term in
   Printf.printf "%s\n%!" (Json.to_string ~compact:false json)

--- a/src/tooling/parsed_json.ml
+++ b/src/tooling/parsed_json.ml
@@ -293,6 +293,19 @@ let rec to_ast_json = function
       ast_node ~typ:"iterable_for" (json_of_iterable_for ~to_json p)
   | `Not t -> ast_node ~typ:"not" [("value", to_json t)]
   | `Negative t -> ast_node ~typ:"negative" [("value", to_json t)]
+  | `String_interpolation l ->
+      let l =
+        List.map
+          (function
+            | `String s ->
+                `Assoc
+                  (ast_node ~typ:"interpolated_string" [("value", `String s)])
+            | `Term tm ->
+                `Assoc
+                  (ast_node ~typ:"interpolated_term" [("value", to_json tm)]))
+          l
+      in
+      ast_node ~typ:"string_interpolation" [("value", `Tuple l)]
   | `Append (t, t') ->
       ast_node ~typ:"append" [("left", to_json t); ("right", to_json t')]
   | `Assoc (t, t') ->


### PR DESCRIPTION
This PR moves the string interpolation to parsed terms, making it available for JSON syntax export. 

It is pretty straight forward with the slight optimization that the final string is now concatenated at once using `string.concat`.

I tried to be smarter and rewrite the parsing to avoid using regexp but it's tricky. The string character delimitator needs to be kept in context to be able to close interpolated strings. This explains why a new special character ` was introduced in javascript for interpolated strings.