### PR TITLE
Add `metadata.getter.source.float`.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,8 @@
 
 New:
 
-- Allow trailing commas in record definition (#3300)
+- Allow trailing commas in record definition (#3300).
+- Add `metadata.getter.source.float` (#3356).
 
 Changed:
 

--- a/src/libs/extra/source.liq
+++ b/src/libs/extra/source.liq
@@ -77,7 +77,7 @@ def overlap_sources(~id=null("overlap_sources"),~normalize=false,
     set_ready(current_position(),true)
   end
   def on_offset(s) =
-    offset = metadata.getter.float(-1.,start_next,s)
+    let (s,offset) = metadata.getter.source.float(-1.,start_next,s)
     on_offset(force=true,offset=offset,on_start_next,s)
   end
   sources = list.map(on_offset,sources)

--- a/src/libs/metadata.liq
+++ b/src/libs/metadata.liq
@@ -17,6 +17,23 @@ def metadata.getter.base(init, map, metadata, s)
   ref.getter(x)
 end
 
+let metadata.getter.source = ()
+
+# Variant of `metadata.getter.base` which also returns the source. Using this
+# variant is a bit more complex, but safer this it does not involve a global
+# state, which might unexpectedly change the metadata if a source is used at
+# various places.
+# @flag hidden
+def metadata.getter.source.base(init, map, metadata, s)
+  x = ref(init)
+  def f(m)
+    v = m[metadata]
+    if v != "" then x := map(v) end
+  end
+  s = source.on_metadata(f)
+  s, ref.getter(x)
+end
+
 # Create a getter from a metadata: this is a string, whose value can be changed
 # with a metadata.
 # @category Metadata
@@ -35,6 +52,16 @@ end
 # @param s Source containing the metadata.
 def metadata.getter.float(init, m, s)
   metadata.getter.base(init, float_of_string, m, s)
+end
+
+# Create a float getter from a metadata: this is a float, whose value can be
+# changed with a metadata. This function also returns the source.
+# @category Metadata
+# @param init Initial value.
+# @param m Metadata on which the value should be updated.
+# @param s Source containing the metadata.
+def metadata.getter.source.float(init, m, s)
+  metadata.getter.source.base(init, float_of_string, m, s)
 end
 
 # Extract filename from metadata.

--- a/src/libs/metadata.liq
+++ b/src/libs/metadata.liq
@@ -30,8 +30,8 @@ def metadata.getter.source.base(init, map, metadata, s)
     v = m[metadata]
     if v != "" then x := map(v) end
   end
-  s = source.on_metadata(f)
-  s, ref.getter(x)
+  s = source.on_metadata(s, f)
+  (s, ref.getter(x))
 end
 
 # Create a getter from a metadata: this is a string, whose value can be changed


### PR DESCRIPTION
This is slighly safer than `metadata.getter.float` since there is no internal state modified to register the metadata handler.