### PR TITLE
feat: Add new assertion functions

### DIFF
--- a/tests/language/math.liq
+++ b/tests/language/math.liq
@@ -1,23 +1,12 @@
-success = ref(true)
+#!../../liquidsoap ../test.liq
 
-def t(x, y) =
-  if
-    x != y
-  then
-    print(
-      "Failure: got #{x} instead of #{y}"
-    )
-    success := false
-  end
-end
-
-epsilon = 0.000000001
-
-def f() =
+def test_db_lin() =
   x = 5.
-  if abs(dB_of_lin(lin_of_dB(x)) - x) >= epsilon then success := false end
-  if abs(lin_of_dB(dB_of_lin(x)) - x) >= epsilon then success := false end
-  if success() then test.pass() else test.fail() end
+
+  test.almost_equals(dB_of_lin(lin_of_dB(x)), x)
+  test.almost_equals(lin_of_dB(dB_of_lin(x)), x)
+
+  test.pass()
 end
 
-test.check(f)
+test.check(test_db_lin)

--- a/tests/streams/replaygain.liq
+++ b/tests/streams/replaygain.liq
@@ -1,12 +1,11 @@
 #!../../liquidsoap ../test.liq
-g = file.replaygain("file1.mp3")
-print(
-  "Replay gain: #{g} dB"
-)
-if
-  null.defined(g) and abs(null.get(g) - 7.37) < 0.05
-then
+
+def test_file_replaygain() =
+  g = file.replaygain("file1.mp3")
+  test.not_equals(g, null())
+  test.almost_equals(null.get(g), 7.39)
+
   test.pass()
-else
-  test.fail()
 end
+
+test.check(test_file_replaygain)

--- a/tests/test.liq
+++ b/tests/test.liq
@@ -111,6 +111,71 @@ def test.equals(v, v') =
   end
 end
 
+def test.not_equals(first, second) =
+  if
+    first == second
+  then
+    error.raise(
+      error.failure,
+      "expected\r\n
+      #{string.quote(string(first))} == #{string.quote(string(second))}\r\n
+      to be false.\r\n"
+    )
+
+    test.fail()
+  end
+end
+
+# Compares two float values for approximate equality.
+# Values are considered almost equal if their difference
+# is within 10^-digits.
+# @param ~digits The number of decimal digits to compare. Default is 7.
+# @flag hidden
+def test._almost_equals(~digits=7, first, second) =
+  diff = abs(float(first) - float(second))
+  if
+    diff * float(pow(10, digits)) < 0.5
+  then
+    true.{diff=diff}
+  else
+    false.{diff=diff}
+  end
+end
+
+# Compares two float values for approximate equality.
+# Values are considered almost equal if their difference
+# is within 10^-digits.
+# @param ~digits The number of decimal digits to compare. Default is 7.
+def test.almost_equals(~digits=7, first, second) =
+  is_almost_equals = test._almost_equals(digits=digits, first, second)
+  if not is_almost_equals then
+    error.raise(
+      error.failure,
+      "#{string.quote(string(first))} != #{string.quote(string(second))}
+       up to #{digits} digits, diff = #{is_almost_equals.diff}."
+    )
+
+    test.fail()
+  end
+end
+
+# Compares two float values for approximate inequality.
+# Values are considered not almost equal if their difference
+# is greater than 10^-digits.
+# @param ~digits The number of decimal digits to compare. Default is 7.
+def test.not_almost_equals(~digits=7, first, second) =
+  is_almost_equals = test._almost_equals(digits=digits, first, second)
+  if is_almost_equals then
+    error.raise(
+      error.failure,
+      "#{string.quote(string(first))} == #{string.quote(string(second))}
+       up to #{digits} digits, diff = #{is_almost_equals.diff}."
+    )
+
+    test.fail()
+  end
+end
+
 def test.raises(fn, e=null()) =
   try
     ignore(fn())


### PR DESCRIPTION
## Summary
This PR adds the following new assertion functions to the test module:

- `test.not_equals(first, second)` - Asserts two values are not equal.
- `test.almost_equals(~places=7, first, second)` - Asserts two values are almost equal.
- `test.not_almost_equals(~places=7, first, second)` - Asserts two values are not almost equal.

Additionally, tests in `language/math.liq` and `streams/replaygain.liq` has been rewritten using these new assertions.

## Details

The new assertion functions are necessary to provide additional validation capabilities beyond just `test.equals`:

- `test.not_equals(first, second)`
   This allows asserting two values are not equal, which is not possible with just `test.equals`.
- `test.almost_equals(~places=7, first, second)`
  `test.equals` only does an exact match, but `almost_equals` allows approximately comparing floats within a precision.
- `test.not_almost_equals(~places=7, first, second)`
  Similar to `almost_equals`, this provides a way to validate two floats are not approximately equal within a precision tolerance.