### PR TITLE
Fix PTS continuity in sequences of copied streams.

### DIFF
--- a/src/core/encoder/encoders/ffmpeg_encoder_common.ml
+++ b/src/core/encoder/encoders/ffmpeg_encoder_common.ml
@@ -49,6 +49,7 @@ type handler = {
 type stream_data = {
   idx : Int64.t;
   mutable last_start : Int64.t;
+  mutable position : Int64.t;
   mutable ready_count : int;
   mutable ready : bool;
 }
@@ -77,7 +78,8 @@ let mk_stream_store total_count =
   let store = Stream.create 1 in
   let add ~last_start ~ready idx =
     let data =
-      Stream.merge store { idx; ready_count = 0; last_start; ready = false }
+      Stream.merge store
+        { idx; ready_count = 0; last_start; position = 0L; ready = false }
     in
     if ready then data.ready_count <- data.ready_count + 1;
     if data.ready_count = total_count then data.ready <- true;


### PR DESCRIPTION
We use global position to account for duration. This allows to start a new stream after the end of the longest stream (most likely the audio). This should also prevent synchronization issues between streams.