### PR TITLE
Finish migration to Re

### DIFF
--- a/src/core/builtins/builtins_sqlite.ml
+++ b/src/core/builtins/builtins_sqlite.ml
@@ -20,6 +20,8 @@
 
  *****************************************************************************)
 
+module Pcre = Re.Pcre
+
 let error fmt =
   Printf.ksprintf
     (fun message -> Runtime_error.raise ~pos:[] ~message "sqlite")

--- a/src/core/encoder/lang/lang_ffmpeg.ml
+++ b/src/core/encoder/lang/lang_ffmpeg.ml
@@ -22,6 +22,7 @@
 
 open Value
 open Ground
+module Pcre = Re.Pcre
 
 type decode_type = [ `Raw | `Internal ]
 type content_type = [ `Audio | `Video ]
@@ -118,8 +119,8 @@ let stream_media_type ~to_pos ~to_static_string name args =
   match (name, args) with
     | _ when has_content ~to_static_string "audio_content" args -> `Audio
     | _ when has_content ~to_static_string "video_content" args -> `Video
-    | _ when Pcre.pmatch ~pat:"audio" name -> `Audio
-    | _ when Pcre.pmatch ~pat:"video" name -> `Video
+    | _ when Pcre.pmatch ~rex:(Pcre.regexp "audio") name -> `Audio
+    | _ when Pcre.pmatch ~rex:(Pcre.regexp "video") name -> `Video
     | _ -> (
         match List.assoc_opt "codec" args with
           | Some t -> (

--- a/src/core/io/ffmpeg_io.ml
+++ b/src/core/io/ffmpeg_io.ml
@@ -22,6 +22,8 @@
 
 exception Not_connected
 
+module Pcre = Re.Pcre
+
 module Metadata = struct
   include Map.Make (struct
     type t = string
@@ -291,7 +293,9 @@ class http_input ~autostart ~self_sync ~poll_delay ~debug ~clock_safe ~on_error
           (fun ret header ->
             if header <> "" then (
               try
-                let res = Pcre.exec ~pat:"([^:]*):\\s*(.*)" header in
+                let res =
+                  Pcre.exec ~rex:(Pcre.regexp "([^:]*):\\s*(.*)") header
+                in
                 (Pcre.get_substring res 1, Pcre.get_substring res 2) :: ret
               with Not_found -> ret)
             else ret)
@@ -548,7 +552,7 @@ let register_input is_http =
                      (Lang.apply fn [("", Lang.metadata_list m)])
              | None ->
                  List.filter (fun (k, _) ->
-                     not (Pcre.pmatch ~pat:"^id3v2_priv" k))
+                     not (Pcre.pmatch ~rex:(Pcre.regexp "^id3v2_priv") k))
          in
          let deduplicate_metadata =
            Lang.to_bool (List.assoc "deduplicate_metadata" p)

--- a/src/core/io/srt_io.ml
+++ b/src/core/io/srt_io.ml
@@ -22,6 +22,8 @@
 
 (** SRT input *)
 
+module Pcre = Re.Pcre
+
 exception Done
 exception Not_connected
 
@@ -291,7 +293,9 @@ let conf_enforced_encryption =
 let log = Log.make ["srt"]
 
 let log_handler { Srt.Log.message } =
-  let message = Pcre.substitute ~pat:"[ \r\n]+$" ~subst:(fun _ -> "") message in
+  let message =
+    Pcre.substitute ~rex:(Pcre.regexp "[ \r\n]+$") ~subst:(fun _ -> "") message
+  in
   log#f conf_level#get "%s" message
 
 (** Common polling task for all srt input/output.

--- a/src/core/operators/frei0r_op.ml
+++ b/src/core/operators/frei0r_op.ml
@@ -23,6 +23,7 @@
 open Mm
 open Source
 open Extralib
+module Pcre = Re.Pcre
 
 let video_frei0r = Lang.add_module ~base:Modules.video "frei0r"
 
@@ -39,7 +40,7 @@ let frei0r_enable =
 let plugin_dirs =
   try
     let path = Unix.getenv "LIQ_FREI0R_PATH" in
-    Pcre.split ~pat:":" path
+    Pcre.split ~rex:(Pcre.regexp ":") path
   with Not_found -> Frei0r.default_paths
 
 class frei0r_filter ~name bgra instance params (source : source) =
@@ -291,7 +292,7 @@ let register_plugin fname =
   let explanation =
     let e = info.Frei0r.explanation in
     let e = String.capitalize_ascii e in
-    let e = Pcre.substitute ~pat:"@" ~subst:(fun _ -> "(at)") e in
+    let e = Pcre.substitute ~rex:(Pcre.regexp "@") ~subst:(fun _ -> "(at)") e in
     if e = "" then e
     else if e.[String.length e - 1] = '.' then
       String.sub e 0 (String.length e - 1)
@@ -299,7 +300,7 @@ let register_plugin fname =
   in
   let author =
     let a = info.Frei0r.author in
-    let a = Pcre.substitute ~pat:"@" ~subst:(fun _ -> "(at)") a in
+    let a = Pcre.substitute ~rex:(Pcre.regexp "@") ~subst:(fun _ -> "(at)") a in
     a
   in
   let descr = Printf.sprintf "%s (by %s)." explanation author in

--- a/src/core/operators/ladspa_op.ml
+++ b/src/core/operators/ladspa_op.ml
@@ -23,6 +23,7 @@
 open Mm
 open Source
 open Ladspa
+module Pcre = Re.Pcre
 
 module String = struct
   include String
@@ -320,7 +321,9 @@ let register_descr plugin_name descr_n d inputs outputs =
     @ if ni = 0 then [] else [("", Lang.source_t input_t, None, None)]
   in
   let maker = Descriptor.maker d in
-  let maker = Pcre.substitute ~pat:"@" ~subst:(fun _ -> "(at)") maker in
+  let maker =
+    Pcre.substitute ~rex:(Pcre.regexp "@") ~subst:(fun _ -> "(at)") maker
+  in
   let descr = Printf.sprintf "%s by %s." (Descriptor.name d) maker in
   let return_t =
     if mono then input_t

--- a/src/core/stream/ffmpeg_raw_content.ml
+++ b/src/core/stream/ffmpeg_raw_content.ml
@@ -21,6 +21,7 @@
  *****************************************************************************)
 
 open Avutil
+module Pcre = Re.Pcre
 
 type 'a frame = {
   stream_idx : Int64.t;

--- a/src/core/synth/dssi_op.ml
+++ b/src/core/synth/dssi_op.ml
@@ -23,6 +23,7 @@
 open Mm
 open Source
 open Dssi
+module Pcre = Re.Pcre
 
 let log = Log.make ["DSSI synthesizer"]
 
@@ -35,13 +36,13 @@ let dssi_enable =
 let dssi_load =
   try
     let venv = Unix.getenv "LIQ_DSSI_LOAD" in
-    Pcre.split ~pat:":" venv
+    Pcre.split ~rex:(Pcre.regexp ":") venv
   with Not_found -> []
 
 let plugin_dirs =
   try
     let path = Unix.getenv "LIQ_DSSI_PATH" in
-    Pcre.split ~pat:":" path
+    Pcre.split ~rex:(Pcre.regexp ":") path
   with Not_found -> ["/usr/lib/dssi"; "/usr/local/lib/dssi"]
 
 (* Number of channels to synthesize when in all mode *)


### PR DESCRIPTION
Apparently some of it leak through `ocaml-duppy''s dependency on `pcre`..

This should finish https://github.com/savonet/liquidsoap/pull/2085