### PR TITLE
Fix default timeout after accepting new connections.

### DIFF
--- a/src/core/harbor/harbor.ml
+++ b/src/core/harbor/harbor.ml
@@ -1018,7 +1018,9 @@ module Make (T : Transport_t) : T with type socket = T.socket = struct
     let server = transport#server in
     let process_client sock =
       try
-        let socket, caller = server#accept sock in
+        let socket, caller =
+          server#accept ?timeout:(Some conf_accept_timeout#get) sock
+        in
         let ip = Utils.name_of_sockaddr ~rev_dns:conf_revdns#get caller in
         log#info "New client on port %i: %s" port ip;
         let unix_socket = T.file_descr_of_socket socket in

--- a/src/core/harbor/harbor_base.ml
+++ b/src/core/harbor/harbor_base.ml
@@ -34,7 +34,7 @@ let conf_harbor_bind_addrs =
 let conf_harbor_max_conn =
   Dtools.Conf.int
     ~p:(conf_harbor#plug "max_connections")
-    ~d:2 "Maximum of pending source requests per port."
+    ~d:128 "Maximum of pending source requests per port."
 
 let conf_pass_verbose =
   Dtools.Conf.bool
@@ -63,10 +63,14 @@ let conf_icy_metadata =
       ]
     "Content-type (mime) of formats which allow shout metadata update."
 
-(* 300 sec timeout is the default value in Apache.. *)
 let conf_timeout =
   Dtools.Conf.float
     ~p:(conf_harbor#plug "timeout")
-    ~d:300. "Timeout for network operations (in seconds)."
+    ~d:120. "Timeout for network operations (in seconds)."
+
+let conf_accept_timeout =
+  Dtools.Conf.float
+    ~p:(conf_harbor#plug "accept_timeout")
+    ~d:3. "Timeout for network accept operations (in seconds)."
 
 let log = Log.make ["harbor"]

--- a/src/core/tools/http.mli
+++ b/src/core/tools/http.mli
@@ -12,7 +12,8 @@ type socket =
   ; close : unit >
 
 and server =
-  < transport : transport ; accept : Unix.file_descr -> socket * Unix.sockaddr >
+  < transport : transport
+  ; accept : ?timeout:float -> Unix.file_descr -> socket * Unix.sockaddr >
 
 and transport =
   < name : string
@@ -42,6 +43,12 @@ val connect :
   string ->
   int ->
   Unix.file_descr
+
+val accept :
+  ?timeout:float -> Unix.file_descr -> Unix.file_descr * Unix.sockaddr
+
+val set_socket_default :
+  read_timeout:float -> write_timeout:float -> Unix.file_descr -> unit
 
 (** Unix transport and socket. *)
 val unix_transport : transport

--- a/src/core/tools/server.ml
+++ b/src/core/tools/server.ml
@@ -373,7 +373,7 @@ let start_socket () =
   let sock = Unix.socket ~cloexec:true Unix.PF_UNIX Unix.SOCK_STREAM 0 in
   let rec incoming _ =
     (try
-       let socket, caller = Unix.accept ~cloexec:true sock in
+       let socket, caller = Http.accept ~timeout:(get_timeout ()) sock in
        let ip = Utils.name_of_sockaddr ~rev_dns:conf_telnet_revdns#get caller in
        log#f conf_log_level#get "New client %s." ip;
        handle_client socket ip

--- a/src/core/tools/tutils.ml
+++ b/src/core/tools/tutils.ml
@@ -329,7 +329,7 @@ type event =
   | `Write of Unix.file_descr
   | `Both of Unix.file_descr ]
 
-(* Wait for [`Read socker], [`Write socket] or [`Both socket] for at most
+(* Wait for [`Read socket], [`Write socket] or [`Both socket] for at most
  * [timeout] seconds on the given [socket]. Raises [Timeout elapsed_time]
  * if timeout is reached. *)
 let wait_for ?(log = fun _ -> ()) event timeout =


### PR DESCRIPTION
This PR fixes issues with clients not sending any data during the initial SSL connection by adding a `timeout` to the `accept` operation. This fixes #3598