### PR TITLE
Move ifdef and co to parsed/reduced terms.

### DIFF
--- a/src/lang/dune
+++ b/src/lang/dune
@@ -18,8 +18,6 @@
   --unused-token
   DOTVAR
   --unused-token
-  PP_DEFINE
-  --unused-token
   PP_ELSE
   --unused-token
   PP_ENDIF

--- a/src/lang/lexer.ml
+++ b/src/lang/lexer.ml
@@ -161,12 +161,12 @@ let rec token lexbuf =
         let matched = Sedlexing.Utf8.lexeme lexbuf in
         let n = String.indexp_from matched 6 (fun c -> c <> ' ') in
         let r = String.rindexp matched (fun c -> c <> ' ') in
-        PP_IFDEF (String.sub matched n (r - n + 1))
+        PP_IFDEF (false, String.sub matched n (r - n + 1))
     | "%ifndef", Plus white_space, var, Star ("" | '.', var) ->
         let matched = Sedlexing.Utf8.lexeme lexbuf in
         let n = String.indexp_from matched 7 (fun c -> c <> ' ') in
         let r = String.rindexp matched (fun c -> c <> ' ') in
-        PP_IFNDEF (String.sub matched n (r - n + 1))
+        PP_IFDEF (true, String.sub matched n (r - n + 1))
     | ( "%ifversion",
         Plus white_space,
         ("==" | ">=" | "<=" | "<" | ">"),
@@ -188,9 +188,9 @@ let rec token lexbuf =
             | ">" -> `Gt
             | _ -> assert false
         in
-        PP_IFVERSION (cmp, ver)
-    | "%ifencoder" -> PP_IFENCODER
-    | "%ifnencoder" -> PP_IFNENCODER
+        PP_IFVERSION (cmp, Lang_string.Version.of_string ver)
+    | "%ifencoder" -> PP_IFENCODER false
+    | "%ifnencoder" -> PP_IFENCODER true
     | "%else" -> PP_ELSE
     | "%endif" -> PP_ENDIF
     | "%include_extra", Star (white_space | '\t'), '"', Star (Compl '"'), '"' ->

--- a/src/lang/term/parsed_term.ml
+++ b/src/lang/term/parsed_term.ml
@@ -105,6 +105,27 @@ and fun_arg =
 
 and list_el = [ `Term of t | `Ellipsis of t ]
 
+and if_def = {
+  if_def_negative : bool;
+  if_def_condition : string;
+  if_def_then : t;
+  if_def_else : t option;
+}
+
+and if_version = {
+  if_version_op : [ `Eq | `Geq | `Leq | `Gt | `Lt ];
+  if_version_version : Lang_string.Version.t;
+  if_version_then : t;
+  if_version_else : t option;
+}
+
+and if_encoder = {
+  if_encoder_negative : bool;
+  if_encoder_condition : string;
+  if_encoder_then : t;
+  if_encoder_else : t option;
+}
+
 and time_el = {
   week : int option;
   hours : int option;
@@ -116,6 +137,9 @@ and time_el = {
 and parsed_ast =
   [ `If of _if
   | `Inline_if of _if
+  | `If_def of if_def
+  | `If_version of if_version
+  | `If_encoder of if_encoder
   | `While of _while
   | `For of _for
   | `Iterable_for of iterable_for
@@ -161,6 +185,15 @@ let rec iter_term fn ({ term; methods } as tm) =
         iter_term fn p.if_condition;
         iter_term fn p.if_then;
         iter_term fn p.if_else
+    | `If_def { if_def_then; if_def_else } -> (
+        iter_term fn if_def_then;
+        match if_def_else with None -> () | Some term -> iter_term fn term)
+    | `If_version { if_version_then; if_version_else } -> (
+        iter_term fn if_version_then;
+        match if_version_else with None -> () | Some term -> iter_term fn term)
+    | `If_encoder { if_encoder_then; if_encoder_else } -> (
+        iter_term fn if_encoder_then;
+        match if_encoder_else with None -> () | Some term -> iter_term fn term)
     | `While { while_condition; while_loop } ->
         iter_term fn while_condition;
         iter_term fn while_loop

--- a/src/libs/playlist.liq
+++ b/src/libs/playlist.liq
@@ -93,8 +93,8 @@ let stdlib_native = native
 # @method remaining_files Songs remaining to be played.
 def playlist.list(~id=null(), ~check_next=null(), ~prefetch=1, ~loop=true,
                   ~mode="normal", ~native=false, ~on_loop={()}, ~on_done={()}, ~max_fail=10, ~on_fail=null(), ~timeout=20., playlist)
-  id = string.id.default(default="playlist.list", id)
   ignore(native)
+  id = string.id.default(default="playlist.list", id)
   mode =
     if not list.mem(mode, ["normal", "random", "randomize"]) then
       log.severe(label=id, "Invalid mode: #{mode}"); "randomize"
@@ -136,16 +136,17 @@ def playlist.list(~id=null(), ~check_next=null(), ~prefetch=1, ~loop=true,
   end
 
   # Instantiate the source
+  default = request.dynamic(id=id, prefetch=prefetch, timeout=timeout, retry_delay=1., available={not has_stopped()}, next)
   s =
 %ifdef native
     if native then
       stdlib_native.request.dynamic(id=id, next)
     else
-%else
-    begin
-%endif
-      request.dynamic(id=id, prefetch=prefetch, timeout=timeout, retry_delay=1., available={not has_stopped()}, next)
+      default
     end
+%else
+    default
+%endif
   source.set_name(s, "playlist.list.reloadable")
 
   # The reload function

--- a/src/libs/request.liq
+++ b/src/libs/request.liq
@@ -8,15 +8,16 @@ let stdlib_native = native
 # @param ~native Use native implementation, when available.
 def replaces request.dynamic(%argsof(request.dynamic), ~native=false, f) =
   ignore(native)
+  default = request.dynamic(%argsof(request.dynamic), f)
 %ifdef native
   if native then
     stdlib_native.request.dynamic(%argsof(request.dynamic), f)
   else
-%else
-  begin
-%endif
-    request.dynamic(%argsof(request.dynamic), f)
+    default
   end
+%else
+  default
+%endif
 end
 
 # Play a queue of requests (the first added request gets played first).
@@ -31,8 +32,8 @@ end
 # @method push Push a request on the request queue.
 # @method length Length of the queue.
 def request.queue(~id=null(), ~interactive=true, ~prefetch=1, ~native=false, ~queue=[], ~timeout=20.)
-  id = string.id.default(default="request.queue", id)
   ignore(native)
+  id = string.id.default(default="request.queue", id)
   queue = ref(queue)
   fetch = ref(fun () -> true)
   def next() =
@@ -54,16 +55,17 @@ def request.queue(~id=null(), ~interactive=true, ~prefetch=1, ~native=false, ~qu
     r = request.create(uri)
     push(r)
   end
+  default = request.dynamic(id=id, prefetch=prefetch, timeout=timeout, available={not list.is_empty(queue())}, next)
   s =
 %ifdef native
     if native then
       stdlib_native.request.dynamic(id=id, timeout=timeout, next)
     else
-%else
-    begin
-%endif
-      request.dynamic(id=id, prefetch=prefetch, timeout=timeout, available={not list.is_empty(queue())}, next)
+      default
     end
+%else
+    default
+%endif
   source.set_name(s, "request.queue")
   fetch := s.fetch
   if interactive then

--- a/src/tooling/parsed_json.ml
+++ b/src/tooling/parsed_json.ml
@@ -44,6 +44,45 @@ let json_of_if ~to_json { if_condition; if_then; if_else } =
     ("else", to_json if_else);
   ]
 
+let json_of_if_def ~to_json
+    { if_def_negative; if_def_condition; if_def_then; if_def_else } =
+  [
+    ("negative", `Bool if_def_negative);
+    ("condition", `String if_def_condition);
+    ("then", to_json if_def_then);
+    ("else", match if_def_else with None -> `Null | Some t -> to_json t);
+  ]
+
+let json_of_if_encoder ~to_json
+    {
+      if_encoder_negative;
+      if_encoder_condition;
+      if_encoder_then;
+      if_encoder_else;
+    } =
+  [
+    ("negative", `Bool if_encoder_negative);
+    ("condition", `String if_encoder_condition);
+    ("then", to_json if_encoder_then);
+    ("else", match if_encoder_else with None -> `Null | Some t -> to_json t);
+  ]
+
+let json_of_if_version ~to_json
+    { if_version_op; if_version_version; if_version_then; if_version_else } =
+  [
+    ( "opt",
+      `String
+        (match if_version_op with
+          | `Eq -> "="
+          | `Geq -> ">="
+          | `Leq -> "<="
+          | `Gt -> ">"
+          | `Lt -> "<") );
+    ("version", `String (Lang_string.Version.str if_version_version));
+    ("then", to_json if_version_then);
+    ("else", match if_version_else with None -> `Null | Some t -> to_json t);
+  ]
+
 let json_of_while ~to_json { while_condition; while_loop } =
   [("condition", to_json while_condition); ("loop", to_json while_loop)]
 
@@ -287,6 +326,9 @@ let rec to_ast_json = function
       ast_node ~typ:"set" [("left", to_json t); ("right", to_json t')]
   | `Inline_if p -> ast_node ~typ:"inline_if" (json_of_if ~to_json p)
   | `If p -> ast_node ~typ:"if" (json_of_if ~to_json p)
+  | `If_def p -> ast_node ~typ:"if_def" (json_of_if_def ~to_json p)
+  | `If_version p -> ast_node ~typ:"if_version" (json_of_if_version ~to_json p)
+  | `If_encoder p -> ast_node ~typ:"if_encoder" (json_of_if_encoder ~to_json p)
   | `While p -> ast_node ~typ:"while" (json_of_while ~to_json p)
   | `For p -> ast_node ~typ:"for" (json_of_for ~to_json p)
   | `Iterable_for p ->

--- a/tests/language/eval.liq
+++ b/tests/language/eval.liq
@@ -30,10 +30,6 @@ def f() =
   echo(l["dix"])
   t("11",{ 2 == list.length(r//.split(l["blo"])) })
 
-%ifdef foobarbaz
-  if = if is not a well-formed expression, and we do not care...
-%endif
-
   echo("1#{1+1}")
   echo(string(int_of_float(float_of_string(default=13.,"blah"))))
 


### PR DESCRIPTION
This PR completes the transition to fully syntactic terms by moving `%ifdef`, `%ifencoder` and `%ifversion` to parsed/reduced terms!