### PR TITLE
feat!: Unify ReplayGain handling and calculation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,9 @@ New:
 - Added `%track.drop` to the `%ffmpeg` encoder to allow partial encoding
   of a source's available tracks (#3480)
 - Added `let { foo? } = ...` pattern matching (#3481)
+- Add `metadata.replaygain` method to extract unified replay gain value from metadata (#3438).
+- Add `compute` parameter to `file.replaygain` to control gain calculation (#3438).
+- Add `compute` parameter to `enable_replaygain_metadata` to control replay gain calculation (#3438).
 
 Changed:
 
@@ -21,6 +24,8 @@ Changed:
   mechanism for updating it (#3355).
 - Disable output paging when `TERM` environment variable is not set.
 - Allow running as `root` user inside `docker` container by default (#3406).
+- BREAKING: `replaygain` no longer takes `ebu_r128` parameter (#3438).
+- BREAKING: assume `replaygain_track_gain` always stores volume in _dB_ (#3438).
 
 # 2.2.0 (2023-07-21)
 

--- a/doc/content/migrating.md
+++ b/doc/content/migrating.md
@@ -15,6 +15,24 @@ close to production. Streaming issues can build up over time. We do our best to
 release the most stable possible code but problems can arise from many reasons
 so, always best to first to a trial run before putting things to production!
 
+## From 2.2.x to 2.3.x
+
+### Replaygain
+
+- There is a new `metadata.replaygain` function that extracts the replay gain value in _dB_ from the metadata.
+  It handles both `r128_track_gain` and `replaygain_track_gain` internally and returns a single unified gain value.
+
+- The `file.replaygain` function now takes a new compute parameter:
+  `file.replaygain(~id=null(), ~compute=true, ~ratio=50., file_name)`.
+  The compute parameter determines if gain should be calculated when the metadata does not already contain replaygain tags.
+
+- The `enable_replaygain_metadata` function now accepts a compute parameter to control replaygain calculation.
+
+- The `replaygain` function no longer takes an `ebu_r128` parameter. The signature is now simply: `replaygain(~id=null(), s)`.
+  Previously, `ebu_r128` allowed controlling whether EBU R128 or standard replaygain was used.
+  However, EBU R128 data is now extracted directly from metadata when available.
+  So `replaygain` cannot control the gain type via this parameter anymore.
+
 ## From 2.1.x to 2.2.x
 
 ### References

--- a/src/libs/replaygain.liq
+++ b/src/libs/replaygain.liq
@@ -3,76 +3,82 @@
 # or the `replaygain:` protocol for this.
 # @category Source / Audio processing
 # @param ~id Force the value of the source ID.
-# @param ~ebu_r128 Also amplify according to EBU R128 tags.
 # @param s Source to be amplified.
-def replaygain(~id=null(), ~ebu_r128=true, s) =
-  # Normalize opus gain
-  def f(m) =
-    def f(m) =
-      let (k, v) = m
-      if
-        k == "r128_track_gain"
-      then
-        v = int_of_string(v)
-        v = v + 5
-
-        # normalize to -18 dB as usual replaygain instead of -23 dB
-        v = lin_of_dB(float(v) / 256.)
-        ("replaygain_track_gain", string.float(v))
-      else
-        (k, v)
-      end
-    end
-
-    if ebu_r128 then list.map(f, m) else m end
-  end
-
-  s = metadata.map(f, s)
+def replaygain(~id=null(), s) =
   amplify(id=id, override="replaygain_track_gain", 1., s)
 end
 
+let file.replaygain = ()
+
 # Compute the ReplayGain for a file (in dB).
 # @category File
-# @param ~ratio Decoding ratio. A value of `50` means try to decode the file `50x` faster than real time, if possible. Use this setting to lower CPU peaks when computing replaygain tags.
-# @param fname File name.
-def file.replaygain(~id=null(), ~ratio=50., fname) =
-  id = string.id.default(default="file.replaygain", id)
-  try
-    meta = file.metadata(exclude=["replaygain_track_gain"], fname)
-    replaygain_meta = meta["replaygain_track_gain"]
-    match = r/([\+\-\d\.]+)\s*dB/i.exec(replaygain_meta)
-    gain = float_of_string(list.assoc(1, match))
-    log.important(
-      label=id,
-      "Detected track replaygain #{gain} dB for #{string.quote(fname)}"
-    )
+# @param ~id Force the value of the source ID.
+# @param ~ratio Decoding ratio. A value of `50` means try to decode the file `50x` faster than real time, if possible.
+#               Use this setting to lower CPU peaks when computing replaygain tags.
+# @param file_name File name.
+# @flag hidden
+def file.replaygain.compute(~ratio=50., file_name) =
+  _request = request.create(resolve_metadata=false, file_name)
+  if request.resolve(_request) then
+    _source = source.replaygain.compute(request.once(_request))
+    source.drop(ratio=ratio, _source)
+    _source.gain()
+  else
+    null()
+  end
+end
 
-    gain
-  catch _ do
-    r = request.create(resolve_metadata=false, fname)
-    if
-      request.resolve(r)
-    then
-      log.important(
-        label=id,
-        "Computing replay gain for #{string.quote(fname)}"
-      )
-
-      t = time()
-      s = source.replaygain.compute(request.once(r))
-      source.drop(ratio=ratio, s)
-      gain = s.gain()
-      log.important(
-        label=id,
-        "Computed replay gain #{gain} dB for #{string.quote(fname)} (time: #{
-          time() - t
-        } s)."
-      )
-
-      gain
-    else
+# Extract the ReplayGain from the metadata (in dB).
+# @category Metadata
+# @param _metadata Metadata from which the ReplayGain should be extracted.
+def metadata.replaygain(_metadata) =
+  if list.assoc.mem("r128_track_gain", _metadata) then
+    try
+      float_of_string(_metadata["r128_track_gain"]) / 256.
+    catch _ do
       null()
     end
+  elsif list.assoc.mem("replaygain_track_gain", _metadata) then
+    replaygain_metadata = _metadata["replaygain_track_gain"]
+    match = r/([+-]?\d*\.?\d*)/.exec(replaygain_metadata)
+    try
+      float_of_string(list.assoc(1, match))
+    catch _ do
+      null()
+    end
+  else
+    null()
+  end
+end
+
+# Get the ReplayGain for a file (in dB).
+# @category File
+# @param ~id Force the value of the source ID.
+# @param ~compute Compute ReplayGain if metadata tag is empty.
+# @param ~ratio Decoding ratio. A value of `50` means try to decode the file `50x` faster than real time, if possible.
+#               Use this setting to lower CPU peaks when computing replaygain tags.
+# @param file_name File name.
+def replaces file.replaygain(~id=null(), ~compute=true, ~ratio=50., file_name) =
+  id = string.id.default(default="file.replaygain", id)
+  file_name_quoted = string.quote(file_name)
+
+  _metadata = file.metadata(exclude=["replaygain_track_gain"], file_name)
+  gain = metadata.replaygain(_metadata)
+
+  if gain != null() then
+    log.info(label=id, "Detected track replaygain #{gain} dB for #{file_name_quoted}.")
+    gain
+  elsif compute then
+    log.info(label=id, "Computing replay gain for #{file_name_quoted}.")
+    start_time = time()
+    gain = file.replaygain.compute(ratio=ratio, file_name)
+    elapsed_time = time() - start_time
+    if gain != null() then
+      log.info(label=id, "Computed replay gain #{gain} dB for #{file_name_quoted} (time: #{elapsed_time} s).")
+    end
+    gain
+  else
+    null()
   end
 end
 
@@ -80,37 +86,17 @@ end
 # decoded by Liquidsoap and add a `replaygain_track_gain` metadata when this
 # value could be computed. For a finer-grained replay gain processing, use the
 # `replaygain:` protocol.
-# @param ~ratio Decoding ratio. A value of `50.` means try to decode the file `50x` faster than real time, if possible. Use this setting to lower CPU peaks when computing replaygain tags.
+# @param ~compute Compute replaygain if metadata tag is empty.
+# @param ~ratio Decoding ratio. A value of `50.` means try to decode the file `50x` faster than real time, if possible.
+#               Use this setting to lower CPU peaks when computing replaygain tags.
 # @category Liquidsoap
-def enable_replaygain_metadata(~ratio=50.) =
-  def replaygain_metadata(~metadata=_, fname) =
-    meta = file.metadata(exclude=["replaygain_track_gain"], fname)
-    replaygain_meta = meta["replaygain_track_gain"]
-    if
-      replaygain_meta != ""
-    then
-      log.important(
-        label="decoder.replaygain.metadata",
-        "Detected replaygain metadata #{replaygain_meta} for #{
-          string.quote(fname)
-        }"
-      )
-
-      [("replaygain_track_gain", replaygain_meta)]
+def enable_replaygain_metadata(~compute=true, ~ratio=50.) =
+  def replaygain_metadata(~metadata=_, file_name) =
+    gain = file.replaygain(compute=compute, ratio=ratio, file_name)
+    if gain != null() then
+      [("replaygain_track_gain", "#{null.get(gain)} dB")]
     else
-      gain = file.replaygain(ratio=ratio, fname)
-      if
-        null.defined(gain)
-      then
-        [
-          (
-            "replaygain_track_gain",
-            "#{null.get(gain)} dB"
-          )
-        ]
-      else
-        []
-      end
+      []
     end
   end
 

--- a/tests/language/dune.inc
+++ b/tests/language/dune.inc
@@ -399,6 +399,18 @@
  (alias citest)
  (package liquidsoap)
  (deps
+  replaygain.liq
+  ../../src/bin/liquidsoap.exe
+  (package liquidsoap)
+  (:stdlib ../../src/libs/stdlib.liq)
+  (:test_liq ../test.liq)
+  (:run_test ../run_test.exe))
+ (action (run %{run_test} replaygain.liq liquidsoap %{test_liq} replaygain.liq)))
+
+(rule
+ (alias citest)
+ (package liquidsoap)
+ (deps
   socket.liq
   ../../src/bin/liquidsoap.exe
   (package liquidsoap)

--- a/tests/language/replaygain.liq
+++ b/tests/language/replaygain.liq
@@ -1,0 +1,38 @@
+#!../../liquidsoap ../test.liq
+
+def test_metadata_replaygain() =
+  test.equals(metadata.replaygain([("r128_track_gain", "0")]), 0.)
+  test.equals(metadata.replaygain([("r128_track_gain", "256")]), 1.)
+  test.equals(metadata.replaygain([("r128_track_gain", "32767")]), 32767./256.)
+  test.equals(metadata.replaygain([("r128_track_gain", "-32768")]), -32768./256.)
+
+  test.equals(metadata.replaygain([("r128_track_gain", "foo")]), null())
+  test.equals(metadata.replaygain([("r128_track_gain", "0 foo")]), null())
+  test.equals(metadata.replaygain([("r128_track_gain", "")]), null())
+
+  test.equals(metadata.replaygain([("replaygain_track_gain", "1 dB")]), 1.)
+  test.equals(metadata.replaygain([("replaygain_track_gain", "1")]), 1.)
+  test.equals(metadata.replaygain([("replaygain_track_gain", "-1 dB")]), -1.)
+  test.equals(metadata.replaygain([("replaygain_track_gain", "-1")]), -1.)
+  test.equals(metadata.replaygain([("replaygain_track_gain", "+0.424046 dB")]), 0.424046)
+  test.equals(metadata.replaygain([("replaygain_track_gain", "+0.424046")]), 0.424046)
+  test.equals(metadata.replaygain([("replaygain_track_gain", "-10.38500 dB")]), -10.38500)
+  test.equals(metadata.replaygain([("replaygain_track_gain", "-10.38500")]), -10.38500)
+
+  test.equals(metadata.replaygain([("replaygain_track_gain", "1 dB")]), 1.)
+  test.equals(metadata.replaygain([("replaygain_track_gain", "1 2 dB")]), 1.)
+  test.equals(metadata.replaygain([("replaygain_track_gain", "1 db")]), 1.)
+  test.equals(metadata.replaygain([("replaygain_track_gain", "1 DB")]), 1.)
+  test.equals(metadata.replaygain([("replaygain_track_gain", "1 foo")]), 1.)
+
+  test.equals(metadata.replaygain([("replaygain_track_gain", "")]), null())
+  test.equals(metadata.replaygain([("replaygain_track_gain", "foo")]), null())
+
+  test.equals(metadata.replaygain([]), null())
+  test.equals(metadata.replaygain([("r128_track_gain", "foo"), ("replaygain_track_gain", "1")]), null())
+  test.equals(metadata.replaygain([("replaygain_track_gain", "1"), ("r128_track_gain", "foo")]), null())
+
+  test.pass()
+end
+
+test.check(test_metadata_replaygain)

--- a/tests/streams/dune
+++ b/tests/streams/dune
@@ -296,3 +296,124 @@
    %{stdlib}
    %{test_liq}
    ./icecast_tls_ssl.liq)))
+
+(rule
+ (alias citest)
+ (target replaygain_track_gain.mp3)
+ (action
+  (run
+   ffmpeg
+   -hide_banner
+   -loglevel
+   error
+   -f
+   lavfi
+   -i
+   "sine=frequency=220:duration=1"
+   -metadata
+   "REPLAYGAIN_TRACK_GAIN=-32.0 dB"
+   %{target})))
+
+(rule
+ (alias citest)
+ (target r128_track_gain.mp3)
+ (action
+  (run
+   ffmpeg
+   -hide_banner
+   -loglevel
+   error
+   -f
+   lavfi
+   -i
+   "sine=frequency=220:duration=1"
+   -metadata
+   "R128_TRACK_GAIN=-4096"
+   %{target})))
+
+(rule
+ (alias citest)
+ (target replaygain_r128_track_gain.mp3)
+ (action
+  (run
+   ffmpeg
+   -hide_banner
+   -loglevel
+   error
+   -f
+   lavfi
+   -i
+   "sine=frequency=220:duration=1"
+   -metadata
+   "REPLAYGAIN_TRACK_GAIN=-32.0 dB"
+   -metadata
+   "R128_TRACK_GAIN=-4096"
+   %{target})))
+
+(rule
+ (alias citest)
+ (target replaygain_track_gain.opus)
+ (action
+  (run
+   ffmpeg
+   -hide_banner
+   -loglevel
+   error
+   -f
+   lavfi
+   -i
+   "sine=frequency=220:duration=1"
+   -metadata
+   "REPLAYGAIN_TRACK_GAIN=-32.0 dB"
+   %{target})))
+
+(rule
+ (alias citest)
+ (target r128_track_gain.opus)
+ (action
+  (run
+   ffmpeg
+   -hide_banner
+   -loglevel
+   error
+   -f
+   lavfi
+   -i
+   "sine=frequency=220:duration=1"
+   -metadata
+   "R128_TRACK_GAIN=-4096"
+   %{target})))
+
+(rule
+ (alias citest)
+ (target replaygain_r128_track_gain.opus)
+ (action
+  (run
+   ffmpeg
+   -hide_banner
+   -loglevel
+   error
+   -f
+   lavfi
+   -i
+   "sine=frequency=220:duration=1"
+   -metadata
+   "REPLAYGAIN_TRACK_GAIN=-32.0 dB"
+   -metadata
+   "R128_TRACK_GAIN=-4096"
+   %{target})))
+
+(rule
+ (alias citest)
+ (target without_replaygain_track_gain.mp3)
+ (action
+  (run
+   ffmpeg
+   -hide_banner
+   -loglevel
+   error
+   -f
+   lavfi
+   -i
+   "sine=frequency=220:duration=1"
+   %{target})))

--- a/tests/streams/dune.inc
+++ b/tests/streams/dune.inc
@@ -15,6 +15,13 @@
   ./jingles
   ./playlist
   ./huge_playlist
+  ./replaygain_track_gain.mp3
+  ./r128_track_gain.mp3
+  ./replaygain_r128_track_gain.mp3
+  ./replaygain_track_gain.opus
+  ./r128_track_gain.opus
+  ./replaygain_r128_track_gain.opus
+  ./without_replaygain_track_gain.mp3
   ../../src/bin/liquidsoap.exe
   (package liquidsoap)
   (:test_liq ../test.liq)
@@ -37,6 +44,13 @@
   ./jingles
   ./playlist
   ./huge_playlist
+  ./replaygain_track_gain.mp3
+  ./r128_track_gain.mp3
+  ./replaygain_r128_track_gain.mp3
+  ./replaygain_track_gain.opus
+  ./r128_track_gain.opus
+  ./replaygain_r128_track_gain.opus
+  ./without_replaygain_track_gain.mp3
   ../../src/bin/liquidsoap.exe
   (package liquidsoap)
   (:test_liq ../test.liq)
@@ -59,6 +73,13 @@
   ./jingles
   ./playlist
   ./huge_playlist
+  ./replaygain_track_gain.mp3
+  ./r128_track_gain.mp3
+  ./replaygain_r128_track_gain.mp3
+  ./replaygain_track_gain.opus
+  ./r128_track_gain.opus
+  ./replaygain_r128_track_gain.opus
+  ./without_replaygain_track_gain.mp3
   ../../src/bin/liquidsoap.exe
   (package liquidsoap)
   (:test_liq ../test.liq)
@@ -81,6 +102,13 @@
   ./jingles
   ./playlist
   ./huge_playlist
+  ./replaygain_track_gain.mp3
+  ./r128_track_gain.mp3
+  ./replaygain_r128_track_gain.mp3
+  ./replaygain_track_gain.opus
+  ./r128_track_gain.opus
+  ./replaygain_r128_track_gain.opus
+  ./without_replaygain_track_gain.mp3
   ../../src/bin/liquidsoap.exe
   (package liquidsoap)
   (:test_liq ../test.liq)
@@ -103,6 +131,13 @@
   ./jingles
   ./playlist
   ./huge_playlist
+  ./replaygain_track_gain.mp3
+  ./r128_track_gain.mp3
+  ./replaygain_r128_track_gain.mp3
+  ./replaygain_track_gain.opus
+  ./r128_track_gain.opus
+  ./replaygain_r128_track_gain.opus
+  ./without_replaygain_track_gain.mp3
   ../../src/bin/liquidsoap.exe
   (package liquidsoap)
   (:test_liq ../test.liq)
@@ -125,6 +160,13 @@
   ./jingles
   ./playlist
   ./huge_playlist
+  ./replaygain_track_gain.mp3
+  ./r128_track_gain.mp3
+  ./replaygain_r128_track_gain.mp3
+  ./replaygain_track_gain.opus
+  ./r128_track_gain.opus
+  ./replaygain_r128_track_gain.opus
+  ./without_replaygain_track_gain.mp3
   ../../src/bin/liquidsoap.exe
   (package liquidsoap)
   (:test_liq ../test.liq)
@@ -147,6 +189,13 @@
   ./jingles
   ./playlist
   ./huge_playlist
+  ./replaygain_track_gain.mp3
+  ./r128_track_gain.mp3
+  ./replaygain_r128_track_gain.mp3
+  ./replaygain_track_gain.opus
+  ./r128_track_gain.opus
+  ./replaygain_r128_track_gain.opus
+  ./without_replaygain_track_gain.mp3
   ../../src/bin/liquidsoap.exe
   (package liquidsoap)
   (:test_liq ../test.liq)
@@ -169,6 +218,13 @@
   ./jingles
   ./playlist
   ./huge_playlist
+  ./replaygain_track_gain.mp3
+  ./r128_track_gain.mp3
+  ./replaygain_r128_track_gain.mp3
+  ./replaygain_track_gain.opus
+  ./r128_track_gain.opus
+  ./replaygain_r128_track_gain.opus
+  ./without_replaygain_track_gain.mp3
   ../../src/bin/liquidsoap.exe
   (package liquidsoap)
   (:test_liq ../test.liq)
@@ -191,6 +247,13 @@
   ./jingles
   ./playlist
   ./huge_playlist
+  ./replaygain_track_gain.mp3
+  ./r128_track_gain.mp3
+  ./replaygain_r128_track_gain.mp3
+  ./replaygain_track_gain.opus
+  ./r128_track_gain.opus
+  ./replaygain_r128_track_gain.opus
+  ./without_replaygain_track_gain.mp3
   ../../src/bin/liquidsoap.exe
   (package liquidsoap)
   (:test_liq ../test.liq)
@@ -213,6 +276,13 @@
   ./jingles
   ./playlist
   ./huge_playlist
+  ./replaygain_track_gain.mp3
+  ./r128_track_gain.mp3
+  ./replaygain_r128_track_gain.mp3
+  ./replaygain_track_gain.opus
+  ./r128_track_gain.opus
+  ./replaygain_r128_track_gain.opus
+  ./without_replaygain_track_gain.mp3
   ../../src/bin/liquidsoap.exe
   (package liquidsoap)
   (:test_liq ../test.liq)
@@ -235,6 +305,13 @@
   ./jingles
   ./playlist
   ./huge_playlist
+  ./replaygain_track_gain.mp3
+  ./r128_track_gain.mp3
+  ./replaygain_r128_track_gain.mp3
+  ./replaygain_track_gain.opus
+  ./r128_track_gain.opus
+  ./replaygain_r128_track_gain.opus
+  ./without_replaygain_track_gain.mp3
   ../../src/bin/liquidsoap.exe
   (package liquidsoap)
   (:test_liq ../test.liq)
@@ -257,6 +334,13 @@
   ./jingles
   ./playlist
   ./huge_playlist
+  ./replaygain_track_gain.mp3
+  ./r128_track_gain.mp3
+  ./replaygain_r128_track_gain.mp3
+  ./replaygain_track_gain.opus
+  ./r128_track_gain.opus
+  ./replaygain_r128_track_gain.opus
+  ./without_replaygain_track_gain.mp3
   ../../src/bin/liquidsoap.exe
   (package liquidsoap)
   (:test_liq ../test.liq)
@@ -279,6 +363,13 @@
   ./jingles
   ./playlist
   ./huge_playlist
+  ./replaygain_track_gain.mp3
+  ./r128_track_gain.mp3
+  ./replaygain_r128_track_gain.mp3
+  ./replaygain_track_gain.opus
+  ./r128_track_gain.opus
+  ./replaygain_r128_track_gain.opus
+  ./without_replaygain_track_gain.mp3
   ../../src/bin/liquidsoap.exe
   (package liquidsoap)
   (:test_liq ../test.liq)
@@ -301,6 +392,13 @@
   ./jingles
   ./playlist
   ./huge_playlist
+  ./replaygain_track_gain.mp3
+  ./r128_track_gain.mp3
+  ./replaygain_r128_track_gain.mp3
+  ./replaygain_track_gain.opus
+  ./r128_track_gain.opus
+  ./replaygain_r128_track_gain.opus
+  ./without_replaygain_track_gain.mp3
   ../../src/bin/liquidsoap.exe
   (package liquidsoap)
   (:test_liq ../test.liq)
@@ -323,6 +421,13 @@
   ./jingles
   ./playlist
   ./huge_playlist
+  ./replaygain_track_gain.mp3
+  ./r128_track_gain.mp3
+  ./replaygain_r128_track_gain.mp3
+  ./replaygain_track_gain.opus
+  ./r128_track_gain.opus
+  ./replaygain_r128_track_gain.opus
+  ./without_replaygain_track_gain.mp3
   ../../src/bin/liquidsoap.exe
   (package liquidsoap)
   (:test_liq ../test.liq)
@@ -345,6 +450,13 @@
   ./jingles
   ./playlist
   ./huge_playlist
+  ./replaygain_track_gain.mp3
+  ./r128_track_gain.mp3
+  ./replaygain_r128_track_gain.mp3
+  ./replaygain_track_gain.opus
+  ./r128_track_gain.opus
+  ./replaygain_r128_track_gain.opus
+  ./without_replaygain_track_gain.mp3
   ../../src/bin/liquidsoap.exe
   (package liquidsoap)
   (:test_liq ../test.liq)
@@ -367,6 +479,13 @@
   ./jingles
   ./playlist
   ./huge_playlist
+  ./replaygain_track_gain.mp3
+  ./r128_track_gain.mp3
+  ./replaygain_r128_track_gain.mp3
+  ./replaygain_track_gain.opus
+  ./r128_track_gain.opus
+  ./replaygain_r128_track_gain.opus
+  ./without_replaygain_track_gain.mp3
   ../../src/bin/liquidsoap.exe
   (package liquidsoap)
   (:test_liq ../test.liq)
@@ -389,6 +508,13 @@
   ./jingles
   ./playlist
   ./huge_playlist
+  ./replaygain_track_gain.mp3
+  ./r128_track_gain.mp3
+  ./replaygain_r128_track_gain.mp3
+  ./replaygain_track_gain.opus
+  ./r128_track_gain.opus
+  ./replaygain_r128_track_gain.opus
+  ./without_replaygain_track_gain.mp3
   ../../src/bin/liquidsoap.exe
   (package liquidsoap)
   (:test_liq ../test.liq)
@@ -411,6 +537,13 @@
   ./jingles
   ./playlist
   ./huge_playlist
+  ./replaygain_track_gain.mp3
+  ./r128_track_gain.mp3
+  ./replaygain_r128_track_gain.mp3
+  ./replaygain_track_gain.opus
+  ./r128_track_gain.opus
+  ./replaygain_r128_track_gain.opus
+  ./without_replaygain_track_gain.mp3
   ../../src/bin/liquidsoap.exe
   (package liquidsoap)
   (:test_liq ../test.liq)
@@ -433,6 +566,13 @@
   ./jingles
   ./playlist
   ./huge_playlist
+  ./replaygain_track_gain.mp3
+  ./r128_track_gain.mp3
+  ./replaygain_r128_track_gain.mp3
+  ./replaygain_track_gain.opus
+  ./r128_track_gain.opus
+  ./replaygain_r128_track_gain.opus
+  ./without_replaygain_track_gain.mp3
   ../../src/bin/liquidsoap.exe
   (package liquidsoap)
   (:test_liq ../test.liq)
@@ -455,6 +595,13 @@
   ./jingles
   ./playlist
   ./huge_playlist
+  ./replaygain_track_gain.mp3
+  ./r128_track_gain.mp3
+  ./replaygain_r128_track_gain.mp3
+  ./replaygain_track_gain.opus
+  ./r128_track_gain.opus
+  ./replaygain_r128_track_gain.opus
+  ./without_replaygain_track_gain.mp3
   ../../src/bin/liquidsoap.exe
   (package liquidsoap)
   (:test_liq ../test.liq)
@@ -477,6 +624,13 @@
   ./jingles
   ./playlist
   ./huge_playlist
+  ./replaygain_track_gain.mp3
+  ./r128_track_gain.mp3
+  ./replaygain_r128_track_gain.mp3
+  ./replaygain_track_gain.opus
+  ./r128_track_gain.opus
+  ./replaygain_r128_track_gain.opus
+  ./without_replaygain_track_gain.mp3
   ../../src/bin/liquidsoap.exe
   (package liquidsoap)
   (:test_liq ../test.liq)
@@ -499,6 +653,13 @@
   ./jingles
   ./playlist
   ./huge_playlist
+  ./replaygain_track_gain.mp3
+  ./r128_track_gain.mp3
+  ./replaygain_r128_track_gain.mp3
+  ./replaygain_track_gain.opus
+  ./r128_track_gain.opus
+  ./replaygain_r128_track_gain.opus
+  ./without_replaygain_track_gain.mp3
   ../../src/bin/liquidsoap.exe
   (package liquidsoap)
   (:test_liq ../test.liq)
@@ -521,6 +682,13 @@
   ./jingles
   ./playlist
   ./huge_playlist
+  ./replaygain_track_gain.mp3
+  ./r128_track_gain.mp3
+  ./replaygain_r128_track_gain.mp3
+  ./replaygain_track_gain.opus
+  ./r128_track_gain.opus
+  ./replaygain_r128_track_gain.opus
+  ./without_replaygain_track_gain.mp3
   ../../src/bin/liquidsoap.exe
   (package liquidsoap)
   (:test_liq ../test.liq)
@@ -543,6 +711,13 @@
   ./jingles
   ./playlist
   ./huge_playlist
+  ./replaygain_track_gain.mp3
+  ./r128_track_gain.mp3
+  ./replaygain_r128_track_gain.mp3
+  ./replaygain_track_gain.opus
+  ./r128_track_gain.opus
+  ./replaygain_r128_track_gain.opus
+  ./without_replaygain_track_gain.mp3
   ../../src/bin/liquidsoap.exe
   (package liquidsoap)
   (:test_liq ../test.liq)
@@ -565,6 +740,13 @@
   ./jingles
   ./playlist
   ./huge_playlist
+  ./replaygain_track_gain.mp3
+  ./r128_track_gain.mp3
+  ./replaygain_r128_track_gain.mp3
+  ./replaygain_track_gain.opus
+  ./r128_track_gain.opus
+  ./replaygain_r128_track_gain.opus
+  ./without_replaygain_track_gain.mp3
   ../../src/bin/liquidsoap.exe
   (package liquidsoap)
   (:test_liq ../test.liq)
@@ -587,6 +769,13 @@
   ./jingles
   ./playlist
   ./huge_playlist
+  ./replaygain_track_gain.mp3
+  ./r128_track_gain.mp3
+  ./replaygain_r128_track_gain.mp3
+  ./replaygain_track_gain.opus
+  ./r128_track_gain.opus
+  ./replaygain_r128_track_gain.opus
+  ./without_replaygain_track_gain.mp3
   ../../src/bin/liquidsoap.exe
   (package liquidsoap)
   (:test_liq ../test.liq)
@@ -609,6 +798,13 @@
   ./jingles
   ./playlist
   ./huge_playlist
+  ./replaygain_track_gain.mp3
+  ./r128_track_gain.mp3
+  ./replaygain_r128_track_gain.mp3
+  ./replaygain_track_gain.opus
+  ./r128_track_gain.opus
+  ./replaygain_r128_track_gain.opus
+  ./without_replaygain_track_gain.mp3
   ../../src/bin/liquidsoap.exe
   (package liquidsoap)
   (:test_liq ../test.liq)
@@ -631,6 +827,13 @@
   ./jingles
   ./playlist
   ./huge_playlist
+  ./replaygain_track_gain.mp3
+  ./r128_track_gain.mp3
+  ./replaygain_r128_track_gain.mp3
+  ./replaygain_track_gain.opus
+  ./r128_track_gain.opus
+  ./replaygain_r128_track_gain.opus
+  ./without_replaygain_track_gain.mp3
   ../../src/bin/liquidsoap.exe
   (package liquidsoap)
   (:test_liq ../test.liq)
@@ -653,6 +856,13 @@
   ./jingles
   ./playlist
   ./huge_playlist
+  ./replaygain_track_gain.mp3
+  ./r128_track_gain.mp3
+  ./replaygain_r128_track_gain.mp3
+  ./replaygain_track_gain.opus
+  ./r128_track_gain.opus
+  ./replaygain_r128_track_gain.opus
+  ./without_replaygain_track_gain.mp3
   ../../src/bin/liquidsoap.exe
   (package liquidsoap)
   (:test_liq ../test.liq)
@@ -675,6 +885,13 @@
   ./jingles
   ./playlist
   ./huge_playlist
+  ./replaygain_track_gain.mp3
+  ./r128_track_gain.mp3
+  ./replaygain_r128_track_gain.mp3
+  ./replaygain_track_gain.opus
+  ./r128_track_gain.opus
+  ./replaygain_r128_track_gain.opus
+  ./without_replaygain_track_gain.mp3
   ../../src/bin/liquidsoap.exe
   (package liquidsoap)
   (:test_liq ../test.liq)
@@ -697,6 +914,13 @@
   ./jingles
   ./playlist
   ./huge_playlist
+  ./replaygain_track_gain.mp3
+  ./r128_track_gain.mp3
+  ./replaygain_r128_track_gain.mp3
+  ./replaygain_track_gain.opus
+  ./r128_track_gain.opus
+  ./replaygain_r128_track_gain.opus
+  ./without_replaygain_track_gain.mp3
   ../../src/bin/liquidsoap.exe
   (package liquidsoap)
   (:test_liq ../test.liq)
@@ -719,6 +943,13 @@
   ./jingles
   ./playlist
   ./huge_playlist
+  ./replaygain_track_gain.mp3
+  ./r128_track_gain.mp3
+  ./replaygain_r128_track_gain.mp3
+  ./replaygain_track_gain.opus
+  ./r128_track_gain.opus
+  ./replaygain_r128_track_gain.opus
+  ./without_replaygain_track_gain.mp3
   ../../src/bin/liquidsoap.exe
   (package liquidsoap)
   (:test_liq ../test.liq)
@@ -741,6 +972,13 @@
   ./jingles
   ./playlist
   ./huge_playlist
+  ./replaygain_track_gain.mp3
+  ./r128_track_gain.mp3
+  ./replaygain_r128_track_gain.mp3
+  ./replaygain_track_gain.opus
+  ./r128_track_gain.opus
+  ./replaygain_r128_track_gain.opus
+  ./without_replaygain_track_gain.mp3
   ../../src/bin/liquidsoap.exe
   (package liquidsoap)
   (:test_liq ../test.liq)
@@ -763,6 +1001,13 @@
   ./jingles
   ./playlist
   ./huge_playlist
+  ./replaygain_track_gain.mp3
+  ./r128_track_gain.mp3
+  ./replaygain_r128_track_gain.mp3
+  ./replaygain_track_gain.opus
+  ./r128_track_gain.opus
+  ./replaygain_r128_track_gain.opus
+  ./without_replaygain_track_gain.mp3
   ../../src/bin/liquidsoap.exe
   (package liquidsoap)
   (:test_liq ../test.liq)
@@ -785,6 +1030,13 @@
   ./jingles
   ./playlist
   ./huge_playlist
+  ./replaygain_track_gain.mp3
+  ./r128_track_gain.mp3
+  ./replaygain_r128_track_gain.mp3
+  ./replaygain_track_gain.opus
+  ./r128_track_gain.opus
+  ./replaygain_r128_track_gain.opus
+  ./without_replaygain_track_gain.mp3
   ../../src/bin/liquidsoap.exe
   (package liquidsoap)
   (:test_liq ../test.liq)
@@ -807,6 +1059,13 @@
   ./jingles
   ./playlist
   ./huge_playlist
+  ./replaygain_track_gain.mp3
+  ./r128_track_gain.mp3
+  ./replaygain_r128_track_gain.mp3
+  ./replaygain_track_gain.opus
+  ./r128_track_gain.opus
+  ./replaygain_r128_track_gain.opus
+  ./without_replaygain_track_gain.mp3
   ../../src/bin/liquidsoap.exe
   (package liquidsoap)
   (:test_liq ../test.liq)
@@ -829,6 +1088,13 @@
   ./jingles
   ./playlist
   ./huge_playlist
+  ./replaygain_track_gain.mp3
+  ./r128_track_gain.mp3
+  ./replaygain_r128_track_gain.mp3
+  ./replaygain_track_gain.opus
+  ./r128_track_gain.opus
+  ./replaygain_r128_track_gain.opus
+  ./without_replaygain_track_gain.mp3
   ../../src/bin/liquidsoap.exe
   (package liquidsoap)
   (:test_liq ../test.liq)
@@ -851,6 +1117,13 @@
   ./jingles
   ./playlist
   ./huge_playlist
+  ./replaygain_track_gain.mp3
+  ./r128_track_gain.mp3
+  ./replaygain_r128_track_gain.mp3
+  ./replaygain_track_gain.opus
+  ./r128_track_gain.opus
+  ./replaygain_r128_track_gain.opus
+  ./without_replaygain_track_gain.mp3
   ../../src/bin/liquidsoap.exe
   (package liquidsoap)
   (:test_liq ../test.liq)
@@ -873,6 +1146,13 @@
   ./jingles
   ./playlist
   ./huge_playlist
+  ./replaygain_track_gain.mp3
+  ./r128_track_gain.mp3
+  ./replaygain_r128_track_gain.mp3
+  ./replaygain_track_gain.opus
+  ./r128_track_gain.opus
+  ./replaygain_r128_track_gain.opus
+  ./without_replaygain_track_gain.mp3
   ../../src/bin/liquidsoap.exe
   (package liquidsoap)
   (:test_liq ../test.liq)
@@ -895,6 +1175,13 @@
   ./jingles
   ./playlist
   ./huge_playlist
+  ./replaygain_track_gain.mp3
+  ./r128_track_gain.mp3
+  ./replaygain_r128_track_gain.mp3
+  ./replaygain_track_gain.opus
+  ./r128_track_gain.opus
+  ./replaygain_r128_track_gain.opus
+  ./without_replaygain_track_gain.mp3
   ../../src/bin/liquidsoap.exe
   (package liquidsoap)
   (:test_liq ../test.liq)
@@ -917,6 +1204,13 @@
   ./jingles
   ./playlist
   ./huge_playlist
+  ./replaygain_track_gain.mp3
+  ./r128_track_gain.mp3
+  ./replaygain_r128_track_gain.mp3
+  ./replaygain_track_gain.opus
+  ./r128_track_gain.opus
+  ./replaygain_r128_track_gain.opus
+  ./without_replaygain_track_gain.mp3
   ../../src/bin/liquidsoap.exe
   (package liquidsoap)
   (:test_liq ../test.liq)
@@ -939,6 +1233,13 @@
   ./jingles
   ./playlist
   ./huge_playlist
+  ./replaygain_track_gain.mp3
+  ./r128_track_gain.mp3
+  ./replaygain_r128_track_gain.mp3
+  ./replaygain_track_gain.opus
+  ./r128_track_gain.opus
+  ./replaygain_r128_track_gain.opus
+  ./without_replaygain_track_gain.mp3
   ../../src/bin/liquidsoap.exe
   (package liquidsoap)
   (:test_liq ../test.liq)
@@ -961,6 +1262,13 @@
   ./jingles
   ./playlist
   ./huge_playlist
+  ./replaygain_track_gain.mp3
+  ./r128_track_gain.mp3
+  ./replaygain_r128_track_gain.mp3
+  ./replaygain_track_gain.opus
+  ./r128_track_gain.opus
+  ./replaygain_r128_track_gain.opus
+  ./without_replaygain_track_gain.mp3
   ../../src/bin/liquidsoap.exe
   (package liquidsoap)
   (:test_liq ../test.liq)
@@ -983,6 +1291,13 @@
   ./jingles
   ./playlist
   ./huge_playlist
+  ./replaygain_track_gain.mp3
+  ./r128_track_gain.mp3
+  ./replaygain_r128_track_gain.mp3
+  ./replaygain_track_gain.opus
+  ./r128_track_gain.opus
+  ./replaygain_r128_track_gain.opus
+  ./without_replaygain_track_gain.mp3
   ../../src/bin/liquidsoap.exe
   (package liquidsoap)
   (:test_liq ../test.liq)
@@ -1005,6 +1320,13 @@
   ./jingles
   ./playlist
   ./huge_playlist
+  ./replaygain_track_gain.mp3
+  ./r128_track_gain.mp3
+  ./replaygain_r128_track_gain.mp3
+  ./replaygain_track_gain.opus
+  ./r128_track_gain.opus
+  ./replaygain_r128_track_gain.opus
+  ./without_replaygain_track_gain.mp3
   ../../src/bin/liquidsoap.exe
   (package liquidsoap)
   (:test_liq ../test.liq)
@@ -1027,6 +1349,13 @@
   ./jingles
   ./playlist
   ./huge_playlist
+  ./replaygain_track_gain.mp3
+  ./r128_track_gain.mp3
+  ./replaygain_r128_track_gain.mp3
+  ./replaygain_track_gain.opus
+  ./r128_track_gain.opus
+  ./replaygain_r128_track_gain.opus
+  ./without_replaygain_track_gain.mp3
   ../../src/bin/liquidsoap.exe
   (package liquidsoap)
   (:test_liq ../test.liq)
@@ -1049,6 +1378,13 @@
   ./jingles
   ./playlist
   ./huge_playlist
+  ./replaygain_track_gain.mp3
+  ./r128_track_gain.mp3
+  ./replaygain_r128_track_gain.mp3
+  ./replaygain_track_gain.opus
+  ./r128_track_gain.opus
+  ./replaygain_r128_track_gain.opus
+  ./without_replaygain_track_gain.mp3
   ../../src/bin/liquidsoap.exe
   (package liquidsoap)
   (:test_liq ../test.liq)
@@ -1071,6 +1407,13 @@
   ./jingles
   ./playlist
   ./huge_playlist
+  ./replaygain_track_gain.mp3
+  ./r128_track_gain.mp3
+  ./replaygain_r128_track_gain.mp3
+  ./replaygain_track_gain.opus
+  ./r128_track_gain.opus
+  ./replaygain_r128_track_gain.opus
+  ./without_replaygain_track_gain.mp3
   ../../src/bin/liquidsoap.exe
   (package liquidsoap)
   (:test_liq ../test.liq)

--- a/tests/streams/gen_dune.ml
+++ b/tests/streams/gen_dune.ml
@@ -35,6 +35,13 @@ let () =
   ./jingles
   ./playlist
   ./huge_playlist
+  ./replaygain_track_gain.mp3
+  ./r128_track_gain.mp3
+  ./replaygain_r128_track_gain.mp3
+  ./replaygain_track_gain.opus
+  ./r128_track_gain.opus
+  ./replaygain_r128_track_gain.opus
+  ./without_replaygain_track_gain.mp3
   ../../src/bin/liquidsoap.exe
   (package liquidsoap)
   (:test_liq ../test.liq)

--- a/tests/streams/replaygain.liq
+++ b/tests/streams/replaygain.liq
@@ -1,9 +1,44 @@
 #!../../liquidsoap ../test.liq
 
 def test_file_replaygain() =
-  g = file.replaygain("file1.mp3")
+  g = file.replaygain("replaygain_track_gain.mp3")
+  test.not_equals(g, null())
+  test.almost_equals(null.get(g), -32.)
+
+  g = file.replaygain("r128_track_gain.mp3")
+  test.not_equals(g, null())
+  test.almost_equals(null.get(g), -16.)
+
+  g = file.replaygain("replaygain_r128_track_gain.mp3")
+  test.not_equals(g, null())
+  test.almost_equals(null.get(g), -16.)
+
+  g = file.replaygain("replaygain_track_gain.opus")
+  test.not_equals(g, null())
+  test.almost_equals(null.get(g), -32.)
+
+  g = file.replaygain("r128_track_gain.opus")
+  test.not_equals(g, null())
+  test.almost_equals(null.get(g), -16.)
+
+  g = file.replaygain("replaygain_r128_track_gain.opus")
+  test.not_equals(g, null())
+  test.almost_equals(null.get(g), -16.)
+
+  g = file.replaygain("replaygain_track_gain.mp3", compute=true)
+  test.not_equals(g, null())
+  test.almost_equals(null.get(g), -32.)
+
+  g = file.replaygain("replaygain_track_gain.mp3", compute=false)
+  test.not_equals(g, null())
+  test.almost_equals(null.get(g), -32.)
+
+  g = file.replaygain("without_replaygain_track_gain.mp3", compute=true)
   test.not_equals(g, null())
   test.almost_equals(null.get(g), 7.39)
+
+  g = file.replaygain("without_replaygain_track_gain.mp3", compute=false)
+  test.equals(g, null())
 
   test.pass()
 end


### PR DESCRIPTION
## Summary

This PR unifies ReplayGain handling by:

-  A new `metadata.replaygain` method extracts a unified replay gain value in *dB* from metadata, handling `r128_track_gain` and `replaygain_track_gain` internally to provide a single gain value. 

- Adding a `compute` parameter to `file.replaygain` and `enable_replaygain_metadata` to control gain calculation when metadata is missing replaygain tags. `enable_replaygain_metadata` calls `file.replaygain` internally with the compute value.

- Removing the unnecessary `ebu_r128` parameter from `replaygain` since EBU R128 data will be extracted from metadata when available.

## Breaking changes

- `replaygain` no longer has the `ebu_r128` named parameter. `r128_track_gain` is now always processed from metadata in the `metadata.replaygain` function.
- `metadata.replaygain` extracts gain from `replaygain_track_gain` always in *dB*.

## Additional

Closes #3435.
Requires #3478.