### PR TITLE
Check ffi/fun content at runtime.

### DIFF
--- a/src/core/builtins/builtins_settings.ml
+++ b/src/core/builtins/builtins_settings.ml
@@ -219,7 +219,7 @@ let print_settings () =
   in
   let print_set ~path = function
     | Value.Tuple [] -> []
-    | (Value.Fun ([], _, _) | Value.FFI ([], _)) as value ->
+    | (Value.Fun ([], _, _) | Value.FFI { ffi_args = []; _ }) as value ->
         let value =
           Lang.apply
             { Value.pos = None; value; methods = Value.Methods.empty }

--- a/src/core/lang.mli
+++ b/src/core/lang.mli
@@ -58,6 +58,11 @@ type value = Liquidsoap_lang.Value.t = {
 and env = (string * value) list
 and lazy_env = (string * value Lazy.t) list
 
+and ffi = Liquidsoap_lang.Value.ffi = {
+  ffi_args : (string * string * value option) list;
+  mutable ffi_fn : env -> value;
+}
+
 and in_value = Liquidsoap_lang.Value.in_value =
   | Ground of Ground.t
   | List of value list
@@ -67,7 +72,7 @@ and in_value = Liquidsoap_lang.Value.in_value =
       (string * string * value option) list * lazy_env * Liquidsoap_lang.Term.t
   (* A function with given arguments (argument label, argument variable, default
      value), closure and value. *)
-  | FFI of (string * string * value option) list * (env -> value)
+  | FFI of ffi
 
 val demeth : value -> value
 val split_meths : value -> (string * value) list * value

--- a/src/core/operators/dyn_op.ml
+++ b/src/core/operators/dyn_op.ml
@@ -174,16 +174,5 @@ let _ =
       let resurection_time =
         List.assoc "resurection_time" p |> Lang.to_valued_option Lang.to_float
       in
-      let next = List.assoc "" p in
-      let frame_t = Lang.univ_t () in
-      Liquidsoap_lang.Lang.(
-        match next.Value.value with
-          | Fun (_, _, { Term.t }) ->
-              Typing.(
-                t <: Lang.nullable_t (Lang.source_t ~methods:false frame_t))
-          | _ -> assert false);
-      let s =
-        new dyn ~init ~track_sensitive ~infallible ~resurection_time next
-      in
-      Typing.(s#frame_type <: frame_t);
-      s)
+      new dyn
+        ~init ~track_sensitive ~infallible ~resurection_time (List.assoc "" p))

--- a/src/lang/builtins_getter.ml
+++ b/src/lang/builtins_getter.ml
@@ -48,7 +48,8 @@ let _ =
       let f = Lang.assoc "" 2 p in
       let g = Lang.assoc "" 3 p in
       match x.Lang.value with
-        | Lang.Fun ([], _, _) | Lang.FFI ([], _) -> Lang.apply g [("", x)]
+        | Lang.Fun ([], _, _) | Lang.FFI { ffi_args = []; _ } ->
+            Lang.apply g [("", x)]
         | _ -> Lang.apply f [("", x)])
 
 let _ =
@@ -75,7 +76,7 @@ let getter_map =
       let f = Lang.assoc "" 1 p in
       let x = Lang.assoc "" 2 p in
       match x.Lang.value with
-        | Lang.Fun ([], _, _) | Lang.FFI ([], _) ->
+        | Lang.Fun ([], _, _) | Lang.FFI { ffi_args = []; _ } ->
             Lang.val_fun [] (fun _ -> Lang.apply f [("", Lang.apply x [])])
         | _ -> Lang.apply f [("", x)])
 
@@ -96,7 +97,7 @@ let _ =
       let f = Lang.assoc "" 1 p in
       let x = Lang.assoc "" 2 p in
       match x.Lang.value with
-        | Lang.Fun ([], _, _) | Lang.FFI ([], _) ->
+        | Lang.Fun ([], _, _) | Lang.FFI { ffi_args = []; _ } ->
             let last_x = ref (Lang.apply x []) in
             let last_y = ref (Lang.apply f [("", !last_x)]) in
             Lang.val_fun [] (fun _ ->

--- a/src/lang/evaluation.ml
+++ b/src/lang/evaluation.ml
@@ -177,7 +177,7 @@ and apply ?pos ~eval_check f l =
             fun pe ->
               let env = Env.adds e pe in
               eval ~eval_check env body )
-      | Value.FFI (p, f) -> (p, fun pe -> f (List.rev pe))
+      | Value.FFI { ffi_args = p; ffi_fn = f } -> (p, fun pe -> f (List.rev pe))
       | _ -> assert false
   in
   (* Record error positions. *)

--- a/src/lang/lang.mli
+++ b/src/lang/lang.mli
@@ -58,6 +58,11 @@ type value = Value.t = {
 and env = (string * value) list
 and lazy_env = (string * value Lazy.t) list
 
+and ffi = Value.ffi = {
+  ffi_args : (string * string * value option) list;
+  mutable ffi_fn : env -> value;
+}
+
 and in_value = Value.in_value =
   | Ground of Ground.t
   | List of value list
@@ -66,7 +71,7 @@ and in_value = Value.in_value =
   | Fun of (string * string * value option) list * lazy_env * Term.t
   (* A function with given arguments (argument label, argument variable, default
      value), closure and value. *)
-  | FFI of (string * string * value option) list * (env -> value)
+  | FFI of ffi
 
 val demeth : value -> value
 val split_meths : value -> (string * value) list * value

--- a/src/lang/lang_core.ml
+++ b/src/lang/lang_core.ml
@@ -101,7 +101,7 @@ let meth v l =
   }
 
 let record = meth unit
-let val_fun p f = mk (FFI (p, f))
+let val_fun p f = mk (FFI { ffi_args = p; ffi_fn = f })
 let term_fun p tm = mk (Fun (p, [], tm))
 
 let val_cst_fun p c =
@@ -122,7 +122,7 @@ let val_cst_fun p c =
         f (mkg Type.Ground.float) (`Ground (Term.Ground.Float i))
     | Ground (String i) ->
         f (mkg Type.Ground.string) (`Ground (Term.Ground.String i))
-    | _ -> mk (FFI (p, fun _ -> c))
+    | _ -> mk (FFI { ffi_args = p; ffi_fn = (fun _ -> c) })
 
 let reference get set =
   let get = val_fun [] (fun _ -> get ()) in
@@ -167,7 +167,12 @@ let add_builtin ~category ~descr ?(flags = []) ?(meth = []) ?(examples = [])
   let value =
     {
       pos = None;
-      value = FFI (List.map (fun (lbl, _, opt, _) -> (lbl, lbl, opt)) proto, f);
+      value =
+        FFI
+          {
+            ffi_args = List.map (fun (lbl, _, opt, _) -> (lbl, lbl, opt)) proto;
+            ffi_fn = f;
+          };
       methods = Methods.empty;
     }
   in
@@ -351,7 +356,7 @@ let to_int_list l = List.map to_int (to_list l)
 
 let to_getter t =
   match t.value with
-    | Fun ([], _, _) | FFI ([], _) -> fun () -> apply t []
+    | Fun ([], _, _) | FFI { ffi_args = []; _ } -> fun () -> apply t []
     | _ -> fun () -> t
 
 let to_ref t =

--- a/src/lang/term/term_reducer.ml
+++ b/src/lang/term/term_reducer.ml
@@ -100,7 +100,7 @@ let mk_time_pred ~pos (a, b, c) =
 let gen_args_of ~only ~except ~pos get_args name =
   match Environment.get_builtin name with
     | Some ((_, t), Value.{ value = Fun (args, _, _) })
-    | Some ((_, t), Value.{ value = FFI (args, _) }) ->
+    | Some ((_, t), Value.{ value = FFI { ffi_args = args; _ } }) ->
         let filtered_args = List.filter (fun (n, _, _) -> n <> "") args in
         let filtered_args =
           if only <> [] then

--- a/src/lang/value.ml
+++ b/src/lang/value.ml
@@ -33,6 +33,11 @@ and env = (string * t) list
 (* Some values have to be lazy in the environment because of recursive functions. *)
 and lazy_env = (string * t Lazy.t) list
 
+and ffi = {
+  ffi_args : (string * string * t option) list;
+  mutable ffi_fn : env -> t;
+}
+
 and in_value =
   | Ground of Ground.t
   | List of t list
@@ -43,7 +48,7 @@ and in_value =
   | Fun of (string * string * t option) list * lazy_env * Term.t
   (* For a foreign function only the arguments are visible, the closure
      doesn't capture anything in the environment. *)
-  | FFI of (string * string * t option) list * (env -> t)
+  | FFI of ffi
 
 let unit : in_value = Tuple []
 

--- a/tests/regression/dune.inc
+++ b/tests/regression/dune.inc
@@ -6,6 +6,7 @@
   115-1.liq
   ../media/all_media_files
   ../../src/bin/liquidsoap.exe
+  ../streams/file1.png
   (package liquidsoap)
   (:stdlib ../../src/libs/stdlib.liq)
   (:test_liq ../test.liq)
@@ -19,6 +20,7 @@
   115-2.liq
   ../media/all_media_files
   ../../src/bin/liquidsoap.exe
+  ../streams/file1.png
   (package liquidsoap)
   (:stdlib ../../src/libs/stdlib.liq)
   (:test_liq ../test.liq)
@@ -32,6 +34,7 @@
   AC5109.liq
   ../media/all_media_files
   ../../src/bin/liquidsoap.exe
+  ../streams/file1.png
   (package liquidsoap)
   (:stdlib ../../src/libs/stdlib.liq)
   (:test_liq ../test.liq)
@@ -45,6 +48,7 @@
   BUG403.liq
   ../media/all_media_files
   ../../src/bin/liquidsoap.exe
+  ../streams/file1.png
   (package liquidsoap)
   (:stdlib ../../src/libs/stdlib.liq)
   (:test_liq ../test.liq)
@@ -58,6 +62,7 @@
   GH-action-919422659.liq
   ../media/all_media_files
   ../../src/bin/liquidsoap.exe
+  ../streams/file1.png
   (package liquidsoap)
   (:stdlib ../../src/libs/stdlib.liq)
   (:test_liq ../test.liq)
@@ -71,6 +76,7 @@
   GH1129.liq
   ../media/all_media_files
   ../../src/bin/liquidsoap.exe
+  ../streams/file1.png
   (package liquidsoap)
   (:stdlib ../../src/libs/stdlib.liq)
   (:test_liq ../test.liq)
@@ -84,6 +90,7 @@
   GH1146.liq
   ../media/all_media_files
   ../../src/bin/liquidsoap.exe
+  ../streams/file1.png
   (package liquidsoap)
   (:stdlib ../../src/libs/stdlib.liq)
   (:test_liq ../test.liq)
@@ -97,6 +104,7 @@
   GH1151.liq
   ../media/all_media_files
   ../../src/bin/liquidsoap.exe
+  ../streams/file1.png
   (package liquidsoap)
   (:stdlib ../../src/libs/stdlib.liq)
   (:test_liq ../test.liq)
@@ -110,6 +118,7 @@
   GH1159.liq
   ../media/all_media_files
   ../../src/bin/liquidsoap.exe
+  ../streams/file1.png
   (package liquidsoap)
   (:stdlib ../../src/libs/stdlib.liq)
   (:test_liq ../test.liq)
@@ -123,6 +132,7 @@
   GH1279.liq
   ../media/all_media_files
   ../../src/bin/liquidsoap.exe
+  ../streams/file1.png
   (package liquidsoap)
   (:stdlib ../../src/libs/stdlib.liq)
   (:test_liq ../test.liq)
@@ -136,6 +146,7 @@
   GH1327.liq
   ../media/all_media_files
   ../../src/bin/liquidsoap.exe
+  ../streams/file1.png
   (package liquidsoap)
   (:stdlib ../../src/libs/stdlib.liq)
   (:test_liq ../test.liq)
@@ -149,6 +160,7 @@
   GH2585.liq
   ../media/all_media_files
   ../../src/bin/liquidsoap.exe
+  ../streams/file1.png
   (package liquidsoap)
   (:stdlib ../../src/libs/stdlib.liq)
   (:test_liq ../test.liq)
@@ -162,6 +174,7 @@
   GH2602.liq
   ../media/all_media_files
   ../../src/bin/liquidsoap.exe
+  ../streams/file1.png
   (package liquidsoap)
   (:stdlib ../../src/libs/stdlib.liq)
   (:test_liq ../test.liq)
@@ -175,6 +188,7 @@
   GH2756-2.liq
   ../media/all_media_files
   ../../src/bin/liquidsoap.exe
+  ../streams/file1.png
   (package liquidsoap)
   (:stdlib ../../src/libs/stdlib.liq)
   (:test_liq ../test.liq)
@@ -188,6 +202,7 @@
   GH2756.liq
   ../media/all_media_files
   ../../src/bin/liquidsoap.exe
+  ../streams/file1.png
   (package liquidsoap)
   (:stdlib ../../src/libs/stdlib.liq)
   (:test_liq ../test.liq)
@@ -201,6 +216,7 @@
   GH2758.liq
   ../media/all_media_files
   ../../src/bin/liquidsoap.exe
+  ../streams/file1.png
   (package liquidsoap)
   (:stdlib ../../src/libs/stdlib.liq)
   (:test_liq ../test.liq)
@@ -214,6 +230,7 @@
   GH2842.liq
   ../media/all_media_files
   ../../src/bin/liquidsoap.exe
+  ../streams/file1.png
   (package liquidsoap)
   (:stdlib ../../src/libs/stdlib.liq)
   (:test_liq ../test.liq)
@@ -227,6 +244,7 @@
   GH2850.liq
   ../media/all_media_files
   ../../src/bin/liquidsoap.exe
+  ../streams/file1.png
   (package liquidsoap)
   (:stdlib ../../src/libs/stdlib.liq)
   (:test_liq ../test.liq)
@@ -240,6 +258,7 @@
   GH2867.liq
   ../media/all_media_files
   ../../src/bin/liquidsoap.exe
+  ../streams/file1.png
   (package liquidsoap)
   (:stdlib ../../src/libs/stdlib.liq)
   (:test_liq ../test.liq)
@@ -253,6 +272,7 @@
   GH2871.liq
   ../media/all_media_files
   ../../src/bin/liquidsoap.exe
+  ../streams/file1.png
   (package liquidsoap)
   (:stdlib ../../src/libs/stdlib.liq)
   (:test_liq ../test.liq)
@@ -266,6 +286,7 @@
   GH2872.liq
   ../media/all_media_files
   ../../src/bin/liquidsoap.exe
+  ../streams/file1.png
   (package liquidsoap)
   (:stdlib ../../src/libs/stdlib.liq)
   (:test_liq ../test.liq)
@@ -279,6 +300,7 @@
   GH2897.liq
   ../media/all_media_files
   ../../src/bin/liquidsoap.exe
+  ../streams/file1.png
   (package liquidsoap)
   (:stdlib ../../src/libs/stdlib.liq)
   (:test_liq ../test.liq)
@@ -292,6 +314,7 @@
   GH2902.liq
   ../media/all_media_files
   ../../src/bin/liquidsoap.exe
+  ../streams/file1.png
   (package liquidsoap)
   (:stdlib ../../src/libs/stdlib.liq)
   (:test_liq ../test.liq)
@@ -305,6 +328,7 @@
   GH2926.liq
   ../media/all_media_files
   ../../src/bin/liquidsoap.exe
+  ../streams/file1.png
   (package liquidsoap)
   (:stdlib ../../src/libs/stdlib.liq)
   (:test_liq ../test.liq)
@@ -318,6 +342,7 @@
   GH3093.liq
   ../media/all_media_files
   ../../src/bin/liquidsoap.exe
+  ../streams/file1.png
   (package liquidsoap)
   (:stdlib ../../src/libs/stdlib.liq)
   (:test_liq ../test.liq)
@@ -331,6 +356,7 @@
   GH3121.liq
   ../media/all_media_files
   ../../src/bin/liquidsoap.exe
+  ../streams/file1.png
   (package liquidsoap)
   (:stdlib ../../src/libs/stdlib.liq)
   (:test_liq ../test.liq)
@@ -344,6 +370,7 @@
   GH3132.liq
   ../media/all_media_files
   ../../src/bin/liquidsoap.exe
+  ../streams/file1.png
   (package liquidsoap)
   (:stdlib ../../src/libs/stdlib.liq)
   (:test_liq ../test.liq)
@@ -357,6 +384,7 @@
   GH3224.liq
   ../media/all_media_files
   ../../src/bin/liquidsoap.exe
+  ../streams/file1.png
   (package liquidsoap)
   (:stdlib ../../src/libs/stdlib.liq)
   (:test_liq ../test.liq)
@@ -370,6 +398,7 @@
   GH3239-2.liq
   ../media/all_media_files
   ../../src/bin/liquidsoap.exe
+  ../streams/file1.png
   (package liquidsoap)
   (:stdlib ../../src/libs/stdlib.liq)
   (:test_liq ../test.liq)
@@ -383,6 +412,7 @@
   GH3239.liq
   ../media/all_media_files
   ../../src/bin/liquidsoap.exe
+  ../streams/file1.png
   (package liquidsoap)
   (:stdlib ../../src/libs/stdlib.liq)
   (:test_liq ../test.liq)
@@ -396,6 +426,7 @@
   GH3276.liq
   ../media/all_media_files
   ../../src/bin/liquidsoap.exe
+  ../streams/file1.png
   (package liquidsoap)
   (:stdlib ../../src/libs/stdlib.liq)
   (:test_liq ../test.liq)
@@ -409,6 +440,7 @@
   GH3316.liq
   ../media/all_media_files
   ../../src/bin/liquidsoap.exe
+  ../streams/file1.png
   (package liquidsoap)
   (:stdlib ../../src/libs/stdlib.liq)
   (:test_liq ../test.liq)
@@ -422,6 +454,7 @@
   LS268.liq
   ../media/all_media_files
   ../../src/bin/liquidsoap.exe
+  ../streams/file1.png
   (package liquidsoap)
   (:stdlib ../../src/libs/stdlib.liq)
   (:test_liq ../test.liq)
@@ -435,6 +468,7 @@
   LS354-1.liq
   ../media/all_media_files
   ../../src/bin/liquidsoap.exe
+  ../streams/file1.png
   (package liquidsoap)
   (:stdlib ../../src/libs/stdlib.liq)
   (:test_liq ../test.liq)
@@ -448,6 +482,7 @@
   LS354-2.liq
   ../media/all_media_files
   ../../src/bin/liquidsoap.exe
+  ../streams/file1.png
   (package liquidsoap)
   (:stdlib ../../src/libs/stdlib.liq)
   (:test_liq ../test.liq)
@@ -461,6 +496,7 @@
   LS460.liq
   ../media/all_media_files
   ../../src/bin/liquidsoap.exe
+  ../streams/file1.png
   (package liquidsoap)
   (:stdlib ../../src/libs/stdlib.liq)
   (:test_liq ../test.liq)
@@ -474,6 +510,7 @@
   LS503.liq
   ../media/all_media_files
   ../../src/bin/liquidsoap.exe
+  ../streams/file1.png
   (package liquidsoap)
   (:stdlib ../../src/libs/stdlib.liq)
   (:test_liq ../test.liq)
@@ -487,6 +524,7 @@
   default_format.liq
   ../media/all_media_files
   ../../src/bin/liquidsoap.exe
+  ../streams/file1.png
   (package liquidsoap)
   (:stdlib ../../src/libs/stdlib.liq)
   (:test_liq ../test.liq)
@@ -500,6 +538,7 @@
   external-encoder.liq
   ../media/all_media_files
   ../../src/bin/liquidsoap.exe
+  ../streams/file1.png
   (package liquidsoap)
   (:stdlib ../../src/libs/stdlib.liq)
   (:test_liq ../test.liq)
@@ -513,6 +552,7 @@
   ffmpeg-copy-encode.liq
   ../media/all_media_files
   ../../src/bin/liquidsoap.exe
+  ../streams/file1.png
   (package liquidsoap)
   (:stdlib ../../src/libs/stdlib.liq)
   (:test_liq ../test.liq)
@@ -526,6 +566,7 @@
   ffmpeg-copy-input-http.liq
   ../media/all_media_files
   ../../src/bin/liquidsoap.exe
+  ../streams/file1.png
   (package liquidsoap)
   (:stdlib ../../src/libs/stdlib.liq)
   (:test_liq ../test.liq)
@@ -539,6 +580,7 @@
   ffmpeg-naming-convention.liq
   ../media/all_media_files
   ../../src/bin/liquidsoap.exe
+  ../streams/file1.png
   (package liquidsoap)
   (:stdlib ../../src/libs/stdlib.liq)
   (:test_liq ../test.liq)
@@ -552,6 +594,7 @@
   infallible-shutdown.liq
   ../media/all_media_files
   ../../src/bin/liquidsoap.exe
+  ../streams/file1.png
   (package liquidsoap)
   (:stdlib ../../src/libs/stdlib.liq)
   (:test_liq ../test.liq)
@@ -565,6 +608,7 @@
   init-error.liq
   ../media/all_media_files
   ../../src/bin/liquidsoap.exe
+  ../streams/file1.png
   (package liquidsoap)
   (:stdlib ../../src/libs/stdlib.liq)
   (:test_liq ../test.liq)
@@ -578,6 +622,7 @@
   initial_request_queue.liq
   ../media/all_media_files
   ../../src/bin/liquidsoap.exe
+  ../streams/file1.png
   (package liquidsoap)
   (:stdlib ../../src/libs/stdlib.liq)
   (:test_liq ../test.liq)
@@ -591,6 +636,7 @@
   input_rtmp.liq
   ../media/all_media_files
   ../../src/bin/liquidsoap.exe
+  ../streams/file1.png
   (package liquidsoap)
   (:stdlib ../../src/libs/stdlib.liq)
   (:test_liq ../test.liq)
@@ -604,6 +650,7 @@
   metadata_cache.liq
   ../media/all_media_files
   ../../src/bin/liquidsoap.exe
+  ../streams/file1.png
   (package liquidsoap)
   (:stdlib ../../src/libs/stdlib.liq)
   (:test_liq ../test.liq)
@@ -617,6 +664,7 @@
   playlist-id.liq
   ../media/all_media_files
   ../../src/bin/liquidsoap.exe
+  ../streams/file1.png
   (package liquidsoap)
   (:stdlib ../../src/libs/stdlib.liq)
   (:test_liq ../test.liq)
@@ -630,6 +678,7 @@
   replaygain.liq
   ../media/all_media_files
   ../../src/bin/liquidsoap.exe
+  ../streams/file1.png
   (package liquidsoap)
   (:stdlib ../../src/libs/stdlib.liq)
   (:test_liq ../test.liq)
@@ -643,6 +692,7 @@
   shoutcast-args.liq
   ../media/all_media_files
   ../../src/bin/liquidsoap.exe
+  ../streams/file1.png
   (package liquidsoap)
   (:stdlib ../../src/libs/stdlib.liq)
   (:test_liq ../test.liq)
@@ -653,9 +703,24 @@
  (alias citest)
  (package liquidsoap)
  (deps
+  source_dynamic.liq
+  ../media/all_media_files
+  ../../src/bin/liquidsoap.exe
+  ../streams/file1.png
+  (package liquidsoap)
+  (:stdlib ../../src/libs/stdlib.liq)
+  (:test_liq ../test.liq)
+  (:run_test ../run_test.exe))
+ (action (run %{run_test} source_dynamic.liq liquidsoap %{test_liq} source_dynamic.liq)))
+
+(rule
+ (alias citest)
+ (package liquidsoap)
+ (deps
   unified-pcm-types.liq
   ../media/all_media_files
   ../../src/bin/liquidsoap.exe
+  ../streams/file1.png
   (package liquidsoap)
   (:stdlib ../../src/libs/stdlib.liq)
   (:test_liq ../test.liq)
@@ -669,6 +734,7 @@
   video-only.liq
   ../media/all_media_files
   ../../src/bin/liquidsoap.exe
+  ../streams/file1.png
   (package liquidsoap)
   (:stdlib ../../src/libs/stdlib.liq)
   (:test_liq ../test.liq)

--- a/tests/regression/gen_dune.ml
+++ b/tests/regression/gen_dune.ml
@@ -16,6 +16,7 @@ let () =
   %s
   ../media/all_media_files
   ../../src/bin/liquidsoap.exe
+  ../streams/file1.png
   (package liquidsoap)
   (:stdlib ../../src/libs/stdlib.liq)
   (:test_liq ../test.liq)

--- a/tests/regression/source_dynamic.liq
+++ b/tests/regression/source_dynamic.liq
@@ -1,0 +1,18 @@
+#!../../liquidsoap ../test.liq
+
+s_ref = ref((fallback([]) : source))
+
+def next() =
+  r = request.create("../streams/file1.png")
+  ignore(request.resolve(r, content_type=s_ref()))
+  s = request.dynamic(fun () -> null())
+  s.set_queue([r])
+  s
+end
+
+s = (source.dynamic(track_sensitive=true, next) : source(video=canvas))
+
+s_ref := s
+
+output.dummy(fallible=true, s)
+thread.run(delay=3., test.pass)

--- a/tests/streams/dune.inc
+++ b/tests/streams/dune.inc
@@ -566,6 +566,13 @@
   ./jingles
   ./playlist
   ./huge_playlist
+  ./replaygain_track_gain.mp3
+  ./r128_track_gain.mp3
+  ./replaygain_r128_track_gain.mp3
+  ./replaygain_track_gain.opus
+  ./r128_track_gain.opus
+  ./replaygain_r128_track_gain.opus
+  ./without_replaygain_track_gain.mp3
   ../../src/bin/liquidsoap.exe
   (package liquidsoap)
   (:test_liq ../test.liq)


### PR DESCRIPTION
Since we unified the type computed during typechecking phase for sources and the source frame type assigned at runtime, we need to make sure this information is properly passed down when starting the runtime.

This is done via `eval_check` (implemented in `Hooks_implementations`) and `check_content` (implemented in `Lang_source`).

Previously, we left out functions in `check_content`. However, it turns out that, with operators such as `source.dynamic`, we do need to tighten up computed types down to functions as well.

This PR implements that. It checks content and type for `Fun` and `FFI` values and changes `FFI` implementation to a mutable field so that the content check can be done at the time the FFI value is computed.