### PR TITLE
Add Type.Fresh API.

### DIFF
--- a/src/core/builtins/builtins_ffmpeg_decoder.ml
+++ b/src/core/builtins/builtins_ffmpeg_decoder.ml
@@ -495,8 +495,7 @@ let mk_decoder mode =
          in
          consumer#set_pos pos;
 
-         let input_frame_t = Typing.generalize ~level:(-1) input_frame_t in
-         let input_frame_t = Typing.instantiate ~level:(-1) input_frame_t in
+         let input_frame_t = Type.fresh input_frame_t in
          Typing.(
            consumer#frame_type
            <: Lang.frame_t (Lang.univ_t ())

--- a/src/core/builtins/builtins_ffmpeg_encoder.ml
+++ b/src/core/builtins/builtins_ffmpeg_encoder.ml
@@ -457,10 +457,7 @@ let mk_encoder mode =
                 (format_val, "Format option is not supported inline encoders"));
 
          let mk_encode_frame generator =
-           let output_frame_t =
-             let s = Typing.generalize ~level:(-1) output_frame_t in
-             Typing.instantiate ~level:(-1) s
-           in
+           let output_frame_t = Type.fresh output_frame_t in
 
            let stream = List.assoc format_field format.Ffmpeg_format.streams in
 
@@ -563,10 +560,7 @@ let mk_encoder mode =
          in
          consumer#set_pos pos;
 
-         let input_frame_t =
-           Typing.instantiate ~level:(-1)
-             (Typing.generalize ~level:(-1) input_frame_t)
-         in
+         let input_frame_t = Type.fresh input_frame_t in
          Typing.(
            consumer#frame_type
            <: Lang.frame_t (Lang.univ_t ())

--- a/src/core/hooks_implementations.ml
+++ b/src/core/hooks_implementations.ml
@@ -14,8 +14,7 @@ let eval_check ~env:_ ~tm v =
   if Lang_source.Source_val.is_value v then (
     let s = Lang_source.Source_val.of_value v in
     if not s#has_content_type then (
-      let scheme = Typing.generalize ~level:(-1) (deep_demeth tm.Term.t) in
-      let ty = Typing.instantiate ~level:(-1) scheme in
+      let ty = Type.fresh (deep_demeth tm.Term.t) in
       Typing.(Lang_source.source_t ~methods:false s#frame_type <: ty);
       s#content_type_computation_allowed))
   else if Track.is_value v then (
@@ -25,10 +24,7 @@ let eval_check ~env:_ ~tm v =
         | _ when field = Frame.Fields.metadata -> ()
         | _ when field = Frame.Fields.track_marks -> ()
         | _ ->
-            let scheme =
-              Typing.generalize ~level:(-1) (deep_demeth tm.Term.t)
-            in
-            let ty = Typing.instantiate ~level:(-1) scheme in
+            let ty = Type.fresh (deep_demeth tm.Term.t) in
             let frame_t =
               Frame_type.make (Lang.univ_t ())
                 (Frame.Fields.add field ty Frame.Fields.empty)

--- a/src/lang/builtins_eval.ml
+++ b/src/lang/builtins_eval.ml
@@ -31,7 +31,6 @@ let _ =
     (Lang.univ_t ())
     (fun p ->
       let ty = Value.RuntimeType.of_value (List.assoc "type" p) in
-      let scheme = Typing.generalize ~level:(-1) ty in
-      let ty = Typing.instantiate ~level:(-1) scheme in
+      let ty = Type.fresh ty in
       let s = Lang.to_string (List.assoc "" p) in
       try Runtime.eval ~ignored:false ~ty s with exn -> raise exn)

--- a/src/lang/builtins_json.ml
+++ b/src/lang/builtins_json.ml
@@ -340,8 +340,7 @@ let _ =
     (fun p ->
       let s = Lang.to_string (List.assoc "" p) in
       let ty = Value.RuntimeType.of_value (List.assoc "type" p) in
-      let scheme = Typing.generalize ~level:(-1) ty in
-      let ty = Typing.instantiate ~level:(-1) scheme in
+      let ty = Type.fresh ty in
       let json5 = Lang.to_bool (List.assoc "json5" p) in
       try
         let json = Json.from_string ~json5 s in

--- a/src/lang/builtins_yaml.ml
+++ b/src/lang/builtins_yaml.ml
@@ -33,8 +33,7 @@ let _ =
     (fun p ->
       let s = Lang.to_string (List.assoc "" p) in
       let ty = Value.RuntimeType.of_value (List.assoc "type" p) in
-      let scheme = Typing.generalize ~level:(-1) ty in
-      let ty = Typing.instantiate ~level:(-1) scheme in
+      let ty = Type.fresh ty in
       let parser = Atomic.get yaml_parser in
       try
         let yaml = parser s in

--- a/src/lang/type.mli
+++ b/src/lang/type.mli
@@ -69,7 +69,6 @@ val string_of_constr : constr -> string
 val num_constr : constr
 val ord_constr : constr
 
-module Subst = Type_base.Subst
 module R = Type_base.R
 
 type custom = Type_base.custom = ..
@@ -107,6 +106,26 @@ val unit : descr
 module Var = Type_base.Var
 module Vars = Type_base.Vars
 
+(** Generate fresh types from existing types. *)
+module Fresh : sig
+  type mapper = Type_base.Fresh.mapper
+
+  (* Use [selector] to pick variables to be re-freshed. If [level] is passed,
+     all new variables are created with the given level. *)
+  val init : ?selector:(var -> bool) -> ?level:int -> unit -> mapper
+
+  (* Generate a fresh var using the parameters passed when initializing
+     the corresponding handler. Generated variables are memoized. *)
+  val make_var : mapper -> var -> var
+
+  (* Generate a fresh type using the parameters passed when initializing
+     the corresponding handler. *)
+  val make : mapper -> t -> t
+end
+
+(* Generate a fully refreshed type. Shared variables are mapped
+   to shared fresh variables. *)
+val fresh : t -> t
 val make : ?pos:Pos.t -> descr -> t
 val deref : t -> t
 val demeth : t -> t


### PR DESCRIPTION
This PR is a preliminary work for the proper merge of https://github.com/savonet/liquidsoap/pull/3547. To make things like `source.dynamic` work at runtime, we need a proper way to extract fresh types from an existing type while preserving variable sharing.

This PR introduces a `Type.Fresh` module which performs this operation. The module can also be used selectively to only refresh certain variables. It is, thus, used to also implement type instantiation.

### Performances

Current `main`:
```
Typechecking: 2.43s
```

This PR:
```
Typechecking: 2.55s
```

That's about `1%` increase.

### Notes

* Variable names are really for display only, What matters at the type inference is the actual variable instance that is shared.
* Type instantiation is used as follows:
  - Inside definitions, a level value is increased.
  - Using level, one can extract variables to be generalized after type checking the defition
  - When, later on, a definition is used, the generalized variables need to be instantiated to avoid sharing generalized variables with the code that uses the definition
  - Previously, all newly instantiated variables would have the same level, which seems abusive. In this PR, we compute the lowest level in the set of generalized variables and use this to compute a level offset. This means that, if the variable using the definition is a level `4` and the definition is at level `2`, all variables at level `3` inside the definition (for instance if the definiton includes itself a definition) are mapped to level `5` after the instantiation.
 * Previous implementation had a bug: variables substitution was done by name only and did not respect constraints. If a variable was present with the same name and different constaints, its constraints would be erased by the constraints of the variables passed in the `generalize` argument.
* Lastly, all the instances where we were abusing `instantiate` to actually fully refresh a type are replaced by simple `Type.fresh` calls.