### PR TITLE
Drop default on_fail.

### DIFF
--- a/src/libs/playlist.liq
+++ b/src/libs/playlist.liq
@@ -342,6 +342,7 @@ end
 #  whole round ("randomize" mode), or pick a random file in the playlist each time \
 #  ("random" mode).
 # @param ~native Use native implementation.
+# @param ~on_fail Function executed when too many requests failed and returning the contents of a fixed playlist.
 # @param ~on_reload Callback called after playlist has reloaded.
 # @param ~prefix Add a constant prefix to all requests. Useful for passing extra \
 #  information using annotate, or for resolution through a particular protocol, \
@@ -364,6 +365,7 @@ def replaces playlist(
   ~mime_type=null(),
   ~mode="randomize",
   ~native=false,
+  ~on_fail=null(),
   ~on_reload=(fun (_) -> ()),
   ~prefix="",
   ~reload=0,
@@ -408,28 +410,6 @@ def replaces playlist(
 
     list.map.right(fun (file) -> prefix ^ file, files)
   end
-
-  # Try to reload playlist when the playlist is looped and has failed.
-  def on_fail() =
-    l = load_playlist()
-    if
-      l == []
-    then
-      log.info(
-        "Failed to reload playlist after failure."
-      )
-
-      # We add a dummy request in order for the playlist not to stop.
-      ["???failed???"]
-    else
-      log.info(
-        "Successfully reload playlist after failure."
-      )
-      l
-    end
-  end
-
-  on_fail = if loop then on_fail else null() end
 
   # Create the source
   files := load_playlist()


### PR DESCRIPTION
This PR drops `on_fail` default behavior or reloading playlist in `playlist` in case of failure.

The reason is that, directory playlists are likely to contain invalid files (for instance the infamous `.DS_Store` on macos). In cases like that, we end up with infinite reloading loops.