### PR TITLE
Inject HLS params.

### DIFF
--- a/doc/content/hls_output.md
+++ b/doc/content/hls_output.md
@@ -121,8 +121,6 @@ required for `mp4` are `movflags` and `frag_duration`.
 radio = ...
 
 aac_lofi = %ffmpeg(format="mp4",
-                   movflags="+dash+skip_sidx+skip_trailer+frag_custom",
-                   frag_duration=10,
                    %audio(
                      codec="aac",
                      channels=2,
@@ -131,8 +129,6 @@ aac_lofi = %ffmpeg(format="mp4",
                    ))
 
 flac_hifi = %ffmpeg(format="mp4",
-                    movflags="+dash+skip_sidx+skip_trailer+frag_custom",
-                    frag_duration=10,
                     strict="-2",
                     %audio(
                       codec="flac",
@@ -141,8 +137,6 @@ flac_hifi = %ffmpeg(format="mp4",
                     ))
 
 flac_hires = %ffmpeg(format="mp4",
-                     movflags="+dash+skip_sidx+skip_trailer+frag_custom",
-                     frag_duration=10,
                      strict="-2",
                      %audio(
                        codec="flac",

--- a/src/core/encoder/encoder.ml
+++ b/src/core/encoder/encoder.ml
@@ -326,7 +326,8 @@ type encoder = {
   stop : unit -> Strings.t;
 }
 
-type factory = pos:Pos.t option -> string -> Frame.Metadata.Export.t -> encoder
+type factory =
+  ?hls:bool -> pos:Pos.t option -> string -> Frame.Metadata.Export.t -> encoder
 
 (** A plugin might or might not accept a given format.
     If it accepts it, it gives a function creating suitable encoders. *)
@@ -344,9 +345,9 @@ let get_factory fmt =
         match f fmt with Some factory -> raise (Found factory) | None -> ());
     raise Not_found
   with Found factory ->
-    fun ~pos name m ->
+    fun ?hls ~pos name m ->
       let { insert_metadata; hls; encode; stop; header } =
-        factory ~pos name m
+        factory ?hls ~pos name m
       in
       (* Protect all functions with a mutex. *)
       let m = Mutex.create () in

--- a/src/core/encoder/encoder.mli
+++ b/src/core/encoder/encoder.mli
@@ -116,7 +116,8 @@ type encoder = {
   stop : unit -> Strings.t;
 }
 
-type factory = pos:Pos.t option -> string -> Frame.Metadata.Export.t -> encoder
+type factory =
+  ?hls:bool -> pos:Pos.t option -> string -> Frame.Metadata.Export.t -> encoder
 
 (** A plugin might or might not accept a given format.
   * If it accepts it, it gives a function creating suitable encoders. *)

--- a/src/core/encoder/encoders/avi_encoder.ml
+++ b/src/core/encoder/encoders/avi_encoder.ml
@@ -91,7 +91,7 @@ let encode_frame ~channels ~samplerate ~width ~height ~converter frame start len
   in
   Strings.add video audio
 
-let encoder ~pos:_ avi =
+let encoder avi =
   let channels = avi.channels in
   let samplerate = Lazy.force avi.samplerate in
   let converter = Audio_converter.Samplerate.create channels in
@@ -122,5 +122,5 @@ let encoder ~pos:_ avi =
 
 let () =
   Plug.register Encoder.plug "avi" ~doc:"Native avi encoder." (function
-    | Encoder.AVI avi -> Some (fun ~pos _ _ -> encoder ~pos avi)
+    | Encoder.AVI avi -> Some (fun ?hls:_ ~pos:_ _ _ -> encoder avi)
     | _ -> None)

--- a/src/core/encoder/encoders/external_encoder.ml
+++ b/src/core/encoder/encoders/external_encoder.ml
@@ -26,7 +26,7 @@ open Mm
 
 open External_encoder_format
 
-let encoder ~pos:_ id ext =
+let encoder id ext =
   let log = Log.make [id] in
   let is_metadata_restart = ref false in
   let is_stop = ref false in
@@ -173,5 +173,5 @@ let encoder ~pos:_ id ext =
 let () =
   Plug.register Encoder.plug "external" ~doc:"Encode using external programs."
     (function
-    | Encoder.External m -> Some (fun ~pos s _ -> encoder ~pos s m)
+    | Encoder.External m -> Some (fun ?hls:_ ~pos:_ s _ -> encoder s m)
     | _ -> None)

--- a/src/core/encoder/encoders/fdkaac_encoder.ml
+++ b/src/core/encoder/encoders/fdkaac_encoder.ml
@@ -118,5 +118,5 @@ let encoder ~pos aac =
 
 let () =
   Plug.register Encoder.plug "fdkaac" ~doc:"" (function
-    | Encoder.FdkAacEnc m -> Some (fun ~pos _ _ -> encoder ~pos m)
+    | Encoder.FdkAacEnc m -> Some (fun ?hls:_ ~pos _ _ -> encoder ~pos m)
     | _ -> None)

--- a/src/core/encoder/encoders/ffmpeg_copy_encoder.ml
+++ b/src/core/encoder/encoders/ffmpeg_copy_encoder.ml
@@ -27,8 +27,7 @@ open Ffmpeg_encoder_common
 
 let log = Log.make ["ffmpeg"; "copy"; "encoder"]
 
-let mk_stream_copy ~pos:_ ~get_stream ~remove_stream ~keyframe_opt ~field output
-    =
+let mk_stream_copy ~get_stream ~remove_stream ~keyframe_opt ~field output =
   let stream = ref None in
   let video_size_ref = ref None in
   let codec_attr = ref None in

--- a/src/core/encoder/encoders/ffmpeg_encoder.ml
+++ b/src/core/encoder/encoders/ffmpeg_encoder.ml
@@ -26,13 +26,58 @@ open Ffmpeg_encoder_common
 
 let () =
   Plug.register Encoder.plug "ffmpeg" ~doc:"" (function
-    | Encoder.Ffmpeg m ->
+    | Encoder.Ffmpeg ffmpeg ->
         Some
-          (fun ~pos _ ->
+          (fun ?(hls = false) ~pos _ ->
+            (* Inject hls params. *)
+            let ffmpeg =
+              if hls then (
+                let opts =
+                  match ffmpeg.Ffmpeg_format.format with
+                    | Some "mp4" ->
+                        let opts = Hashtbl.copy ffmpeg.Ffmpeg_format.opts in
+                        let movflags =
+                          Option.value
+                            ~default:
+                              (`String
+                                "+dash+skip_sidx+skip_trailer+frag_custom")
+                            (Hashtbl.find_opt ffmpeg.Ffmpeg_format.opts
+                               "movflags")
+                        in
+                        Hashtbl.replace opts "movflags" movflags;
+                        let frag_duration =
+                          Option.value ~default:(`Int 10)
+                            (Hashtbl.find_opt ffmpeg.Ffmpeg_format.opts
+                               "frag_duration")
+                        in
+                        Hashtbl.replace opts "frag_duration" frag_duration;
+                        opts
+                    | _ -> ffmpeg.Ffmpeg_format.opts
+                in
+                let streams =
+                  List.map
+                    (function
+                      | ( lbl,
+                          `Encode
+                            ({ Ffmpeg_format.opts } as stream :
+                              Ffmpeg_format.encoded_stream) ) ->
+                          let opts = Hashtbl.copy opts in
+                          let flags =
+                            Option.value ~default:(`String "+global_header")
+                              (Hashtbl.find_opt opts "flags")
+                          in
+                          Hashtbl.replace opts "flags" flags;
+                          (lbl, `Encode { stream with Ffmpeg_format.opts })
+                      | s -> s)
+                    ffmpeg.Ffmpeg_format.streams
+                in
+                { ffmpeg with Ffmpeg_format.streams; opts })
+              else ffmpeg
+            in
             let copy_count =
               List.fold_left
                 (fun cur (_, c) -> match c with `Copy _ -> cur + 1 | _ -> cur)
-                0 m.streams
+                0 ffmpeg.streams
             in
             let get_stream, remove_stream = mk_stream_store copy_count in
             let mk_streams output =
@@ -42,7 +87,7 @@ let () =
                     | `Drop -> streams
                     | `Copy keyframe_opt ->
                         Frame.Fields.add field
-                          (Ffmpeg_copy_encoder.mk_stream_copy ~pos ~get_stream
+                          (Ffmpeg_copy_encoder.mk_stream_copy ~get_stream
                              ~remove_stream ~keyframe_opt ~field output)
                           streams
                     | `Encode Ffmpeg_format.{ codec = None } ->
@@ -74,7 +119,7 @@ let () =
                           (Ffmpeg_internal_encoder.mk_video ~pos ~mode ~params
                              ~options ~codec ~field output)
                           streams)
-                Frame.Fields.empty m.streams
+                Frame.Fields.empty ffmpeg.streams
             in
-            encoder ~pos ~mk_streams m)
+            encoder ~pos ~mk_streams ffmpeg)
     | _ -> None)

--- a/src/core/encoder/encoders/flac_encoder.ml
+++ b/src/core/encoder/encoders/flac_encoder.ml
@@ -24,7 +24,7 @@ open Mm
 
 (** FLAC encoder *)
 
-let encoder ~pos:_ flac meta =
+let encoder flac meta =
   let comments =
     Frame.Metadata.to_list (Frame.Metadata.Export.to_metadata meta)
   in
@@ -75,5 +75,5 @@ let encoder ~pos:_ flac meta =
 
 let () =
   Plug.register Encoder.plug "flac" ~doc:"Flac encoder." (function
-    | Encoder.Flac m -> Some (fun ~pos _ -> encoder ~pos m)
+    | Encoder.Flac m -> Some (fun ?hls:_ ~pos:_ _ -> encoder m)
     | _ -> None)

--- a/src/core/encoder/encoders/gstreamer_encoder.ml
+++ b/src/core/encoder/encoders/gstreamer_encoder.ml
@@ -200,7 +200,7 @@ let encoder ext =
 let () =
   Plug.register Encoder.plug "gstreamer" ~doc:"" (function
     | Encoder.GStreamer params ->
-        let f ~pos:_ _ m =
+        let f ?hls:_ ~pos:_ _ m =
           let encoder = encoder params in
           encoder.Encoder.insert_metadata m;
           encoder

--- a/src/core/encoder/encoders/lame_encoder.ml
+++ b/src/core/encoder/encoders/lame_encoder.ml
@@ -75,7 +75,7 @@ let () =
     Lame.init_params enc;
     enc
   in
-  let mp3_encoder ~pos:_ mp3 metadata =
+  let mp3_encoder mp3 metadata =
     let enc = create_encoder mp3 in
     let channels = if mp3.Mp3_format.stereo then 2 else 1 in
     (* Lame accepts data of a fixed length.. *)
@@ -125,5 +125,5 @@ let () =
     }
   in
   Plug.register Encoder.plug "lame" ~doc:"LAME mp3 encoder." (function
-    | Encoder.MP3 mp3 -> Some (fun ~pos _ meta -> mp3_encoder ~pos mp3 meta)
+    | Encoder.MP3 mp3 -> Some (fun ?hls:_ ~pos:_ _ meta -> mp3_encoder mp3 meta)
     | _ -> None)

--- a/src/core/encoder/encoders/ogg_encoder.ml
+++ b/src/core/encoder/encoders/ogg_encoder.ml
@@ -142,5 +142,5 @@ let encoder ~pos { Ogg_format.audio; video } =
 
 let () =
   Plug.register Encoder.plug "ogg" ~doc:"ogg encoder." (function
-    | Encoder.Ogg m -> Some (encoder m)
+    | Encoder.Ogg m -> Some (fun ?hls:_ ~pos v -> encoder ~pos m v)
     | _ -> None)

--- a/src/core/encoder/encoders/shine_encoder.ml
+++ b/src/core/encoder/encoders/shine_encoder.ml
@@ -27,7 +27,7 @@ open Shine_format
 let create_encoder ~samplerate ~bitrate ~channels =
   Shine.create { Shine.channels; samplerate; bitrate }
 
-let encoder ~pos:_ shine =
+let encoder shine =
   let channels = shine.channels in
   let samplerate = Lazy.force shine.samplerate in
   let enc = create_encoder ~samplerate ~bitrate:shine.bitrate ~channels in
@@ -75,5 +75,5 @@ let encoder ~pos:_ shine =
 let () =
   Plug.register Encoder.plug "shine" ~doc:"SHINE fixed-point mp3 encoder."
     (function
-    | Encoder.Shine m -> Some (fun ~pos _ _ -> encoder ~pos m)
+    | Encoder.Shine m -> Some (fun ?hls:_ ~pos:_ _ _ -> encoder m)
     | _ -> None)

--- a/src/core/encoder/encoders/wav_encoder.ml
+++ b/src/core/encoder/encoders/wav_encoder.ml
@@ -79,5 +79,5 @@ let encoder ~pos wav =
 
 let () =
   Plug.register Encoder.plug "wav" ~doc:"Native wav encoder." (function
-    | Encoder.WAV w -> Some (fun ~pos _ _ -> encoder ~pos w)
+    | Encoder.WAV w -> Some (fun ?hls:_ ~pos _ _ -> encoder ~pos w)
     | _ -> None)

--- a/src/core/encoder/lang/lang_ffmpeg.ml
+++ b/src/core/encoder/lang/lang_ffmpeg.ml
@@ -284,12 +284,14 @@ let qp2lambda = ref 0
 let set_global_quality q opts =
   let flags =
     match Hashtbl.find_opt opts "flags" with
-      | Some (`Int f) -> f
+      | Some (`Int i) -> `Int (i lor Avcodec.flag_qscale)
+      | Some (`Int64 i) ->
+          `Int64 (Int64.logor i (Int64.of_int Avcodec.flag_qscale))
+      | Some (`String s) -> `String (s ^ "+qscale")
       | Some _ -> assert false
-      | None -> 0
+      | None -> `Int Avcodec.flag_qscale
   in
-  let flags = flags lor Avcodec.flag_qscale in
-  Hashtbl.replace opts "flags" (`Int flags);
+  Hashtbl.replace opts "flags" flags;
   Hashtbl.replace opts "global_quality" (`Float (float Avutil.qp2lambda *. q))
 
 let ffmpeg_gen params =

--- a/src/core/outputs/hls_output.ml
+++ b/src/core/outputs/hls_output.ml
@@ -434,7 +434,8 @@ class hls_output p =
           raise (Error.Invalid_value (fmt_val, "Unsupported format"))
       in
       let encoder =
-        encoder_factory ~pos:fmt_val.Value.pos name Frame.Metadata.Export.empty
+        encoder_factory ~hls:true ~pos:fmt_val.Value.pos name
+          Frame.Metadata.Export.empty
       in
       let bandwidth =
         lazy

--- a/src/core/outputs/pipe_output.ml
+++ b/src/core/outputs/pipe_output.ml
@@ -28,7 +28,7 @@ let encoder_factory ?format format_val =
   let format =
     match format with Some f -> f | None -> Lang.to_format format_val
   in
-  try (Encoder.get_factory format) ~pos:format_val.Value.pos
+  try (Encoder.get_factory format) ~hls:false ~pos:format_val.Value.pos
   with Not_found ->
     raise (Error.Invalid_value (format_val, "Unsupported encoding format"))
 

--- a/tests/streams/dune.inc
+++ b/tests/streams/dune.inc
@@ -421,6 +421,28 @@
  (alias citest)
  (package liquidsoap)
  (deps
+  hls_global_headers.liq
+  ./file1.mp3
+  ./file2.mp3
+  ./file3.mp3
+  ./jingle1.mp3
+  ./jingle2.mp3
+  ./jingle3.mp3
+  ./file1.png
+  ./file2.png
+  ./jingles
+  ./playlist
+  ./huge_playlist
+  ../../src/bin/liquidsoap.exe
+  (package liquidsoap)
+  (:test_liq ../test.liq)
+  (:run_test ../run_test.exe))
+ (action (run %{run_test} hls_global_headers.liq liquidsoap %{test_liq} hls_global_headers.liq)))
+
+(rule
+ (alias citest)
+ (package liquidsoap)
+ (deps
   hls_id3v2.liq
   ./file1.mp3
   ./file2.mp3

--- a/tests/streams/hls_global_headers.liq
+++ b/tests/streams/hls_global_headers.liq
@@ -1,0 +1,29 @@
+tmp_dir = file.temp_dir("tmp")
+on_cleanup({file.rmdir(tmp_dir)})
+
+s = video.testsrc.ffmpeg(duration=10.)
+
+s = mksafe(s)
+
+def main_playlist_writer(~extra_tags=_, ~prefix=_, ~version=_, streams) =
+  let [{codecs = c1, ..._}, {codecs = c2, ..._}] = streams
+  if
+    c1 == "avc1.64001f" and c2 == "avc1.64001f"
+  then
+    test.pass()
+  else
+    test.fail()
+  end
+  ""
+end
+
+output.file.hls(
+  main_playlist_writer=main_playlist_writer,
+  segment_duration=2.0,
+  tmp_dir,
+  [
+    ("ts", %ffmpeg(format = "mpegts", %video(codec = "libx264", b = "500k"))),
+    ("mp4", %ffmpeg(format = "mp4", %video(codec = "libx264", b = "500k")))
+  ],
+  s
+)


### PR DESCRIPTION
This PR implements a fix for #3483.

One of the complication with HLS is that the format/protocol blurs the lines between codec/container and transport.

One of the issue is that, in order to be able to compute the proper codec attributes (and probably for other reasons), `ffmpeg` needs to set the `global_header` variable to true in all containers.

In `ffmpeg`, this is done by declaring the hls `container` as requiring global headers. However, in liquidsoap, since we re-implement the HLS logic on top of `ffmpeg`, we need to manually inject this option into all streams.

This PR, thus, adds an optional `hls` parameter to encoder creation which can be used by `ffmpeg` to injects the correct parameters for HLS streams. This also makes it possible to abstract some of the mp4-specific configurations which, until now, were left to the user.

The general logic is that all these parameters are set only if the user has not set them otherwise. If already set, we expect the user to also set the HLS-related settings correctly. This makes it possible to fully override this automatic mechanism if needed in a "simple things are simpel but complex things are possibly" fashion.

Fixes: #3483