### PR TITLE
Uminus improvements.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ package-lock.json
 src/tooling/prettier-plugin-liquidsoap/dist/liquidsoap.js
 src/tooling/prettier-plugin-liquidsoap/dist/web.mjs
 src/tooling/prettier-plugin-liquidsoap/dist/node.js
+*.conflicts

--- a/src/lang/lexer.ml
+++ b/src/lang/lexer.ml
@@ -249,6 +249,7 @@ let rec token lexbuf =
     | ';' -> SEQ
     | ";;" -> SEQSEQ
     | "~" -> TILD
+    | "?." -> QUESTION_DOT
     | "?" -> QUESTION
     | "-" -> MINUS
     | "while" -> WHILE

--- a/src/lang/preprocessor.ml
+++ b/src/lang/preprocessor.ml
@@ -133,8 +133,11 @@ let uminus tokenizer =
   let no_uminus = ref false in
   let token () =
     match tokenizer () with
-      | (Parser.INT _, _ | Parser.FLOAT _, _ | Parser.VAR _, _ | Parser.RPAR, _)
-        as t ->
+      | ( Parser.INT _, _
+        | Parser.FLOAT _, _
+        | Parser.VAR _, _
+        | Parser.RPAR, _
+        | Parser.RCUR, _ ) as t ->
           no_uminus := true;
           t
       | Parser.MINUS, pos when not !no_uminus ->

--- a/src/lang/typechecking.ml
+++ b/src/lang/typechecking.ml
@@ -224,7 +224,8 @@ let rec check ?(print_toplevel = false) ~throw ~level ~(env : Typing.env) e =
           check ~level ~env a;
           let rec aux t =
             match (Type.deref t).Type.descr with
-              | Type.(Meth ({ meth = l'; scheme = s }, _)) when l = l' ->
+              | Type.(Meth ({ meth = l'; scheme = s; optional = false }, _))
+                when l = l' ->
                   (fst s, Typing.instantiate ~level s)
               | Type.(Meth (_, c)) -> aux c
               | _ ->

--- a/tests/core/more_types.ml
+++ b/tests/core/more_types.ml
@@ -61,3 +61,30 @@ let () =
           | [{ Type.meth = "foo"; optional = true; _ }] -> ()
           | _ -> assert false)
     | _ -> assert false
+
+exception Failed
+
+let () =
+  (* term = (1 : int.{opt?: string}).foo *)
+  let typ = Type.meth ~optional:true "opt" ([], Lang.string_t) Lang.int_t in
+  let term =
+    {
+      Term.t = typ;
+      term = `Ground (Term.Ground.Int 1);
+      methods = Term.Methods.empty;
+    }
+  in
+  let invoke =
+    {
+      Term.t = Lang.univ_t ();
+      term =
+        `Invoke { Term.invoked = term; invoke_default = None; meth = "opt" };
+      methods = Term.Methods.empty;
+    }
+  in
+  try
+    Typechecking.check ~throw:(fun exn -> raise exn) invoke;
+    raise Failed
+  with
+    | Failed -> raise Failed
+    | _ -> ()

--- a/tests/language/math.liq
+++ b/tests/language/math.liq
@@ -6,6 +6,18 @@ def test_db_lin() =
   test.almost_equals(dB_of_lin(lin_of_dB(x)), x)
   test.almost_equals(lin_of_dB(dB_of_lin(x)), x)
 
+  y = -x
+  test.equals(y, -5.)
+  test.equals(y == -5., true)
+
+  y = 1 + -2
+  test.equals(y, -1)
+
+  def f() =
+    1 + -2
+  end
+  test.equals(f(), -1)
+
   test.pass()
 end
 

--- a/tests/language/record.liq
+++ b/tests/language/record.liq
@@ -271,6 +271,10 @@ def f() =
 
   let json.parse.foo = 456
 
+  x = 1
+  y = x.{foo=123} - 3
+  test.equals("#{y}", "#{-2}")
+
   test.pass()
 end
 

--- a/tests/regression/ffmpeg-copy-encode.liq
+++ b/tests/regression/ffmpeg-copy-encode.liq
@@ -15,7 +15,7 @@ def f() =
       )
 
     let json.parse ({streams = [s1, s2]} : {streams: [{channels?: int}]}) = j
-    if s1.channels != 2 or s2.channels != 1 then test.fail() end
+    if s1?.channels != 2 or s2?.channels != 1 then test.fail() end
     test.pass()
   end
 

--- a/tests/regression/ffmpeg-naming-convention.liq
+++ b/tests/regression/ffmpeg-naming-convention.liq
@@ -36,10 +36,10 @@ def f() =
       {streams: [{codec_type: string, channels?: int}]}
     ) = j
 
-    test.equals(s1.channels, 2)
-    test.equals(s2.channels, 1)
-    test.equals(s3.channels, 2)
-    test.equals(s4.channels, 1)
+    test.equals(s1?.channels, 2)
+    test.equals(s2?.channels, 1)
+    test.equals(s3?.channels, 2)
+    test.equals(s4?.channels, 1)
     test.equals(s5.codec_type, "video")
     test.equals(s6.codec_type, "video")
     test.pass()


### PR DESCRIPTION
This PR improves unitary minus by adding support for any `- <expr>` via a top-level precedence. This fixes #3405

The other part of these changes add `}` to our manual unitary minus hack. This hack is because our grammar:
* Ignores new lines
* Supports `<expr> - <expr>` and `- <expr>`

This means that, the following expressions are the same:
```liquidsoap
x
-123
```

and:
```liquidsoap
x - 123
```

However, what we really have been doing since the beginning is treating line return as an expression separator. This is the same reason we differentiate between:
```liquidsoap
def f(x, y)
  true
 end
 ```
and:
```liquidsoap
def f
  (x,y )
  true
end
```

My recommendation for future improvements would be:
* Find a way to bring back line return as expression separator
* Force all `def` functions to use `=`

BTW, we also support `;` for expression separator.. 🙂  