### PR TITLE
test: Add forgotten `test.pass()` call to the string tests.

### DIFF
--- a/tests/language/string.liq
+++ b/tests/language/string.liq
@@ -131,6 +131,7 @@ def test_escape_html() =
   test.equals(string.escape.html("\\"), "\\")
   test.equals(string.escape.html("/"), "/")
   test.equals(string.escape.html("`"), "`")
+  test.pass()
 end
 
 test.check(test_escape_html)


### PR DESCRIPTION
## Summary

The function `test_escape_html()` has no `test.pass()` call at the end.