### PR TITLE
Clock exceptions cleanup

### DIFF
--- a/src/core/builtins/builtins_ffmpeg_decoder.ml
+++ b/src/core/builtins/builtins_ffmpeg_decoder.ml
@@ -437,6 +437,11 @@ let mk_decoder mode =
            Lang.to_default_option ~default:name Lang.to_string
              (List.assoc "id" p)
          in
+         let pos =
+           match Liquidsoap_lang.Lang_core.pos p with
+             | [] -> None
+             | p :: _ -> Some p
+         in
          let field, source = Lang.to_track (List.assoc "" p) in
 
          let mk_decode_frame generator =
@@ -488,6 +493,7 @@ let mk_decoder mode =
              ~always_enabled:true ~write_frame:decode_frame
              ~name:(id ^ ".consumer") ~source:(Lang.source source) ()
          in
+         consumer#set_pos pos;
 
          let input_frame_t = Typing.generalize ~level:(-1) input_frame_t in
          let input_frame_t = Typing.instantiate ~level:(-1) input_frame_t in
@@ -499,7 +505,7 @@ let mk_decoder mode =
          ( field,
            new Producer_consumer.producer
            (* We are expecting real-rate with a couple of hickups.. *)
-             ~create_known_clock:false ~check_self_sync:false
+             ?pos ~create_known_clock:false ~check_self_sync:false
              ~consumers:[consumer] ~name:(id ^ ".producer") () )))
 
 let () =

--- a/src/core/builtins/builtins_ffmpeg_encoder.ml
+++ b/src/core/builtins/builtins_ffmpeg_encoder.ml
@@ -428,6 +428,11 @@ let mk_encoder mode =
            Lang.to_default_option ~default:name Lang.to_string
              (List.assoc "id" p)
          in
+         let pos =
+           match Liquidsoap_lang.Lang_core.pos p with
+             | [] -> None
+             | p :: _ -> Some p
+         in
          let format_val = Lang.assoc "" 1 p in
          let format =
            match Lang.to_format format_val with
@@ -556,6 +561,8 @@ let mk_encoder mode =
              ~write_frame:encode_frame ~name:(id ^ ".consumer")
              ~source:(Lang.source source) ()
          in
+         consumer#set_pos pos;
+
          let input_frame_t =
            Typing.instantiate ~level:(-1)
              (Typing.generalize ~level:(-1) input_frame_t)
@@ -568,7 +575,7 @@ let mk_encoder mode =
          ( field,
            new Producer_consumer.producer
            (* We are expecting real-rate with a couple of hickups.. *)
-             ~create_known_clock:false ~check_self_sync:false
+             ?pos ~create_known_clock:false ~check_self_sync:false
              ~consumers:[consumer] ~name:(id ^ ".producer") () )))
 
 let () =

--- a/src/core/builtins/builtins_source.ml
+++ b/src/core/builtins/builtins_source.ml
@@ -198,7 +198,7 @@ let _ =
       let p = (("id", Lang.string "source_dumper") :: p) @ proto in
       let fo = Pipe_output.new_file_output p in
       let clock = Clock.clock ~start:false "source_dumper" in
-      Clock.unify fo#clock (Clock.create_known clock);
+      Clock.unify ~pos:fo#pos fo#clock (Clock.create_known clock);
       ignore (clock#start_outputs (fun _ -> true) ());
       log#info "Start dumping source.";
       while (not (Atomic.get should_stop)) && fo#is_ready do
@@ -225,7 +225,7 @@ let _ =
           ~autostart:true (Lang.source s)
       in
       let clock = Clock.clock ~start:false "source_dropper" in
-      Clock.unify o#clock (Clock.create_known clock);
+      Clock.unify ~pos:o#pos o#clock (Clock.create_known clock);
       ignore (clock#start_outputs (fun _ -> true) ());
       log#info "Start dropping source.";
       while (not (Atomic.get should_stop)) && o#is_ready do

--- a/src/core/clock.ml
+++ b/src/core/clock.ml
@@ -382,7 +382,8 @@ module MkClock (Time : Liq_time.T) = struct
         fun () ->
           let to_start =
             if to_start <> [] then
-              log#info "Starting %d source(s)..." (List.length to_start);
+              log#info "Starting source(s): %s"
+                (String.concat ", " (List.map (fun s -> s#id) to_start));
             List.map
               (fun (s : active_source) ->
                 try
@@ -529,7 +530,7 @@ let collect ~must_lock =
             if should_start o#clock then get_default ()
             else create_follow_clock o#id
           in
-          ignore (unify o#clock (create_known clock))));
+          ignore (unify ~pos:o#pos o#clock (create_known clock))));
     gc_alarm ();
     let filter _ = true in
     let collects =
@@ -569,7 +570,7 @@ let force_init filter =
       (fun () ->
         Source.iterate_new_outputs (fun o ->
             if filter o && not (is_known o#clock) then
-              ignore (unify o#clock (create_known (get_default ()))));
+              ignore (unify ~pos:o#pos o#clock (create_known (get_default ()))));
         gc_alarm ();
         Clocks.fold (fun s l -> s#start_outputs filter :: l) clocks [])
       ()

--- a/src/core/clock.mli
+++ b/src/core/clock.mli
@@ -171,6 +171,6 @@ val create_unknown :
   clock_variable
 
 val create_known : Source.clock -> clock_variable
-val unify : clock_variable -> clock_variable -> unit
+val unify : pos:Pos.Option.t -> clock_variable -> clock_variable -> unit
 val forget : clock_variable -> clock_variable -> unit
 val get : clock_variable -> Source.clock

--- a/src/core/io/alsa_io.ml
+++ b/src/core/io/alsa_io.ml
@@ -169,7 +169,7 @@ class output ~clock_safe ~start ~infallible ~on_stop ~on_start dev val_source =
     method! private set_clock =
       super#set_clock;
       if clock_safe then
-        Clock.unify self#clock
+        Clock.unify ~pos:self#pos self#clock
           (Clock.create_known (Alsa_settings.get_clock () :> Source.clock))
 
     val mutable samplerate_converter = None

--- a/src/core/io/gstreamer_io.ml
+++ b/src/core/io/gstreamer_io.ml
@@ -190,7 +190,7 @@ class output ~clock_safe ~on_error ~infallible ~on_start ~on_stop
     method! private set_clock =
       super#set_clock;
       if clock_safe then
-        Clock.unify self#clock
+        Clock.unify ~pos:self#pos self#clock
           (Clock.create_known (gst_clock () :> Source.clock))
 
     method start =

--- a/src/core/io/oss_io.ml
+++ b/src/core/io/oss_io.ml
@@ -50,7 +50,7 @@ class output ~clock_safe ~on_start ~on_stop ~infallible ~start dev val_source =
     method! private set_clock =
       super#set_clock;
       if clock_safe then
-        Clock.unify self#clock
+        Clock.unify ~pos:self#pos self#clock
           (Clock.create_known (get_clock () :> Source.clock))
 
     val mutable fd = None

--- a/src/core/io/portaudio_io.ml
+++ b/src/core/io/portaudio_io.ml
@@ -161,7 +161,7 @@ class output ~clock_safe ~start ~on_start ~on_stop ~infallible ~device_id
     method! private set_clock =
       super#set_clock;
       if clock_safe then
-        Clock.unify self#clock
+        Clock.unify ~pos:self#pos self#clock
           (Clock.create_known (get_clock () :> Source.clock))
 
     val mutable stream = None

--- a/src/core/io/pulseaudio_io.ml
+++ b/src/core/io/pulseaudio_io.ml
@@ -64,7 +64,7 @@ class output ~infallible ~start ~on_start ~on_stop p =
     method! private set_clock =
       super#set_clock;
       if clock_safe then
-        Clock.unify self#clock
+        Clock.unify ~pos:self#pos self#clock
           (Clock.create_known (get_clock () :> Source.clock))
 
     val mutable stream = None

--- a/src/core/operators/cross.ml
+++ b/src/core/operators/cross.ml
@@ -117,7 +117,7 @@ class cross val_source ~duration_getter ~override_duration ~persist_override
     method private prepare_transition_source s =
       let s = (s :> source) in
       s#get_ready ~dynamic:true [(self :> source)];
-      Clock.unify source#clock s#clock;
+      Clock.unify ~pos:self#pos source#clock s#clock;
       transition_source <- Some s
 
     method cleanup_transition_source =
@@ -368,7 +368,7 @@ class cross val_source ~duration_getter ~override_duration ~persist_override
                 self#log#important "Not enough data for crossing.";
                 (new Sequence.sequence [before; after] :> source))
             in
-            Clock.unify compound#clock s#clock;
+            Clock.unify ~pos:self#pos compound#clock s#clock;
             Typing.(compound#frame_type <: self#frame_type);
             compound)
       in

--- a/src/core/operators/dyn_op.ml
+++ b/src/core/operators/dyn_op.ml
@@ -61,7 +61,7 @@ class dyn ~init ~track_sensitive ~infallible ~resurection_time f =
                | None -> ()
                | Some s ->
                    Typing.(s#frame_type <: self#frame_type);
-                   Clock.unify s#clock self#clock;
+                   Clock.unify ~pos:self#pos s#clock self#clock;
                    s#get_ready activation;
                    self#unregister_source ~already_locked:true;
                    source <- Some s))

--- a/src/core/operators/max_duration.ml
+++ b/src/core/operators/max_duration.ml
@@ -30,7 +30,7 @@ class max_duration ~override_meta ~duration source =
     val mutable remaining = duration
     val mutable s : Source.source = source
     method self_sync = source#self_sync
-    method! private set_clock = Clock.unify self#clock s#clock
+    method! private set_clock = Clock.unify ~pos:self#pos self#clock s#clock
 
     method! private wake_up activation =
       let activation = (self :> Source.operator) :: activation in

--- a/src/core/operators/switch.ml
+++ b/src/core/operators/switch.ml
@@ -210,7 +210,7 @@ class virtual switch ~name ~override_meta ~transition_length
                                   ~merge:true [s; new_source]
                         in
                         Typing.(s#frame_type <: self#frame_type);
-                        Clock.unify s#clock self#clock;
+                        Clock.unify ~pos:self#pos s#clock self#clock;
                         s#get_ready activation;
                         selected <- Some { child = c; effective_source = s })
                 | _ ->

--- a/src/core/outputs/alsa_out.ml
+++ b/src/core/outputs/alsa_out.ml
@@ -50,7 +50,7 @@ class output ~clock_safe ~infallible ~on_stop ~on_start ~start dev source =
     method! private set_clock =
       super#set_clock;
       if clock_safe then
-        Clock.unify self#clock
+        Clock.unify ~pos:self#pos self#clock
           (Clock.create_known (Alsa_settings.get_clock () :> Source.clock))
 
     val mutable device = None

--- a/src/core/outputs/ao_out.ml
+++ b/src/core/outputs/ao_out.ml
@@ -55,7 +55,7 @@ class output ~clock_safe ~nb_blocks ~driver ~infallible ~on_start ~on_stop
     method! private set_clock =
       super#set_clock;
       if clock_safe then
-        Clock.unify self#clock
+        Clock.unify ~pos:self#pos self#clock
           (Clock.create_known (get_clock () :> Source.clock))
 
     val mutable device = None

--- a/src/core/outputs/bjack_out.ml
+++ b/src/core/outputs/bjack_out.ml
@@ -51,7 +51,7 @@ class output ~clock_safe ~infallible ~on_stop ~on_start ~nb_blocks ~server
     method! private set_clock =
       super#set_clock;
       if clock_safe then
-        Clock.unify self#clock
+        Clock.unify ~pos:self#pos self#clock
           (Clock.create_known (Bjack_in.bjack_clock () :> Source.clock))
 
     val mutable device = None

--- a/src/core/source.ml
+++ b/src/core/source.ml
@@ -20,6 +20,8 @@
 
  *****************************************************************************)
 
+open Liquidsoap_lang.Error
+
 (** In this module we define the central streaming concepts: sources, active
     sources and clocks.
 
@@ -184,36 +186,34 @@ let var_eq a b =
     | Known a, Known b -> a = b
     | _, _ -> false
 
-exception Clock_conflict of string * string
-exception Clock_loop of string * string
-
 let rec sub_clocks = function
   | Known c -> c#sub_clocks
   | Link { contents = Unknown { sub_clocks } } -> sub_clocks
   | Link { contents = Same_as x } -> sub_clocks x
 
-let occurs_check x y =
+let occurs_check ~pos x y =
   let rec aux = function
     | [] -> ()
     | [] :: tl -> aux tl
     | (x' :: clocks) :: tl ->
         if var_eq x x' then
-          raise (Clock_loop (variable_to_string x, variable_to_string y));
+          raise (Clock_loop (pos, variable_to_string x, variable_to_string y));
         aux (sub_clocks x' :: clocks :: tl)
   in
   aux [sub_clocks y]
 
-let occurs_check x y =
-  occurs_check x y;
-  occurs_check y x
+let occurs_check ~pos x y =
+  occurs_check ~pos x y;
+  occurs_check ~pos y x
 
-let rec unify a b =
+let rec unify ~pos a b =
   match (a, b) with
-    | Link { contents = Same_as a }, _ -> unify a b
-    | _, Link { contents = Same_as b } -> unify a b
+    | Link { contents = Same_as a }, _ -> unify ~pos a b
+    | _, Link { contents = Same_as b } -> unify ~pos a b
     | Known s, Known s' ->
         if s <> s' then
-          raise (Clock_conflict (variable_to_string a, variable_to_string b))
+          raise
+            (Clock_conflict (pos, variable_to_string a, variable_to_string b))
     | Link ra, Link rb when ra == rb -> ()
     | ( Link
           ({ contents = Unknown { start; sources = sa; sub_clocks = ca } } as
@@ -229,9 +229,10 @@ let rec unify a b =
             | Some v, Some v' when v = v' -> Some v
             | _ ->
                 raise
-                  (Clock_conflict (variable_to_string a, variable_to_string b))
+                  (Clock_conflict
+                     (pos, variable_to_string a, variable_to_string b))
         in
-        occurs_check a b;
+        occurs_check ~pos a b;
         let merge =
           let s = List.sort_uniq Stdlib.compare (List.rev_append sa sb) in
           let sc = List.sort_uniq Stdlib.compare (List.rev_append ca cb) in
@@ -247,8 +248,9 @@ let rec unify a b =
           ({ contents = Unknown { start; sources = s; sub_clocks = sc } } as r),
         Known c ) ->
         if start <> None && c#start <> Option.get start then
-          raise (Clock_conflict (variable_to_string a, variable_to_string b));
-        occurs_check (Known c) (Link r);
+          raise
+            (Clock_conflict (pos, variable_to_string a, variable_to_string b));
+        occurs_check ~pos (Known c) (Link r);
         List.iter c#attach s;
         List.iter c#attach_clock sc;
         r := Same_as (Known c)
@@ -306,7 +308,7 @@ let add_new_output, iterate_new_outputs =
         List.iter f !l;
         l := []) )
 
-class virtual operator ?(name = "src") sources =
+class virtual operator ?pos ?(name = "src") sources =
   let frame_type = Type.var () in
   object (self)
     (** Monitoring *)
@@ -314,6 +316,9 @@ class virtual operator ?(name = "src") sources =
 
     method add_watcher w = watchers <- w :: watchers
     method private iter_watchers fn = List.iter fn watchers
+    val mutable pos : Pos.Option.t = pos
+    method pos = pos
+    method set_pos p = pos <- p
 
     (** Logging and identification *)
 
@@ -374,7 +379,7 @@ class virtual operator ?(name = "src") sources =
     method virtual self_sync : self_sync
 
     method private set_clock =
-      List.iter (fun s -> unify self#clock s#clock) sources
+      List.iter (fun s -> unify ~pos self#clock s#clock) sources
 
     initializer self#set_clock
 
@@ -788,15 +793,15 @@ class virtual operator ?(name = "src") sources =
   end
 
 (** Entry-point sources, which need to actively perform some task. *)
-and virtual active_operator ?name sources =
+and virtual active_operator ?pos ?name sources =
   object (self)
-    inherit operator ?name sources
+    inherit operator ?pos ?name sources
 
     initializer
       has_outputs := true;
       add_new_output (self :> active_operator);
       ignore
-        (unify self#clock
+        (unify ~pos:self#pos self#clock
            (create_unknown
               ~sources:[(self :> active_operator)]
               ~sub_clocks:[] ()))
@@ -812,14 +817,14 @@ and virtual active_operator ?name sources =
 
 (** Shortcuts for defining sources with no children *)
 
-and virtual source ?name () =
+and virtual source ?pos ?name () =
   object
-    inherit operator ?name []
+    inherit operator ?pos ?name []
   end
 
-class virtual active_source ?name () =
+class virtual active_source ?pos ?name () =
   object
-    inherit active_operator ?name []
+    inherit active_operator ?pos ?name []
   end
 
 class virtual no_seek =

--- a/src/core/source.mli
+++ b/src/core/source.mli
@@ -74,7 +74,8 @@ type watcher = {
 
 (** The [source] use is to send data frames through the [get] method. *)
 class virtual source :
-  ?name:string
+  ?pos:Pos.t
+  -> ?name:string
   -> unit
   -> object
        method private mutexify : 'a 'b. ('a -> 'b) -> 'a -> 'b
@@ -86,6 +87,11 @@ class virtual source :
 
        method set_name : string -> unit
        method set_id : ?definitive:bool -> string -> unit
+
+       (** Position in script *)
+       method pos : Pos.Option.t
+
+       method set_pos : Pos.Option.t -> unit
 
        (* {1 Liveness type}
           [stype] is the liveness type, telling whether a scheduler is
@@ -228,7 +234,8 @@ class virtual source :
 
 (* Entry-points sources, which need to actively perform some task. *)
 and virtual active_source :
-  ?name:string
+  ?pos:Pos.t
+  -> ?name:string
   -> unit
   -> object
        inherit source
@@ -242,7 +249,8 @@ and virtual active_source :
 
 (* This is for defining a source which has children *)
 class virtual operator :
-  ?name:string
+  ?pos:Pos.t
+  -> ?name:string
   -> source list
   -> object
        inherit source
@@ -251,7 +259,8 @@ class virtual operator :
 (* Most usual active source: the active_operator, pulling one source's data
  * and outputting it. *)
 class virtual active_operator :
-  ?name:string
+  ?pos:Pos.t
+  -> ?name:string
   -> source list
   -> object
        inherit active_source
@@ -306,9 +315,6 @@ class type clock =
     method end_tick : unit
   end
 
-exception Clock_conflict of string * string
-exception Clock_loop of string * string
-
 module Clock_variables : sig
   val to_string : clock_variable -> string
 
@@ -320,7 +326,7 @@ module Clock_variables : sig
     clock_variable
 
   val create_known : clock -> clock_variable
-  val unify : clock_variable -> clock_variable -> unit
+  val unify : pos:Pos.Option.t -> clock_variable -> clock_variable -> unit
   val forget : clock_variable -> clock_variable -> unit
   val get : clock_variable -> clock
   val is_known : clock_variable -> bool

--- a/src/core/tools/child_support.ml
+++ b/src/core/tools/child_support.ml
@@ -56,14 +56,17 @@ class virtual base ?(create_known_clock = true) ~check_self_sync children_val =
     method virtual id : string
     method virtual clock : Source.clock_variable
     method private child_clock = Option.get child_clock
+    method virtual pos : Pos.Option.t
 
     method private set_clock =
       child_clock <- Some (create_child_clock self#id);
 
-      Clock.unify self#clock
+      Clock.unify ~pos:self#pos self#clock
         (Clock.create_unknown ~sources:[] ~sub_clocks:[self#child_clock] ());
 
-      List.iter (fun c -> Clock.unify self#child_clock c#clock) children;
+      List.iter
+        (fun c -> Clock.unify ~pos:c#pos self#child_clock c#clock)
+        children;
 
       Gc.finalise (finalise_child_clock self#child_clock) self
 

--- a/src/core/tools/producer_consumer.ml
+++ b/src/core/tools/producer_consumer.ml
@@ -65,11 +65,11 @@ class consumer ?(always_enabled = false) ~write_frame ~name ~source () =
 (** The source which produces data by reading the buffer.
     We do NOT want to use [operator] here b/c the [consumers]
     may have different content-kind when this is used in the muxers. *)
-class producer ?create_known_clock ~check_self_sync ~consumers ~name () =
+class producer ?pos ?create_known_clock ~check_self_sync ~consumers ~name () =
   let infallible = List.for_all (fun s -> s#stype = `Infallible) consumers in
   let self_sync_type = Utils.self_sync_type consumers in
   object (self)
-    inherit Source.source ~name () as super
+    inherit Source.source ?pos ~name () as super
 
     inherit!
       Child_support.base

--- a/src/core/tools/start_stop.ml
+++ b/src/core/tools/start_stop.ml
@@ -92,7 +92,7 @@ class virtual active_source ?get_clock ~name ~clock_safe
     method! private set_clock =
       super#set_clock;
       if clock_safe then
-        Clock.unify self#clock
+        Clock.unify ~pos:self#pos self#clock
           (Clock.create_known (self#get_clock :> Source.clock))
 
     method virtual private get_frame : Frame.t -> unit

--- a/src/libs/replaygain.liq
+++ b/src/libs/replaygain.liq
@@ -27,8 +27,9 @@ end
 
 # Compute the ReplayGain for a file (in dB).
 # @category File
+# @param ~ratio Decoding ratio. A value of `50` means try to decode the file `50x` faster than real time, if possible. Use this setting to lower CPU peaks when computing replaygain tags.
 # @param fname File name.
-def file.replaygain(~id=null(), fname)
+def file.replaygain(~id=null(), ~ratio=50., fname)
   id = string.id.default(default="file.replaygain", id)
   try
     meta = file.metadata(exclude=["replaygain_track_gain"], fname)
@@ -43,7 +44,7 @@ def file.replaygain(~id=null(), fname)
       log.important(label=id, "Computing replay gain for #{string.quote(fname)}")
       t = time()
       s = source.replaygain.compute(request.once(r))
-      source.drop(s)
+      source.drop(ratio=ratio, s)
       gain = s.gain()
       log.important(label=id, "Computed replay gain #{gain} dB for #{string.quote(fname)} (time: #{time() - t} s).")
       gain
@@ -57,8 +58,9 @@ end
 # decoded by Liquidsoap and add a `replaygain_track_gain` metadata when this
 # value could be computed. For a finer-grained replay gain processing, use the
 # `replaygain:` protocol.
+# @param ~ratio Decoding ratio. A value of `50.` means try to decode the file `50x` faster than real time, if possible. Use this setting to lower CPU peaks when computing replaygain tags.
 # @category Liquidsoap
-def enable_replaygain_metadata()
+def enable_replaygain_metadata(~ratio=50.)
   def replaygain_metadata(~metadata=_, fname)
     meta = file.metadata(exclude=["replaygain_track_gain"], fname)
     replaygain_meta = meta["replaygain_track_gain"]
@@ -66,7 +68,7 @@ def enable_replaygain_metadata()
       log.important(label="decoder.replaygain.metadata", "Detected replaygain metadata #{replaygain_meta} for #{string.quote(fname)}")
       [("replaygain_track_gain", replaygain_meta)]
     else
-      gain = file.replaygain(fname)
+      gain = file.replaygain(ratio=ratio, fname)
       if null.defined(gain) then
         [("replaygain_track_gain","#{null.get(gain)} dB")]
       else

--- a/tests/core/output_test.ml
+++ b/tests/core/output_test.ml
@@ -30,7 +30,7 @@ let () =
   let failed = new failed in
   let o = new dummy ~on_start ~autostart:true failed in
   let clock = Clock.clock ~start:false "source" in
-  Clock.unify o#clock (Clock.create_known clock);
+  Clock.unify ~pos:o#pos o#clock (Clock.create_known clock);
   assert (not o#is_ready);
   o#content_type_computation_allowed;
   o#test_wake_up;

--- a/tests/core/source_test.ml
+++ b/tests/core/source_test.ml
@@ -8,9 +8,9 @@ let () =
   let c3 = create_unknown ~sources:[] ~sub_clocks:[c1] () in
   (* Make sure unification of a variable with itself
      works as expected. *)
-  unify c2 c2;
+  unify ~pos:None c2 c2;
   assert (subclocks c2 = [c1]);
   (* Make sure subclocks don't get duplicated during inification. *)
-  unify c2 c3;
+  unify ~pos:None c2 c3;
   assert (subclocks c2 = [c1]);
   assert (subclocks c3 = [c1])


### PR DESCRIPTION
Remove duplicate clock exceptions, attach position to sources and tracks, use them to raise positions-aware language specific exceptions.

~~This PR also brings back the `v2.1.4` clock restrictions on ffmeg inline encoders and decoders following #3309~~
Edit: there still are problems with bringing that back because of muxing. I need a closer look at it.