### PR TITLE
Add support for %*.drop tracks in ffmpeg encoder.

### DIFF
--- a/src/core/encoder/formats/ffmpeg_format.ml
+++ b/src/core/encoder/formats/ffmpeg_format.ml
@@ -61,7 +61,7 @@ type encoded_stream = {
   opts : opts;
 }
 
-type stream = [ `Copy of copy_opt | `Encode of encoded_stream ]
+type stream = [ `Copy of copy_opt | `Encode of encoded_stream | `Drop ]
 
 type t = {
   format : string option;
@@ -101,11 +101,13 @@ let to_string m =
         let name = Frame.Fields.string_of_field field in
         let name =
           match stream with
+            | `Drop -> "%" ^ name ^ ".drop"
             | `Copy _ -> "%" ^ name ^ ".copy"
             | `Encode { mode = `Raw } -> "%" ^ name ^ ".raw"
             | _ -> "%" ^ name
         in
         match stream with
+          | `Drop -> name :: opts
           | `Copy opt ->
               Printf.sprintf "%s(%s)" name (string_of_copy_opt opt) :: opts
           | `Encode { codec; options = `Video options; opts = stream_opts } ->

--- a/tests/media/ffmpeg_drop_tracks.liq
+++ b/tests/media/ffmpeg_drop_tracks.liq
@@ -1,0 +1,119 @@
+output_dir = file.temp_dir("liq", "hls")
+
+def cleanup() =
+  file.rmdir(output_dir)
+end
+
+input_a = sine(duration=10.)
+input_b = sine(duration=10.)
+input_c = sine(duration=10.)
+
+let {audio = audio_a} = source.tracks(input_a)
+let {audio = audio_b} = source.tracks(input_b)
+let {audio = audio_c} = source.tracks(input_c)
+
+muxed_input = source({audio_a=audio_a, audio_b=audio_b, audio_c=audio_c})
+
+streams =
+  [
+    (
+      "a",
+      %ffmpeg(
+        format = "mpegts",
+        %audio_a(codec = "aac"),
+        %audio_b.drop,
+        %audio_c.drop
+      )
+    ),
+    (
+      "b",
+      %ffmpeg(
+        format = "mpegts",
+        %audio_a.drop,
+        %audio_b(codec = "aac"),
+        %audio_c.drop
+      )
+    ),
+    (
+      "c",
+      %ffmpeg(
+        format = "mpegts",
+        %audio_a.drop,
+        %audio_b.drop,
+        %audio_c(codec = "aac")
+      )
+    )
+  ]
+
+is_done = ref(false)
+
+def check_stream() =
+  if
+    not is_done()
+  then
+    is_done := true
+
+    process.run("sync")
+
+    def check_stream(name) =
+      stream = process.quote("#{output_dir}/#{name}.m3u8")
+
+      ojson =
+        process.read(
+          "ffprobe -v quiet -print_format json -show_streams #{stream}"
+        )
+
+      let json.parse (parsed :
+        {
+          streams: [
+            {
+              channel_layout: string?,
+              sample_rate: string?,
+              sample_fmt: string?,
+              codec_name: string?
+            }
+          ]
+        }
+      ) = ojson
+
+      audio_stream =
+        list.find(
+          (fun (stream) -> null.defined(stream.sample_rate)), parsed.streams
+        )
+
+      null.get(audio_stream.channel_layout) == "stereo"
+    and
+      null.get(audio_stream.codec_name) == "aac"
+    and
+      null.get(audio_stream.sample_fmt) == "fltp"
+    and
+      null.get(audio_stream.sample_rate) == "44100"
+    end
+
+    if
+      check_stream("a") and check_stream("b") and check_stream("c")
+    then
+      test.pass()
+    else
+      test.fail()
+    end
+  end
+end
+
+def segment_name(~position, ~extname, stream_name) =
+  if position > 2 then check_stream() end
+  timestamp = int_of_float(time())
+  "#{stream_name}_#{timestamp}_#{position}.#{extname}"
+end
+
+output.file.hls(
+  fallible=true,
+  playlist="live.m3u8",
+  segment_duration=2.0,
+  segments=5,
+  segments_overhead=5,
+  segment_name=segment_name,
+  output_dir,
+  streams,
+  muxed_input
+)


### PR DESCRIPTION
This PR adds a new `%track.drop` to the `%ffmpeg` encoder. 

This allows to selectively encoder a sub-set of a larger multi-track source, making it possible to e.g. mux several heterogenous track into a single larger source and then output sub-sets of it through a HLS output.

See https://github.com/savonet/liquidsoap/issues/3477 for more details!