### PR TITLE
Nullable record pattern

### DIFF
--- a/doc/content/language.md
+++ b/doc/content/language.md
@@ -1113,6 +1113,13 @@ let _.{foo, bar} = "aabbcc".{foo = 123, bar = "baz", gni = true}
 # Record capture with sub-patterns. Same works for module!
 let {foo = [x, y, z], gni} = {foo = [1, 2, 3], gni = "baz"}
 # foo = [1, 2, 3], x = 1, y = 2, z = 3, gni = "baz"
+
+# Record capture with optional methods:
+let { foo? } = ()
+# foo = null()
+
+let { foo? } = { foo = 123 }
+# foo = 123
 ```
 
 ## Combining patterns

--- a/src/lang/evaluation.ml
+++ b/src/lang/evaluation.ml
@@ -95,8 +95,15 @@ let rec eval_pat pat v =
           let env = match pat with None -> env | Some pat -> aux env pat v in
           List.fold_left
             (fun env (lbl, pat) ->
-              let v = List.assoc lbl m in
-              (match pat with None -> [] | Some pat -> eval_pat pat v)
+              let v =
+                try List.assoc lbl m
+                with Not_found when pat = `Nullable ->
+                  Value.
+                    { pos = v.Value.pos; value = Null; methods = Methods.empty }
+              in
+              (match pat with
+                | `None | `Nullable -> []
+                | `Pattern pat -> eval_pat pat v)
               @ [([lbl], v)]
               @ env)
             env l

--- a/src/lang/parser.mly
+++ b/src/lang/parser.mly
@@ -436,8 +436,9 @@ list_pattern:
   | LBRA pattern_list_with_spread RBRA { `PList $2 }
 
 meth_pattern_el:
-  | VAR              { $1, None }
-  | VAR GETS pattern { $1, Some $3 }
+  | VAR              { $1, `None }
+  | VAR QUESTION     { $1, `Nullable }
+  | VAR GETS pattern { $1, `Pattern $3 }
 
 meth_pattern_list:
   |                                         { [] }
@@ -456,12 +457,12 @@ record_spread_pattern:
   | LCUR meth_spread_list RCUR { $2 }
 
 meth_pattern:
-  | record_spread_pattern            { `PMeth $1                      }
-  | record_pattern                   { `PMeth (None,              $1) }
+  | record_spread_pattern            { `PMeth $1                       }
+  | record_pattern                   { `PMeth (None,               $1) }
   | VAR DOT record_pattern           { `PMeth (Some (`PVar [$1]),  $3) }
   | UNDERSCORE DOT record_pattern    { `PMeth (Some (`PVar ["_"]), $3) }
-  | tuple_pattern DOT record_pattern { `PMeth (Some $1,           $3) }
-  | list_pattern DOT record_pattern  { `PMeth (Some $1,           $3) }
+  | tuple_pattern DOT record_pattern { `PMeth (Some $1,            $3) }
+  | list_pattern DOT record_pattern  { `PMeth (Some $1,            $3) }
 
 var_pattern:
   | optvar { `PVar [$1] }

--- a/src/lang/parser_helper.ml
+++ b/src/lang/parser_helper.ml
@@ -168,7 +168,8 @@ let mk_json_assoc_object_ty ~pos = function
   | _ -> raise (Term_base.Parse_error (pos, "Invalid type constructor"))
 
 type let_opt_el = string * Term.t
-type meth_pattern_el = string * Term.pattern option
+type meth_term_default = [ `Nullable | `Pattern of Term.pattern | `None ]
+type meth_pattern_el = string * meth_term_default
 
 let let_decoration_of_lexer_let_decoration = function
   | `Json_parse -> `Json_parse []

--- a/src/lang/parser_helper.mli
+++ b/src/lang/parser_helper.mli
@@ -33,7 +33,8 @@ type lexer_let_decoration =
 type explicit_binding = [ `Def of Term._let | `Let of Term._let ]
 type binding = [ explicit_binding | `Binding of Term._let ]
 type let_opt_el = string * Term.t
-type meth_pattern_el = string * Term.pattern option
+type meth_term_default = [ `Nullable | `Pattern of Term.pattern | `None ]
+type meth_pattern_el = string * meth_term_default
 
 val clear_comments : unit -> unit
 val append_comment : pos:Pos.t -> string -> unit

--- a/src/lang/term/runtime_term.ml
+++ b/src/lang/term/runtime_term.ml
@@ -14,8 +14,10 @@ type pattern =
   [ `PVar of string list  (** a field *)
   | `PTuple of pattern list  (** a tuple *)
   | `PList of pattern list * string option * pattern list  (** a list *)
-  | `PMeth of pattern option * (string * pattern option) list
+  | `PMeth of pattern option * (string * meth_term_default) list
     (** a value with methods *) ]
+
+and meth_term_default = [ `Nullable | `Pattern of pattern | `None ]
 
 type 'a term = { mutable t : Type.t; term : 'a; methods : 'a term Methods.t }
 

--- a/src/lang/term/term_base.ml
+++ b/src/lang/term/term_base.ml
@@ -208,8 +208,9 @@ let rec string_of_pat = function
           (List.map
              (fun (lbl, pat) ->
                match pat with
-                 | None -> lbl
-                 | Some pat -> lbl ^ ": " ^ string_of_pat pat)
+                 | `None -> lbl
+                 | `Nullable -> lbl ^ "?"
+                 | `Pattern pat -> lbl ^ ": " ^ string_of_pat pat)
              l)
       ^ "}"
 
@@ -292,7 +293,9 @@ let rec free_vars_pat = function
            (List.fold_left
               (fun cur (lbl, pat) ->
                 [`PVar [lbl]]
-                @ (match pat with None -> [] | Some pat -> [pat])
+                @ (match pat with
+                    | `None | `Nullable -> []
+                    | `Pattern pat -> [pat])
                 @ cur)
               [] l))
 
@@ -313,7 +316,9 @@ let rec bound_vars_pat = function
            (List.fold_left
               (fun cur (lbl, pat) ->
                 [`PVar [lbl]]
-                @ (match pat with None -> [] | Some pat -> [pat])
+                @ (match pat with
+                    | `None | `Nullable -> []
+                    | `Pattern pat -> [pat])
                 @ cur)
               [] l))
 

--- a/tests/language/record.liq
+++ b/tests/language/record.liq
@@ -248,6 +248,14 @@ def f() =
   # Allow optional trailing comma
   x = {foo="bar", gni=123}
   x = "aabb".{foo="bar", gni=123}
+
+  # Allow optional method extraction
+  let { x? } = ()
+  test.equals(x, null())
+
+  let { x? } = { x = 123 }
+  test.equals(x, 123)
+
   test.pass()
 end
 

--- a/tests/language/type_errors.liq
+++ b/tests/language/type_errors.liq
@@ -153,6 +153,12 @@ def f() =
   incorrect(
     "let v.{foo=123} = {foo=123}"
   )
+  incorrect("def f(x) =
+      let { foo? } = x
+      foo
+    end
+    f(()) + 123")
+
   section("ENCODERS")
   correct('%ffmpeg(%video(codec="h264_nvenc"))')
   correct('%ffmpeg(%video(codec="h264_nvenc",hwaccel="none"))')


### PR DESCRIPTION
This PR adds support for optional methods extraction patterns:

```liquidsoap
# foo = null()
let { foo? } = ()

# foo = 123
let { foo? } = { foo = 123 }
```

This ties up with inferred types:
```liquidsoap
def f(x) =
  let { foo? } = x
  foo
end;;
f : ({foo? : 'a}) -> 'a? = <fun>
```