### PR TITLE
Cleanup output telnet functions on shutdown, add option to skip registering commands.

### DIFF
--- a/src/core/builtins/builtins_source.ml
+++ b/src/core/builtins/builtins_source.ml
@@ -247,7 +247,7 @@ let _ =
           ~infallible:false
           ~on_start:(fun () -> ())
           ~on_stop:(fun () -> ())
-          ~autostart:true (Lang.source s)
+          ~register_telnet:false ~autostart:true (Lang.source s)
       in
       let ratio = Lang.to_float (List.assoc "ratio" p) in
       let latency = Time.of_float (Lazy.force Frame.duration /. ratio) in

--- a/src/core/io/alsa_io.ml
+++ b/src/core/io/alsa_io.ml
@@ -155,14 +155,15 @@ class virtual base dev mode =
       self#open_device
   end
 
-class output ~clock_safe ~start ~infallible ~on_stop ~on_start dev val_source =
+class output ~clock_safe ~start ~infallible ~register_telnet ~on_stop ~on_start
+  dev val_source =
   let samples_per_second = Lazy.force Frame.audio_rate in
   let name = Printf.sprintf "alsa_out(%s)" dev in
   object (self)
     inherit
       Output.output
-        ~infallible ~on_stop ~on_start ~name ~output_kind:"output.alsa"
-          val_source start as super
+        ~infallible ~register_telnet ~on_stop ~on_start ~name
+          ~output_kind:"output.alsa" val_source start as super
 
     inherit! base dev [Pcm.Playback]
 
@@ -301,6 +302,7 @@ let _ =
       let device = e Lang.to_string "device" in
       let source = List.assoc "" p in
       let infallible = not (Lang.to_bool (List.assoc "fallible" p)) in
+      let register_telnet = Lang.to_bool (List.assoc "register_telnet" p) in
       let start = Lang.to_bool (List.assoc "start" p) in
       let on_start =
         let f = List.assoc "on_start" p in
@@ -312,11 +314,13 @@ let _ =
       in
       if bufferize then
         (new Alsa_out.output
-           ~clock_safe ~start ~on_start ~on_stop ~infallible device source
+           ~clock_safe ~start ~on_start ~on_stop ~infallible ~register_telnet
+           device source
           :> Output.output)
       else
         (new output
-           ~clock_safe ~infallible ~start ~on_start ~on_stop device source
+           ~clock_safe ~infallible ~register_telnet ~start ~on_start ~on_stop
+           device source
           :> Output.output))
 
 let _ =

--- a/src/core/io/ffmpeg_filter_io.ml
+++ b/src/core/io/ffmpeg_filter_io.ml
@@ -82,8 +82,8 @@ class virtual ['a] base_output ~pass_metadata ~name ~frame_t ~field source =
   object (self)
     inherit
       Output.output
-        ~infallible:false ~on_stop:noop ~on_start:noop ~name
-          ~output_kind:"ffmpeg.filter.input" (Lang.source source) true as super
+        ~infallible:false ~register_telnet:false ~on_stop:noop ~on_start:noop
+          ~name ~output_kind:"ffmpeg.filter.input" (Lang.source source) true as super
 
     inherit ['a] duration_converter
     inherit! Source.no_seek

--- a/src/core/io/gstreamer_io.ml
+++ b/src/core/io/gstreamer_io.ml
@@ -165,8 +165,9 @@ class virtual ['a, 'b] element_factory ~on_error =
 
 (* Audio/video output *)
 
-class output ~clock_safe ~on_error ~infallible ~on_start ~on_stop
-  ?(blocking = true) source start (pipeline, audio_pipeline, video_pipeline) =
+class output ~clock_safe ~on_error ~infallible ~register_telnet ~on_start
+  ~on_stop ?(blocking = true) source start
+  (pipeline, audio_pipeline, video_pipeline) =
   let has_audio, audio_pipeline =
     match audio_pipeline with
       | Some audio_pipeline -> (true, audio_pipeline)
@@ -180,7 +181,7 @@ class output ~clock_safe ~on_error ~infallible ~on_start ~on_stop
   object (self)
     inherit
       Output.output
-        ~infallible ~on_start ~on_stop ~name:"output.gstreamer"
+        ~infallible ~register_telnet ~on_start ~on_stop ~name:"output.gstreamer"
           ~output_kind:"gstreamer" source start as super
 
     inherit [App_src.t, App_src.t] element_factory ~on_error
@@ -343,6 +344,7 @@ let _ =
       let clock_safe = Lang.to_bool (List.assoc "clock_safe" p) in
       let pipeline = Lang.to_string (List.assoc "pipeline" p) in
       let infallible = not (Lang.to_bool (List.assoc "fallible" p)) in
+      let register_telnet = Lang.to_bool (List.assoc "register_telnet" p) in
       let on_error = List.assoc "on_error" p in
       let on_error error =
         let msg = Printexc.to_string error in
@@ -359,8 +361,8 @@ let _ =
       in
       let source = List.assoc "" p in
       (new output
-         ~clock_safe ~on_error ~infallible ~on_start ~on_stop source start
-         ("", Some pipeline, None)
+         ~clock_safe ~on_error ~infallible ~register_telnet ~on_start ~on_stop
+         source start ("", Some pipeline, None)
         :> Output.output))
 
 let _ =
@@ -375,6 +377,7 @@ let _ =
       let clock_safe = Lang.to_bool (List.assoc "clock_safe" p) in
       let pipeline = Lang.to_string (List.assoc "pipeline" p) in
       let infallible = not (Lang.to_bool (List.assoc "fallible" p)) in
+      let register_telnet = Lang.to_bool (List.assoc "register_telnet" p) in
       let on_error = List.assoc "on_error" p in
       let on_error error =
         let msg = Printexc.to_string error in
@@ -391,8 +394,8 @@ let _ =
       in
       let source = List.assoc "" p in
       (new output
-         ~clock_safe ~infallible ~on_error ~on_start ~on_stop source start
-         ("", None, Some pipeline)
+         ~clock_safe ~infallible ~register_telnet ~on_error ~on_start ~on_stop
+         source start ("", None, Some pipeline)
         :> Output.output))
 
 let _ =
@@ -425,6 +428,7 @@ let _ =
       let audio_pipeline = Lang.to_string (List.assoc "audio_pipeline" p) in
       let video_pipeline = Lang.to_string (List.assoc "video_pipeline" p) in
       let infallible = not (Lang.to_bool (List.assoc "fallible" p)) in
+      let register_telnet = Lang.to_bool (List.assoc "register_telnet" p) in
       let on_error = List.assoc "on_error" p in
       let on_error error =
         let msg = Printexc.to_string error in
@@ -442,8 +446,8 @@ let _ =
       in
       let source = List.assoc "" p in
       (new output
-         ~clock_safe ~infallible ~on_error ~on_start ~on_stop ~blocking source
-         start
+         ~clock_safe ~infallible ~register_telnet ~on_error ~on_start ~on_stop
+         ~blocking source start
          (pipeline, Some audio_pipeline, Some video_pipeline)
         :> Output.output))
 

--- a/src/core/io/portaudio_io.ml
+++ b/src/core/io/portaudio_io.ml
@@ -148,14 +148,14 @@ let open_device ~mode ~latency ~channels ~buflen device_id =
         Portaudio.open_stream inparams outparams (float samples_per_second)
           buflen []
 
-class output ~clock_safe ~start ~on_start ~on_stop ~infallible ~device_id
-  ~latency buflen val_source =
+class output ~clock_safe ~start ~on_start ~on_stop ~infallible ~register_telnet
+  ~device_id ~latency buflen val_source =
   object (self)
     inherit base
 
     inherit!
       Output.output
-        ~infallible ~on_stop ~on_start ~name:"output.portaudio"
+        ~infallible ~register_telnet ~on_stop ~on_start ~name:"output.portaudio"
           ~output_kind:"output.portaudio" val_source start as super
 
     method! private set_clock =
@@ -276,6 +276,7 @@ let _ =
         Lang.to_valued_option Lang.to_float (List.assoc "latency" p)
       in
       let infallible = not (Lang.to_bool (List.assoc "fallible" p)) in
+      let register_telnet = Lang.to_bool (List.assoc "register_telnet" p) in
       let start = Lang.to_bool (List.assoc "start" p) in
       let on_start =
         let f = List.assoc "on_start" p in
@@ -288,8 +289,8 @@ let _ =
       let source = List.assoc "" p in
       let clock_safe = Lang.to_bool (List.assoc "clock_safe" p) in
       (new output
-         ~start ~on_start ~on_stop ~infallible ~clock_safe ~device_id ~latency
-         buflen source
+         ~start ~on_start ~on_stop ~infallible ~register_telnet ~clock_safe
+         ~device_id ~latency buflen source
         :> Output.output))
 
 let _ =

--- a/src/core/io/pulseaudio_io.ml
+++ b/src/core/io/pulseaudio_io.ml
@@ -46,7 +46,7 @@ class virtual base ~client ~device =
     method self_sync : Source.self_sync = (`Dynamic, dev <> None)
   end
 
-class output ~infallible ~start ~on_start ~on_stop p =
+class output ~infallible ~register_telnet ~start ~on_start ~on_stop p =
   let client = Lang.to_string (List.assoc "client" p) in
   let device = Lang.to_string (List.assoc "device" p) in
   let name = Printf.sprintf "pulse_out(%s:%s)" client device in
@@ -58,8 +58,8 @@ class output ~infallible ~start ~on_start ~on_stop p =
 
     inherit!
       Output.output
-        ~infallible ~on_stop ~on_start ~name ~output_kind:"output.pulseaudio"
-          val_source start as super
+        ~infallible ~register_telnet ~on_stop ~on_start ~name
+          ~output_kind:"output.pulseaudio" val_source start as super
 
     method! private set_clock =
       super#set_clock;
@@ -182,6 +182,7 @@ let _ =
     ~descr:"Output the source's stream to a pulseaudio output device."
     (fun p ->
       let infallible = not (Lang.to_bool (List.assoc "fallible" p)) in
+      let register_telnet = Lang.to_bool (List.assoc "register_telnet" p) in
       let start = Lang.to_bool (List.assoc "start" p) in
       let on_start =
         let f = List.assoc "on_start" p in
@@ -191,7 +192,8 @@ let _ =
         let f = List.assoc "on_stop" p in
         fun () -> ignore (Lang.apply f [])
       in
-      (new output ~infallible ~on_start ~on_stop ~start p :> Output.output))
+      (new output ~infallible ~register_telnet ~on_start ~on_stop ~start p
+        :> Output.output))
 
 let _ =
   let return_t =

--- a/src/core/io/udp_io.ml
+++ b/src/core/io/udp_io.ml
@@ -53,12 +53,13 @@ module Tutils = struct
     (kill, wait)
 end
 
-class output ~on_start ~on_stop ~infallible ~autostart ~hostname ~port
-  ~encoder_factory source =
+class output ~on_start ~on_stop ~register_telnet ~infallible ~autostart
+  ~hostname ~port ~encoder_factory source =
   object (self)
     inherit
       Output.encoded
-        ~output_kind:"udp" ~on_start ~on_stop ~infallible ~autostart
+        ~output_kind:"udp" ~on_start ~on_stop ~register_telnet ~infallible
+          ~autostart
         ~name:(Printf.sprintf "udp://%s:%d" hostname port)
         source
 
@@ -208,6 +209,7 @@ let _ =
       (* Generic output parameters *)
       let autostart = Lang.to_bool (List.assoc "start" p) in
       let infallible = not (Lang.to_bool (List.assoc "fallible" p)) in
+      let register_telnet = Lang.to_bool (List.assoc "register_telnet" p) in
       let on_start =
         let f = List.assoc "on_start" p in
         fun () -> ignore (Lang.apply f [])
@@ -229,8 +231,8 @@ let _ =
       in
       let source = Lang.assoc "" 2 p in
       (new output
-         ~on_start ~on_stop ~infallible ~autostart ~hostname ~port
-         ~encoder_factory:fmt source
+         ~on_start ~on_stop ~register_telnet ~infallible ~autostart ~hostname
+         ~port ~encoder_factory:fmt source
         :> Source.source))
 
 let _ =

--- a/src/core/operators/time_warp.ml
+++ b/src/core/operators/time_warp.ml
@@ -159,7 +159,8 @@ module Buffer = struct
     object
       inherit
         Output.output
-          ~output_kind:id ~infallible ~on_start ~on_stop source_val autostart
+          ~output_kind:id ~infallible ~register_telnet:false ~on_start ~on_stop
+            source_val autostart
 
       method! reset = ()
       method start = ()
@@ -423,8 +424,9 @@ module AdaptativeBuffer = struct
     object (self)
       inherit
         Output.output
-          ~output_kind:"buffer" ~name:"buffer.adaptative.consumer" ~infallible
-            ~on_start ~on_stop source_val autostart
+          ~output_kind:"buffer" ~register_telnet:false
+            ~name:"buffer.adaptative.consumer" ~infallible ~on_start ~on_stop
+            source_val autostart
 
       method! reset = ()
       method start = ()

--- a/src/core/outputs/alsa_out.ml
+++ b/src/core/outputs/alsa_out.ml
@@ -26,7 +26,8 @@ open Mm
 
 open Alsa
 
-class output ~clock_safe ~infallible ~on_stop ~on_start ~start dev source =
+class output ~clock_safe ~infallible ~register_telnet ~on_stop ~on_start ~start
+  dev source =
   let buffer_length = AFrame.size () in
   let alsa_buffer = Alsa_settings.alsa_buffer#get in
   let nb_blocks = Alsa_settings.conf_buffer_length#get in
@@ -36,8 +37,8 @@ class output ~clock_safe ~infallible ~on_stop ~on_start ~start dev source =
   object (self)
     inherit
       Output.output
-        ~infallible ~on_stop ~on_start ~name ~output_kind:"output.alsa" source
-          start as super
+        ~infallible ~register_telnet ~on_stop ~on_start ~name
+          ~output_kind:"output.alsa" source start as super
 
     inherit [Content.Audio.data] IoRing.output ~nb_blocks as ioring
     val mutable initialized = false

--- a/src/core/outputs/ao_out.ml
+++ b/src/core/outputs/ao_out.ml
@@ -30,16 +30,16 @@ open Ao
   * per driver... but it might also depend on driver options. *)
 let get_clock = Tutils.lazy_cell (fun () -> Clock.clock "ao")
 
-class output ~clock_safe ~nb_blocks ~driver ~infallible ~on_start ~on_stop
-  ~options ?channels_matrix source start =
+class output ~clock_safe ~nb_blocks ~driver ~register_telnet ~infallible
+  ~on_start ~on_stop ~options ?channels_matrix source start =
   let samples_per_frame = AFrame.size () in
   let samples_per_second = Lazy.force Frame.audio_rate in
   let bytes_per_sample = 2 in
   object (self)
     inherit
       Output.output
-        ~infallible ~on_start ~on_stop ~name:"ao" ~output_kind:"output.ao"
-          source start as super
+        ~register_telnet ~infallible ~on_start ~on_stop ~name:"ao"
+          ~output_kind:"output.ao" source start as super
 
     inherit [Bytes.t] IoRing.output ~nb_blocks as ioring
 
@@ -151,6 +151,7 @@ let _ =
         if channels_matrix = "" then None else Some channels_matrix
       in
       let infallible = not (Lang.to_bool (List.assoc "fallible" p)) in
+      let register_telnet = Lang.to_bool (List.assoc "register_telnet" p) in
       let start = Lang.to_bool (List.assoc "start" p) in
       let on_start =
         let f = List.assoc "on_start" p in
@@ -162,6 +163,6 @@ let _ =
       in
       let source = List.assoc "" p in
       (new output
-         ~clock_safe ~nb_blocks ~driver ~infallible ~on_start ~on_stop
-         ?channels_matrix ~options source start
+         ~clock_safe ~nb_blocks ~driver ~infallible ~register_telnet ~on_start
+         ~on_stop ?channels_matrix ~options source start
         :> Output.output))

--- a/src/core/outputs/bjack_out.ml
+++ b/src/core/outputs/bjack_out.ml
@@ -26,15 +26,15 @@ open Mm
 
 let bytes_per_sample = 2
 
-class output ~clock_safe ~infallible ~on_stop ~on_start ~nb_blocks ~server
-  source =
+class output ~clock_safe ~infallible ~register_telnet ~on_stop ~on_start
+  ~nb_blocks ~server source =
   let samples_per_frame = AFrame.size () in
   let seconds_per_frame = Frame.seconds_of_audio samples_per_frame in
   let samples_per_second = Lazy.force Frame.audio_rate in
   object (self)
     inherit
       Output.output
-        ~infallible ~on_stop ~on_start ~name:"output.jack"
+        ~infallible ~register_telnet ~on_stop ~on_start ~name:"output.jack"
           ~output_kind:"output.jack" source true as super
 
     inherit [Bytes.t] IoRing.output ~nb_blocks as ioring
@@ -138,6 +138,7 @@ let _ =
       let nb_blocks = Lang.to_int (List.assoc "buffer_size" p) in
       let server = Lang.to_string (List.assoc "server" p) in
       let infallible = not (Lang.to_bool (List.assoc "fallible" p)) in
+      let register_telnet = Lang.to_bool (List.assoc "register_telnet" p) in
       let on_start =
         let f = List.assoc "on_start" p in
         fun () -> ignore (Lang.apply f [])
@@ -147,5 +148,6 @@ let _ =
         fun () -> ignore (Lang.apply f [])
       in
       (new output
-         ~clock_safe ~infallible ~on_start ~on_stop ~nb_blocks ~server source
+         ~clock_safe ~infallible ~register_telnet ~on_start ~on_stop ~nb_blocks
+         ~server source
         :> Output.output))

--- a/src/core/outputs/graphics_out.ml
+++ b/src/core/outputs/graphics_out.ml
@@ -21,12 +21,12 @@
 
 open Mm
 
-class output ~infallible ~autostart ~on_start ~on_stop source =
+class output ~infallible ~register_telnet ~autostart ~on_start ~on_stop source =
   object (self)
     inherit
       Output.output
-        ~name:"graphics" ~output_kind:"output.graphics" ~infallible ~on_start
-          ~on_stop source autostart
+        ~name:"graphics" ~output_kind:"output.graphics" ~infallible
+          ~register_telnet ~on_start ~on_stop source autostart
 
     val mutable sleep = false
     method stop = sleep <- true
@@ -63,6 +63,7 @@ let _ =
     (fun p ->
       let autostart = Lang.to_bool (List.assoc "start" p) in
       let infallible = not (Lang.to_bool (List.assoc "fallible" p)) in
+      let register_telnet = Lang.to_bool (List.assoc "register_telnet" p) in
       let on_start =
         let f = List.assoc "on_start" p in
         fun () -> ignore (Lang.apply f [])
@@ -72,5 +73,6 @@ let _ =
         fun () -> ignore (Lang.apply f [])
       in
       let source = List.assoc "" p in
-      (new output ~infallible ~autostart ~on_start ~on_stop source
+      (new output
+         ~infallible ~register_telnet ~autostart ~on_start ~on_stop source
         :> Output.output))

--- a/src/core/outputs/harbor_output.ml
+++ b/src/core/outputs/harbor_output.ml
@@ -356,6 +356,7 @@ class output p =
   in
   let autostart = Lang.to_bool (List.assoc "start" p) in
   let infallible = not (Lang.to_bool (List.assoc "fallible" p)) in
+  let register_telnet = Lang.to_bool (List.assoc "register_telnet" p) in
   let on_start =
     let f = List.assoc "on_start" p in
     fun () -> ignore (Lang.apply f [])
@@ -415,8 +416,8 @@ class output p =
     (** File descriptor where to dump. *)
     inherit
       Output.encoded
-        ~output_kind:"output.harbor" ~infallible ~autostart ~on_start ~on_stop
-          ~name:mount source
+        ~output_kind:"output.harbor" ~infallible ~register_telnet ~autostart
+          ~on_start ~on_stop ~name:mount source
 
     val mutable dump = None
     val mutable encoder = None

--- a/src/core/outputs/hls_output.ml
+++ b/src/core/outputs/hls_output.ml
@@ -324,6 +324,7 @@ class hls_output p =
   in
   let autostart = Lang.to_bool (List.assoc "start" p) in
   let infallible = not (Lang.to_bool (List.assoc "fallible" p)) in
+  let register_telnet = Lang.to_bool (List.assoc "register_telnet" p) in
   let prefix = Lang.to_string (List.assoc "prefix" p) in
   let main_playlist_writer =
     Option.map
@@ -573,8 +574,8 @@ class hls_output p =
   object (self)
     inherit
       Output.encoded
-        ~infallible ~on_start ~on_stop ~autostart ~output_kind:"output.file"
-          ~name:main_playlist_filename source
+        ~infallible ~register_telnet ~on_start ~on_stop ~autostart
+          ~output_kind:"output.file" ~name:main_playlist_filename source
 
     (** Available segments *)
     val mutable segments = List.map (fun { name } -> (name, ref [])) streams

--- a/src/core/outputs/icecast2.ml
+++ b/src/core/outputs/icecast2.ml
@@ -409,6 +409,7 @@ class output p =
   in
   let autostart = Lang.to_bool (List.assoc "start" p) in
   let infallible = not (Lang.to_bool (List.assoc "fallible" p)) in
+  let register_telnet = Lang.to_bool (List.assoc "register_telnet" p) in
   let on_start =
     let f = List.assoc "on_start" p in
     fun () -> ignore (Lang.apply f [])
@@ -454,8 +455,8 @@ class output p =
   object (self)
     inherit
       Output.encoded
-        ~output_kind:"output.icecast" ~infallible ~autostart ~on_start ~on_stop
-          ~name source
+        ~output_kind:"output.icecast" ~infallible ~register_telnet ~autostart
+          ~on_start ~on_stop ~name source
 
     (** In this operator, we don't exactly follow the start/stop
     * mechanism of Output.encoded because we want to control

--- a/src/core/outputs/output.mli
+++ b/src/core/outputs/output.mli
@@ -31,6 +31,7 @@ class virtual output :
   output_kind:string
   -> ?name:string
   -> infallible:bool
+  -> register_telnet:bool
   -> on_start:(unit -> unit)
   -> on_stop:(unit -> unit)
   -> Lang.value
@@ -66,6 +67,7 @@ class virtual encoded :
   -> infallible:bool
   -> on_start:(unit -> unit)
   -> on_stop:(unit -> unit)
+  -> register_telnet:bool
   -> autostart:bool
   -> Lang.value
   -> object
@@ -84,6 +86,7 @@ class dummy :
   -> on_start:(unit -> unit)
   -> on_stop:(unit -> unit)
   -> autostart:bool
+  -> register_telnet:bool
   -> Lang.value
   -> object
        inherit output

--- a/src/core/outputs/pipe_output.ml
+++ b/src/core/outputs/pipe_output.ml
@@ -39,6 +39,7 @@ class virtual base ~source ~name p =
   (* Output settings *)
   let autostart = e Lang.to_bool "start" in
   let infallible = not (Lang.to_bool (List.assoc "fallible" p)) in
+  let register_telnet = Lang.to_bool (List.assoc "register_telnet" p) in
   let on_start =
     let f = List.assoc "on_start" p in
     fun () -> ignore (Lang.apply f [])
@@ -50,8 +51,8 @@ class virtual base ~source ~name p =
   object (self)
     inherit
       Output.encoded
-        ~infallible ~on_start ~on_stop ~autostart ~output_kind:"output.file"
-          ~name source
+        ~infallible ~register_telnet ~on_start ~on_stop ~autostart
+          ~output_kind:"output.file" ~name source
 
     val mutable encoder = None
     val mutable current_metadata = None

--- a/src/core/outputs/sdl_out.ml
+++ b/src/core/outputs/sdl_out.ml
@@ -26,13 +26,13 @@ open Mm
 
 open Tsdl
 
-class output ~infallible ~on_start ~on_stop ~autostart source =
+class output ~infallible ~register_telnet ~on_start ~on_stop ~autostart source =
   let () = Sdl_utils.init [Sdl.Init.video] in
   object (self)
     inherit
       Output.output
-        ~name:"sdl" ~output_kind:"output.sdl" ~infallible ~on_start ~on_stop
-          source autostart
+        ~name:"sdl" ~output_kind:"output.sdl" ~infallible ~register_telnet
+          ~on_start ~on_stop source autostart
 
     val mutable fullscreen = false
     val mutable window = None
@@ -110,6 +110,7 @@ let output_sdl =
     (fun p ->
       let autostart = Lang.to_bool (List.assoc "start" p) in
       let infallible = not (Lang.to_bool (List.assoc "fallible" p)) in
+      let register_telnet = Lang.to_bool (List.assoc "register_telnet" p) in
       let on_start =
         let f = List.assoc "on_start" p in
         fun () -> ignore (Lang.apply f [])
@@ -119,7 +120,8 @@ let output_sdl =
         fun () -> ignore (Lang.apply f [])
       in
       let source = List.assoc "" p in
-      (new output ~infallible ~autostart ~on_start ~on_stop source
+      (new output
+         ~infallible ~register_telnet ~autostart ~on_start ~on_stop source
         :> Output.output))
 
 let _ =

--- a/src/core/tools/producer_consumer.ml
+++ b/src/core/tools/producer_consumer.ml
@@ -44,7 +44,8 @@ class consumer ?(always_enabled = false) ~write_frame ~name ~source () =
   object (self)
     inherit
       Output.output
-        ~output_kind:name ~infallible ~on_start:noop ~on_stop:noop source true as super
+        ~output_kind:name ~register_telnet:false ~infallible ~on_start:noop
+          ~on_stop:noop source true as super
 
     val mutable output_enabled = false
     val mutable producer_buffer = Generator.create Frame.Fields.empty

--- a/tests/core/output_encoded_test.ml
+++ b/tests/core/output_encoded_test.ml
@@ -9,6 +9,7 @@ class encoded_test =
     inherit
       Output.encoded
         ~output_kind:"foo" ~name:"encoded_test" ~infallible:false
+          ~register_telnet:false
         ~on_start:(fun _ -> ())
         ~on_stop:(fun _ -> ())
         ~autostart:false

--- a/tests/core/output_test.ml
+++ b/tests/core/output_test.ml
@@ -2,7 +2,7 @@ class dummy ~autostart ~on_start source =
   object (self)
     inherit
       Output.dummy
-        ~autostart ~infallible:false ~on_start
+        ~autostart ~infallible:false ~register_telnet:false ~on_start
         ~on_stop:(fun () -> ())
         (Lang.source (source :> Source.source))
 


### PR DESCRIPTION
Fixes: #3541