### PR TITLE
Prevent lists of encoders from being sup-typed.

### DIFF
--- a/tests/language/encoders.liq
+++ b/tests/language/encoders.liq
@@ -20,6 +20,34 @@ def f() =
   end
 
   try
+    let eval _ = "l = [%wav(channels=1), %wav(channels=2)]"
+    test.fail()
+  catch _ do
+    ()
+  end
+
+  try
+    let eval _ = "l = [%mp3(stereo), %wav(channels=1)]"
+    test.fail()
+  catch _ do
+    ()
+  end
+
+  try
+    let eval _ = "l = [(blank():source(audio=pcm(stereo))), (blank():source(audio=pcm(mono)))]"
+    test.fail()
+  catch _ do
+    ()
+  end
+
+  try
+    let eval _ = "l = [(blank():source(audio=pcm(mono))), (blank():source(audio=pcm(stereo)))]"
+    test.fail()
+  catch _ do
+    ()
+  end
+
+  try
     let eval _ = "n = false
                   ignore(%mp3(stereo=n))"
     test.fail()


### PR DESCRIPTION
To ease the user's burden, we have a mechanism where, if a list contains different types that may not be directly compatible, we compute a type that is compatible with all of them and use it for the list.

For instance, a list with two numbers, one with methods:
```liquidsoap
let l = [
  123,
  456.{foo = "aabb"}
]
```
will be typed as `[int]`, leaving out the fact that one element has methods.

This is safe for most of the regular operations. However, for formats if we have such a list we get:
```liquidsoap
let l = [%wav(channels=1), %mp3(stereo)];;
l : [format(unit)] =
  [%wav(samplerate=44100,channels=1,samplesize=16,header=true), %mp3(stereo,bitrate=128,samplerate=44100,id3v2=none)]
```
Here, the type associated with the formats becomes `unit` as it is computed as the only mutually compatible type.

This is a problem because we use the computed format type at runtime to drive the source's content type and, so, in cases like this, the number of channels is not properly specified and we end up initializing inconsistent sources..

The same problem can occur with lists of sources with incompatible channel count:
```liquidsoap
# l = [(blank():source(audio=pcm(mono))), (blank():source(audio=pcm(stereo)))];;
l : [source(unit)] =
  [<source#blank>.{time=<fun>, fallible=false, skip=<fun>, seek=<fun>, is_active=<fun>, is_up=<fun>, log={level=<fun>.{set=<fun>}}, self_sync=<fun>, duration=<fun>, elapsed=<fun>, remaining=<fun>, on_track=<fun>, on_shutdown=<fun>, on_wake_up=<fun>, on_metadata=<fun>, last_metadata=<fun>, buffered=<fun>, is_ready=<fun>, id=<fun>}, <source#blank.2>.{time=<fun>, fallible=false, skip=<fun>, seek=<fun>, is_active=<fun>, is_up=<fun>, log={level=<fun>.{set=<fun>}}, self_sync=<fun>, duration=<fun>, elapsed=<fun>, remaining=<fun>, on_track=<fun>, on_shutdown=<fun>, on_wake_up=<fun>, on_metadata=<fun>, last_metadata=<fun>, buffered=<fun>, is_ready=<fun>, id=<fun>}]
```

In this PR, we make it so that sources and formats cannot be sup-typed like other types and we get the proper errors:

<img width="600" alt="Screenshot 2023-10-14 at 10 53 04 AM" src="https://github.com/savonet/liquidsoap/assets/871060/d74bd309-f9ec-4aaa-8632-566d48142697">

<img width="660" alt="Screenshot 2023-10-14 at 10 53 22 AM" src="https://github.com/savonet/liquidsoap/assets/871060/80a6c2b0-4ea2-4e61-bd13-4de7cd3e008d">


