### PR TITLE
typo correction

### DIFF
--- a/src/libs/extra/deprecations.liq
+++ b/src/libs/extra/deprecations.liq
@@ -851,7 +851,7 @@ end
 # Deprecated: use `source.stereo`
 # @flag deprecated
 def audio_to_stereo(~id=null(), s) =
-  deprecated("audio_to_sterep", "stereo")
+  deprecated("audio_to_stereo", "stereo")
   stereo(id=id, s)
 end
 


### PR DESCRIPTION
A small edit to correct a typo in the obsolescence message