### PR TITLE
test: Update deprecated reference notation

### DIFF
--- a/tests/language/eval.liq
+++ b/tests/language/eval.liq
@@ -3,7 +3,7 @@ count = ref(1)
 fail = ref(false)
 
 def echo(s) =
-  if s != string(!count) then fail := true end
+  if s != string(count()) then fail := true end
   count := count() + 1
   ()
 end

--- a/tests/language/json.liq
+++ b/tests/language/json.liq
@@ -28,7 +28,7 @@ def test_parse_error(name, f, msg) =
   end
 
   if
-    not !error_caught
+    not error_caught()
   then
     print("parse error test #{name} failed: no error caught")
     test.fail()
@@ -286,7 +286,7 @@ def f() =
   end
 
   f(infinity)
-  if not null.defined(!e) then test.fail() end
+  if not null.defined(e()) then test.fail() end
   test.pass()
 end
 

--- a/tests/language/math.liq
+++ b/tests/language/math.liq
@@ -15,7 +15,7 @@ def f() =
   x = 5.
   if abs(dB_of_lin(lin_of_dB(x)) - x) >= epsilon then success := false end
   if abs(lin_of_dB(dB_of_lin(x)) - x) >= epsilon then success := false end
-  if !success then test.pass() else test.fail() end
+  if success() then test.pass() else test.fail() end
 end
 
 test.check(f)

--- a/tests/language/pp.liq
+++ b/tests/language/pp.liq
@@ -49,7 +49,7 @@ def f() =
 %endif
 
   t(x, 6)
-  if !success then test.pass() else test.fail() end
+  if success() then test.pass() else test.fail() end
 end
 
 test.check(f)

--- a/tests/language/record.liq
+++ b/tests/language/record.liq
@@ -34,8 +34,8 @@ def f() =
   n = ref(0)
 
   def counter() =
-    n := !n + 1
-    !n
+    n := n() + 1
+    n()
   end
 
   def counter.reset() =


### PR DESCRIPTION
## Summary

Update references in tests to remove warnings about deprecated functions. Use `r()` instead of the deprecated `!r` to get the value of ref type variables.