### PR TITLE
Add scripted main playlist writer for HLS output.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,8 @@ New:
 
 - Allow trailing commas in record definition (#3300).
 - Add `metadata.getter.source.float` (#3356).
+- Added optional `main_playlist_writer` to `output.file.hls` and
+  derivated operator (#3484)
 - Added `is_nan`, `is_infinite`, `ceil`, `floor`, `sign` and `round` (#3407)
 
 Changed:

--- a/src/libs/hls.liq
+++ b/src/libs/hls.liq
@@ -1,3 +1,69 @@
+let hls = {playlist=()}
+
+# Generate a main HLS playlist
+# @category String
+def hls.playlist.main(~extra_tags=[], ~prefix="", ~version, streams) =
+  prefix = prefix == "" or r/\/$/.test(prefix) ? prefix : "#{prefix}/"
+
+  streams =
+    list.fold(
+      fun (streams, s) ->
+        begin
+          let ({bandwidth, codecs, video_size?, ...s} :
+            string.{ bandwidth: int, codecs: string, video_size?: (int*int) }
+          ) = s
+          resolution =
+            if
+              null.defined(video_size)
+            then
+              let (w, h) = null.get(video_size)
+              ",RESOLUTION=#{w}x#{h}"
+            else
+              ""
+            end
+
+          [
+            ...streams,
+            "#EXT-X-STREAM-INF:BANDWIDTH=#{bandwidth},CODECS=#{
+              string.quote(codecs)
+            }#{resolution}",
+            "#{prefix}#{s}.m3u8"
+          ]
+        end,
+      [],
+      streams
+    )
+
+  string.concat(
+    separator="\r\n",
+    [
+      "#EXTM3U",
+      "#EXT-X-VERSION:#{(version : int)}",
+      ...extra_tags,
+      ...streams,
+
+      ""
+    ]
+  )
+end
+
+# @docof output.file.hls
+def replaces output.file.hls(
+  %argsof(output.file.hls[!main_playlist_writer]),
+  ~main_playlist_writer=null(hls.playlist.main),
+  dir,
+  streams,
+  s
+) =
+  output.file.hls(
+    %argsof(output.file.hls[!main_playlist_writer]),
+    main_playlist_writer=main_playlist_writer,
+    dir,
+    streams,
+    s
+  )
+end
+
 let input.hls = ()
 
 # Play an HLS stream.

--- a/tests/streams/dune.inc
+++ b/tests/streams/dune.inc
@@ -443,6 +443,28 @@
  (alias citest)
  (package liquidsoap)
  (deps
+  hls_main_playlist.liq
+  ./file1.mp3
+  ./file2.mp3
+  ./file3.mp3
+  ./jingle1.mp3
+  ./jingle2.mp3
+  ./jingle3.mp3
+  ./file1.png
+  ./file2.png
+  ./jingles
+  ./playlist
+  ./huge_playlist
+  ../../src/bin/liquidsoap.exe
+  (package liquidsoap)
+  (:test_liq ../test.liq)
+  (:run_test ../run_test.exe))
+ (action (run %{run_test} hls_main_playlist.liq liquidsoap %{test_liq} hls_main_playlist.liq)))
+
+(rule
+ (alias citest)
+ (package liquidsoap)
+ (deps
   huge-playlist.liq
   ./file1.mp3
   ./file2.mp3

--- a/tests/streams/hls_main_playlist.liq
+++ b/tests/streams/hls_main_playlist.liq
@@ -1,0 +1,54 @@
+def f() =
+  playlist =
+    hls.playlist.main(
+      extra_tags=["foo", "bar"],
+      version=54,
+      prefix="prefix",
+      [
+        "stream_a".{bandwidth=123, codecs="codecs_a"},
+        "steam_b".{bandwidth=456, codecs="codecs_b", video_size=(12, 34)}
+      ]
+    )
+  test.equals(playlist, '#EXTM3U\r
+#EXT-X-VERSION:54\r
+foo\r
+bar\r
+#EXT-X-STREAM-INF:BANDWIDTH=123,CODECS="codecs_a"\r
+prefix/stream_a.m3u8\r
+#EXT-X-STREAM-INF:BANDWIDTH=456,CODECS="codecs_b",RESOLUTION=12x34\r
+prefix/steam_b.m3u8\r
+')
+
+  playlist =
+    hls.playlist.main(
+      extra_tags=["foo", "bar"],
+      version=54,
+      prefix="prefix/",
+      [
+        "stream_a".{bandwidth=123, codecs="codecs_a"},
+        "steam_b".{bandwidth=456, codecs="codecs_b", video_size=(12, 34)}
+      ]
+    )
+  test.equals(playlist, '#EXTM3U\r
+#EXT-X-VERSION:54\r
+foo\r
+bar\r
+#EXT-X-STREAM-INF:BANDWIDTH=123,CODECS="codecs_a"\r
+prefix/stream_a.m3u8\r
+#EXT-X-STREAM-INF:BANDWIDTH=456,CODECS="codecs_b",RESOLUTION=12x34\r
+prefix/steam_b.m3u8\r
+')
+
+  playlist = hls.playlist.main(version=54, ["stream_a".{bandwidth=123,codecs="codecs_a"}, "steam_b".{bandwidth=456, codecs="codecs_b", video_size = (12,34)}])
+	test.equals(playlist, '#EXTM3U\r
+#EXT-X-VERSION:54\r
+#EXT-X-STREAM-INF:BANDWIDTH=123,CODECS="codecs_a"\r
+stream_a.m3u8\r
+#EXT-X-STREAM-INF:BANDWIDTH=456,CODECS="codecs_b",RESOLUTION=12x34\r
+steam_b.m3u8\r
+')
+
+  test.pass()
+end
+
+test.check(f)


### PR DESCRIPTION
This PR extracts the HLS main playlist writer to make it a scriptable argument to `output.file.hls`, making it possible to disable writing the main playlist in cases when you want to manage your own.