### PR TITLE
Fix `file.touch`.

### DIFF
--- a/src/libs/file.liq
+++ b/src/libs/file.liq
@@ -53,7 +53,13 @@ def replaces file.write(~data, ~perms=0o644, ~append=false, path) =
   def rec write() =
     s = getter.get(data) ?? ""
     cb(s)
-    if getter.is_constant(data) then cb("") elsif s != "" then write() end
+    if
+      s == ""
+    then
+      ()
+    elsif getter.is_constant(data) then cb("")
+    elsif s != "" then write()
+    end
   end
 
   write()

--- a/tests/language/file.liq
+++ b/tests/language/file.liq
@@ -30,6 +30,10 @@ def f() =
   dst_file3 = path.concat(tmpdir, "test-dst-file3")
   file.move(src_file, dst_file3)
   test.equals(file.exists(dst_file3), true)
+
+  file.touch("test-dst-file4")
+  test.equals(file.exists("test-dst-file4"), true)
+
   test.pass()
 end
 


### PR DESCRIPTION
The function `file.touch` raises `"Bad file descriptor in close()"` when called, as illustrated with this test.