### PR TITLE
Add an option to disable fallibility check.

### DIFF
--- a/doc/content/quick_start.md
+++ b/doc/content/quick_start.md
@@ -61,7 +61,7 @@ fallback([your_fallible_source_here, single("failure.ogg")])
 ```
 
 Finally, if you do not care about failures, you can pass the parameter
-`fallible=true` to most outputs. In that case, the output
+`fallible=true` to most outputs (or pass the option `--no-fallible-check` to Liquidsoap). In that case, the output
 will accept a fallible source, and stop whenever the source fails
 and restart when it is ready to produce data again.
 

--- a/src/core/outputs/output.ml
+++ b/src/core/outputs/output.ml
@@ -24,6 +24,8 @@
 
 open Source
 
+let fallibility_check = ref true
+
 let proto =
   Start_stop.output_proto
   @ [
@@ -48,8 +50,8 @@ class virtual output ~output_kind ?(name = "") ~infallible
     initializer
       (* This should be done before the active_operator initializer attaches us
          to a clock. *)
-      if infallible && source#stype <> `Infallible then
-        raise (Error.Invalid_value (val_source, "That source is fallible"))
+      if !fallibility_check && infallible && source#stype <> `Infallible then
+        raise (Error.Invalid_value (val_source, "That source is fallible."))
 
     initializer Typing.(source#frame_type <: self#frame_type)
     inherit active_operator ~name:output_kind [source]

--- a/src/core/outputs/output.mli
+++ b/src/core/outputs/output.mli
@@ -22,6 +22,8 @@
 
 (** Abstract classes for easy creation of output nodes. *)
 
+val fallibility_check : bool ref
+
 (** Parameters needed to instantiate an output. *)
 val proto : (string * Lang.t * Lang.value option * string option) list
 

--- a/src/runtime/main.ml
+++ b/src/runtime/main.ml
@@ -423,6 +423,9 @@ See <http://liquidsoap.info> for more information.
         ( ["--safe"],
           Arg.Unit (fun () -> Typing.do_occur_check := true),
           "Disable the effects of --unsafe." );
+        ( ["--no-fallible-check"],
+          Arg.Unit (fun () -> Output.fallibility_check := false),
+          "Ignore fallible sources." );
       ])
 
 let expand_options options =


### PR DESCRIPTION
This is sometimes useful, especially when checking scripts in examples where we don't have the files...