### PR TITLE
Add support for bigstring.

### DIFF
--- a/.github/opam/liquidsoap-core-windows.opam
+++ b/.github/opam/liquidsoap-core-windows.opam
@@ -28,6 +28,8 @@ depends: [
   "sedlex-windows" {>= "3.2"}
   "menhir"
   "menhirLib-windows"
+  "bigstringaf-windows"
+  "bigstring-unix-windows"
   "metadata-windows"
   "dune-site-windows"
   "dune-build-info-windows"

--- a/.github/scripts/build-posix.sh
+++ b/.github/scripts/build-posix.sh
@@ -27,6 +27,9 @@ echo "::endgroup::"
 
 echo "::group::Setting up specific dependencies"
 
+opam update
+opam install -y bigstringaf bigstring-unix
+
 cd /tmp/liquidsoap-full/liquidsoap
 
 ./.github/scripts/checkout-deps.sh

--- a/dune-project
+++ b/dune-project
@@ -52,6 +52,8 @@
     (ocurl (>= 0.9.2))
     (cry (>= 1.0.0))
     (camomile (>= 2.0.0))
+    bigstringaf
+    bigstring-unix
     uri
     fileutils
     menhirLib
@@ -152,6 +154,7 @@
   (depends
     (ocaml (>= 4.14.0))
     dune-site
+    bigstringaf
     (re (>= 1.11.0))
     (ppx_string :build)
     (sedlex (>= 3.2))

--- a/liquidsoap-core.opam
+++ b/liquidsoap-core.opam
@@ -17,6 +17,8 @@ depends: [
   "ocurl" {>= "0.9.2"}
   "cry" {>= "1.0.0"}
   "camomile" {>= "2.0.0"}
+  "bigstringaf"
+  "bigstring-unix"
   "uri"
   "fileutils"
   "menhirLib"

--- a/liquidsoap-lang.opam
+++ b/liquidsoap-lang.opam
@@ -11,6 +11,7 @@ depends: [
   "dune" {>= "3.6"}
   "ocaml" {>= "4.14.0"}
   "dune-site"
+  "bigstringaf"
   "re" {>= "1.11.0"}
   "ppx_string" {build}
   "sedlex" {>= "3.2"}

--- a/src/core/builtins/builtins_files.ml
+++ b/src/core/builtins/builtins_files.ml
@@ -422,7 +422,10 @@ let _ =
         Some "Default file rights if created." );
       ("", Lang.string_t, None, None);
     ]
-    Builtins_socket.Socket_value.t ~descr:"Open a file."
+    Builtins_socket.Socket_value.t
+    ~descr:
+      "Open a file. File descriptors behave like socket descriptors except \
+       that bigstring reads return data mmap'd directly from the file on disk."
     (fun p ->
       let write = Lang.to_bool (List.assoc "write" p) in
       let access_flag = if write then Unix.O_RDWR else Unix.O_RDONLY in

--- a/src/core/builtins/builtins_socket.ml
+++ b/src/core/builtins/builtins_socket.ml
@@ -322,7 +322,7 @@ module Socket_value = struct
             (Lang.val_fun
                [
                  ("timeout", "timeout", Some (Lang.float 10.));
-                 ("bigstring", "bigstring", Some (Lang.bool true));
+                 ("bigstring", "bigstring", Some (Lang.bool false));
                  ("", "", Some (Lang.int Utils.pagesize));
                ]
                (fun p ->

--- a/src/core/builtins/builtins_ssl.ml
+++ b/src/core/builtins/builtins_ssl.ml
@@ -52,7 +52,14 @@ let ssl_socket transport ssl =
       Tutils.wait_for ?log event timeout
 
     method read = Ssl.read ssl
+
+    method read_bigstring ?dst len =
+      let dst = match dst with Some b -> b | None -> Bigstringaf.create len in
+      let n = Ssl.read_into_bigarray ssl dst 0 len in
+      Bigstringaf.sub ~off:0 ~len:n dst
+
     method write = Ssl.write ssl
+    method write_bigstring = Ssl.write_bigarray ssl
 
     method close =
       let fd = Ssl.file_descr_of_socket ssl in

--- a/src/core/dune
+++ b/src/core/dune
@@ -19,6 +19,7 @@
   (pps ppx_string))
  (libraries
   mm
+  bigstring-unix
   dtools
   dune-build-info
   duppy

--- a/src/core/lang.mli
+++ b/src/core/lang.mli
@@ -31,12 +31,21 @@ type module_name = Liquidsoap_lang.Lang.module_name
 type scheme = Liquidsoap_lang.Type.scheme
 type regexp = Liquidsoap_lang.Lang.regexp
 
+type bigstring =
+  (char, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t
+
 (** {2 Values} *)
 
 (** A typed value. *)
 module Ground : sig
   type t = Liquidsoap_lang.Term.Ground.t = ..
-  type t += Bool of bool | Int of int | String of string | Float of float
+
+  type t +=
+    | Bool of bool
+    | Int of int
+    | String of string
+    | Bigstring of bigstring
+    | Float of float
 
   type content = Liquidsoap_lang.Term.Ground.content = {
     descr : t -> string;
@@ -280,6 +289,7 @@ val int : int -> value
 val bool : bool -> value
 val float : float -> value
 val string : string -> value
+val bigstring : bigstring -> value
 val regexp : regexp -> value
 val list : value list -> value
 val null : value

--- a/src/core/tools/http.mli
+++ b/src/core/tools/http.mli
@@ -2,13 +2,18 @@
 
 type event = [ `Write | `Read | `Both ]
 
+type bigstring =
+  (char, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t
+
 type socket =
   < typ : string
   ; transport : transport
   ; file_descr : Unix.file_descr
   ; wait_for : ?log:(string -> unit) -> event -> float -> unit
   ; write : Bytes.t -> int -> int -> int
+  ; write_bigstring : bigstring -> int -> int -> int
   ; read : Bytes.t -> int -> int -> int
+  ; read_bigstring : ?dst:bigstring -> int -> bigstring
   ; close : unit >
 
 and server =

--- a/src/lang/builtins_string.ml
+++ b/src/lang/builtins_string.ml
@@ -6,6 +6,10 @@ let string =
         Lang.bool_t,
         Some (Lang.bool false),
         Some "Show toplevel fields around the value." );
+      ( "bigstring",
+        Lang.bool_t,
+        Some (Lang.bool false),
+        Some "Return the value as a bigstring." );
       ("", Lang.univ_t (), None, None);
     ]
     Lang.string_t
@@ -17,10 +21,19 @@ let string =
       let show_fields =
         if dv.Lang.value = Value.unit then true else show_fields
       in
+      let bigstring = Lang.to_bool (List.assoc "bigstring" p) in
       let v = if show_fields then v else dv in
       match v with
-        | { Lang.value = Lang.(Ground (Ground.String s)); _ } -> Lang.string s
-        | v -> Lang.string (Value.to_string v))
+        | { Lang.value = Lang.(Ground (Ground.String s)); _ } ->
+            if bigstring then Lang.bigstring (Lang_core.bigstring_of_string s)
+            else Lang.string s
+        | { Lang.value = Lang.(Ground (Ground.Bigstring s)); _ } ->
+            if bigstring then Lang.bigstring s
+            else Lang.string (Bigstringaf.to_string s)
+        | v ->
+            let s = Value.to_string v in
+            if bigstring then Lang.bigstring (Lang_core.bigstring_of_string s)
+            else Lang.string s)
 
 let _ =
   Lang.add_builtin ~base:string "bigstring" ~category:`String

--- a/src/lang/builtins_string.ml
+++ b/src/lang/builtins_string.ml
@@ -330,11 +330,16 @@ let _ =
         Lang.int_t,
         None,
         Some "Return a sub string of `length` characters." );
+      ( "raise",
+        Lang.bool_t,
+        Some (Lang.bool false),
+        Some "Raise a `error.string` error if bounds do not match." );
     ]
     Lang.string_t
     (fun p ->
       let start = Lang.to_int (List.assoc "start" p) in
       let len = Lang.to_int (List.assoc "length" p) in
+      let raise = Lang.to_bool (List.assoc "raise" p) in
       try
         match (List.assoc "" p).Value.value with
           | Ground (Term.Ground.String s) ->
@@ -342,7 +347,7 @@ let _ =
           | Ground (Term.Ground.Bigstring bs) ->
               Lang.bigstring (Bigstringaf.sub bs ~off:start ~len)
           | _ -> assert false
-      with exn ->
+      with exn when raise ->
         let bt = Printexc.get_raw_backtrace () in
         Lang.raise_as_runtime ~bt ~kind:"string" exn)
 

--- a/src/lang/builtins_string.ml
+++ b/src/lang/builtins_string.ml
@@ -347,9 +347,11 @@ let _ =
           | Ground (Term.Ground.Bigstring bs) ->
               Lang.bigstring (Bigstringaf.sub bs ~off:start ~len)
           | _ -> assert false
-      with exn when raise ->
-        let bt = Printexc.get_raw_backtrace () in
-        Lang.raise_as_runtime ~bt ~kind:"string" exn)
+      with
+        | exn when raise ->
+            let bt = Printexc.get_raw_backtrace () in
+            Lang.raise_as_runtime ~bt ~kind:"string" exn
+        | _ -> Lang.string "")
 
 let _ =
   Lang.add_builtin ~base:string "index" ~category:`String

--- a/src/lang/dune
+++ b/src/lang/dune
@@ -82,7 +82,7 @@
  (public_name liquidsoap-lang)
  (preprocess
   (pps sedlex.ppx ppx_string))
- (libraries liquidsoap-lang.console dune-site re str unix menhirLib)
+ (libraries liquidsoap-lang.console dune-site re str bigstringaf unix menhirLib)
  (modules
   build_config
   builtins_bool

--- a/src/lang/lang.mli
+++ b/src/lang/lang.mli
@@ -29,12 +29,21 @@ type module_name
 type scheme = Type.scheme
 type regexp = Builtins_regexp.regexp
 
+type bigstring =
+  (char, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t
+
 (** {2 Values} *)
 
 (** A typed value. *)
 module Ground : sig
   type t = Term.Ground.t = ..
-  type t += Bool of bool | Int of int | String of string | Float of float
+
+  type t +=
+    | Bool of bool
+    | Int of int
+    | String of string
+    | Bigstring of bigstring
+    | Float of float
 
   type content = Term.Ground.content = {
     descr : t -> string;
@@ -135,7 +144,9 @@ val to_unit : value -> unit
 val to_bool : value -> bool
 val to_bool_getter : value -> unit -> bool
 val to_string : value -> string
+val to_bigstring : value -> bigstring
 val to_string_getter : value -> unit -> string
+val to_bigstring_getter : value -> unit -> bigstring
 val to_regexp : value -> regexp
 val to_float : value -> float
 val to_float_getter : value -> unit -> float
@@ -200,6 +211,7 @@ val int : int -> value
 val bool : bool -> value
 val float : float -> value
 val string : string -> value
+val bigstring : bigstring -> value
 val regexp : regexp -> value
 val list : value list -> value
 val null : value

--- a/src/lang/term/term_base.ml
+++ b/src/lang/term/term_base.ml
@@ -186,6 +186,12 @@ module Ground = struct
         | _ -> assert false
     in
 
+    let to_string = function
+      | String s -> Lang_string.quote_string s
+      | Bigstring bs -> Lang_string.quote_string (Bigstringaf.to_string bs)
+      | _ -> assert false
+    in
+
     let to_json ~pos:_ = function
       | String s -> `String s
       | Bigstring bs -> `String (Bigstringaf.to_string bs)

--- a/src/lang/term/term_base.ml
+++ b/src/lang/term/term_base.ml
@@ -189,7 +189,7 @@ module Ground = struct
       };
 
     let to_string = function
-      | Bigstring bs -> Lang_string.quote_string (Bigstringaf.to_string bs)
+      | Bigstring bs -> Bigstringaf.to_string bs
       | _ -> assert false
     in
     let to_json ~pos:_ = function

--- a/src/libs/file.liq
+++ b/src/libs/file.liq
@@ -83,7 +83,10 @@ end
 def file.contents(~mmap_threshold=4096, fname) =
   fd = file.open(write=false, fname)
   size = file.size(fname)
-  s = fd.read(bigstring=null.case({false}, fun (n) -> n <= size), size)
+  s =
+    fd.read(
+      bigstring=null.case(mmap_threshold, {false}, fun (n) -> n <= size), size
+    )
   fd.close()
   s
 end

--- a/src/libs/file.liq
+++ b/src/libs/file.liq
@@ -75,14 +75,10 @@ end
 # Read the whole contents of a file.
 # @category File
 def file.contents(fname) =
-  fn = file.read(fname)
-
-  def rec f(cur) =
-    s = fn()
-    if s == "" then cur else f("#{cur}#{s}") end
-  end
-
-  f("")
+  fd = file.open(write=false, fname)
+  s = fd.read(bigstring=true, file.size(fname))
+  fd.close()
+  s
 end
 
 # Get the list of lines of a file.

--- a/src/libs/string.liq
+++ b/src/libs/string.liq
@@ -64,39 +64,35 @@ end
 # @param s The string to look into.
 def string.contains(~prefix="", ~substring="", ~suffix="", s) =
   ans = ref(prefix == "" and substring == "" and suffix == "")
-  try
-    if
-      prefix != ""
-    then
-      ans :=
-        ans() or string.sub(s, start=0, length=string.length(prefix)) == prefix
-    end
-
-    if
-      suffix != ""
-    then
-      suflen = string.length(suffix)
-      ans :=
-        ans()
-      or
-        string.sub(s, start=string.length(s) - suflen, length=suflen) == suffix
-    end
-
-    if
-      substring != ""
-    then
-      sublen = string.length(substring)
-      for i = 0 to
-        string.length(s) - sublen
-      do
-        ans := ans() or (string.sub(s, start=i, length=sublen) == substring)
-      end
-    end
-
-    ans()
-  catch _ do
-    false
+  if
+    prefix != ""
+  then
+    ans :=
+      ans() or string.sub(s, start=0, length=string.length(prefix)) == prefix
   end
+
+  if
+    suffix != ""
+  then
+    suflen = string.length(suffix)
+    ans :=
+      ans()
+    or
+      string.sub(s, start=string.length(s) - suflen, length=suflen) == suffix
+  end
+
+  if
+    substring != ""
+  then
+    sublen = string.length(substring)
+    for i = 0 to
+      string.length(s) - sublen
+    do
+      ans := ans() or (string.sub(s, start=i, length=sublen) == substring)
+    end
+  end
+
+  ans()
 end
 
 # What remains of a string after a given prefix.

--- a/src/libs/string.liq
+++ b/src/libs/string.liq
@@ -64,35 +64,39 @@ end
 # @param s The string to look into.
 def string.contains(~prefix="", ~substring="", ~suffix="", s) =
   ans = ref(prefix == "" and substring == "" and suffix == "")
-  if
-    prefix != ""
-  then
-    ans :=
-      ans() or string.sub(s, start=0, length=string.length(prefix)) == prefix
-  end
-
-  if
-    suffix != ""
-  then
-    suflen = string.length(suffix)
-    ans :=
-      ans()
-    or
-      string.sub(s, start=string.length(s) - suflen, length=suflen) == suffix
-  end
-
-  if
-    substring != ""
-  then
-    sublen = string.length(substring)
-    for i = 0 to
-      string.length(s) - sublen
-    do
-      ans := ans() or (string.sub(s, start=i, length=sublen) == substring)
+  try
+    if
+      prefix != ""
+    then
+      ans :=
+        ans() or string.sub(s, start=0, length=string.length(prefix)) == prefix
     end
-  end
 
-  ans()
+    if
+      suffix != ""
+    then
+      suflen = string.length(suffix)
+      ans :=
+        ans()
+      or
+        string.sub(s, start=string.length(s) - suflen, length=suflen) == suffix
+    end
+
+    if
+      substring != ""
+    then
+      sublen = string.length(substring)
+      for i = 0 to
+        string.length(s) - sublen
+      do
+        ans := ans() or (string.sub(s, start=i, length=sublen) == substring)
+      end
+    end
+
+    ans()
+  catch _ do
+    false
+  end
 end
 
 # What remains of a string after a given prefix.

--- a/tests/harbor/http.liq
+++ b/tests/harbor/http.liq
@@ -150,7 +150,7 @@ def f() =
   test.equals("#{resp}", "")
 
   # Chunked query
-  def handler(req, res) =
+  def handler(req, _) =
     test.equals(req.http_version, "1.1")
     test.equals(req.method, "POST")
     test.equals(req.query, [])
@@ -193,7 +193,7 @@ def f() =
   test.equals("#{resp}", "")
 
   # Large chunked query
-  def handler(req, res) =
+  def handler(req, _) =
     test.equals(req.http_version, "1.1")
     test.equals(req.method, "POST")
     test.equals(req.query, [])
@@ -216,14 +216,14 @@ def f() =
       if ret != "" then f(count + string.length(ret)) else count end
     end
 
-    test.equals(f(0), 10_000_000)
+    test.equals(f(0), 100_000)
   end
 
   harbor.http.register("/large_chunked", method="POST", port=3456, handler)
   data =
     begin
       tmp = string.make(10_000)
-      count = ref(10_000_000 / 10_000)
+      count = ref(10)
       fun () ->
         if
           0 < count()
@@ -234,6 +234,13 @@ def f() =
           ""
         end
     end
+
+  resp = http.post(data=data, "http://localhost:3456/large_chunked")
+  test.equals(resp.status_message, "OK")
+  test.equals(resp.status_code, 200)
+  test.equals(resp.http_version, "1.1")
+  test.equals(resp.headers, [])
+  test.equals("#{resp}", "")
 
   # Custom response
   def handler(req) =
@@ -298,7 +305,7 @@ def f() =
   test.equals(resp.status_code, 200)
   try
     fn = read()
-    fn(timeout=10.)
+    ignore(fn(timeout=10.))
     test.fail()
   catch err : [error.http] do
     test.equals(

--- a/tests/language/file.liq
+++ b/tests/language/file.liq
@@ -10,18 +10,28 @@ def f() =
 
   tmpdir = file.temp_dir("testfile")
   on_cleanup({file.rmdir(tmpdir)})
+
   src_file = path.concat(tmpdir, "test-src-file")
   file.write(data="blablo", src_file)
+
   dst_file = path.concat(tmpdir, "test-dst-file")
   file.copy(src_file, dst_file)
+
   test.equals(file.exists(dst_file), true)
+
   tmpdir2 = file.temp_dir("testfile")
   on_cleanup({file.rmdir(tmpdir2)})
+
   file.copy(recursive=true, tmpdir, tmpdir2)
+
   targetdir = path.concat(tmpdir2, path.basename(tmpdir))
+
   test.equals(file.exists(path.concat(targetdir, "test-src-file")), true)
+
   non_existent = path.concat(tmpdir, "non-existent")
+
   dst_file2 = path.concat(tmpdir2, "another_dst")
+
   try
     file.copy(non_existent, dst_file2)
     test.fail()
@@ -30,14 +40,26 @@ def f() =
   end
 
   dst_file3 = path.concat(tmpdir, "test-dst-file3")
+
   file.move(src_file, dst_file3)
   test.equals(file.exists(dst_file3), true)
 
-  file.touch("test-dst-file4")
-  test.equals(file.exists("test-dst-file4"), true)
+  dst_file4 = path.concat(tmpdir, "test-dst-file4")
+  file.touch(dst_file4)
+  test.equals(file.exists(dst_file4), true)
 
-  file.mkdir(parents=true, "/tmp/a/b/c/d")
-  test.equals(file.exists("/tmp/a/b/c/d"), true)
+  dst_dir = path.concat(tmpdir, "a/b/c/d")
+  file.mkdir(parents=true, dst_dir)
+  test.equals(file.exists(dst_dir), true)
+
+  dst_file5 = path.concat(tmpdir, "test-dst-file5")
+  fd = file.open(write=true, dst_file5)
+
+  content = string(bigstring=true, "aabbcc")
+  fd.write(content)
+  fd.close()
+
+  test.equals(content, file.contents(dst_file5))
 
   test.pass()
 end


### PR DESCRIPTION
This PR adds support for bigstring to the language. Bigstrings are represented by bigarrays and can also potentially be `mmap`'d data coming directly from a file.

Its expected use is to handle large strings to be written and read from different sources, in particular:
* Socket
* Files
* Metadata (cover art)