### PR TITLE
Better record spread.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,7 +28,7 @@ repos:
       - id: ocamlformat
 
   - repo: https://github.com/savonet/pre-commit-liquidsoap
-    rev: a0fd8e7
+    rev: 754afa5
     hooks:
       - id: liquidsoap-prettier
 

--- a/src/js/index.html
+++ b/src/js/index.html
@@ -22,9 +22,9 @@
         "@codemirror/state": "https://esm.sh/@codemirror/state@6.2.1",
         "@codemirror/language": "https://esm.sh/@codemirror/language@6.9.1",
         "@codemirror/view": "https://esm.sh/@codemirror/view@6.21.3",
-        "codemirror-lang-liquidsoap": "https://esm.sh/codemirror-lang-liquidsoap@0.2.5?external=@codemirror/state,@codemirror/language,@codemirror/view",
+        "codemirror-lang-liquidsoap": "https://esm.sh/codemirror-lang-liquidsoap@0.2.7?external=@codemirror/state,@codemirror/language,@codemirror/view",
         "prettier": "https://esm.sh/prettier@3.0.2/standalone.mjs",
-        "liquidsoap-prettier": "https://esm.sh/liquidsoap-prettier/src/index.js"
+        "liquidsoap-prettier": "https://esm.sh/liquidsoap-prettier@1.4.8/src/index.js"
       }
     }
   </script>

--- a/tests/language/record.liq
+++ b/tests/language/record.liq
@@ -283,6 +283,31 @@ def f() =
     {...x, gna=3.14, ...y, foo="bar"}, {foo="bar", bla=3.14, gni="aabb"}
   )
 
+  x = {foo=1}
+  y = {foo=2}
+  test.equals({...x, ...y}, {foo=2})
+  test.equals({...y, ...x}, {foo=1})
+
+  x = {foo=1}
+  y = {foo=null()}
+  test.equals({...x, ...y}, {foo=null()})
+  test.equals({...y, ...x}, {foo=1})
+
+  x = {foo=null()}
+  y = {foo=null()}
+  test.equals({...x, ...y}, {foo=null()})
+  test.equals({...y, ...x}, {foo=null()})
+
+  x = {foo=1}
+  y = {foo="a"}
+  test.equals({...x, ...y}, {foo="a"})
+  test.equals({...y, ...x}, {foo=1})
+
+  x = {foo=1}
+  y = {foo={bar=1}}
+  test.equals({...x, ...y}, {foo={bar=1}})
+  test.equals({...y, ...x}, {foo=1})
+
   test.pass()
 end
 

--- a/tests/language/record.liq
+++ b/tests/language/record.liq
@@ -275,6 +275,14 @@ def f() =
   y = x.{foo=123} - 3
   test.equals("#{y}", "#{-2}")
 
+  x = {foo=123}
+  y = {gni="aabb"}
+  test.equals({...x, ...y}, {foo=123, gni="aabb"})
+  test.equals({...x, gna=3.14, ...y}, {foo=123, bla=3.14, gni="aabb"})
+  test.equals(
+    {...x, gna=3.14, ...y, foo="bar"}, {foo="bar", bla=3.14, gni="aabb"}
+  )
+
   test.pass()
 end
 


### PR DESCRIPTION
This PR improves record spread by allowing multiple spread inside records:

```liquidsoap
  x = {foo=123}
  y = {gni="aabb"}
  test.equals({...x, ...y}, {foo=123, gni="aabb"})
  test.equals({...x, gna=3.14, ...y}, {foo=123, bla=3.14, gni="aabb"})
  test.equals(
    {...x, gna=3.14, ...y, foo="bar"}, {foo="bar", bla=3.14, gni="aabb"}
  )
```

Refs: #3512