### PR TITLE
Remove dynamic activations.

### DIFF
--- a/src/core/operators/cross.ml
+++ b/src/core/operators/cross.ml
@@ -116,7 +116,7 @@ class cross val_source ~duration_getter ~override_duration ~persist_override
 
     method private prepare_transition_source s =
       let s = (s :> source) in
-      s#get_ready ~dynamic:true [(self :> source)];
+      s#get_ready [(self :> source)];
       Clock.unify ~pos:self#pos source#clock s#clock;
       transition_source <- Some s
 
@@ -124,24 +124,20 @@ class cross val_source ~duration_getter ~override_duration ~persist_override
       match transition_source with
         | None -> ()
         | Some s ->
-            s#leave ~dynamic:true (self :> source);
+            s#leave (self :> source);
             transition_source <- None
 
     method! private wake_up a =
       self#reset_analysis;
       super#wake_up a;
-      source#get_ready ~dynamic:true [(self :> source)];
       source#get_ready [(self :> source)];
-      Lang.iter_sources
-        (fun s -> s#get_ready ~dynamic:true [(self :> source)])
-        transition
+      source#get_ready [(self :> source)];
+      Lang.iter_sources (fun s -> s#get_ready [(self :> source)]) transition
 
     method! private sleep =
       source#leave (self :> source);
-      s#leave ~dynamic:true (self :> source);
-      Lang.iter_sources
-        (fun s -> s#leave ~dynamic:true (self :> source))
-        transition;
+      s#leave (self :> source);
+      Lang.iter_sources (fun s -> s#leave (self :> source)) transition;
       self#cleanup_transition_source
 
     (* in main time *)

--- a/src/core/operators/dyn_op.ml
+++ b/src/core/operators/dyn_op.ml
@@ -73,14 +73,12 @@ class dyn ~init ~track_sensitive ~infallible ~resurection_time f =
       Lang.iter_sources
         (fun s ->
           Typing.(s#frame_type <: self#frame_type);
-          s#get_ready ~dynamic:true activation)
+          s#get_ready activation)
         f;
       self#select
 
     method! private sleep =
-      Lang.iter_sources
-        (fun s -> s#leave ~dynamic:true (self :> Source.source))
-        f;
+      Lang.iter_sources (fun s -> s#leave (self :> Source.source)) f;
       self#unregister_source ~already_locked:false
 
     method private _is_ready ?frame () =

--- a/src/core/operators/switch.ml
+++ b/src/core/operators/switch.ml
@@ -97,19 +97,15 @@ class virtual switch ~name ~override_meta ~transition_length
       activation <- (self :> source) :: activator;
       List.iter
         (fun { transition; source = s; _ } ->
-          s#get_ready ~dynamic:true activation;
-          Lang.iter_sources
-            (fun s -> s#get_ready ~dynamic:true activation)
-            transition)
+          s#get_ready activation;
+          Lang.iter_sources (fun s -> s#get_ready activation) transition)
         cases
 
     method! private sleep =
       List.iter
         (fun { transition; source = s; _ } ->
-          s#leave ~dynamic:true (self :> source);
-          Lang.iter_sources
-            (fun s -> s#leave ~dynamic:true (self :> source))
-            transition)
+          s#leave (self :> source);
+          Lang.iter_sources (fun s -> s#leave (self :> source)) transition)
         cases;
       if self#is_selected_generated then
         (Option.get selected).effective_source#leave (self :> source)

--- a/src/core/source.mli
+++ b/src/core/source.mli
@@ -125,7 +125,7 @@ class virtual source :
        method private set_clock : unit
 
        (** The operator says to the source that he will ask it frames. It may be called multiple times. *)
-       method get_ready : ?dynamic:bool -> source list -> unit
+       method get_ready : source list -> unit
 
        (** Register a callback when wake_up is called. *)
        method on_wake_up : (unit -> unit) -> unit
@@ -137,7 +137,7 @@ class virtual source :
        method private wake_up : source list -> unit
 
        (** Opposite of [get_ready] : the operator no longer needs the source. it may be called multiple times. *)
-       method leave : ?failed_to_start:bool -> ?dynamic:bool -> source -> unit
+       method leave : ?failed_to_start:bool -> source -> unit
 
        (** Register a callback when sleep is called. *)
        method on_sleep : (unit -> unit) -> unit

--- a/src/core/tools/producer_consumer.ml
+++ b/src/core/tools/producer_consumer.ml
@@ -107,14 +107,13 @@ class producer ?pos ?create_known_clock ~check_self_sync ~consumers ~name () =
       List.iter
         (fun c ->
           c#set_producer_buffer self#buffer;
-          c#get_ready ?dynamic:None [(self :> Source.source)])
+          c#get_ready [(self :> Source.source)])
         consumers
 
     method! sleep =
       super#sleep;
       List.iter
-        (fun c ->
-          c#leave ?failed_to_start:None ?dynamic:None (self :> Source.source))
+        (fun c -> c#leave ?failed_to_start:None (self :> Source.source))
         consumers
 
     method private get_frame buf =


### PR DESCRIPTION
In anticipation of future large scale changes, we should clean up some old functionalities that we do not use anymore.

This PR removes the notion of dynamic vs. static activations which hasn't been used in operators and sources for a long time.