### PR TITLE
Make sure all encoded data is flushed in pipe-based outputs.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@ Changed:
 - Bumped internal ogg decoder to make sure that it is used over the ffmpeg decoder whenever possible.
   FFmpeg has issues with metadata in chained streams which needs to be fixed upstream. Unfortunately,
   `input.http` can only use the ffmpeg decoder at the moment.
+- Cleanup `output.file` encoding and file handling logic (#3328)
 
 Fixed:
 
@@ -26,6 +27,7 @@ Fixed:
 - Remove use of `stereo:` protocol in `say:` protocol:
   this is now handled automatically by the decoder and generates latency via
   high CPU usage peak.
+- Fixed `output.file` reopening with flac encoding (#3328)
 
 ---
 

--- a/src/core/outputs/pipe_output.ml
+++ b/src/core/outputs/pipe_output.ml
@@ -53,11 +53,13 @@ class virtual base ~source ~name p =
 
     val mutable encoder = None
     val mutable current_metadata = None
+    method virtual start : unit
+    method virtual stop : unit
 
     method virtual private encoder_factory
         : string -> Export_metadata.metadata -> Encoder.encoder
 
-    method start =
+    method create_encoder =
       let enc = self#encoder_factory self#id in
       let meta =
         match current_metadata with
@@ -68,24 +70,28 @@ class virtual base ~source ~name p =
 
     (* Make sure to call stop on the encoder to close any open
        connection. *)
-    method stop =
+    method close_encoder =
       match encoder with
-        | None -> ()
+        | None -> Strings.empty
         | Some enc ->
-            (try ignore (enc.Encoder.stop ()) with _ -> ());
-            encoder <- None
+            let flushed = try enc.Encoder.stop () with _ -> Strings.empty in
+            encoder <- None;
+            flushed
 
     method! reset = ()
 
     method encode frame ofs len =
-      let enc = Option.get encoder in
-      enc.Encoder.encode frame ofs len
+      match encoder with
+        | None -> Strings.empty
+        | Some encoder -> encoder.Encoder.encode frame ofs len
 
     method virtual write_pipe : string -> int -> int -> unit
     method send b = Strings.iter self#write_pipe b
 
     method insert_metadata m =
-      ignore (Option.map (fun e -> e.Encoder.insert_metadata m) encoder)
+      match encoder with
+        | None -> ()
+        | Some encoder -> encoder.Encoder.insert_metadata m
   end
 
 (** url output: discard encoded data, try to restart on encoding error (can be
@@ -147,54 +153,49 @@ class url_output p =
   let self_sync = Lang.to_bool (List.assoc "self_sync" p) in
   let name = "output.url" in
   object (self)
-    inherit base p ~source ~name as super
+    inherit base p ~source ~name as base
     method private encoder_factory = encoder_factory ~format format_val
     val mutable restart_time = 0.
+    method can_connect = restart_time <= Unix.gettimeofday ()
 
-    method! start =
+    method on_error ~bt exn =
+      (try ignore self#close_encoder with _ -> ());
+      Utils.log_exception ~log:self#log
+        ~bt:(Printexc.raw_backtrace_to_string bt)
+        (Printf.sprintf "Error while connecting: %s" (Printexc.to_string exn));
+      on_error ~bt exn;
+      match restart_delay with
+        | None -> Printexc.raise_with_backtrace exn bt
+        | Some delay ->
+            restart_time <- Unix.gettimeofday () +. delay;
+            self#log#important "Will try again in %.02f seconds." delay
+
+    method connect =
       match encoder with
-        | None when restart_time <= Unix.gettimeofday () -> (
+        | None when self#can_connect -> (
             try
-              super#start;
+              self#create_encoder;
               on_start ()
-            with exn -> (
+            with exn ->
               let bt = Printexc.get_raw_backtrace () in
-              Utils.log_exception ~log:self#log
-                ~bt:(Printexc.raw_backtrace_to_string bt)
-                (Printf.sprintf "Error while connecting: %s"
-                   (Printexc.to_string exn));
-              on_error ~bt exn;
-              match restart_delay with
-                | None -> Printexc.raise_with_backtrace exn bt
-                | Some delay ->
-                    restart_time <- Unix.gettimeofday () +. delay;
-                    self#log#important "Will try again in %.02f seconds." delay)
-            )
+              self#on_error ~bt exn)
         | _ -> ()
+
+    method start = self#connect
+    method stop = ignore self#close_encoder
 
     method! encode frame ofs len =
       try
         match encoder with
-          | None when restart_time <= Unix.gettimeofday () ->
-              super#start;
-              on_start ();
-              super#encode frame ofs len
+          | None when self#can_connect ->
+              self#connect;
+              base#encode frame ofs len
           | None -> Strings.empty
-          | Some _ -> super#encode frame ofs len
-      with exn -> (
+          | Some _ -> base#encode frame ofs len
+      with exn ->
         let bt = Printexc.get_raw_backtrace () in
-        Utils.log_exception ~log:self#log
-          ~bt:(Printexc.raw_backtrace_to_string bt)
-          (Printf.sprintf "Error while encoding data: %s"
-             (Printexc.to_string exn));
-        on_error ~bt exn;
-        match restart_delay with
-          | None -> Printexc.raise_with_backtrace exn bt
-          | Some delay ->
-              self#stop;
-              restart_time <- Unix.gettimeofday () +. delay;
-              self#log#important "Will try again in %.02f seconds." delay;
-              Strings.empty)
+        self#on_error ~bt exn;
+        Strings.empty
 
     method write_pipe _ _ _ = ()
     method! self_sync = (`Static, self_sync)
@@ -303,7 +304,7 @@ class virtual piped_output ~name p =
   let on_reopen = List.assoc "on_reopen" p in
   let on_reopen () = ignore (Lang.apply on_reopen []) in
   object (self)
-    inherit base ~source ~name p as super
+    inherit base ~source ~name p as base
     val mutable open_date = 0.
     val need_reopen = Atomic.make false
     method need_reopen = Atomic.set need_reopen true
@@ -323,25 +324,20 @@ class virtual piped_output ~name p =
     method prepare_pipe =
       self#open_pipe;
       open_date <- Unix.gettimeofday ();
-      Atomic.set need_reopen false
+      Atomic.set need_reopen false;
+      self#create_encoder
 
-    method private close_encoder =
-      match encoder with
-        | None -> ()
-        | Some encoder ->
-            let flush = encoder.Encoder.stop () in
-            super#send flush
-
-    method! stop =
+    method cleanup_pipe =
       if self#is_open then (
-        self#close_encoder;
-        self#close_pipe);
-      super#stop
+        base#send self#close_encoder;
+        self#close_pipe)
+
+    method start = self#prepare_pipe
+    method stop = self#cleanup_pipe
 
     method reopen =
       self#log#important "Re-opening output pipe.";
-      self#close_encoder;
-      self#close_pipe;
+      self#cleanup_pipe;
       self#prepare_pipe;
       on_reopen ()
 
@@ -357,13 +353,10 @@ class virtual piped_output ~name p =
               (Printexc.to_string exn) reopen_delay
 
     method! output =
-      try super#output
+      try base#output
       with exn ->
         let bt = Printexc.get_raw_backtrace () in
-        (try
-           self#close_encoder;
-           self#close_pipe
-         with _ -> ());
+        (try self#cleanup_pipe with _ -> ());
         self#reopen_on_error ~bt exn
 
     method! send b =
@@ -377,12 +370,12 @@ class virtual piped_output ~name p =
             Atomic.set need_reopen true;
             open_date <- Unix.gettimeofday ()
         | _ -> ());
-      if self#is_open then super#send b
+      if self#is_open then base#send b
 
     method! insert_metadata metadata =
       if reopen_on_metadata (Export_metadata.to_metadata metadata) then
         self#reopen;
-      super#insert_metadata metadata
+      base#insert_metadata metadata
   end
 
 (** Out channel virtual class: takes care of current out channel and writing to
@@ -477,7 +470,8 @@ class virtual ['a] file_output_base p =
     method close_chan fd =
       try
         self#close_out fd;
-        self#on_close (Option.get (Atomic.get current_filename));
+        (try self#on_close (Option.get (Atomic.get current_filename))
+         with _ -> ());
         Atomic.set current_filename None
       with Sys_error _ as exn ->
         let bt = Printexc.get_raw_backtrace () in
@@ -506,9 +500,11 @@ class file_output ~format_val p =
 class file_output_using_encoder ~format_val p =
   let format = Lang.to_format format_val in
   let append = Lang.to_bool (List.assoc "append" p) in
+  let on_close = List.assoc "on_close" p in
+  let on_close s = Lang.to_unit (Lang.apply on_close [("", Lang.string s)]) in
   let p = ("append", Lang.bool true) :: List.remove_assoc "append" p in
   object (self)
-    inherit piped_output ~name:"output.file" p
+    inherit piped_output ~name:"output.file" p as base
     inherit [unit] chan_output p
     inherit [unit] file_output_base p
 
@@ -520,9 +516,16 @@ class file_output_using_encoder ~format_val p =
     method encoder_factory name meta =
       (* Make sure the file is created with the right perms. *)
       let filename, mode, perm = self#prepare_filename in
+      Atomic.set current_filename (Some filename);
       self#open_out_gen mode perm filename;
       let format = Encoder.with_file_output ~append format filename in
       encoder_factory ~format format_val name meta
+
+    method! close_encoder =
+      let ret = base#close_encoder in
+      (try on_close (Option.get (Atomic.get current_filename)) with _ -> ());
+      Atomic.set current_filename None;
+      ret
 
     method output_substring () _ _ _ = ()
     method flush () = ()

--- a/tests/media/encoder.liq.in
+++ b/tests/media/encoder.liq.in
@@ -8,5 +8,5 @@ s = once(@SOURCE@(duration=0.5))
 #clock.assign_new(sync="none",[s])
 
 output.file(
-  fallible=true,on_stop=test.pass,
+  fallible=true,on_close=fun (_) -> test.pass(),
   @FORMAT@,file,s)

--- a/tests/media/ffmpeg_add_text.liq
+++ b/tests/media/ffmpeg_add_text.liq
@@ -26,9 +26,9 @@ s.on_track(on_track)
 
 #clock.assign_new(id='test_clock',sync='none',[s])
 
-def on_done () =
+def on_close(filename) =
   if !started then
-    ojson = process.read("ffprobe -v quiet -print_format json -show_streams #{process.quote(out)}")
+    ojson = process.read("ffprobe -v quiet -print_format json -show_streams #{process.quote(filename)}")
 
     output_format = json.parse(default=[("streams", [[("samplerate", "0")]])], ojson)
 
@@ -78,4 +78,4 @@ def on_done () =
   end
 end
 
-output.file(fallible=true, on_stop=on_done, %ffmpeg(format="mkv",%audio(codec="aac"),%video(codec="libx264")), out, s)
+output.file(fallible=true, on_close=on_close, %ffmpeg(format="mkv",%audio(codec="aac"),%video(codec="libx264")), out, s)

--- a/tests/media/ffmpeg_audio_decoder.liq
+++ b/tests/media/ffmpeg_audio_decoder.liq
@@ -15,9 +15,9 @@ s = sequence([s, s, once(s)])
 
 #clock.assign_new(sync='none',[s])
 
-def on_done () =
-  thread.run(delay=0.2, fun () -> begin
-    j = process.read("ffprobe -v quiet -print_format json -show_streams #{process.quote(out)}")
+def on_close(filename) =
+  if not test.done() then
+    j = process.read("ffprobe -v quiet -print_format json -show_streams #{process.quote(filename)}")
 
     let json.parse ( parsed: {
       streams: [{
@@ -33,7 +33,7 @@ def on_done () =
     else
       test.fail()
     end
-  end)
+  end
 end
 
-output.file(fallible=true, on_stop=on_done, %wav(mono), out, s)
+output.file(fallible=true, on_close=on_close, %wav(mono), out, s)

--- a/tests/media/ffmpeg_copy_and_encode_decoder.liq
+++ b/tests/media/ffmpeg_copy_and_encode_decoder.liq
@@ -14,32 +14,34 @@ s = once(s)
 
 #clock.assign_new(sync='none',[s])
 
-def on_done () =
-  j = process.read("ffprobe -v quiet -print_format json -show_streams #{process.quote(out)}")
+def on_close (filename) =
+  if not test.done() then
+    j = process.read("ffprobe -v quiet -print_format json -show_streams #{process.quote(filename)}")
 
-  let json.parse ( parsed : {
-    streams: [{
-      channel_layout: string?,
-      sample_rate: string?,
-      sample_fmt: string?,
-      codec_name: string?,
-      pix_fmt: string?
-    }]
-  }) = j
+    let json.parse ( parsed : {
+      streams: [{
+        channel_layout: string?,
+        sample_rate: string?,
+        sample_fmt: string?,
+        codec_name: string?,
+        pix_fmt: string?
+      }]
+    }) = j
 
-  video_stream = list.find((fun (stream) -> null.defined(stream.pix_fmt)), parsed.streams)
-  audio_stream = list.find((fun (stream) -> null.defined(stream.sample_rate)), parsed.streams)
+    video_stream = list.find((fun (stream) -> null.defined(stream.pix_fmt)), parsed.streams)
+    audio_stream = list.find((fun (stream) -> null.defined(stream.sample_rate)), parsed.streams)
 
-  if null.get(video_stream.codec_name) == "h264" and
-     null.get(video_stream.pix_fmt) == "yuv420p" and
-     null.get(audio_stream.channel_layout) == "stereo" and
-     null.get(audio_stream.codec_name) == "aac" and
-     null.get(audio_stream.sample_fmt) == "fltp" and
-     null.get(audio_stream.sample_rate) == "44100" then
-    test.pass()
-  else
-    test.fail()
+    if null.get(video_stream.codec_name) == "h264" and
+       null.get(video_stream.pix_fmt) == "yuv420p" and
+       null.get(audio_stream.channel_layout) == "stereo" and
+       null.get(audio_stream.codec_name) == "aac" and
+       null.get(audio_stream.sample_fmt) == "fltp" and
+       null.get(audio_stream.sample_rate) == "44100" then
+      test.pass()
+    else
+      test.fail()
+    end
   end
 end
 
-output.file(fallible=true, on_stop=on_done, %ffmpeg(format="mkv",%audio(codec="aac"),%video.copy), out, s)
+output.file(fallible=true, on_close=on_close, %ffmpeg(format="mkv",%audio(codec="aac"),%video.copy), out, s)

--- a/tests/media/ffmpeg_copy_concat.liq
+++ b/tests/media/ffmpeg_copy_concat.liq
@@ -8,26 +8,28 @@ s = sequence([s1,s2,s3,switch([])])
 
 #clock.assign_new(sync='none',[s])
 
-def on_done () =
-  ojson = process.read("ffprobe -v quiet -print_format json -show_streams #{process.quote(out)}")
+def on_close (filename) =
+  if not test.done() then
+    ojson = process.read("ffprobe -v quiet -print_format json -show_streams #{process.quote(filename)}")
 
-  let json.parse {
-    streams = [
-      {duration}
-    ]
-  } = ojson
+    let json.parse {
+      streams = [
+        {duration}
+      ]
+    } = ojson
 
-  # Actual time is 59.93..
-  if int(float_of_string(duration)) == 59 then
-    test.pass()
-  else
-    test.fail()
+    # Actual time is 59.93..
+    if int(float_of_string(duration)) == 59 then
+      test.pass()
+    else
+      test.fail()
+    end
   end
 end
 
 output.file(
   fallible=true,
-  on_stop=on_done,
+  on_close=on_close,
   %ffmpeg(%video.copy),
   out,
   s

--- a/tests/media/ffmpeg_copy_decoder.liq
+++ b/tests/media/ffmpeg_copy_decoder.liq
@@ -14,46 +14,48 @@ s = once(s)
 
 #clock.assign_new(sync='none',[s])
 
-def on_done () =
-  ijson = process.read("ffprobe -v quiet -print_format json -show_streams #{process.quote(fname)}")
-  ojson = process.read("ffprobe -v quiet -print_format json -show_streams #{process.quote(out)}")
+def on_close (encoded_fname) =
+  if not test.done() then
+    ijson = process.read("ffprobe -v quiet -print_format json -show_streams #{process.quote(fname)}")
+    ojson = process.read("ffprobe -v quiet -print_format json -show_streams #{process.quote(encoded_fname)}")
 
-  let json.parse ( iparsed : {
-    streams: [{
-      index: int,
-      channel_layout: string?,
-      sample_rate: string?,
-      sample_fmt: string?,
-      codec_type: string,
-      pix_fmt: string?
-    }]
-  }) = ijson
+    let json.parse ( iparsed : {
+      streams: [{
+        index: int,
+        channel_layout: string?,
+        sample_rate: string?,
+        sample_fmt: string?,
+        codec_type: string,
+        pix_fmt: string?
+      }]
+    }) = ijson
 
-  let json.parse ( oparsed : {
-    streams: [{
-      index: int,
-      channel_layout: string?,
-      sample_rate: string?,
-      sample_fmt: string?,
-      codec_type: string,
-      pix_fmt: string?
-    }]
-  }) = ojson
+    let json.parse ( oparsed : {
+      streams: [{
+        index: int,
+        channel_layout: string?,
+        sample_rate: string?,
+        sample_fmt: string?,
+        codec_type: string,
+        pix_fmt: string?
+      }]
+    }) = ojson
 
-  filter = fun(type, l) -> list.filter(fun (s) -> s.codec_type == type, l)
-  sort = fun (l) -> list.sort(fun (s1, s2) -> if s1.index < s2.index then -1 else 1 end, l)
+    filter = fun(type, l) -> list.filter(fun (s) -> s.codec_type == type, l)
+    sort = fun (l) -> list.sort(fun (s1, s2) -> if s1.index < s2.index then -1 else 1 end, l)
 
-  let [{index, ...iaudio}] = sort(filter("audio", iparsed.streams))
-  let [{index, ...ivideo}] = sort(filter("video", iparsed.streams))
+    let [{index, ...iaudio}] = sort(filter("audio", iparsed.streams))
+    let [{index, ...ivideo}] = sort(filter("video", iparsed.streams))
 
-  let [{index, ...oaudio}] = sort(filter("audio", oparsed.streams))
-  let [{index, ...ovideo}] = sort(filter("video", oparsed.streams))
+    let [{index, ...oaudio}] = sort(filter("audio", oparsed.streams))
+    let [{index, ...ovideo}] = sort(filter("video", oparsed.streams))
 
-  if iaudio == oaudio and ivideo == ovideo then
-    test.pass()
-  else
-    test.fail()
+    if iaudio == oaudio and ivideo == ovideo then
+      test.pass()
+    else
+      test.fail()
+    end
   end
 end
 
-output.file(fallible=true, on_stop=on_done, %ffmpeg(format="mkv",%audio.copy,%video.copy), out, s)
+output.file(fallible=true, on_close=on_close, %ffmpeg(format="mkv",%audio.copy,%video.copy), out, s)

--- a/tests/media/ffmpeg_filter.liq
+++ b/tests/media/ffmpeg_filter.liq
@@ -42,9 +42,9 @@ s.on_track(on_track)
 
 #clock.assign_new(id='test_clock',sync='none',[s])
 
-def on_done () =
-  if !started then
-    j = process.read("ffprobe -v quiet -print_format json -show_streams #{process.quote(out)}")
+def on_close (filename) =
+  if !started and not test.done() then
+    j = process.read("ffprobe -v quiet -print_format json -show_streams #{process.quote(filename)}")
 
     let json.parse ( parsed : {
       streams: [{
@@ -72,4 +72,4 @@ def on_done () =
   end
 end
 
-output.file(fallible=true, on_stop=on_done, %ffmpeg(format="mkv",%audio.raw(codec="aac"),%video.raw(codec="libx264")), out, s)
+output.file(fallible=true, on_close=on_close, %ffmpeg(format="mkv",%audio.raw(codec="aac"),%video.raw(codec="libx264")), out, s)

--- a/tests/media/ffmpeg_inline_encode_decode.liq
+++ b/tests/media/ffmpeg_inline_encode_decode.liq
@@ -16,7 +16,7 @@ s = once(blank(duration=10.))
 
 todo = ref(2)
 
-def on_done () =
+def on_close (_) =
   def check(out) =
     j = process.read("ffprobe -v quiet -print_format json -show_streams #{process.quote(out)}")
 
@@ -43,7 +43,7 @@ def on_done () =
 
   todo := !todo - 1
 
-  if !todo == 0 then
+  if not test.done() and !todo == 0 then
     if check(out_copy) and check(out_encode) then
       test.pass()
     else
@@ -63,7 +63,7 @@ s = ffmpeg.encode.audio_video(
 
 output.file(
   fallible=true,
-  on_stop=on_done,
+  on_close=on_close,
   %ffmpeg(
     %video.copy,
     %audio.copy,
@@ -78,7 +78,7 @@ s = ffmpeg.decode.audio_video(id="decoder", s)
 
 output.file(
   fallible=true,
-  on_stop=on_done,
+  on_close=on_close,
   %ffmpeg(
     %video(codec="libx264", b="5m"),
     %audio(codec="aac")

--- a/tests/media/ffmpeg_inline_encode_decode_audio.liq
+++ b/tests/media/ffmpeg_inline_encode_decode_audio.liq
@@ -16,7 +16,7 @@ s = once(blank(duration=10.))
 
 todo = ref(2)
 
-def on_done () =
+def on_close (_) =
   def check(out) =
     j = process.read("ffprobe -v quiet -print_format json -show_streams #{process.quote(out)}")
 
@@ -39,7 +39,7 @@ def on_done () =
 
   todo := !todo - 1
 
-  if !todo == 0 then
+  if not test.done() and !todo == 0 then
     if check(out_copy) and check(out_encode) then
       test.pass()
     else
@@ -57,7 +57,7 @@ s = ffmpeg.encode.audio(
 
 output.file(
   fallible=true,
-  on_stop=on_done,
+  on_close=on_close,
   %ffmpeg(
     %audio.copy,
   ),
@@ -71,7 +71,7 @@ s = ffmpeg.decode.audio(s)
 
 output.file(
   fallible=true,
-  on_stop=on_done,
+  on_close=on_close,
   %ffmpeg(
     %audio(codec="aac")
   ),

--- a/tests/media/ffmpeg_inline_encode_decode_video.liq
+++ b/tests/media/ffmpeg_inline_encode_decode_video.liq
@@ -18,34 +18,32 @@ s = source.mux.video(video=v, a)
 
 todo = ref(2)
 
-def on_done () =
-  thread.run(delay=1., fun () -> begin
-    def check(out) =
-      j = process.read("ffprobe -v quiet -print_format json -show_streams #{process.quote(out)}")
+def on_close (_) =
+  def check(out) =
+    j = process.read("ffprobe -v quiet -print_format json -show_streams #{process.quote(out)}")
 
-      let json.parse ( parsed : {
-        streams: [{
-          codec_name: string,
-          pix_fmt: string
-        }]
-      }) = j
+    let json.parse ( parsed : {
+      streams: [{
+        codec_name: string,
+        pix_fmt: string
+      }]
+    }) = j
 
-      let [stream] = parsed.streams
+    let [stream] = parsed.streams
 
-      stream.codec_name == "h264" and
-      stream.pix_fmt == "yuv420p"
+    stream.codec_name == "h264" and
+    stream.pix_fmt == "yuv420p"
+  end
+
+  todo := !todo - 1
+
+  if not test.done () and !todo == 0 then
+    if check(out_copy) and check(out_encode) then
+      test.pass()
+    else
+      test.fail()
     end
-
-    todo := !todo - 1
-
-    if !todo == 0 then
-      if check(out_copy) and check(out_encode) then
-        test.pass()
-      else
-        test.fail()
-      end
-    end
-  end)
+  end
 end
 
 s = ffmpeg.encode.video(
@@ -57,7 +55,7 @@ s = ffmpeg.encode.video(
 
 output.file(
   fallible=true,
-  on_stop=on_done,
+  on_close=on_close,
   %ffmpeg(
     %video.copy,
   ),
@@ -71,7 +69,7 @@ s = ffmpeg.decode.video(s)
 
 output.file(
   fallible=true,
-  on_stop=on_done,
+  on_close=on_close,
   %ffmpeg(
     %video(codec="libx264")
   ),

--- a/tests/media/ffmpeg_raw_and_copy_decoder.liq
+++ b/tests/media/ffmpeg_raw_and_copy_decoder.liq
@@ -14,46 +14,48 @@ s = once(s)
 
 #clock.assign_new(sync='none',[s])
 
-def on_done () =
-  ijson = process.read("ffprobe -v quiet -print_format json -show_streams #{process.quote(fname)}")
-  ojson = process.read("ffprobe -v quiet -print_format json -show_streams #{process.quote(out)}")
+def on_close (encoded_fname) =
+  if not test.done() then
+    ijson = process.read("ffprobe -v quiet -print_format json -show_streams #{process.quote(fname)}")
+    ojson = process.read("ffprobe -v quiet -print_format json -show_streams #{process.quote(encoded_fname)}")
 
-  let json.parse ( iparsed : {
-    streams: [{
-      index: int,
-      channel_layout: string?,
-      sample_rate: string?,
-      sample_fmt: string?,
-      codec_type: string,
-      pix_fmt: string?
-    }]
-  }) = ijson
+    let json.parse ( iparsed : {
+      streams: [{
+        index: int,
+        channel_layout: string?,
+        sample_rate: string?,
+        sample_fmt: string?,
+        codec_type: string,
+        pix_fmt: string?
+      }]
+    }) = ijson
 
-  let json.parse ( oparsed : {
-    streams: [{
-      index: int,
-      channel_layout: string?,
-      sample_rate: string?,
-      sample_fmt: string?,
-      codec_type: string,
-      pix_fmt: string?
-    }]
-  }) = ojson
+    let json.parse ( oparsed : {
+      streams: [{
+        index: int,
+        channel_layout: string?,
+        sample_rate: string?,
+        sample_fmt: string?,
+        codec_type: string,
+        pix_fmt: string?
+      }]
+    }) = ojson
 
-  filter = fun(type, l) -> list.filter(fun (s) -> s.codec_type == type, l)
-  sort = fun (l) -> list.sort(fun (s1, s2) -> if s1.index < s2.index then -1 else 1 end, l)
+    filter = fun(type, l) -> list.filter(fun (s) -> s.codec_type == type, l)
+    sort = fun (l) -> list.sort(fun (s1, s2) -> if s1.index < s2.index then -1 else 1 end, l)
 
-  let [{index, ...iaudio}] = sort(filter("audio", iparsed.streams))
-  let [{index, ...ivideo}] = sort(filter("video", iparsed.streams))
+    let [{index, ...iaudio}] = sort(filter("audio", iparsed.streams))
+    let [{index, ...ivideo}] = sort(filter("video", iparsed.streams))
 
-  let [{index, ...oaudio}] = sort(filter("audio", oparsed.streams))
-  let [{index, ...ovideo}] = sort(filter("video", oparsed.streams))
+    let [{index, ...oaudio}] = sort(filter("audio", oparsed.streams))
+    let [{index, ...ovideo}] = sort(filter("video", oparsed.streams))
 
-  if iaudio == oaudio and ivideo == ovideo then
-    test.pass()
-  else
-    test.fail()
+    if iaudio == oaudio and ivideo == ovideo then
+      test.pass()
+    else
+      test.fail()
+    end
   end
 end
 
-output.file(fallible=true, on_stop=on_done, %ffmpeg(format="mkv",%audio.copy,%video.raw(codec="libx264")), out, s)
+output.file(fallible=true, on_close=on_close, %ffmpeg(format="mkv",%audio.copy,%video.raw(codec="libx264")), out, s)

--- a/tests/media/ffmpeg_raw_and_encode_decoder.liq
+++ b/tests/media/ffmpeg_raw_and_encode_decoder.liq
@@ -1,6 +1,8 @@
 log.level.set(5)
 settings.decoder.decoders.set(["ffmpeg"])
 
+test.skip()
+
 fname = argv(default="",1)
 out = "#{fname}+ffmpeg_raw_and_encode_decoder.mp4"
 
@@ -14,9 +16,9 @@ s = sequence([s, s, once(s)])
 
 #clock.assign_new(sync='none',[s])
 
-def on_done () =
-  thread.run(delay=0.2, fun () -> begin
-    j = process.read("ffprobe -v quiet -print_format json -show_streams #{process.quote(out)}")
+def on_close (filename) =
+  if not test.done() then
+    j = process.read("ffprobe -v quiet -print_format json -show_streams #{process.quote(filename)}")
 
     let json.parse ( parsed : {
       streams: [{
@@ -41,7 +43,7 @@ def on_done () =
     else
       test.fail()
     end
-  end)
+  end
 end
 
-output.file(fallible=true, on_stop=on_done, %ffmpeg(format="mkv",%audio(codec="aac"),%video.raw(codec="libx264")), out, s)
+output.file(fallible=true, on_close=on_close, %ffmpeg(format="mkv",%audio(codec="aac"),%video.raw(codec="libx264")), out, s)

--- a/tests/media/ffmpeg_raw_decoder.liq
+++ b/tests/media/ffmpeg_raw_decoder.liq
@@ -14,32 +14,34 @@ s = once(s)
 
 #clock.assign_new(sync='none',[s])
 
-def on_done () =
-  ojson = process.read("ffprobe -v quiet -print_format json -show_streams #{process.quote(out)}")
+def on_close (filename) =
+  if not test.done() then
+    ojson = process.read("ffprobe -v quiet -print_format json -show_streams #{process.quote(filename)}")
 
-  let json.parse ( parsed : {
-    streams: [{
-      channel_layout: string?,
-      sample_rate: string?,
-      sample_fmt: string?,
-      codec_name: string?,
-      pix_fmt: string?
-    }]
-  }) = ojson
+    let json.parse ( parsed : {
+      streams: [{
+        channel_layout: string?,
+        sample_rate: string?,
+        sample_fmt: string?,
+        codec_name: string?,
+        pix_fmt: string?
+      }]
+    }) = ojson
 
-  video_stream = list.find((fun (stream) -> null.defined(stream.pix_fmt)), parsed.streams)
-  audio_stream = list.find((fun (stream) -> null.defined(stream.sample_rate)), parsed.streams)
+    video_stream = list.find((fun (stream) -> null.defined(stream.pix_fmt)), parsed.streams)
+    audio_stream = list.find((fun (stream) -> null.defined(stream.sample_rate)), parsed.streams)
 
-  if null.get(video_stream.codec_name) == "h264" and
-     null.get(video_stream.pix_fmt) == "yuv420p" and
-     null.get(audio_stream.channel_layout) == "stereo" and
-     null.get(audio_stream.codec_name) == "aac" and
-     null.get(audio_stream.sample_fmt) == "fltp" and
-     null.get(audio_stream.sample_rate) == "44100" then
-    test.pass()
-  else
-    test.fail()
+    if null.get(video_stream.codec_name) == "h264" and
+       null.get(video_stream.pix_fmt) == "yuv420p" and
+       null.get(audio_stream.channel_layout) == "stereo" and
+       null.get(audio_stream.codec_name) == "aac" and
+       null.get(audio_stream.sample_fmt) == "fltp" and
+       null.get(audio_stream.sample_rate) == "44100" then
+      test.pass()
+    else
+      test.fail()
+    end
   end
 end
 
-output.file(fallible=true, on_stop=on_done, %ffmpeg(format="mkv",%audio.raw(codec="aac"),%video.raw(codec="libx264")), out, s)
+output.file(fallible=true, on_close=on_close, %ffmpeg(format="mkv",%audio.raw(codec="aac"),%video.raw(codec="libx264")), out, s)

--- a/tests/media/ffmpeg_transparency_filter.liq
+++ b/tests/media/ffmpeg_transparency_filter.liq
@@ -37,8 +37,8 @@ s.on_track(on_track)
 
 #clock.assign_new(id='test_clock',sync='none',[s])
 
-def on_done () =
-  if !started then
+def on_close (_) =
+  if not test.done() and !started then
     j = process.read("ffprobe -v quiet -print_format json -show_streams #{process.quote(out)}")
 
     let json.parse ( parsed : {
@@ -74,6 +74,6 @@ encoder = %ffmpeg(
 
 output.file(
   encoder,
-  on_stop=on_done,
+  on_close=on_close,
   fallible=true,
   out, s)

--- a/tests/media/ffmpeg_video_decoder.liq
+++ b/tests/media/ffmpeg_video_decoder.liq
@@ -16,23 +16,25 @@ s = once(s)
 
 #clock.assign_new(sync='none',[s])
 
-def on_done () =
-  j = process.read("ffprobe -v quiet -print_format json -show_streams #{process.quote(out)}")
+def on_close (filename) =
+  if not test.done() then
+    j = process.read("ffprobe -v quiet -print_format json -show_streams #{process.quote(filename)}")
 
-  let json.parse ( parsed: {
-    streams: [{
-      r_frame_rate: string,
-      codec_name: string
-    }]
-  }) = j
+    let json.parse ( parsed: {
+      streams: [{
+        r_frame_rate: string,
+        codec_name: string
+      }]
+    }) = j
 
-  let [stream] = parsed.streams
+    let [stream] = parsed.streams
 
-  if stream.r_frame_rate == "45/1" and stream.codec_name == "h264" then
-    test.pass()
-  else
-    test.fail()
+    if stream.r_frame_rate == "45/1" and stream.codec_name == "h264" then
+      test.pass()
+    else
+      test.fail()
+    end
   end
 end
 
-output.file(fallible=true, on_stop=on_done, %ffmpeg(format="mp4",%video(codec="libx264")), out, s)
+output.file(fallible=true, on_close=on_close, %ffmpeg(format="mp4",%video(codec="libx264")), out, s)

--- a/tests/media/mono.liq
+++ b/tests/media/mono.liq
@@ -15,9 +15,9 @@ s = sequence([s, s, once(s)])
 
 #clock.assign_new(sync='none',[s])
 
-def on_done () =
-  thread.run(delay=0.2, fun () -> begin
-    j = process.read("ffprobe -v quiet -print_format json -show_streams #{process.quote(out)}")
+def on_close (filename) =
+  if not test.done() then
+    j = process.read("ffprobe -v quiet -print_format json -show_streams #{process.quote(filename)}")
 
     let json.parse ( parsed: {
       streams: [{
@@ -33,7 +33,7 @@ def on_done () =
     else
       test.fail()
     end
-  end)
+  end
 end
 
-output.file(fallible=true, on_stop=on_done, %wav(mono), out, s)
+output.file(fallible=true, on_close=on_close, %wav(mono), out, s)

--- a/tests/media/multitrack.liq
+++ b/tests/media/multitrack.liq
@@ -53,39 +53,41 @@ enc = %ffmpeg(
   %video.copy
 )
 
-def on_stop() =
-  test.equals(meta_seen(), true)
-  test.equals(track_seen(), true)
-  test.equals(file_no_meta_seen(), true)
-  test.equals(file_track_seen(), 1)
+def on_close(filename) =
+  if not test.done() then
+    test.equals(meta_seen(), true)
+    test.equals(track_seen(), true)
+    test.equals(file_no_meta_seen(), true)
+    test.equals(file_track_seen(), 1)
 
-  ojson = process.read("ffprobe -v quiet -print_format json -show_streams #{process.quote(out)}")
+    ojson = process.read("ffprobe -v quiet -print_format json -show_streams #{process.quote(filename)}")
 
-  let json.parse ( parsed : {
-    streams: [{
-      channel_layout: string?,
-      sample_rate: string?,
-      sample_fmt: string?,
-      codec_name: string?,
-      pix_fmt: string?
-    }]
-  }) = ojson
+    let json.parse ( parsed : {
+      streams: [{
+        channel_layout: string?,
+        sample_rate: string?,
+        sample_fmt: string?,
+        codec_name: string?,
+        pix_fmt: string?
+      }]
+    }) = ojson
 
-  test.equals(list.length(parsed.streams), 3)
+    test.equals(list.length(parsed.streams), 3)
 
-  video_stream = list.find((fun (stream) -> null.defined(stream.pix_fmt)), parsed.streams)
-  aac_stream = list.find((fun (stream) -> stream.codec_name == "aac"), parsed.streams)
-  mp3_stream = list.find((fun (stream) -> stream.codec_name == "mp3"), parsed.streams)
+    video_stream = list.find((fun (stream) -> null.defined(stream.pix_fmt)), parsed.streams)
+    aac_stream = list.find((fun (stream) -> stream.codec_name == "aac"), parsed.streams)
+    mp3_stream = list.find((fun (stream) -> stream.codec_name == "mp3"), parsed.streams)
 
-  test.equals(video_stream.codec_name, "h264")
-  test.equals(video_stream.pix_fmt, "yuv420p")
-  test.equals(aac_stream.channel_layout, "stereo")
-  test.equals(mp3_stream.channel_layout, "mono")
+    test.equals(video_stream.codec_name, "h264")
+    test.equals(video_stream.pix_fmt, "yuv420p")
+    test.equals(aac_stream.channel_layout, "stereo")
+    test.equals(mp3_stream.channel_layout, "mono")
 
-  test.pass()
+    test.pass()
+  end
 end
 
-output.file(fallible=true, on_stop=on_stop, enc, out, s)
+output.file(fallible=true, on_close=on_close, enc, out, s)
 
 meta_count = ref(0)
 

--- a/tests/media/stereo.liq
+++ b/tests/media/stereo.liq
@@ -15,9 +15,9 @@ s = sequence([s, s, once(s)])
 
 #clock.assign_new(sync='none',[s])
 
-def on_done () =
-  thread.run(delay=0.2, fun () -> begin
-    j = process.read("ffprobe -v quiet -print_format json -show_streams #{process.quote(out)}")
+def on_close (filename) =
+  if not test.done() then
+    j = process.read("ffprobe -v quiet -print_format json -show_streams #{process.quote(filename)}")
 
     let json.parse ( parsed: {
       streams: [{
@@ -33,7 +33,7 @@ def on_done () =
     else
       test.fail()
     end
-  end)
+  end
 end
 
-output.file(fallible=true, on_stop=on_done, %wav(stereo), out, s)
+output.file(fallible=true, on_close=on_close, %wav(stereo), out, s)

--- a/tests/media/stream_audio.liq.in
+++ b/tests/media/stream_audio.liq.in
@@ -12,7 +12,7 @@ s = noise(duration=2.)
 
 s = once(s)
 
-clock.assign_new(sync='none',[s])
+#clock.assign_new(sync='none',[s])
 
 output.udp(id="output",port=5001,host="localhost",fallible=true,@FORMAT@,s)
 
@@ -23,22 +23,24 @@ s = (s:source(1,0,0))
 #clock.assign_new(sync='none',[s])
 
 def on_done () =
-  j = process.read("ffprobe -v quiet -print_format json -show_streams #{process.quote(out)}")
+  if not test.done() then
+    j = process.read("ffprobe -v quiet -print_format json -show_streams #{process.quote(out)}")
 
-  let json.parse ( parsed: {
-    streams: [{
-      channels: int,
-      sample_rate: string
-    }]
-  }) = j
+    let json.parse ( parsed: {
+      streams: [{
+        channels: int,
+        sample_rate: string
+      }]
+    }) = j
 
-  let [stream] = parsed.streams
+    let [stream] = parsed.streams
 
-  if stream.channels == 1 and stream.sample_rate == "48000" then
-    test.pass()
-  else
-    test.fail()
+    if stream.channels == 1 and stream.sample_rate == "48000" then
+      test.pass()
+    else
+      test.fail()
+    end
   end
 end
 
-output.file(fallible=true, on_stop=on_done, %wav(mono), out, s)
+output.file(fallible=true, on_close=on_close, %wav(mono), out, s)

--- a/tests/media/stream_video.liq.in
+++ b/tests/media/stream_video.liq.in
@@ -12,7 +12,7 @@ s = noise(duration=2.)
 
 s = once(s)
 
-clock.assign_new(sync='none',[s])
+#clock.assign_new(sync='none',[s])
 
 output.udp(id="output",port=5001,host="localhost",fallible=true,@FORMAT@,s)
 
@@ -23,22 +23,24 @@ s = (s:source(1,1,0))
 #clock.assign_new(sync='none',[s])
 
 def on_done () =
-  j = process.read("ffprobe -v quiet -print_format json -show_streams #{process.quote(out)}")
+  if not test.done() then
+    j = process.read("ffprobe -v quiet -print_format json -show_streams #{process.quote(out)}")
 
-  let json.parse ( parsed: {
-    streams: [{
-      r_frame_rate: string,
-      codec_name: string
-    }]
-  }) = j
+    let json.parse ( parsed: {
+      streams: [{
+        r_frame_rate: string,
+        codec_name: string
+      }]
+    }) = j
 
-  let [stream] = parsed.streams
+    let [stream] = parsed.streams
 
-  if stream.r_frame_rate == "45/1" and stream.codec_name == "h264" then
-    test.pass()
-  else
-    test.fail()
+    if stream.r_frame_rate == "45/1" and stream.codec_name == "h264" then
+      test.pass()
+    else
+      test.fail()
+    end
   end
 end
 
-output.file(fallible=true, on_stop=on_done, %ffmpeg(format="mp4",%audio(codec="aac",channels=1),%video(codec="libx264")), out, s)
+output.file(fallible=true, on_close=on_close, %ffmpeg(format="mp4",%audio(codec="aac",channels=1),%video(codec="libx264")), out, s)

--- a/tests/media/video_size.liq
+++ b/tests/media/video_size.liq
@@ -16,25 +16,27 @@ s = source({audio=source.tracks(blank()).audio, video=source.tracks(s).video})
 
 #clock.assign_new(sync='none',[s])
 
-def on_done () =
-  j = process.read("ffprobe -v quiet -print_format json -show_streams #{process.quote(out)}")
+def on_close (filename) =
+  if not test.done() then
+    j = process.read("ffprobe -v quiet -print_format json -show_streams #{process.quote(filename)}")
 
-  let json.parse ( parsed: {
-    streams: ({
-      width: int,
-      height: int
-    } * _)
-  }) = j
+    let json.parse ( parsed: {
+      streams: ({
+        width: int,
+        height: int
+      } * _)
+    }) = j
 
-  let stream = fst(parsed.streams)
+    let stream = fst(parsed.streams)
 
-  print("Output video size is #{stream.width}x#{stream.height}.")
+    print("Output video size is #{stream.width}x#{stream.height}.")
 
-  if stream.width == 47 and stream.height == 52 then
-    test.pass()
-  else
-    test.fail()
+    if stream.width == 47 and stream.height == 52 then
+      test.pass()
+    else
+      test.fail()
+    end
   end
 end
 
-output.file(fallible=true, on_stop=on_done, %avi(width=47, height=52), out, s)
+output.file(fallible=true, on_close=on_close, %avi(width=47, height=52), out, s)

--- a/tests/regression/GH2850.liq
+++ b/tests/regression/GH2850.liq
@@ -9,7 +9,7 @@ def f() =
   error_count = ref(0)
 
   def on_error(_) =
-    error_count := !error_count + 1
+    error_count := error_count() + 1
   end
 
   s = sine()
@@ -27,7 +27,7 @@ def f() =
   )
 
   thread.run(delay=1., {begin
-    if !has_connected or !error_count == 0 then
+    if has_connected() or error_count() == 0 then
       test.fail()
     end
 
@@ -38,19 +38,21 @@ def f() =
         test.fail()
       end
 
+      print("Shutting down initial source")
       s.shutdown()
       error_count := 0
 
       thread.run(delay=3., {begin
-        if !error_count == 0 then
+        if error_count() == 0 then
           test.fail()
         end
 
         has_connected := false
+        print("Starting new source")
         input.harbor(port=8005,password="hackme","test")
 
         thread.run(delay=1., {begin
-          if not !has_connected then
+          if not has_connected() then
             test.fail()
           end
 

--- a/tests/regression/GH3316.liq
+++ b/tests/regression/GH3316.liq
@@ -1,0 +1,46 @@
+log.level := 4
+
+s = sine()
+
+count = ref(0)
+
+def on_close(filename) =
+  count := count() + 1
+
+  j = process.read("ffprobe -v quiet -print_format json -show_streams #{process.quote(filename)}")
+
+  let json.parse ( parsed: {
+    streams: [{
+      codec_name: string
+   }]
+  }) = j
+
+  if (list.hd(parsed.streams).codec_name != "flac") then
+     test.fail()
+  end
+
+  if count() == 3 then
+    test.pass()
+  end
+end
+
+dir = file.temp_dir("flac")
+
+on_cleanup({file.rmdir(dir)})
+
+last_time = ref(time())
+
+def reopen_when() =
+  current_time = time()
+  time_diff = current_time - last_time()
+  last_time := current_time
+  2. < time_diff
+end
+
+output.file(%flac,
+  reopen_delay=2.,
+  reopen_when=reopen_when,
+  on_close=on_close,
+  {time.string("#{dir}/%Hh%M_%S.flac")},
+  s
+)


### PR DESCRIPTION
Fixes: #3316 