### PR TITLE
Add parents option to `file.mkdir`.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -32,6 +32,7 @@ Changed:
   as expected.
 - BREAKING: `replaygain` no longer takes `ebu_r128` parameter (#3438).
 - BREAKING: assume `replaygain_track_gain` always stores volume in _dB_ (#3438).
+- Added `parents` option of `file.mkdir`.
 
 ---
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -32,7 +32,7 @@ Changed:
   as expected.
 - BREAKING: `replaygain` no longer takes `ebu_r128` parameter (#3438).
 - BREAKING: assume `replaygain_track_gain` always stores volume in _dB_ (#3438).
-- Added `parents` option of `file.mkdir`.
+- Added `parents` option of `file.mkdir` (#3600, #3601).
 
 ---
 

--- a/src/core/builtins/builtins_files.ml
+++ b/src/core/builtins/builtins_files.ml
@@ -129,8 +129,9 @@ let _ =
       let dir = List.assoc "" p |> Lang.to_string in
       try
         let rec recmkdir dir =
-          if not (Sys.file_exists dir) then recmkdir (Filename.dirname dir);
-          Unix.mkdir dir perms
+          if not (Sys.file_exists dir) then (
+            recmkdir (Filename.dirname dir);
+            Unix.mkdir dir perms)
         in
         let mkdir dir =
           if parents then recmkdir dir else Unix.mkdir dir perms

--- a/src/core/builtins/builtins_files.ml
+++ b/src/core/builtins/builtins_files.ml
@@ -133,10 +133,7 @@ let _ =
             recmkdir (Filename.dirname dir);
             Unix.mkdir dir perms)
         in
-        let mkdir dir =
-          if parents then recmkdir dir else Unix.mkdir dir perms
-        in
-        mkdir dir;
+        if parents then recmkdir dir else Unix.mkdir dir perms;
         Lang.unit
       with _ -> Lang.unit)
 

--- a/src/core/builtins/builtins_files.ml
+++ b/src/core/builtins/builtins_files.ml
@@ -112,6 +112,10 @@ let _ =
   Lang.add_builtin ~base:file "mkdir" ~category:`File
     ~descr:"Create a directory."
     [
+      ( "parents",
+        Lang.bool_t,
+        Some (Lang.bool false),
+        Some "Also create parent directories if they do not exist." );
       ( "perms",
         Lang.int_t,
         Some (Lang.int 0o755),
@@ -120,10 +124,18 @@ let _ =
     ]
     Lang.unit_t
     (fun p ->
+      let parents = List.assoc "parents" p |> Lang.to_bool in
       let perms = List.assoc "perms" p |> Lang.to_int in
       let dir = List.assoc "" p |> Lang.to_string in
       try
-        Unix.mkdir dir perms;
+        let rec recmkdir dir =
+          if not (Sys.file_exists dir) then recmkdir (Filename.dirname dir);
+          Unix.mkdir dir perms
+        in
+        let mkdir dir =
+          if parents then recmkdir dir else Unix.mkdir dir perms
+        in
+        mkdir dir;
         Lang.unit
       with _ -> Lang.unit)
 

--- a/tests/language/file.liq
+++ b/tests/language/file.liq
@@ -37,7 +37,7 @@ def f() =
   test.equals(file.exists("test-dst-file4"), true)
 
   file.mkdir(parents=true, "/tmp/a/b/c/d")
-  test.equals(file.exists("/tmp/a/b/c/d", true))
+  test.equals(file.exists("/tmp/a/b/c/d"), true)
 
   test.pass()
 end

--- a/tests/language/file.liq
+++ b/tests/language/file.liq
@@ -1,8 +1,10 @@
+#!../../liquidsoap ../test.liq
+
 def f() =
   try
     ignore(file.read("mqlskjdfdjnsi"))
     test.fail()
-  catch e : [error.file] do
+  catch _ : [error.file] do
     ()
   end
 
@@ -23,7 +25,7 @@ def f() =
   try
     file.copy(non_existent, dst_file2)
     test.fail()
-  catch e : [error.file] do
+  catch _ : [error.file] do
     ()
   end
 
@@ -33,6 +35,9 @@ def f() =
 
   file.touch("test-dst-file4")
   test.equals(file.exists("test-dst-file4"), true)
+
+  file.mkdir(parents=true, "/tmp/a/b/c/d")
+  test.equals(file.exists("/tmp/a/b/c/d", true))
 
   test.pass()
 end


### PR DESCRIPTION
Fixes #3600.