### PR TITLE
[2.2] fix: Deprecated settings format

### DIFF
--- a/src/libs/server.liq
+++ b/src/libs/server.liq
@@ -2,6 +2,6 @@
 # @category Interaction
 # @param ~port Port on which we should listen.
 def server.telnet(~port=1234) =
-  settings.server.telnet.port.set(port)
-  settings.server.telnet.set(true)
+  settings.server.telnet.port := port
+  settings.server.telnet := true
 end

--- a/src/runtime/main.ml
+++ b/src/runtime/main.ml
@@ -556,7 +556,7 @@ let check_directories () =
       Printf.printf
         {|FATAL ERROR: %s directory %S does not exist.
 To change it, add the following to your script:
-  %s.set("<path>")|}
+  %s := "<path>"|}
         kind dir
         (Dtools.Conf.string_of_path (List.hd routes));
       flush_all ();
@@ -664,8 +664,8 @@ let () =
         | None -> ()
         | Some err ->
             Printf.eprintf
-              "init: security exit, %s. Override with \
-               settings.init.allow_root.set(true)\n"
+              "init: security exit, %s. Override with settings.init.allow_root \
+               := true\n"
               err;
             sync_cleanup ();
             exit (-1));


### PR DESCRIPTION
## Summary
- Replace old style `set()` function with new assignment `:=` style for settings and recommendations.

Backport of #3376.