### PR TITLE
Cleanup: crossfade, muxer rewrite, fix add

### DIFF
--- a/src/core/operators/add.ml
+++ b/src/core/operators/add.ml
@@ -137,9 +137,9 @@ class audio_add ~renorm ~power ~field tracks =
       in
       let total_weight = if power then sqrt total_weight else total_weight in
       let pos = self#frames_position frames in
-      let audio_len = Frame.audio_of_main pos in
       let buf = Frame.create ~length:pos self#content_type in
       let pcm = Content.Audio.get_data (Frame.get buf field) in
+      let audio_len = Frame.audio_of_main pos in
       Audio.clear pcm 0 audio_len;
       List.iter
         (fun { data; fields } ->

--- a/src/core/operators/add.ml
+++ b/src/core/operators/add.ml
@@ -82,7 +82,7 @@ class virtual base ~name tracks =
              match (pos, data) with
                | _, None -> pos
                | None, Some frame -> Some (Frame.position frame)
-               | Some p, Some frame -> Some (min p (Frame.position frame)))
+               | Some p, Some frame -> Some (max p (Frame.position frame)))
            None frames)
 
     method seek_source =
@@ -139,8 +139,7 @@ class audio_add ~renorm ~power ~field tracks =
       let pos = self#frames_position frames in
       let buf = Frame.create ~length:pos self#content_type in
       let pcm = Content.Audio.get_data (Frame.get buf field) in
-      let audio_len = Frame.audio_of_main pos in
-      Audio.clear pcm 0 audio_len;
+      Audio.clear pcm 0 (Audio.length pcm);
       List.iter
         (fun { data; fields } ->
           match data with
@@ -152,6 +151,7 @@ class audio_add ~renorm ~power ~field tracks =
                       Content.Audio.get_data (Frame.get frame field)
                     in
                     let c = if renorm then weight /. total_weight else weight in
+                    let audio_len = Audio.length track_pcm in
                     if c <> 1. then Audio.amplify c track_pcm 0 audio_len;
                     Audio.add pcm 0 track_pcm 0 audio_len)
                   fields)

--- a/src/core/operators/amplify.ml
+++ b/src/core/operators/amplify.ml
@@ -35,16 +35,13 @@ class amplify ~field (source : source) override_field coeff =
     method self_sync = source#self_sync
 
     method private process buf =
-      let content = Frame.get buf field in
       let k = match override with Some o -> o | None -> coeff () in
-      let content =
-        if k <> 1. then (
-          let data = Content.Audio.get_data content in
-          Audio.amplify k data 0 (Frame.audio_of_main (Content.length content));
-          Content.Audio.lift_data data)
-        else content
-      in
-      Frame.set buf field content
+      if k <> 1. then (
+        let content = Frame.get buf field in
+        let data = Content.Audio.get_data content in
+        Audio.amplify k data 0 (Audio.length data);
+        Frame.set_data buf field Content.Audio.lift_data data)
+      else buf
 
     method private set_override buf =
       match override_field with

--- a/src/core/source.ml
+++ b/src/core/source.ml
@@ -590,7 +590,7 @@ class virtual operator ?pos ?(name = "src") sources =
 
       self#on_after_output (fun () ->
           match (streaming_state, consumed) with
-            | `Done _, 0 -> _cache <- None
+            | `Done buf, 0 -> _cache <- Some buf
             | `Done buf, n ->
                 let pos = Frame.position buf in
                 assert (n <= pos);

--- a/src/core/sources/generated.ml
+++ b/src/core/sources/generated.ml
@@ -113,18 +113,3 @@ class virtual source ?(seek = false) ?(replay_meta = false) ~bufferize
           else buf)
         ()
   end
-
-class consumer buffer =
-  object (self)
-    inherit Source.source ~name:"buffer" ()
-    method stype = `Fallible
-    method private can_generate_frame = 0 < Generator.length buffer
-
-    method private generate_frame =
-      Generator.slice buffer (Lazy.force Frame.size)
-
-    method abort_track = Generator.clear buffer
-    method self_sync = (`Static, false)
-    method seek_source = (self :> Source.source)
-    method remaining = Generator.remaining buffer
-  end

--- a/src/core/stream/frame.ml
+++ b/src/core/stream/frame.ml
@@ -143,4 +143,4 @@ let free_metadata frame pos =
   in
   Content.Metadata.set_data new_metadata
     (List.filter (fun (p, _) -> p <> pos) (Content.Metadata.get_data metadata));
-  Fields.add Fields.metadata metadata frame
+  Fields.add Fields.metadata new_metadata frame

--- a/src/libs/fades.liq
+++ b/src/libs/fades.liq
@@ -536,6 +536,8 @@ end
 # @param ~medium       Smart crossfade: value, in dB, for medium sound level.
 # @param ~margin       Smart crossfade: margin to detect sources that have too different \
 #                      sound level for crossing.
+# @param ~deduplicate  Crossfade transitions can generate duplicate metadata. When `true`, the operator \
+#                      removes duplicate metadata from the returned source.
 # @param s             The input source.
 def crossfade(
   ~id=null(),
@@ -549,6 +551,7 @@ def crossfade(
   ~high=-15.,
   ~medium=-32.,
   ~margin=4.,
+  ~deduplicate=true,
   ~duration_margin=0.1,
   ~width=2.,
   s
@@ -661,13 +664,28 @@ def crossfade(
 
   transition = if smart then smart_transition else simple_transition end
 
-  cross(
-    id=id,
-    width=width,
-    duration=duration,
-    persist_override=persist_override,
-    override_duration=override_duration,
-    transition,
-    s
-  )
+  let (cross_id, deduplicate_id) =
+    deduplicate ? (null(), null(id)) : (null(id), null())
+
+  crossed =
+    cross(
+      id=cross_id,
+      width=width,
+      duration=duration,
+      persist_override=persist_override,
+      override_duration=override_duration,
+      transition,
+      s
+    )
+
+  s =
+    if
+      deduplicate
+    then
+      metadata.deduplicate(id=deduplicate_id, crossed)
+    else
+      crossed
+    end
+
+  s.{cross_duration={crossed.cross_duration()}}
 end

--- a/src/libs/fades.liq
+++ b/src/libs/fades.liq
@@ -57,7 +57,6 @@ def mkfade(~type="lin", ~start=0., ~stop=1., ~duration=3., ~on_done={()}, s) =
   def fade() =
     if start_time() < 0. then start_time := source.time(s) end
     t = source.time(s) - start_time()
-    duration = min(source.remaining(s), duration)
 
     if
       t >= duration
@@ -100,7 +99,7 @@ def fade.out(
   ~override_duration="liq_fade_out",
   ~override_type="liq_fade_type",
   ~persist_overrides=false,
-  ~track_sensitive=true,
+  ~track_sensitive=false,
   ~type="lin",
   s
 ) =
@@ -299,7 +298,7 @@ def fade.in(
   ~override_duration="liq_fade_in",
   ~override_type="liq_fade_type",
   ~persist_overrides=false,
-  ~track_sensitive=true,
+  ~track_sensitive=false,
   ~type="lin",
   s
 ) =

--- a/src/libs/fades.liq
+++ b/src/libs/fades.liq
@@ -57,6 +57,8 @@ def mkfade(~type="lin", ~start=0., ~stop=1., ~duration=3., ~on_done={()}, s) =
   def fade() =
     if start_time() < 0. then start_time := source.time(s) end
     t = source.time(s) - start_time()
+    duration = min(source.remaining(s), duration)
+
     if
       t >= duration
     then

--- a/src/libs/fades.liq
+++ b/src/libs/fades.liq
@@ -510,6 +510,23 @@ def cross.smart(
   end
 end
 
+# @docof cross
+# @param ~deduplicate  Crossfade transitions can generate duplicate metadata. When `true`, the operator \
+#                      removes duplicate metadata from the returned source.
+def replaces cross(%argsof(cross), ~deduplicate=true, transition, s) =
+  if
+    not deduplicate
+  then
+    cross(%argsof(cross), transition, s)
+  else
+    s = cross(%argsof(cross[!id]), transition, s)
+    def replaces s =
+      metadata.deduplicate(s)
+    end
+    s
+  end
+end
+
 # Crossfade between tracks, taking the respective volume levels into account in
 # the choice of the transition.
 # @category Source / Fade
@@ -664,28 +681,14 @@ def crossfade(
 
   transition = if smart then smart_transition else simple_transition end
 
-  let (cross_id, deduplicate_id) =
-    deduplicate ? (null(), null(id)) : (null(id), null())
-
-  crossed =
-    cross(
-      id=cross_id,
-      width=width,
-      duration=duration,
-      persist_override=persist_override,
-      override_duration=override_duration,
-      transition,
-      s
-    )
-
-  s =
-    if
-      deduplicate
-    then
-      metadata.deduplicate(id=deduplicate_id, crossed)
-    else
-      crossed
-    end
-
-  s.{cross_duration={crossed.cross_duration()}}
+  cross(
+    id=id,
+    width=width,
+    duration=duration,
+    persist_override=persist_override,
+    override_duration=override_duration,
+    deduplicate=deduplicate,
+    transition,
+    s
+  )
 end

--- a/src/libs/fades.liq
+++ b/src/libs/fades.liq
@@ -514,16 +514,19 @@ end
 # @param ~deduplicate  Crossfade transitions can generate duplicate metadata. When `true`, the operator \
 #                      removes duplicate metadata from the returned source.
 def replaces cross(%argsof(cross), ~deduplicate=true, transition, s) =
+  log(
+    level=1,
+    "cross here, deduplicate: #{deduplicate}"
+  )
   if
     not deduplicate
   then
     cross(%argsof(cross), transition, s)
   else
     s = cross(%argsof(cross[!id]), transition, s)
-    def replaces s =
-      metadata.deduplicate(s)
-    end
-    s
+    dedup = metadata.deduplicate(s)
+
+    dedup.{buffered=s.buffered, cross_duration=s.cross_duration}
   end
 end
 

--- a/tests/streams/cross.liq
+++ b/tests/streams/cross.liq
@@ -34,7 +34,7 @@ def check_duplicate(m) =
   end
 end
 
-s.on_metadata(check_duplicate)
+s = source.on_metadata(s, check_duplicate)
 clock.assign_new(sync="none", [s])
 
 def on_stop() =


### PR DESCRIPTION
This PR cleans up some of the recent changes:
* Backport the fix for https://github.com/savonet/liquidsoap/issues/3318 on the `add` operator
* Rewrite the muxer to be trivially simple!
* Rewrite the crossfade operator to take advantage of the `Source.generate_from_multiple_sources` logic.

One important change: `fade.in` and `fade.out` used to be triggered by track marks by default. However, with these changes and to be more in-tune with the new handling of track marks, the sources used to compute crossfade transitions do not have initial track marks unless they are in the underlying data. 

Since most use of `fade.in` and `fade.out` are inside crossfade transitions it seems to make sense to change them to trigger immediately. The old behavior can still be obtained by passing `track_sensitive=true`.