### PR TITLE
Add hex and oct integers

### DIFF
--- a/src/core/builtins/builtins_files.ml
+++ b/src/core/builtins/builtins_files.ml
@@ -118,8 +118,8 @@ let _ =
         Some "Also create parent directories if they do not exist." );
       ( "perms",
         Lang.int_t,
-        Some (Lang.int 0o755),
-        Some "Default file rights if created (default is `0o755`)." );
+        Some (Lang.octal_int 0o755),
+        Some "Default file rights if created." );
       ("", Lang.string_t, None, None);
     ]
     Lang.unit_t
@@ -395,8 +395,8 @@ let _ =
         Some "Open in non-blocking mode." );
       ( "perms",
         Lang.int_t,
-        Some (Lang.int 0o644),
-        Some "Default file rights if created. Default: `0o644`" );
+        Some (Lang.octal_int 0o644),
+        Some "Default file rights if created." );
       ("", Lang.string_t, None, None);
     ]
     Builtins_socket.Socket_value.t ~descr:"Open a file."

--- a/src/core/lang.mli
+++ b/src/core/lang.mli
@@ -277,6 +277,8 @@ val http_transport_base_t : t
 
 val unit : value
 val int : int -> value
+val octal_int : int -> value
+val hex_int : int -> value
 val bool : bool -> value
 val float : float -> value
 val string : string -> value

--- a/src/core/outputs/hls_output.ml
+++ b/src/core/outputs/hls_output.ml
@@ -131,19 +131,14 @@ let hls_proto frame_t =
         Some "Number of segments per playlist." );
       ( "perm",
         Lang.int_t,
-        Some (Lang.int 0o666),
-        Some
-          "Permission of the created files, up to umask. You can and should \
-           write this number in octal notation: 0oXXX. The default value is \
-           however displayed in decimal (0o666 = 6×8^2 + 4×8 + 4 = 412)." );
+        Some (Lang.octal_int 0o666),
+        Some "Permission of the created files, up to umask." );
       ( "dir_perm",
         Lang.int_t,
-        Some (Lang.int 0o777),
+        Some (Lang.octal_int 0o777),
         Some
           "Permission of the directories if some have to be created, up to \
-           umask. Although you can enter values in octal notation (0oXXX) they \
-           will be displayed in decimal (for instance, 0o777 = 7×8^2 + 7×8 + 7 \
-           = 511)." );
+           umask." );
       ( "temp_dir",
         Lang.nullable_t Lang.string_t,
         Some Lang.null,

--- a/src/core/sources/video_board.ml
+++ b/src/core/sources/video_board.ml
@@ -90,7 +90,7 @@ let _ =
   let line_to board =
     Lang.val_fun
       [
-        ("color", "c", Some (Lang.int 0xffffff));
+        ("color", "c", Some (Lang.hex_int 0xffffff));
         ("", "x", None);
         ("", "y", None);
       ]

--- a/src/core/sources/video_text.ml
+++ b/src/core/sources/video_text.ml
@@ -100,7 +100,7 @@ let register name init render_text =
         ("size", Lang.getter_t Lang.int_t, Some (Lang.int 18), Some "Font size.");
         ( "color",
           Lang.getter_t Lang.int_t,
-          Some (Lang.int 0xffffff),
+          Some (Lang.hex_int 0xffffff),
           Some "Text color (in 0xRRGGBB format)." );
         ( "duration",
           Lang.nullable_t Lang.float_t,

--- a/src/lang/lang.mli
+++ b/src/lang/lang.mli
@@ -197,6 +197,8 @@ val getter_t : t -> t
 
 val unit : value
 val int : int -> value
+val octal_int : int -> value
+val hex_int : int -> value
 val bool : bool -> value
 val float : float -> value
 val string : string -> value

--- a/src/lang/lang_core.ml
+++ b/src/lang/lang_core.ml
@@ -86,6 +86,8 @@ let ref_t a = Type.reference a
 let mk ?pos value = { pos; value; methods = Methods.empty }
 let unit = mk unit
 let int i = mk (Ground (Int i))
+let octal_int i = mk (Ground (OctalInt i))
+let hex_int i = mk (Ground (HexInt i))
 let bool i = mk (Ground (Bool i))
 let float i = mk (Ground (Float i))
 let string i = mk (Ground (String i))
@@ -322,21 +324,24 @@ let to_float_getter t =
             | _ -> assert false)
     | _ -> assert false
 
-let to_int t = match t.value with Ground (Int s) -> s | _ -> assert false
+let to_int t =
+  match t.value with
+    | Ground (Int s) | Ground (OctalInt s) | Ground (HexInt s) -> s
+    | _ -> assert false
 
 let to_int_getter t =
   match t.value with
-    | Ground (Int n) -> fun () -> n
+    | Ground (Int n) | Ground (OctalInt n) | Ground (HexInt n) -> fun () -> n
     | Fun _ | FFI _ -> (
         fun () ->
           match (apply t []).value with
-            | Ground (Int n) -> n
+            | Ground (Int n) | Ground (OctalInt n) | Ground (HexInt n) -> n
             | _ -> assert false)
     | _ -> assert false
 
 let to_num t =
   match t.value with
-    | Ground (Int n) -> `Int n
+    | Ground (Int n) | Ground (OctalInt n) | Ground (HexInt n) -> `Int n
     | Ground (Float x) -> `Float x
     | _ -> assert false
 

--- a/src/lang/term/term_reducer.ml
+++ b/src/lang/term/term_reducer.ml
@@ -830,6 +830,12 @@ let rec to_ast ~pos : parsed_ast -> Term.runtime_ast = function
   | `List l -> list_reducer ~pos ~to_term (List.rev l)
   | `Tuple l -> `Tuple (List.map to_term l)
   | `String (sep, s) -> `Ground (String (render_string ~pos ~sep s))
+  | `Int i
+    when String.length i >= 2 && String.(lowercase_ascii (sub i 0 2)) = "0x" ->
+      `Ground (HexInt (int_of_string i))
+  | `Int i
+    when String.length i >= 2 && String.(lowercase_ascii (sub i 0 2)) = "0o" ->
+      `Ground (OctalInt (int_of_string i))
   | `Int i -> `Ground (Int (int_of_string i))
   | `Float (sign, ipart, fpart) ->
       let fpart =


### PR DESCRIPTION
This PR adds octal and hexadecimal ground terms so that they can be represented properly in the doc!

<img width="480" alt="Screenshot 2023-12-21 at 10 41 46 AM" src="https://github.com/savonet/liquidsoap/assets/871060/0936b45b-df32-4b15-9432-68be53a26cb0">
