### PR TITLE
Smaller frames

### DIFF
--- a/src/core/builtins/builtins_ffmpeg_bitstream_filters.ml
+++ b/src/core/builtins/builtins_ffmpeg_bitstream_filters.ml
@@ -84,7 +84,7 @@ let process (type a) ~put_data ~(mk_params : a mk_params)
       packets
   in
   let data =
-    { Ffmpeg_content_base.params = Some (mk_params params); data; length }
+    { Content_video.Base.params = Some (mk_params params); data; length }
   in
   let data = Ffmpeg_copy_content.lift_data data in
   put_data generator data
@@ -121,7 +121,7 @@ let on_data (type a)
        a handler) ~put_data ~(get_params : a get_params)
     ~(get_packet : a get_packet) ~(mk_params : a mk_params)
     ~(mk_packet : a mk_packet) ~generator
-    ({ Ffmpeg_content_base.params; data } : Ffmpeg_copy_content.data) =
+    ({ Content_video.Base.params; data } : Ffmpeg_copy_content.data) =
   List.iter
     (fun (_, { Ffmpeg_copy_content.stream_idx; time_base; packet }) ->
       let handler =

--- a/src/core/builtins/builtins_ffmpeg_bitstream_filters.ml
+++ b/src/core/builtins/builtins_ffmpeg_bitstream_filters.ml
@@ -83,9 +83,7 @@ let process (type a) ~put_data ~(mk_params : a mk_params)
           } ))
       packets
   in
-  let data =
-    { Content_video.Base.params = Some (mk_params params); data; length }
-  in
+  let data = { Content.Video.params = Some (mk_params params); data; length } in
   let data = Ffmpeg_copy_content.lift_data data in
   put_data generator data
 
@@ -121,7 +119,7 @@ let on_data (type a)
        a handler) ~put_data ~(get_params : a get_params)
     ~(get_packet : a get_packet) ~(mk_params : a mk_params)
     ~(mk_packet : a mk_packet) ~generator
-    ({ Content_video.Base.params; data } : Ffmpeg_copy_content.data) =
+    ({ Content.Video.params; data } : Ffmpeg_copy_content.data) =
   List.iter
     (fun (_, { Ffmpeg_copy_content.stream_idx; time_base; packet }) ->
       let handler =

--- a/src/core/builtins/builtins_ffmpeg_decoder.ml
+++ b/src/core/builtins/builtins_ffmpeg_decoder.ml
@@ -98,7 +98,7 @@ let decode_audio_frame ~field ~mode generator =
     | `Frame frame ->
         let data, params =
           match Ffmpeg_copy_content.get_data frame with
-            | { Ffmpeg_content_base.data; params = Some (`Audio params) } ->
+            | { Content_video.Base.data; params = Some (`Audio params) } ->
                 (data, params)
             | _ -> assert false
         in
@@ -165,7 +165,7 @@ let decode_audio_frame ~field ~mode generator =
 
     function
     | `Frame frame ->
-        let { Ffmpeg_content_base.data; params } =
+        let { Content_video.Base.data; params } =
           Ffmpeg_raw_content.Audio.get_data frame
         in
         let data =
@@ -181,14 +181,14 @@ let decode_audio_frame ~field ~mode generator =
 
   let convert
         : 'a 'b.
-          get_data:(Content.data -> ('a, 'b) Ffmpeg_content_base.content) ->
+          get_data:(Content.data -> ('a, 'b) Content_video.Base.content) ->
           decoder:([ `Frame of Content.data | `Flush ] -> unit) ->
           [ `Frame of Frame.t | `Flush ] ->
           unit =
    fun ~get_data ~decoder -> function
     | `Frame frame ->
         let frame = Frame.get frame field in
-        let { Ffmpeg_content_base.data; _ } = get_data frame in
+        let { Content_video.Base.data; _ } = get_data frame in
         if data = [] then () else decoder (`Frame frame)
     | `Flush -> decoder `Flush
   in
@@ -318,7 +318,7 @@ let decode_video_frame ~field ~mode generator =
     | `Frame frame ->
         let data, params =
           match Ffmpeg_copy_content.get_data frame with
-            | { Ffmpeg_content_base.data; params = Some (`Video params) } ->
+            | { Content_video.Base.data; params = Some (`Video params) } ->
                 (data, params)
             | _ -> assert false
         in
@@ -364,7 +364,7 @@ let decode_video_frame ~field ~mode generator =
     let last_params = ref None in
     function
     | `Frame frame ->
-        let { Ffmpeg_content_base.data; _ } =
+        let { Content_video.Base.data; _ } =
           Ffmpeg_raw_content.Video.get_data frame
         in
         let data =
@@ -385,14 +385,14 @@ let decode_video_frame ~field ~mode generator =
 
   let convert
         : 'a 'b.
-          get_data:(Content.data -> ('a, 'b) Ffmpeg_content_base.content) ->
+          get_data:(Content.data -> ('a, 'b) Content_video.Base.content) ->
           decoder:([ `Frame of Content.data | `Flush ] -> unit) ->
           [ `Frame of Frame.t | `Flush ] ->
           unit =
    fun ~get_data ~decoder -> function
     | `Frame frame ->
         let frame = Frame.get frame field in
-        let { Ffmpeg_content_base.data; _ } = get_data frame in
+        let { Content_video.Base.data; _ } = get_data frame in
         if data = [] then () else decoder (`Frame frame)
     | `Flush -> decoder `Flush
   in

--- a/src/core/builtins/builtins_ffmpeg_decoder.ml
+++ b/src/core/builtins/builtins_ffmpeg_decoder.ml
@@ -253,8 +253,7 @@ let decode_video_frame ~field ~mode generator =
         Ffmpeg_utils.unpack_image ~width:internal_width ~height:internal_height
           (InternalScaler.convert scaler data)
       in
-      let data = Video.Canvas.single_image img in
-      let data = Content.Video.lift_data data in
+      let data = Content.Video.lift_image (Video.Canvas.Image.make img) in
       Generator.put generator field data
     in
 

--- a/src/core/builtins/builtins_ffmpeg_decoder.ml
+++ b/src/core/builtins/builtins_ffmpeg_decoder.ml
@@ -98,7 +98,7 @@ let decode_audio_frame ~field ~mode generator =
     | `Frame frame ->
         let data, params =
           match Ffmpeg_copy_content.get_data frame with
-            | { Content_video.Base.data; params = Some (`Audio params) } ->
+            | { Content.Video.data; params = Some (`Audio params) } ->
                 (data, params)
             | _ -> assert false
         in
@@ -165,7 +165,7 @@ let decode_audio_frame ~field ~mode generator =
 
     function
     | `Frame frame ->
-        let { Content_video.Base.data; params } =
+        let { Content.Video.data; params } =
           Ffmpeg_raw_content.Audio.get_data frame
         in
         let data =
@@ -188,7 +188,7 @@ let decode_audio_frame ~field ~mode generator =
    fun ~get_data ~decoder -> function
     | `Frame frame ->
         let frame = Frame.get frame field in
-        let { Content_video.Base.data; _ } = get_data frame in
+        let { Content.Video.data; _ } = get_data frame in
         if data = [] then () else decoder (`Frame frame)
     | `Flush -> decoder `Flush
   in
@@ -317,7 +317,7 @@ let decode_video_frame ~field ~mode generator =
     | `Frame frame ->
         let data, params =
           match Ffmpeg_copy_content.get_data frame with
-            | { Content_video.Base.data; params = Some (`Video params) } ->
+            | { Content.Video.data; params = Some (`Video params) } ->
                 (data, params)
             | _ -> assert false
         in
@@ -363,7 +363,7 @@ let decode_video_frame ~field ~mode generator =
     let last_params = ref None in
     function
     | `Frame frame ->
-        let { Content_video.Base.data; _ } =
+        let { Content.Video.data; _ } =
           Ffmpeg_raw_content.Video.get_data frame
         in
         let data =
@@ -391,7 +391,7 @@ let decode_video_frame ~field ~mode generator =
    fun ~get_data ~decoder -> function
     | `Frame frame ->
         let frame = Frame.get frame field in
-        let { Content_video.Base.data; _ } = get_data frame in
+        let { Content.Video.data; _ } = get_data frame in
         if data = [] then () else decoder (`Frame frame)
     | `Flush -> decoder `Flush
   in

--- a/src/core/builtins/builtins_ffmpeg_encoder.ml
+++ b/src/core/builtins/builtins_ffmpeg_encoder.ml
@@ -110,7 +110,7 @@ let encode_audio_frame ~source_idx ~type_t ~mode ~opts ?codec ~format
                           } ))
                       packets
                   in
-                  let data = { Content_video.Base.params; data; length } in
+                  let data = { Content.Video.params; data; length } in
                   let data = Ffmpeg_copy_content.lift_data data in
                   Generator.put generator field data
               | None -> ()
@@ -160,7 +160,7 @@ let encode_audio_frame ~source_idx ~type_t ~mode ~opts ?codec ~format
                               } ))
                           frames
                       in
-                      let data = { Content_video.Base.params; data; length } in
+                      let data = { Content.Video.params; data; length } in
                       let data = Ffmpeg_raw_content.Audio.lift_data data in
                       Generator.put generator field data
                   | None -> ())
@@ -294,7 +294,7 @@ let encode_video_frame ~source_idx ~type_t ~mode ~opts ?codec ~format ~field
                           } ))
                       packets
                   in
-                  let data = { Content_video.Base.params; data; length } in
+                  let data = { Content.Video.params; data; length } in
                   let data = Ffmpeg_copy_content.lift_data data in
                   Generator.put generator field data
               | None -> ()
@@ -350,7 +350,7 @@ let encode_video_frame ~source_idx ~type_t ~mode ~opts ?codec ~format ~field
                             } ))
                         frames
                     in
-                    let data = { Content_video.Base.params; data; length } in
+                    let data = { Content.Video.params; data; length } in
                     let data = Ffmpeg_raw_content.Video.lift_data data in
                     Generator.put generator field data
                 | None -> ())
@@ -377,7 +377,7 @@ let encode_video_frame ~source_idx ~type_t ~mode ~opts ?codec ~format ~field
           Avutil.Frame.set_pts frame (Some !nb_frames);
           nb_frames := Int64.succ !nb_frames;
           encode_ffmpeg_frame frame)
-        vbuf.Content_video.Base.data
+        vbuf.Content.Video.data
   | `Flush -> encode_frame `Flush
 
 let mk_encoder mode =

--- a/src/core/builtins/builtins_ffmpeg_encoder.ml
+++ b/src/core/builtins/builtins_ffmpeg_encoder.ml
@@ -110,7 +110,7 @@ let encode_audio_frame ~source_idx ~type_t ~mode ~opts ?codec ~format
                           } ))
                       packets
                   in
-                  let data = { Ffmpeg_content_base.params; data; length } in
+                  let data = { Content_video.Base.params; data; length } in
                   let data = Ffmpeg_copy_content.lift_data data in
                   Generator.put generator field data
               | None -> ()
@@ -160,7 +160,7 @@ let encode_audio_frame ~source_idx ~type_t ~mode ~opts ?codec ~format
                               } ))
                           frames
                       in
-                      let data = { Ffmpeg_content_base.params; data; length } in
+                      let data = { Content_video.Base.params; data; length } in
                       let data = Ffmpeg_raw_content.Audio.lift_data data in
                       Generator.put generator field data
                   | None -> ())
@@ -294,7 +294,7 @@ let encode_video_frame ~source_idx ~type_t ~mode ~opts ?codec ~format ~field
                           } ))
                       packets
                   in
-                  let data = { Ffmpeg_content_base.params; data; length } in
+                  let data = { Content_video.Base.params; data; length } in
                   let data = Ffmpeg_copy_content.lift_data data in
                   Generator.put generator field data
               | None -> ()
@@ -350,7 +350,7 @@ let encode_video_frame ~source_idx ~type_t ~mode ~opts ?codec ~format ~field
                             } ))
                         frames
                     in
-                    let data = { Ffmpeg_content_base.params; data; length } in
+                    let data = { Content_video.Base.params; data; length } in
                     let data = Ffmpeg_raw_content.Video.lift_data data in
                     Generator.put generator field data
                 | None -> ())

--- a/src/core/decoder/decoder.ml
+++ b/src/core/decoder/decoder.ml
@@ -240,7 +240,7 @@ let test_file ?(log = log) ?mimes ?extensions fname =
     ext_ok || mime_ok)
 
 let channel_layout audio =
-  Lazy.force Content.(Audio.(get_params audio).Content.channel_layout)
+  Lazy.force Content.(Audio.(get_params audio).Content.Audio.channel_layout)
 
 let can_decode_type decoded_type target_type =
   let map_convertible cur (field, target_field) =
@@ -453,11 +453,11 @@ let mk_buffer ~ctype generator =
           in
           let params =
             {
-              Content_video.Specs.width = Some Frame.video_width;
+              Content.Video.width = Some Frame.video_width;
               height = Some Frame.video_height;
             }
           in
-          let interval = Frame.video_of_main 1 in
+          let interval = Frame.main_of_video 1 in
           fun ~fps img ->
             match video_resample ~in_freq:fps ~out_freq img with
               | [] -> ()
@@ -470,7 +470,7 @@ let mk_buffer ~ctype generator =
                   let length = List.length data * interval in
                   let buf =
                     Content.Video.lift_data
-                      { Content_video.Specs.params; length; data }
+                      { Content.Video.params; length; data }
                   in
                   Generator.put generator field buf)
         else fun ~fps:_ _ -> ()

--- a/src/core/decoder/decoder.mli
+++ b/src/core/decoder/decoder.mli
@@ -49,8 +49,8 @@ type fps = { num : int; den : int }
     - Implicit content drop *)
 type buffer = {
   generator : Generator.t;
-  put_pcm : ?field:Frame.field -> samplerate:int -> Content.Audio.data -> unit;
-  put_yuva420p : ?field:Frame.field -> fps:fps -> Content.Video.data -> unit;
+  put_pcm : ?field:Frame.field -> samplerate:int -> Audio.t -> unit;
+  put_yuva420p : ?field:Frame.field -> fps:fps -> Video.Canvas.image -> unit;
 }
 
 type decoder = {

--- a/src/core/decoder/decoder_utils.ml
+++ b/src/core/decoder/decoder_utils.ml
@@ -108,30 +108,37 @@ let video_resample ~in_freq ~out_freq =
    *     which o: nearest neighbour in the currently available buffer.
    *     This is not as good as nearest neighbour in the real stream.
    *
-   * Turns out the same code codes for when out_freq>in_freq too. *)
+   * Turns out the same code codes for when out_freq>in_freq works too. *)
   let in_pos = ref 0 in
   let in_freq = in_freq.num * out_freq.den
   and out_freq = out_freq.num * in_freq.num in
   let ratio = out_freq / in_freq in
-  fun input off len ->
+  fun buf ->
+    let input = buf.Content_video.Base.data in
+    let len = List.length input in
     let new_in_pos = !in_pos + len in
     let already_out_len = !in_pos * ratio in
     let needed_out_len = new_in_pos * ratio in
     let out_len = needed_out_len - already_out_len in
     in_pos := new_in_pos mod in_freq;
-    Array.init out_len (fun i -> input.(off + (i * ratio)))
+    {
+      buf with
+      Content_video.Base.data =
+        List.init out_len (fun i ->
+            let pos, img = List.nth input (i * ratio) in
+            (pos / ratio, img));
+    }
 
 let video_resample () =
   let state = ref None in
-  let exec resampler data = resampler data 0 (Video.Canvas.length data) in
   fun ~in_freq ~out_freq (data : Content.Video.data) : Content.Video.data ->
     if in_freq = out_freq then data
     else (
       match !state with
         | Some (resampler, _in_freq, _out_freq)
           when in_freq = _in_freq && out_freq = _out_freq ->
-            exec resampler data
+            resampler data
         | _ ->
             let resampler = video_resample ~in_freq ~out_freq in
             state := Some (resampler, in_freq, out_freq);
-            exec resampler data)
+            resampler data)

--- a/src/core/decoder/decoder_utils.mli
+++ b/src/core/decoder/decoder_utils.mli
@@ -59,5 +59,5 @@ val video_resample :
   unit ->
   in_freq:fps ->
   out_freq:fps ->
-  Content.Video.data ->
-  Content.Video.data
+  Video.Canvas.image ->
+  Video.Canvas.image list

--- a/src/core/decoder/ffmpeg_copy_decoder.ml
+++ b/src/core/decoder/ffmpeg_copy_decoder.ml
@@ -54,7 +54,7 @@ let mk_decoder ~stream_idx ~stream_time_base ~mk_packet ~put_data params =
               } ))
           packets
       in
-      let data = { Content_video.Base.params = Some params; data; length } in
+      let data = { Content.Video.params = Some params; data; length } in
       let data = Ffmpeg_copy_content.lift_data data in
       put_data buffer.Decoder.generator data
     with Empty | Corrupt (* Might want to change that later. *) -> ()

--- a/src/core/decoder/ffmpeg_copy_decoder.ml
+++ b/src/core/decoder/ffmpeg_copy_decoder.ml
@@ -54,7 +54,7 @@ let mk_decoder ~stream_idx ~stream_time_base ~mk_packet ~put_data params =
               } ))
           packets
       in
-      let data = { Ffmpeg_content_base.params = Some params; data; length } in
+      let data = { Content_video.Base.params = Some params; data; length } in
       let data = Ffmpeg_copy_content.lift_data data in
       put_data buffer.Decoder.generator data
     with Empty | Corrupt (* Might want to change that later. *) -> ()

--- a/src/core/decoder/ffmpeg_internal_decoder.ml
+++ b/src/core/decoder/ffmpeg_internal_decoder.ml
@@ -157,12 +157,18 @@ let mk_video_decoder ~width ~height ~stream ~field codec =
   in
   let time_base = Av.get_time_base stream in
   let pixel_aspect = Av.get_pixel_aspect stream in
+  let params =
+    {
+      Content_video.Specs.width = Some (lazy target_width);
+      height = Some (lazy height);
+    }
+  in
+  let length = Frame.main_of_video 1 in
   let cb ~buffer frame =
     let img = scale frame in
-    let content = Video.Canvas.single img in
     buffer.Decoder.put_yuva420p ~field
       ~fps:{ Decoder.num = target_fps; den = 1 }
-      content;
+      { Content_video.Base.params; length; data = [(0, img)] };
     let metadata = Avutil.Frame.metadata frame in
     if metadata <> [] then
       Generator.add_metadata buffer.Decoder.generator

--- a/src/core/decoder/ffmpeg_internal_decoder.ml
+++ b/src/core/decoder/ffmpeg_internal_decoder.ml
@@ -157,18 +157,11 @@ let mk_video_decoder ~width ~height ~stream ~field codec =
   in
   let time_base = Av.get_time_base stream in
   let pixel_aspect = Av.get_pixel_aspect stream in
-  let params =
-    {
-      Content_video.Specs.width = Some (lazy target_width);
-      height = Some (lazy height);
-    }
-  in
-  let length = Frame.main_of_video 1 in
   let cb ~buffer frame =
     let img = scale frame in
     buffer.Decoder.put_yuva420p ~field
       ~fps:{ Decoder.num = target_fps; den = 1 }
-      { Content_video.Base.params; length; data = [(0, img)] };
+      img;
     let metadata = Avutil.Frame.metadata frame in
     if metadata <> [] then
       Generator.add_metadata buffer.Decoder.generator

--- a/src/core/decoder/ffmpeg_raw_decoder.ml
+++ b/src/core/decoder/ffmpeg_raw_decoder.ml
@@ -45,7 +45,7 @@ let mk_decoder ~stream_idx ~stream_time_base ~mk_params ~lift_data ~put_data
                   frames
               in
               let data =
-                { Content_video.Base.params = mk_params params; data; length }
+                { Content.Video.params = mk_params params; data; length }
               in
               let data = lift_data data in
               put_data buffer.Decoder.generator data

--- a/src/core/decoder/ffmpeg_raw_decoder.ml
+++ b/src/core/decoder/ffmpeg_raw_decoder.ml
@@ -45,7 +45,7 @@ let mk_decoder ~stream_idx ~stream_time_base ~mk_params ~lift_data ~put_data
                   frames
               in
               let data =
-                { Ffmpeg_content_base.params = mk_params params; data; length }
+                { Content_video.Base.params = mk_params params; data; length }
               in
               let data = lift_data data in
               put_data buffer.Decoder.generator data

--- a/src/core/decoder/gstreamer_decoder.ml
+++ b/src/core/decoder/gstreamer_decoder.ml
@@ -138,9 +138,8 @@ let create_decoder ?(merge_tracks = false) _ ~width ~height ~channels ~mode
       let y_stride = round4 width in
       let uv_stride = round4 (width / 2) in
       let img = Image.YUV420.make_data width height buf y_stride uv_stride in
-      let stream = Video.Canvas.single_image img in
       let fps = { Decoder.num = Lazy.force Frame.video_rate; den = 1 } in
-      buffer.Decoder.put_yuva420p ~fps stream);
+      buffer.Decoder.put_yuva420p ~fps (Video.Canvas.Image.make img));
     GU.flush ~log gst.bin
   in
   let seek off =

--- a/src/core/decoder/image_decoder.ml
+++ b/src/core/decoder/image_decoder.ml
@@ -133,10 +133,10 @@ let create_decoder ~ctype ~width ~height ~metadata img =
     let frame =
       Frame.set_data frame Frame.Fields.video Content.Video.lift_data video
     in
-    match Frame.Fields.find_opt Frame.Fields.audio frame with
+    match Frame.Fields.find_opt Frame.Fields.audio ctype with
       | None -> frame
-      | Some data ->
-          let pcm = Content.Audio.get_data data in
+      | Some format ->
+          let pcm = Content.Audio.get_data (Content.make ~length format) in
           Audio.clear pcm 0 (Frame.audio_of_main length);
           Frame.set_data frame Frame.Fields.audio Content.Audio.lift_data pcm
   in

--- a/src/core/decoder/liq_ogg_decoder.ml
+++ b/src/core/decoder/liq_ogg_decoder.ml
@@ -170,14 +170,14 @@ let create_decoder ?(merge_tracks = false) source input =
       in
       let video_feed track buf =
         let info, _ = Ogg_decoder.video_info decoder track in
-        let rgb = video_convert video_scale buf in
+        let img = video_convert video_scale buf in
         let fps =
           {
             Decoder.num = info.Ogg_decoder.fps_numerator;
             den = info.Ogg_decoder.fps_denominator;
           }
         in
-        buffer.Decoder.put_yuva420p ~fps (Video.Canvas.single_image rgb)
+        buffer.Decoder.put_yuva420p ~fps (Video.Canvas.Image.make img)
       in
       let decode_audio, decode_video =
         if decode_audio && decode_video then

--- a/src/core/decoder/midi_decoder.ml
+++ b/src/core/decoder/midi_decoder.ml
@@ -69,7 +69,7 @@ let () =
         (fun ~metadata:_ ~ctype:_ _ ->
           Some
             (Frame.Fields.make
-               ~midi:Content.(Midi.lift_params { Content.channels = 16 })
+               ~midi:Content.(Midi.lift_params { Content.Midi.channels = 16 })
                ()));
       file_decoder =
         Some (fun ~metadata:_ ~ctype filename -> decoder ~ctype filename);

--- a/src/core/encoder/encoder.ml
+++ b/src/core/encoder/encoder.ml
@@ -96,7 +96,7 @@ let type_of_format f =
                     assert (channels > 0);
                     let params =
                       {
-                        Content.channel_layout =
+                        Content.Audio.channel_layout =
                           lazy
                             (Audio_converter.Channel_layout.layout_of_channels
                                channels);

--- a/src/core/encoder/encoders/avi_encoder.ml
+++ b/src/core/encoder/encoders/avi_encoder.ml
@@ -85,7 +85,7 @@ let encode_frame ~channels ~samplerate ~width ~height ~converter frame start len
           for j = 0 to (height / 2) - 1 do
             Strings.Mutable.add_substring data v (j * uv_stride) (width / 2)
           done))
-      vbuf.Content_video.Base.data;
+      vbuf.Content.Video.data;
     Avi.video_chunk_strings data
   in
   Strings.add video audio

--- a/src/core/encoder/encoders/ffmpeg_copy_encoder.ml
+++ b/src/core/encoder/encoders/ffmpeg_copy_encoder.ml
@@ -41,7 +41,7 @@ let mk_stream_copy ~get_stream ~remove_stream ~keyframe_opt ~field output =
   let initialized_stream = Av.new_uninitialized_stream_copy output in
 
   let mk_stream frame =
-    let { Content_video.Base.params } =
+    let { Content.Video.params } =
       Ffmpeg_copy_content.get_data (Frame.get frame field)
     in
     let mk_stream params =
@@ -165,7 +165,7 @@ let mk_stream_copy ~get_stream ~remove_stream ~keyframe_opt ~field output =
 
   let encode frame start len =
     let content = Content.sub (Frame.get frame field) start len in
-    let data = (Ffmpeg_copy_content.get_data content).Content_video.Base.data in
+    let data = (Ffmpeg_copy_content.get_data content).Content.Video.data in
 
     was_keyframe := false;
 

--- a/src/core/encoder/encoders/ffmpeg_copy_encoder.ml
+++ b/src/core/encoder/encoders/ffmpeg_copy_encoder.ml
@@ -41,7 +41,7 @@ let mk_stream_copy ~get_stream ~remove_stream ~keyframe_opt ~field output =
   let initialized_stream = Av.new_uninitialized_stream_copy output in
 
   let mk_stream frame =
-    let { Ffmpeg_content_base.params } =
+    let { Content_video.Base.params } =
       Ffmpeg_copy_content.get_data (Frame.get frame field)
     in
     let mk_stream params =
@@ -165,9 +165,7 @@ let mk_stream_copy ~get_stream ~remove_stream ~keyframe_opt ~field output =
 
   let encode frame start len =
     let content = Content.sub (Frame.get frame field) start len in
-    let data =
-      (Ffmpeg_copy_content.get_data content).Ffmpeg_content_base.data
-    in
+    let data = (Ffmpeg_copy_content.get_data content).Content_video.Base.data in
 
     was_keyframe := false;
 

--- a/src/core/encoder/encoders/ffmpeg_internal_encoder.ml
+++ b/src/core/encoder/encoders/ffmpeg_internal_encoder.ml
@@ -221,7 +221,7 @@ let mk_audio ~pos ~mode ~codec ~params ~options ~field output =
     fun frame start len ->
       let frames =
         Ffmpeg_raw_content.Audio.(get_data (Frame.get frame field))
-          .Content_video.Base.data
+          .Content.Video.data
       in
       let frames =
         List.filter (fun (pos, _) -> start <= pos && pos < start + len) frames
@@ -456,7 +456,7 @@ let mk_video ~pos ~mode ~codec ~params ~options ~field output =
           Avutil.Frame.set_pts frame (Some !nb_frames);
           nb_frames := Int64.succ !nb_frames;
           cb ~stream_idx ~time_base frame)
-        buf.Content_video.Base.data
+        buf.Content.Video.data
   in
 
   let raw_converter cb =

--- a/src/core/encoder/encoders/ffmpeg_internal_encoder.ml
+++ b/src/core/encoder/encoders/ffmpeg_internal_encoder.ml
@@ -440,23 +440,23 @@ let mk_video ~pos ~mode ~codec ~params ~options ~field output =
     let time_base = Ffmpeg_utils.liq_video_sample_time_base () in
     let stream_idx = 1L in
 
-    fun frame start len ->
-      let vstart = Frame.video_of_main start in
-      let vstop = Frame.video_of_main (start + len) in
-      let vbuf = VFrame.data ~field frame in
-      for i = vstart to vstop - 1 do
-        let f =
-          Video.Canvas.get vbuf i
-          (* TODO: we could scale instead of aggressively changing the viewport *)
-          |> Video.Canvas.Image.viewport src_width src_height
-          |> Video.Canvas.Image.render ~transparent:false
-        in
-        let vdata = Ffmpeg_utils.pack_image f in
-        let frame = InternalScaler.convert scaler vdata in
-        Avutil.Frame.set_pts frame (Some !nb_frames);
-        nb_frames := Int64.succ !nb_frames;
-        cb ~stream_idx ~time_base frame
-      done
+    fun frame offset length ->
+      let content = Content.sub (Frame.get frame field) offset length in
+      let buf = Content.Video.get_data content in
+      List.iter
+        (fun (_, img) ->
+          let f =
+            img
+            (* TODO: we could scale instead of aggressively changing the viewport *)
+            |> Video.Canvas.Image.viewport src_width src_height
+            |> Video.Canvas.Image.render ~transparent:false
+          in
+          let vdata = Ffmpeg_utils.pack_image f in
+          let frame = InternalScaler.convert scaler vdata in
+          Avutil.Frame.set_pts frame (Some !nb_frames);
+          nb_frames := Int64.succ !nb_frames;
+          cb ~stream_idx ~time_base frame)
+        buf.Content_video.Base.data
   in
 
   let raw_converter cb =

--- a/src/core/encoder/encoders/ffmpeg_internal_encoder.ml
+++ b/src/core/encoder/encoders/ffmpeg_internal_encoder.ml
@@ -221,7 +221,7 @@ let mk_audio ~pos ~mode ~codec ~params ~options ~field output =
     fun frame start len ->
       let frames =
         Ffmpeg_raw_content.Audio.(get_data (Frame.get frame field))
-          .Ffmpeg_content_base.data
+          .Content_video.Base.data
       in
       let frames =
         List.filter (fun (pos, _) -> start <= pos && pos < start + len) frames

--- a/src/core/encoder/encoders/gstreamer_encoder.ml
+++ b/src/core/encoder/encoders/gstreamer_encoder.ml
@@ -183,7 +183,7 @@ let encoder ext =
           Gstreamer.Buffer.set_presentation_time buf presentation_time;
           Gstreamer.Buffer.set_duration buf vduration;
           Gstreamer.App_src.push_buffer (Option.get gst.video_src) buf)
-        buf.Content_video.Base.data);
+        buf.Content.Video.data);
     GU.flush ~log gst.bin;
 
     (* Return result. *)

--- a/src/core/encoder/encoders/ogg_encoder.ml
+++ b/src/core/encoder/encoders/ogg_encoder.ml
@@ -60,7 +60,7 @@ let encode_video encoder id frame start len =
   let data =
     List.map
       (fun (_, img) -> Video.Canvas.Image.render img)
-      buf.Content_video.Base.data
+      buf.Content.Video.data
   in
   match data with
     | [] -> ()

--- a/src/core/io/gstreamer_io.ml
+++ b/src/core/io/gstreamer_io.ml
@@ -293,7 +293,7 @@ class output ~clock_safe ~on_error ~infallible ~register_telnet ~on_start
                 Gstreamer.Buffer.set_duration buf duration;
                 Gstreamer.Buffer.set_presentation_time buf presentation_time;
                 Gstreamer.App_src.push_buffer (Option.get el.video) buf)
-              buf.Content_video.Base.data);
+              buf.Content.Video.data);
           presentation_time <- Int64.add presentation_time duration;
           GU.flush ~log:self#log
             ~on_error:(fun err -> raise (Flushing_error err))

--- a/src/core/io/gstreamer_io.ml
+++ b/src/core/io/gstreamer_io.ml
@@ -282,17 +282,18 @@ class output ~clock_safe ~on_error ~infallible ~register_telnet ~on_start
               (Option.get el.audio) data 0 (Bytes.length data));
           if has_video then (
             let buf = VFrame.data frame in
-            for i = 0 to Video.Canvas.length buf - 1 do
-              let img = Video.Canvas.render buf i in
-              let y, u, v = Image.YUV420.data img in
-              let buf =
-                Gstreamer.Buffer.of_data_list
-                  (List.map (fun d -> (d, 0, Image.Data.length d)) [y; u; v])
-              in
-              Gstreamer.Buffer.set_duration buf duration;
-              Gstreamer.Buffer.set_presentation_time buf presentation_time;
-              Gstreamer.App_src.push_buffer (Option.get el.video) buf
-            done);
+            List.iter
+              (fun (_, img) ->
+                let img = Video.Canvas.Image.render img in
+                let y, u, v = Image.YUV420.data img in
+                let buf =
+                  Gstreamer.Buffer.of_data_list
+                    (List.map (fun d -> (d, 0, Image.Data.length d)) [y; u; v])
+                in
+                Gstreamer.Buffer.set_duration buf duration;
+                Gstreamer.Buffer.set_presentation_time buf presentation_time;
+                Gstreamer.App_src.push_buffer (Option.get el.video) buf)
+              buf.Content_video.Base.data);
           presentation_time <- Int64.add presentation_time duration;
           GU.flush ~log:self#log
             ~on_error:(fun err -> raise (Flushing_error err))
@@ -605,9 +606,8 @@ class audio_video_input p (pipeline, audio_pipeline, video_pipeline) =
           Image.YUV420.make_data width height b (Image.Data.round 4 width)
             (Image.Data.round 4 (width / 2))
         in
-        let stream = Video.Canvas.single_image img in
         Generator.put self#buffer Frame.Fields.video
-          (Content.Video.lift_data stream)
+          (Content.Video.lift_image (Video.Canvas.Image.make img))
       done
 
     method generate_frame =

--- a/src/core/operators/add.ml
+++ b/src/core/operators/add.ml
@@ -207,13 +207,13 @@ class video_add ~field ~add tracks =
                 (fun img (rank, last_image, data) ->
                   add rank img (self#nearest_image ~pos ~last_image data))
                 img frames ))
-          buf.Content_video.Base.data
+          buf.Content.Video.data
       in
       let frame =
         Frame.set_data
           (Frame.create ~length:pos Frame.Fields.empty)
           field Content.Video.lift_data
-          { buf with Content_video.Base.data }
+          { buf with Content.Video.data }
       in
       self#set_metadata frame
   end

--- a/src/core/operators/add.ml
+++ b/src/core/operators/add.ml
@@ -168,7 +168,7 @@ class video_add ~field ~add tracks =
 
     method private generate_frame =
       let frames = self#generate_frames in
-      let pos = self#frames_position frames in
+      let length = self#frames_position frames in
       let frames =
         List.fold_left
           (fun frames { data; fields } ->
@@ -198,20 +198,20 @@ class video_add ~field ~add tracks =
                   self#nearest_image ~pos ~last_image data),
                 rest )
       in
-      let buf = self#generate_video ~field ~create pos in
+      let buf = self#generate_video ~field ~create length in
       let data =
         List.map
           (fun (pos, img) ->
             ( pos,
               List.fold_left
                 (fun img (rank, last_image, data) ->
-                  add rank img (self#nearest_image ~pos ~last_image data))
+                  add rank (self#nearest_image ~pos ~last_image data) img)
                 img frames ))
           buf.Content.Video.data
       in
       let frame =
         Frame.set_data
-          (Frame.create ~length:pos Frame.Fields.empty)
+          (Frame.create ~length Frame.Fields.empty)
           field Content.Video.lift_data
           { buf with Content.Video.data }
       in

--- a/src/core/operators/frei0r_op.ml
+++ b/src/core/operators/frei0r_op.ml
@@ -112,12 +112,17 @@ class frei0r_mixer ~name bgra instance params (source : source) source2 =
     val mutable t = 0.
 
     method private generate_frame =
-      let c = source#get_mutable_content Frame.Fields.video in
-      let c' = Frame.get source2#get_frame Frame.Fields.video in
-      let length = min (Content.length c) (Content.length c') in
-
-      let c = Content.sub c 0 length in
-      let c' = Content.sub c' 0 length in
+      let length = min source#frame_position source2#frame_position in
+      let c =
+        Frame.get
+          (source#get_partial_frame (fun f -> Frame.slice f length))
+          Frame.Fields.video
+      in
+      let c' =
+        Frame.get
+          (source2#get_partial_frame (fun f -> Frame.slice f length))
+          Frame.Fields.video
+      in
 
       let rgb = Content.Video.get_data c in
       let rgb =

--- a/src/core/operators/frei0r_op.ml
+++ b/src/core/operators/frei0r_op.ml
@@ -74,10 +74,10 @@ class frei0r_filter ~name bgra instance params (source : source) =
       source#set_frame_data Frame.Fields.video Content.Video.lift_data
         {
           buf with
-          Content_video.Base.data =
+          Content.Video.data =
             List.map
               (fun (pos, img) -> (pos, self#render img))
-              buf.Content_video.Base.data;
+              buf.Content.Video.data;
         }
   end
 
@@ -156,10 +156,10 @@ class frei0r_mixer ~name bgra instance params (source : source) source2 =
             let img = Image.YUV420.of_RGBA32 img in
             t <- t +. dt;
             (pos, Video.Canvas.Image.make img))
-          rgb.Content_video.Base.data
+          rgb.Content.Video.data
       in
       source#set_frame_data Frame.Fields.video Content.Video.lift_data
-        { rgb with Content_video.Base.data }
+        { rgb with Content.Video.data }
   end
 
 class frei0r_source ~name bgra instance params =
@@ -198,10 +198,10 @@ class frei0r_source ~name bgra instance params =
         let data =
           List.map
             (fun (pos, img) -> (pos, self#render_image img))
-            rgb.Content_video.Base.data
+            rgb.Content.Video.data
         in
         Frame.set_data buf Frame.Fields.video Content.Video.lift_data
-          { rgb with Content_video.Base.data })
+          { rgb with Content.Video.data })
   end
 
 (** Make a list of parameters. *)

--- a/src/core/operators/frei0r_op.ml
+++ b/src/core/operators/frei0r_op.ml
@@ -112,20 +112,23 @@ class frei0r_mixer ~name bgra instance params (source : source) source2 =
     val mutable t = 0.
 
     method private generate_frame =
-      let rgb =
-        Content.Video.get_data (source#get_mutable_content Frame.Fields.video)
-      in
+      let c = source#get_mutable_content Frame.Fields.video in
+      let c' = Frame.get source2#get_frame Frame.Fields.video in
+      let length = min (Content.length c) (Content.length c') in
+
+      let c = Content.sub c 0 length in
+      let c' = Content.sub c' 0 length in
+
+      let rgb = Content.Video.get_data c in
       let rgb =
         self#generate_video ~field:Frame.Fields.video
           ~create:(fun ~pos ~width:_ ~height:_ () ->
             self#nearest_image ~pos
               ~last_image:(source#last_image Frame.Fields.video)
               rgb)
-          source#frame_position
+          length
       in
-      let rgb' =
-        Content.Video.get_data (Frame.get source2#get_frame Frame.Fields.video)
-      in
+      let rgb' = Content.Video.get_data c' in
 
       params ();
 

--- a/src/core/operators/still_frame.ml
+++ b/src/core/operators/still_frame.ml
@@ -49,7 +49,7 @@ class still_frame ~name (source : source) =
         | None -> ()
         | Some f -> (
             let v = Content.Video.get_data (Frame.get buf Frame.Fields.video) in
-            match v.Content_video.Base.data with
+            match v.Content.Video.data with
               | [] -> ()
               | (_, i) :: _ ->
                   let i =

--- a/src/core/operators/video_effects.ml
+++ b/src/core/operators/video_effects.ml
@@ -81,7 +81,7 @@ class virtual base ~name (source : source) f =
     method private generate_frame =
       let c = source#get_mutable_content Frame.Fields.video in
       let buf = Content.Video.get_data c in
-      let data = buf.Content_video.Base.data in
+      let data = buf.Content.Video.data in
       let data =
         if data = [] then data
         else (
@@ -89,7 +89,7 @@ class virtual base ~name (source : source) f =
             List.fold_left
               (fun (positions, images) (pos, img) ->
                 (pos :: positions, img :: images))
-              ([], []) buf.Content_video.Base.data
+              ([], []) buf.Content.Video.data
           in
           let positions = List.rev positions in
           let video = Array.of_list (List.rev images) in
@@ -97,7 +97,7 @@ class virtual base ~name (source : source) f =
           List.mapi (fun i pos -> (pos, Video.Canvas.get video i)) positions)
       in
       source#set_frame_data Frame.Fields.video Content.Video.lift_data
-        { buf with Content_video.Base.data }
+        { buf with Content.Video.data }
   end
 
 class effect ~name (source : source) effect =

--- a/src/core/operators/video_fade.ml
+++ b/src/core/operators/video_fade.ml
@@ -70,11 +70,11 @@ class fade_in ?(meta = "liq_video_fade_in") duration fader fadefun source =
               let m = fade (Frame.video_of_main position + i) in
               ignore (fadefun img m);
               (pos, img))
-            buf.Content_video.Base.data
+            buf.Content.Video.data
         in
         state <- `Play (fade, fadefun, duration, position + Frame.position frame);
         Frame.set_data frame Frame.Fields.video Content.Video.lift_data
-          { buf with Content_video.Base.data })
+          { buf with Content.Video.data })
       else frame
 
     method private generate_frame =
@@ -135,11 +135,11 @@ class fade_out ?(meta = "liq_video_fade_out") duration fader fadefun source =
               (* TODO @smimram *)
               ignore (fadefun img m);
               (pos, img))
-            buf.Content_video.Base.data
+            buf.Content.Video.data
         in
 
         Frame.set_data frame Frame.Fields.video Content.Video.lift_data
-          { buf with Content_video.Base.data })
+          { buf with Content.Video.data })
       else frame
 
     method private generate_frame =

--- a/src/core/outputs/graphics_out.ml
+++ b/src/core/outputs/graphics_out.ml
@@ -39,14 +39,17 @@ class output ~infallible ~register_telnet ~autostart ~on_start ~on_stop source =
       sleep <- false
 
     method send_frame buf =
-      let img =
-        let width, height = self#video_dimensions in
-        Video.Canvas.get (VFrame.data buf) 0
-        |> Video.Canvas.Image.viewport width height
-        |> Video.Canvas.Image.render ~transparent:false
-        |> Image.YUV420.to_int_image |> Graphics.make_image
-      in
-      Graphics.draw_image img 0 0
+      match (VFrame.data buf).Content_video.Base.data with
+        | [] -> ()
+        | (_, img) :: _ ->
+            let width, height = self#video_dimensions in
+            let img =
+              img
+              |> Video.Canvas.Image.viewport width height
+              |> Video.Canvas.Image.render ~transparent:false
+              |> Image.YUV420.to_int_image |> Graphics.make_image
+            in
+            Graphics.draw_image img 0 0
 
     method! reset = ()
   end

--- a/src/core/outputs/graphics_out.ml
+++ b/src/core/outputs/graphics_out.ml
@@ -39,7 +39,7 @@ class output ~infallible ~register_telnet ~autostart ~on_start ~on_stop source =
       sleep <- false
 
     method send_frame buf =
-      match (VFrame.data buf).Content_video.Base.data with
+      match (VFrame.data buf).Content.Video.data with
         | [] -> ()
         | (_, img) :: _ ->
             let width, height = self#video_dimensions in

--- a/src/core/outputs/sdl_out.ml
+++ b/src/core/outputs/sdl_out.ml
@@ -87,15 +87,18 @@ class output ~infallible ~register_telnet ~on_start ~on_stop ~autostart source =
       self#process_events;
       let window = Option.get window in
       let surface = Sdl_utils.check Sdl.get_window_surface window in
-      let img =
-        let width, height = self#video_dimensions in
-        (* We only display the first image of each frame *)
-        Video.Canvas.get (VFrame.data buf) 0
-        |> Video.Canvas.Image.viewport width height
-        |> Video.Canvas.Image.render ~transparent:false
-      in
-      Sdl_utils.Surface.of_img surface img;
-      Sdl_utils.check Sdl.update_window_surface window
+      let width, height = self#video_dimensions in
+      match (VFrame.data buf).Content.Video.data with
+        | [] -> ()
+        | (_, img) :: _ ->
+            (* We only display the first image of each frame *)
+            let img =
+              img
+              |> Video.Canvas.Image.viewport width height
+              |> Video.Canvas.Image.render ~transparent:false
+            in
+            Sdl_utils.Surface.of_img surface img;
+            Sdl_utils.check Sdl.update_window_surface window
   end
 
 let output_sdl =

--- a/src/core/source.ml
+++ b/src/core/source.ml
@@ -599,7 +599,7 @@ class virtual operator ?pos ?(name = "src") sources =
                 else _cache <- Some (Frame.chunk ~start:n ~stop:(pos - n) buf)
             | _ -> ())
 
-    method get_partial_frame cb =
+    method peek_frame =
       self#has_ticked;
       match streaming_state with
         | `Unavailable ->
@@ -607,11 +607,13 @@ class virtual operator ?pos ?(name = "src") sources =
             raise Unavailable
         | `Ready fn ->
             fn ();
-            self#get_partial_frame cb
-        | `Done data ->
-            let data = cb data in
-            consumed <- max consumed (Frame.position data);
-            data
+            self#peek_frame
+        | `Done data -> data
+
+    method get_partial_frame cb =
+      let data = cb self#peek_frame in
+      consumed <- max consumed (Frame.position data);
+      data
 
     method get_frame = self#get_partial_frame (fun f -> f)
 

--- a/src/core/source.ml
+++ b/src/core/source.ml
@@ -737,13 +737,13 @@ class virtual operator ?pos ?(name = "src") sources =
             match current with
               | Some (p', _) when abs (p - pos) < abs (p' - pos) -> Some (p, img)
               | _ -> Some (p, img))
-          None buf.Content_video.Base.data
+          None buf.Content.Video.data
       in
       match nearest with Some (_, img) -> img | None -> last_image
 
     method private normalize_video ~field content =
       let buf = Content.Video.get_data content in
-      let data = buf.Content_video.Base.data in
+      let data = buf.Content.Video.data in
       (match
          List.rev (List.sort (fun (p, _) (p', _) -> Int.compare p p') data)
        with

--- a/src/core/source.ml
+++ b/src/core/source.ml
@@ -746,13 +746,17 @@ class virtual operator ?pos ?(name = "src") sources =
     method private normalize_video ~field content =
       let buf = Content.Video.get_data content in
       let data = buf.Content.Video.data in
-      (match List.rev data with
-        | (_, img) :: _ -> self#set_last_image ~field img
-        | [] -> ());
+      let last_image =
+        match List.rev data with
+          | (_, img) :: _ ->
+              self#set_last_image ~field img;
+              img
+          | [] -> self#last_image field
+      in
       Content.Video.lift_data
         (self#internal_generate_video ~field ~priv:true
            ~create:(fun ~pos ~width:_ ~height:_ () ->
-             self#nearest_image ~pos ~last_image:(self#last_image field) buf)
+             self#nearest_image ~pos ~last_image buf)
            (Content.length content))
 
     method private normalize_video_content =

--- a/src/core/source.ml
+++ b/src/core/source.ml
@@ -735,7 +735,7 @@ class virtual operator ?pos ?(name = "src") sources =
         List.fold_left
           (fun current (p, img) ->
             match current with
-              | Some (p', _) when abs (p - pos) < abs (p' - pos) -> Some (p, img)
+              | Some (p', _) when abs (p' - pos) < abs (p - pos) -> current
               | _ -> Some (p, img))
           None buf.Content.Video.data
       in
@@ -744,9 +744,7 @@ class virtual operator ?pos ?(name = "src") sources =
     method private normalize_video ~field content =
       let buf = Content.Video.get_data content in
       let data = buf.Content.Video.data in
-      (match
-         List.rev (List.sort (fun (p, _) (p', _) -> Int.compare p p') data)
-       with
+      (match List.rev data with
         | (_, img) :: _ -> self#set_last_image ~field img
         | [] -> ());
       Content.Video.lift_data

--- a/src/core/source.ml
+++ b/src/core/source.ml
@@ -763,8 +763,10 @@ class virtual operator ?pos ?(name = "src") sources =
 
     method private normalize_video_content =
       Frame.Fields.mapi (fun field content ->
-          if Content.Video.is_data content then
-            self#normalize_video ~field content
+          if
+            Content.Video.is_data content
+            && Frame.Fields.mem field self#content_type
+          then self#normalize_video ~field content
           else content)
 
     method private instrumented_generate_frame =

--- a/src/core/source.mli
+++ b/src/core/source.mli
@@ -20,6 +20,8 @@
 
  *****************************************************************************)
 
+open Mm
+
 type clock_variable
 
 (** In [`CPU] mode, synchronization is governed by the CPU clock.
@@ -172,6 +174,15 @@ class virtual source :
 
        (** A buffer that can be used by the source. *)
        method buffer : Generator.t
+
+       method private generate_video :
+         ?create:
+           (pos:int -> width:int -> height:int -> unit -> Video.Canvas.image) ->
+         field:Frame.Fields.field ->
+         int ->
+         Content.Video.data
+
+       method last_image : Frame.Fields.field -> Video.Canvas.image
 
        (** An empty frame that can be used by the source. *)
        method empty_frame : Frame.t

--- a/src/core/source.mli
+++ b/src/core/source.mli
@@ -184,6 +184,12 @@ class virtual source :
 
        method last_image : Frame.Fields.field -> Video.Canvas.image
 
+       method private nearest_image :
+         pos:int ->
+         last_image:Video.Canvas.image ->
+         Content.Video.data ->
+         Video.Canvas.image
+
        (** An empty frame that can be used by the source. *)
        method empty_frame : Frame.t
 

--- a/src/core/source.mli
+++ b/src/core/source.mli
@@ -261,6 +261,9 @@ class virtual source :
            is the same as the partial chunk returned for the callback for easy method call chaining. *)
        method get_partial_frame : (Frame.t -> Frame.t) -> Frame.t
 
+       (** Check a frame without consuming any of its data. *)
+       method peek_frame : Frame.t
+
        (** This method requests a specific field of the frame that can be mutated. It is used
            by a consumer of the source that will modify the source's data (e.g. [amplify]). The
            source will do its best to minimize data copy according to the streaming context. Typically,

--- a/src/core/sources/external_input_video.ml
+++ b/src/core/sources/external_input_video.ml
@@ -169,7 +169,7 @@ let _ =
                      (width * height * 3));
               let data = (Option.get !video_converter) data in
               Generator.put buffer Frame.Fields.video
-                (Content.Video.lift_data (Video.Canvas.single data))
+                (Content.Video.lift_image data)
           | `Frame (`Audio, _, data) ->
               let converter = Option.get !audio_converter in
               let data, ofs, len =
@@ -234,8 +234,7 @@ let _ =
         (* Img.swap_rb data; *)
         (* Img.Effect.flip data; *)
         Generator.put buffer Frame.Fields.video
-          (Content.Video.lift_data
-             (Video.Canvas.single (Video.Canvas.Image.make data)))
+          (Content.Video.lift_image (Video.Canvas.Image.make data))
       in
       let bufferize = Lang.to_float (List.assoc "buffer" p) in
       let restart = Lang.to_bool (List.assoc "restart" p) in

--- a/src/core/sources/video_board.ml
+++ b/src/core/sources/video_board.ml
@@ -52,14 +52,11 @@ class board ?duration img0 () =
             last_point <- Some (x, y)
 
     method private synthesize length =
-      let frame = Frame.create ~length self#content_type in
-      let frame_width, frame_height = self#video_dimensions in
-      let len = Frame.video_of_main length in
-      let buf = Content.Video.get_data (Frame.get frame Frame.Fields.video) in
-      for i = 0 to len - 1 do
-        buf.(i) <-
-          Video.Canvas.Image.make ~width:frame_width ~height:frame_height img
-      done;
+      let frame = Frame.create ~length Frame.Fields.empty in
+      let create ~pos:_ ~width ~height () =
+        Video.Canvas.Image.make ~width ~height img
+      in
+      let buf = self#generate_video ~field:Frame.Fields.video ~create length in
       Frame.set_data frame Frame.Fields.video Content.Video.lift_data buf
   end
 

--- a/src/core/sources/video_testsrc.ml
+++ b/src/core/sources/video_testsrc.ml
@@ -39,13 +39,10 @@ class testsrc ?(duration = None) ~width ~height () =
     val mutable dvy' = 2
 
     method private synthesize length =
-      let frame = Frame.create ~length self#content_type in
-      let frame_width, frame_height = self#video_dimensions in
-      let width = if width < 0 then frame_width else width in
-      let height = if height < 0 then frame_height else height in
-      let len = Frame.video_of_main length in
-      let buf = VFrame.data frame in
-      for i = 0 to len - 1 do
+      let frame = Frame.create ~length Frame.Fields.empty in
+      let create ~pos:_ ~width:frame_width ~height:frame_height () =
+        let width = if width < 0 then frame_width else width in
+        let height = if height < 0 then frame_height else height in
         let img = Image.YUV420.create width height in
         u0 <- u0 + u0';
         if u0 < 0 then u0' <- abs u0';
@@ -68,9 +65,9 @@ class testsrc ?(duration = None) ~width ~height () =
         Image.YUV420.gradient_uv img (u0, v0)
           (u0 + dux, v0 + dvx)
           (u0 + duy, v0 + dvy);
-        buf.(i) <-
-          Video.Canvas.Image.make ~width:frame_width ~height:frame_height img
-      done;
+        Video.Canvas.Image.make ~width:frame_width ~height:frame_height img
+      in
+      let buf = self#generate_video ~field:Frame.Fields.video ~create length in
       Frame.set_data frame Frame.Fields.video Content.Video.lift_data buf
   end
 

--- a/src/core/sources/video_text.ml
+++ b/src/core/sources/video_text.ml
@@ -58,8 +58,7 @@ class text init render_text ttf ttf_size color duration text =
             Option.get text_frame
 
     method private synthesize length =
-      let frame = Frame.create ~length self#content_type in
-      let len = Frame.video_of_main length in
+      let frame = Frame.create ~length Frame.Fields.empty in
       let ttf = ttf () in
       let ttf_size = ttf_size () in
       let color = color () in
@@ -74,14 +73,11 @@ class text init render_text ttf ttf_size color duration text =
         cur_text <- text;
         self#render_text);
       let tf = self#get_text_frame in
-      let buf = VFrame.data frame in
-      for i = 0 to len - 1 do
-        let img = buf.(i) in
-        let width = Video.Canvas.Image.width img in
-        let height = Video.Canvas.Image.height img in
-        buf.(i) <- Video.Canvas.Image.viewport width height tf
-      done;
-      Frame.set frame Frame.Fields.video (Content.Video.lift_data ~length buf)
+      let create ~pos:_ ~width ~height () =
+        Video.Canvas.Image.viewport width height tf
+      in
+      let buf = self#generate_video ~field:Frame.Fields.video ~create length in
+      Frame.set_data frame Frame.Fields.video Content.Video.lift_data buf
   end
 
 let register name init render_text =

--- a/src/core/stream/content.ml
+++ b/src/core/stream/content.ml
@@ -115,7 +115,7 @@ module Video = struct
     let initial_pos = gen.position in
     gen.position <- Int64.add gen.position (Int64.of_int length);
     let rec f data pos =
-      if length < pos then List.rev data
+      if length <= pos then List.rev data
       else (
         let data =
           if gen.next_sample <= Int64.add initial_pos (Int64.of_int pos) then (

--- a/src/core/stream/content.ml
+++ b/src/core/stream/content.ml
@@ -115,7 +115,7 @@ module Video = struct
     let initial_pos = gen.position in
     gen.position <- Int64.add gen.position (Int64.of_int length);
     let rec f data pos =
-      if length <= pos then List.rev data
+      if length < pos then List.rev data
       else (
         let data =
           if gen.next_sample <= Int64.add initial_pos (Int64.of_int pos) then (

--- a/src/core/stream/content.ml
+++ b/src/core/stream/content.ml
@@ -20,6 +20,7 @@
 
  *****************************************************************************)
 
+open Mm
 include Content_base
 
 module MkContent (C : ContentSpecs) = struct
@@ -44,6 +45,7 @@ type video_params = Content_video.Specs.params = {
   height : int Lazy.t option;
 }
 
+type video_data = (video_params, Video.Canvas.image) Content_video.Base.content
 type midi_params = Content_midi.Specs.params = { channels : int }
 
 module Audio = Content_audio

--- a/src/core/stream/content.mli
+++ b/src/core/stream/content.mli
@@ -155,7 +155,7 @@ module Audio : sig
     Content
       with type kind = [ `Pcm ]
        and type params = audio_params
-       and type data = Audio.Mono.buffer array
+       and type data = Audio.t
 
   val kind : Contents.kind
   val channels_of_format : Contents.format -> int

--- a/src/core/stream/content.mli
+++ b/src/core/stream/content.mli
@@ -52,6 +52,7 @@ type video_params = Content_video.Specs.params = {
   height : int Lazy.t option;
 }
 
+type video_data = (video_params, Video.Canvas.image) Content_video.Base.content
 type midi_params = Content_midi.Specs.params = { channels : int }
 
 module type ContentSpecs = sig
@@ -166,10 +167,15 @@ module Video : sig
     Content
       with type kind = [ `Canvas ]
        and type params = video_params
-       and type data = Video.Canvas.t
+       and type data = video_data
 
   val kind : Contents.kind
   val dimensions_of_format : Contents.format -> int * int
+
+  val lift_canvas :
+    ?offset:int -> ?length:int -> Video.Canvas.t -> Contents.data
+
+  val get_canvas : Contents.data -> Video.Canvas.t
 end
 
 module Midi : sig

--- a/src/core/stream/content.mli
+++ b/src/core/stream/content.mli
@@ -171,11 +171,17 @@ module Video : sig
 
   val kind : Contents.kind
   val dimensions_of_format : Contents.format -> int * int
+  val lift_image : Video.Canvas.image -> Contents.data
 
-  val lift_canvas :
-    ?offset:int -> ?length:int -> Video.Canvas.t -> Contents.data
+  type generator
 
-  val get_canvas : Contents.data -> Video.Canvas.t
+  val make_generator : params -> generator
+
+  val generate :
+    ?create:(pos:int -> width:int -> height:int -> unit -> Video.Canvas.image) ->
+    generator ->
+    int ->
+    data
 end
 
 module Midi : sig

--- a/src/core/stream/content_video.ml
+++ b/src/core/stream/content_video.ml
@@ -23,24 +23,68 @@
 open Mm
 open Content_base
 
+module Base = struct
+  type ('a, 'b) content = {
+    length : int;
+    mutable params : 'a;
+    mutable data : (int * 'b) list;
+  }
+
+  let make ?(length = 0) params = { length; params; data = [] }
+  let length { length } = length
+
+  let blit :
+        'a 'b.
+        copy:('b -> 'b) ->
+        ('a, 'b) content ->
+        int ->
+        ('a, 'b) content ->
+        int ->
+        int ->
+        unit =
+   fun ~copy src src_pos dst dst_pos len ->
+    (* No compatibility check here, it's
+       assumed to have been done beforehand. *)
+    dst.params <- src.params;
+    let data =
+      List.filter
+        (fun (pos, _) -> pos < dst_pos || dst_pos + len <= pos)
+        dst.data
+    in
+    let src_end = src_pos + len in
+    let data =
+      List.fold_left
+        (fun data (pos, p) ->
+          if src_pos <= pos && pos < src_end then (
+            let pos = dst_pos + (pos - src_pos) in
+            (pos, copy p) :: data)
+          else data)
+        data src.data
+    in
+    dst.data <- List.sort (fun (pos, _) (pos', _) -> compare pos pos') data
+
+  let fill :
+        'a 'b. ('a, 'b) content -> int -> ('a, 'b) content -> int -> int -> unit
+      =
+   fun src src_pos dst dst_pos len ->
+    blit ~copy:(fun x -> x) src src_pos dst dst_pos len
+
+  let copy ~copy { length; data; params } =
+    { length; data = List.map (fun (pos, x) -> (pos, copy x)) data; params }
+
+  let params { params } = params
+end
+
 module Specs = struct
   open Frame_settings
+  include Base
 
   type kind = [ `Canvas ]
   type params = { width : int Lazy.t option; height : int Lazy.t option }
-  type data = Video.Canvas.t
+  type data = (params, Video.Canvas.image) content
 
   let internal_content_type = Some `Video
   let string_of_kind = function `Canvas -> "canvas"
-
-  let make ?(length = 0) (p : params) : data =
-    let width = !!(Option.value ~default:video_width p.width) in
-    let height = !!(Option.value ~default:video_height p.height) in
-    (* We need to round off to make sure we always have room *)
-    let length = int_of_float (Float.ceil (video_of_main_f length)) in
-    Video.Canvas.make length (width, height)
-
-  let length d = main_of_video (Video.Canvas.length d)
 
   let string_of_params { width; height } =
     print_optional
@@ -77,23 +121,10 @@ module Specs = struct
     in
     compare (p.width, p'.width) && compare (p.height, p'.height)
 
-  let blit src src_pos dst dst_pos len =
-    let ( ! ) = Frame_settings.video_of_main in
-    let len = !(dst_pos + len) - !dst_pos in
-    let src_pos = !src_pos in
-    let dst_pos = !dst_pos in
-    Video.Canvas.blit src src_pos dst dst_pos len
+  let blit = fill
 
-  let copy = Video.Canvas.copy
-
-  let params data =
-    if Array.length data = 0 then { width = None; height = None }
-    else (
-      let i = data.(0) in
-      {
-        width = Some (lazy (Video.Canvas.Image.width i));
-        height = Some (lazy (Video.Canvas.Image.height i));
-      })
+  let copy : 'a. ('a, 'b) content -> ('a, 'b) content =
+   fun src -> copy ~copy:(fun x -> x) src
 
   let kind = `Canvas
   let default_params _ = { width = None; height = None }
@@ -102,9 +133,6 @@ end
 
 include MkContentBase (Specs)
 
-(* Internal video chunks are rounded off to the nearest integer
-   so we do need to make sure length is always specified. *)
-let make ?(length = 0) = make ~length
 let kind = lift_kind `Canvas
 
 let dimensions_of_format p =
@@ -116,3 +144,27 @@ let dimensions_of_format p =
     Lazy.force (Option.value ~default:Frame_settings.video_height p.height)
   in
   (width, height)
+
+let lift_canvas ?(offset = 0) ?length data =
+  let interval = Frame_settings.main_of_video 1 in
+  let data = Array.(to_list (mapi (fun pos d -> (pos * interval, d)) data)) in
+  let params =
+    match data with
+      | [] -> { Specs.width = None; height = None }
+      | (_, i) :: _ ->
+          {
+            Specs.width = Some (lazy (Video.Canvas.Image.width i));
+            height = Some (lazy (Video.Canvas.Image.height i));
+          }
+  in
+  let length =
+    match length with Some l -> l | None -> List.length data * interval
+  in
+  let data =
+    List.filter (fun (pos, _) -> offset <= pos && pos < offset + length) data
+  in
+  lift_data ~length { length; params; data }
+
+let get_canvas data =
+  let { Base.data } = get_data data in
+  Array.of_list (List.map snd data)

--- a/src/core/stream/content_video.ml
+++ b/src/core/stream/content_video.ml
@@ -93,6 +93,16 @@ module Specs = struct
         ("height", Option.map (fun x -> string_of_int !!x) height);
       ]
 
+  let make ?(length = 0) params =
+    let width = !!(Option.value ~default:video_width params.width) in
+    let height = !!(Option.value ~default:video_height params.height) in
+    let interval = main_of_video 1 in
+    let img = Video.Canvas.Image.create width height in
+    let data =
+      List.init (video_of_main length) (fun i -> (i * interval, img))
+    in
+    { length; params; data }
+
   let parse_param label value =
     match label with
       | "width" ->

--- a/src/core/stream/ffmpeg_content_base.ml
+++ b/src/core/stream/ffmpeg_content_base.ml
@@ -20,61 +20,13 @@
 
  *****************************************************************************)
 
-type ('a, 'b) content = {
-  length : int;
-  mutable params : 'a;
-  mutable data : (int * 'b) list;
-}
-
 let conf_ffmpeg_content =
   Dtools.Conf.void
     ~p:(Ffmpeg_utils.conf_ffmpeg#plug "content")
     "FFmpeg content configuration"
 
-let make ?(length = 0) params = { length; params; data = [] }
-let length { length } = length
 let stream_idx = ref 0L
 
 let new_stream_idx () =
   stream_idx := Int64.succ !stream_idx;
   !stream_idx
-
-let compare (x : int) (y : int) = x - y [@@inline always]
-
-let blit :
-      'a 'b.
-      copy:('b -> 'b) ->
-      ('a, 'b) content ->
-      int ->
-      ('a, 'b) content ->
-      int ->
-      int ->
-      unit =
- fun ~copy src src_pos dst dst_pos len ->
-  (* No compatibility check here, it's
-     assumed to have been done beforehand. *)
-  dst.params <- src.params;
-  let data =
-    List.filter (fun (pos, _) -> pos < dst_pos || dst_pos + len <= pos) dst.data
-  in
-  let src_end = src_pos + len in
-  let data =
-    List.fold_left
-      (fun data (pos, p) ->
-        if src_pos <= pos && pos < src_end then (
-          let pos = dst_pos + (pos - src_pos) in
-          (pos, copy p) :: data)
-        else data)
-      data src.data
-  in
-  dst.data <- List.sort (fun (pos, _) (pos', _) -> compare pos pos') data
-
-let fill :
-      'a 'b. ('a, 'b) content -> int -> ('a, 'b) content -> int -> int -> unit =
- fun src src_pos dst dst_pos len ->
-  blit ~copy:(fun x -> x) src src_pos dst dst_pos len
-
-let copy ~copy { length; data; params } =
-  { length; data = List.map (fun (pos, x) -> (pos, copy x)) data; params }
-
-let params { params } = params

--- a/src/core/stream/ffmpeg_copy_content.ml
+++ b/src/core/stream/ffmpeg_copy_content.ml
@@ -47,7 +47,7 @@ type packet_payload = {
 }
 
 module Specs = struct
-  include Ffmpeg_content_base
+  include Content_video.Base
 
   type kind = [ `Copy ]
   type params = params_payload option

--- a/src/core/stream/ffmpeg_raw_content.ml
+++ b/src/core/stream/ffmpeg_raw_content.ml
@@ -29,7 +29,7 @@ type 'a frame = {
 }
 
 module BaseSpecs = struct
-  include Ffmpeg_content_base
+  include Content_video.Base
 
   type kind = [ `Raw ]
 

--- a/src/core/stream/frame_settings.ml
+++ b/src/core/stream/frame_settings.ml
@@ -37,7 +37,7 @@ let conf =
       ]
 
 let conf_duration =
-  Conf.float ~p:(conf#plug "duration") ~d:0.01
+  Conf.float ~p:(conf#plug "duration") ~d:0.04
     "Tentative frame duration in seconds"
     ~comments:
       [

--- a/tests/core/decoder_test.ml
+++ b/tests/core/decoder_test.ml
@@ -14,7 +14,7 @@ let () =
       Audio.lift_params { Content.channel_layout = lazy `Five_point_one })
   in
   let canvas = Content.default_format Content_video.kind in
-  let midi = Content.(Midi.lift_params { Content.channels = 1 }) in
+  let midi = Content.(Midi.lift_params { Content.Audio.channels = 1 }) in
   assert (
     Decoder.can_decode_type
       (Frame.Fields.make ~audio:stereo ())

--- a/tests/core/decoder_test.ml
+++ b/tests/core/decoder_test.ml
@@ -4,17 +4,17 @@ let () =
 
 let () =
   let mono =
-    Content.(Audio.lift_params { Content.channel_layout = lazy `Mono })
+    Content.(Audio.lift_params { Content.Audio.channel_layout = lazy `Mono })
   in
   let stereo =
-    Content.(Audio.lift_params { Content.channel_layout = lazy `Stereo })
+    Content.(Audio.lift_params { Content.Audio.channel_layout = lazy `Stereo })
   in
   let five_point_one =
     Content.(
-      Audio.lift_params { Content.channel_layout = lazy `Five_point_one })
+      Audio.lift_params { Content.Audio.channel_layout = lazy `Five_point_one })
   in
   let canvas = Content.default_format Content_video.kind in
-  let midi = Content.(Midi.lift_params { Content.Audio.channels = 1 }) in
+  let midi = Content.(Midi.lift_params { Content.Midi.channels = 1 }) in
   assert (
     Decoder.can_decode_type
       (Frame.Fields.make ~audio:stereo ())


### PR DESCRIPTION
## Summary

This PR makes it possible to define sub-video sample frames.

Typically, this makes it possible to have a latency of `0.01s` with audio/video scripts.

The trade-off in CPU vs. memory usage is not as great as expected but, nonetheless, I believe that is fundamental that we should be able to do low-latency stream generation.

Video memory, on the other hand, is greatly improved. Not because if the change of frame size but because of the more efficient APIs to generate content without allocating empty frames. See below for the report.

### TODO

- [x] Cleanup, proof read
- [x] Large video example.

## API changes

In order to make this work, these changes:

### Merge the video payload from ffmpeg into plain video content

This means that we are not longer using `Video.Canvas` but our own list of `(position, image)`. This is pretty much the same but allows us to keep track of the position of an image within the content for easy content sub/append.

### Video frame normalization

Once we start having frames that are sub-video sample, it is possible to have:
* Frames without video image, for instance:
```
frame size = 0.01s = 441 samples
video rate = 25 = 1 video image each 4 frames

|-------|------|------|------|
| i     |      |      |      |
|-------|------|------|------|
```

In dynamic swiching context, it is then possible to append two frames with initial image from two different sources, leading to situations like:

```
|-------|------|------|------|
| i  i  |      |      |   i  |
|-------|------|------|------|
```

Things become even more complicated when dealing with operators such as `add`.

Thus, in order to remediate this, a new `video generator` facility is created. This API keeps track of its current position and is able to generate video with the expected frame rate. It also takes a `create` function which is used to return the image that should be used when creating video content.

Using this new API we can normalize all source's video content as follow:
* All sources keep track of the last image they have produced.
* When producing a video frame, the source calls its own `video generator` with that frame's length and uses the closest image from the generated content, if available, or its latest image, to generate the new content.

This, essentially, means that all sources are video-rate controlled using a nearest sample mechanism.

This makes it possible to normalize assumptions such as having images available to consistently add them in the `video.add` operators.

Here are the new API:
```ocaml
       method private generate_video :
         ?create:
           (pos:int -> width:int -> height:int -> unit -> Video.Canvas.image) ->
         field:Frame.Fields.field ->
         int ->
         Content.Video.data

       method last_image : Frame.Fields.field -> Video.Canvas.image

       method private nearest_image :
         pos:int ->
         last_image:Video.Canvas.image ->
         Content.Video.data ->
         Video.Canvas.image
```

And here's how we normalize each frame while generating content:

```ocaml
    method private normalize_video ~field content =
      let buf = Content.Video.get_data content in
      let data = buf.Content.Video.data in
      let last_image =
        match List.rev data with
          | (_, img) :: _ ->
              self#set_last_image ~field img;
              img
          | [] -> self#last_image field
      in
      Content.Video.lift_data
        (self#internal_generate_video ~field ~priv:true
           ~create:(fun ~pos ~width:_ ~height:_ () ->
             self#nearest_image ~pos ~last_image buf)
           (Content.length content))

    method private normalize_video_content =
      Frame.Fields.mapi (fun field content ->
          if Content.Video.is_data content then
            self#normalize_video ~field content
          else content)
```

### Mapping for content manipulation

On the consumer side, manipulating the content becomes a simple matter of mapping the list of images:
```ocaml
    method private generate_frame =
      let buf =
        Content.Video.get_data (source#get_mutable_content Frame.Fields.video)
      in
      params ();
      source#set_frame_data Frame.Fields.video Content.Video.lift_data
        {
          buf with
          Content.Video.data =
            List.map
              (fun (pos, img) -> (pos, self#render img))
              buf.Content.Video.data;
        }
```

## Performances

First tests seem to show that performance is the same for a `0.04s` frame and decreases memory usage by about `10%` with a `0.01s` frame at the cost of an increased CPU usage.

Script:
```liquidsoap
def f() =
  s = playlist("~/sources/test-stream/audio")
  s = crossfade(s)
  output.dummy(fallible=true, s)
end

for i = 0 to 100 do
  thread.run(delay=float_of_int(i), f)
end

output.dummy(blank())
```

### `main`, `0.04s` frame

<img width="229" alt="Screenshot 2023-12-31 at 9 38 15 AM" src="https://github.com/savonet/liquidsoap/assets/871060/399e052b-6b0c-4ad4-bc29-9d896a59a85f">

<img width="1288" alt="Screenshot 2023-12-31 at 9 38 27 AM" src="https://github.com/savonet/liquidsoap/assets/871060/b6e99389-4fd4-4cd7-96dd-ad0f39cf6a1b">

### This PR, `0.04s` frame:

<img width="314" alt="Screenshot 2023-12-31 at 9 41 32 AM" src="https://github.com/savonet/liquidsoap/assets/871060/59569da8-ea8f-43fa-9a14-022294179f3a">

<img width="1286" alt="Screenshot 2023-12-31 at 9 41 45 AM" src="https://github.com/savonet/liquidsoap/assets/871060/c058e4e7-6402-4af0-9210-4b61eeca6b70">

### This PR, `0.01s` frame

<img width="301" alt="Screenshot 2023-12-31 at 9 34 38 AM" src="https://github.com/savonet/liquidsoap/assets/871060/4a240e72-534b-4967-841b-a7220e0b40d1">

<img width="1274" alt="Screenshot 2023-12-31 at 9 34 53 AM" src="https://github.com/savonet/liquidsoap/assets/871060/1f9f9f46-5228-48ce-bb23-f78e34e9b6ef">

## Complex video performace

This is the script that generates this:

<img width="1281" alt="Screenshot 2023-12-31 at 5 12 14 PM" src="https://github.com/savonet/liquidsoap/assets/871060/38c54ac9-7a87-4ccb-b4f7-79b21635ebda">

### Main, `0.04s` frame

<img width="321" alt="Screenshot 2023-12-31 at 5 09 58 PM" src="https://github.com/savonet/liquidsoap/assets/871060/a7be4fbf-1a4d-4c62-8d48-b71894e993e9">

<img width="815" alt="Screenshot 2023-12-31 at 5 10 08 PM" src="https://github.com/savonet/liquidsoap/assets/871060/12953337-2cb6-4688-b7de-8f3ca324509f">


### This PR, `0.04s` frame

<img width="325" alt="Screenshot 2023-12-31 at 5 11 37 PM" src="https://github.com/savonet/liquidsoap/assets/871060/e22254f2-605f-48a2-99ce-8662fc4db6c1">

<img width="1133" alt="Screenshot 2023-12-31 at 5 11 50 PM" src="https://github.com/savonet/liquidsoap/assets/871060/30227140-7409-451b-8ac7-fbb609264288">
