### PR TITLE
Split HLS segment on the latest keyframe when available.

### DIFF
--- a/doc/content/hls_output.md
+++ b/doc/content/hls_output.md
@@ -43,14 +43,13 @@ To make sure that all these requirements operate correctly, you should make sure
 keyframe per segment.
 
 For instance, if your segments are at most `2s` long and encoded using `libx264`, you can use the `keyint` and `keyint-min` parameters, which are expressed
-in number of frames. If your video frame rate is `25fps` (liquidsoap's default), you should have at least one keyframe every `12` frames, which is `25/2` rounded
-to the lowest integer:
+in number of frames. If your video frame rate is `25fps` (liquidsoap's default), you should have at least one keyframe every `2 * 25 = 50` frames.
 
 ```liquidsoap
 %ffmpeg(
   ...,
   %video(codec="libx264",
-         x264opts="keyint=12:min-keyint=12")
+         x264opts="keyint=50:min-keyint=50")
 )
 ```
 

--- a/doc/content/hls_output.md
+++ b/doc/content/hls_output.md
@@ -28,6 +28,32 @@ Liquidsoap also provides `output.harbor.hls` which allows to serve HLS streams d
 liquidsoap. Their options should be the same as `output.file.hls`, except for harbor-specifc options `port` and `path`. It is
 not recommended for listener-facing setup but can be useful to sync up with a caching system such as cloudfront.
 
+## Keyframes and segment length
+
+In codec terminology, a `keyframe` can be understood as a piece of encoded data that contains enough information to start decoding the stream.
+Keyframes are very common in video codecs and can exist in audio codecs.
+
+In order to make sure that a HLS playlist can be decoded starting from any segment, liquidsoap tries to split segments on keyframe boundaries. When not possible,
+you will see a warning in the logs.
+
+Segment split is forced when reaching the value specified by `EXT-X-TARGETDURATION` to follow the HLS specifications. For metadata and extra tags, segment split will
+occur at the next keyframe.
+
+To make sure that all these requirements operate correctly, you should make sure to set a keyframe frequency in your encoder's settings that generates at lease one
+keyframe per segment.
+
+For instance, if your segments are at most `2s` long and encoded using `libx264`, you can use the `keyint` and `keyint-min` parameters, which are expressed
+in number of frames. If your video frame rate is `25fps` (liquidsoap's default), you should have at least one keyframe every `12` frames, which is `25/2` rounded
+to the lowest integer:
+
+```liquidsoap
+%ffmpeg(
+  ...,
+  %video(codec="libx264",
+         x264opts="keyint=12:min-keyint=12")
+)
+```
+
 ## Metadata
 
 HLS outputs supports metadata in two ways:

--- a/src/core/io/srt_io.ml
+++ b/src/core/io/srt_io.ml
@@ -893,7 +893,7 @@ class virtual output_base ~payload_size ~messageapi ~on_start ~on_stop
     inherit base
 
     inherit
-      Output.encoded
+      [Strings.t] Output.encoded
         ~output_kind:"srt" ~on_start ~on_stop ~infallible ~register_telnet
           ~export_cover_metadata:false ~autostart ~name:"output.srt" source
 

--- a/src/core/io/udp_io.ml
+++ b/src/core/io/udp_io.ml
@@ -57,7 +57,7 @@ class output ~on_start ~on_stop ~register_telnet ~infallible ~autostart
   ~hostname ~port ~encoder_factory source =
   object (self)
     inherit
-      Output.encoded
+      [Strings.t] Output.encoded
         ~output_kind:"udp" ~on_start ~on_stop ~register_telnet ~infallible
           ~autostart ~export_cover_metadata:false
         ~name:(Printf.sprintf "udp://%s:%d" hostname port)

--- a/src/core/outputs/harbor_output.ml
+++ b/src/core/outputs/harbor_output.ml
@@ -415,7 +415,7 @@ class output p =
   object (self)
     (** File descriptor where to dump. *)
     inherit
-      Output.encoded
+      [Strings.t] Output.encoded
         ~output_kind:"output.harbor" ~infallible ~register_telnet ~autostart
           ~export_cover_metadata:false ~on_start ~on_stop ~name:mount source
 

--- a/src/core/outputs/hls_output.ml
+++ b/src/core/outputs/hls_output.ml
@@ -177,6 +177,9 @@ let hls_proto frame_t =
 type atomic_out_channel =
   < output_string : string -> unit
   ; output_substring : string -> int -> int -> unit
+  ; position : int
+  ; truncate : int -> unit
+  ; read : int -> int -> string
   ; close : unit >
 
 type segment = {
@@ -188,6 +191,7 @@ type segment = {
   mutable init_filename : string option;
   mutable out_channel : atomic_out_channel option;
   mutable len : int;
+  mutable last_segmentable_position : (int * int) option;
 }
 
 let json_of_segment
@@ -199,6 +203,7 @@ let json_of_segment
       init_filename;
       segment_extra_tags;
       len;
+      last_segmentable_position;
     } =
   `Assoc
     [
@@ -210,6 +215,10 @@ let json_of_segment
         match init_filename with Some f -> `String f | None -> `Null );
       ("extra_tags", `Tuple (List.map (fun s -> `String s) segment_extra_tags));
       ("len", `Int len);
+      ( "last_segmentable_position",
+        match last_segmentable_position with
+          | None -> `Null
+          | Some (len, offset) -> `Tuple [`Int len; `Int offset] );
     ]
 
 let segment_of_json = function
@@ -222,6 +231,7 @@ let segment_of_json = function
         ("init_filename", init_filename);
         ("extra_tags", `Tuple segment_extra_tags);
         ("len", `Int len);
+        ("last_segmentable_position", last_segmentable_position);
       ] ->
       let segment_extra_tags =
         List.map
@@ -234,6 +244,12 @@ let segment_of_json = function
           | `Null -> None
           | _ -> raise Invalid_state
       in
+      let last_segmentable_position =
+        match last_segmentable_position with
+          | `Tuple [`Int len; `Int offset] -> Some (len, offset)
+          | `Null -> None
+          | _ -> raise Invalid_state
+      in
       {
         id;
         discontinuous;
@@ -243,6 +259,7 @@ let segment_of_json = function
         len;
         segment_extra_tags;
         out_channel = None;
+        last_segmentable_position;
       }
   | _ -> raise Invalid_state
 
@@ -568,7 +585,7 @@ class hls_output p =
   in
   object (self)
     inherit
-      Output.encoded
+      [(int * Strings.t option * Strings.t) list] Output.encoded
         ~infallible ~register_telnet ~on_start ~on_stop ~autostart
           ~export_cover_metadata:false ~output_kind:"output.file"
           ~name:main_playlist_filename source
@@ -590,17 +607,36 @@ class hls_output p =
 
     method private open_out filename =
       let state = if Sys.file_exists filename then `Updated else `Created in
-      let mode = [Open_wronly; Open_creat; Open_trunc] in
-      let tmp_file, oc =
-        Filename.open_temp_file ?temp_dir ~mode ~perms "liq" "tmp"
+      let tmp_file = Filename.temp_file ?temp_dir "liq" "tmp" in
+      Unix.chmod tmp_file perms;
+      let fd =
+        Unix.openfile tmp_file
+          [Unix.O_RDWR; Unix.O_CREAT; Unix.O_TRUNC; Unix.O_CLOEXEC]
+          perms
       in
-      set_binary_mode_out oc true;
       object
-        method output_string = output_string oc
-        method output_substring = output_substring oc
+        method output_string s = Utils.write_all fd (Bytes.unsafe_of_string s)
+
+        method output_substring s ofs len =
+          Utils.write_all fd (Bytes.sub (Bytes.unsafe_of_string s) ofs len)
+
+        method position = Unix.lseek fd 0 Unix.SEEK_CUR
+        method truncate = Unix.ftruncate fd
+
+        method read ofs len =
+          Unix.fsync fd;
+          assert (ofs = Unix.lseek fd ofs Unix.SEEK_SET);
+          let b = Bytes.create len in
+          let rec f n =
+            if n < len then (
+              let r = Unix.read fd b n (len - n) in
+              if r <> 0 then f (n + r) else n)
+            else n
+          in
+          Bytes.sub_string b 0 (f 0)
 
         method close =
-          Stdlib.close_out_noerr oc;
+          (try Unix.close fd with _ -> ());
           Fun.protect
             ~finally:(fun () -> try Sys.remove tmp_file with _ -> ())
             (fun () ->
@@ -611,7 +647,9 @@ class hls_output p =
                     on a different file system. Please set it to the same one \
                     using `temp_dir` argument to guarantee atomic file \
                     operations!";
-                 Utils.copy ~mode ~perms tmp_file filename;
+                 Utils.copy
+                   ~mode:[Open_creat; Open_trunc; Open_binary]
+                   ~perms tmp_file filename;
                  Sys.remove tmp_file);
               on_file_change ~state filename)
       end
@@ -624,34 +662,32 @@ class hls_output p =
         self#log#important "Could not remove file %s: %s" filename
           (Unix.error_message e)
 
-    method private close_segment s =
-      ignore
-        (Option.map
-           (fun segment ->
-             (Option.get segment.out_channel)#close;
-             segment.out_channel <- None;
-             let segments = List.assoc s.name segments in
-             push_segment segment segments;
-             if List.length !segments >= max_segments then (
-               let segment = remove_segment segments in
-               self#unlink segment.filename;
-               ignore
-                 (Option.map
-                    (fun filename ->
-                      if
-                        Sys.file_exists filename
-                        && not
-                             (List.exists
-                                (fun s ->
-                                  s.init_filename = segment.init_filename)
-                                !segments)
-                      then self#unlink filename)
-                    segment.init_filename)))
-           s.current_segment);
-      s.current_segment <- None;
-      if state <> `Stopped then (
-        self#write_playlist s;
-        self#write_main_playlist)
+    method private close_segment =
+      function
+      | { current_segment = Some ({ out_channel = Some oc } as segment) } as s
+        ->
+          oc#close;
+          segment.out_channel <- None;
+          let segments = List.assoc s.name segments in
+          push_segment segment segments;
+          if List.length !segments >= max_segments then (
+            let segment = remove_segment segments in
+            self#unlink segment.filename;
+            match segment.init_filename with
+              | None -> ()
+              | Some filename ->
+                  if
+                    Sys.file_exists filename
+                    && not
+                         (List.exists
+                            (fun s -> s.init_filename = segment.init_filename)
+                            !segments)
+                  then self#unlink filename);
+          s.current_segment <- None;
+          if state <> `Stopped then (
+            self#write_playlist s;
+            self#write_main_playlist)
+      | _ -> ()
 
     method private open_segment s =
       self#log#debug "Opening segment %d for stream %s." s.position s.name;
@@ -682,6 +718,7 @@ class hls_output p =
           init_filename =
             (match s.init_state with `Has_init f -> Some f | _ -> None);
           out_channel = Some out_channel;
+          last_segmentable_position = None;
         }
       in
       s.current_segment <- Some segment;
@@ -697,10 +734,28 @@ class hls_output p =
             | `Sent _ | `None -> []
         in
         let frame_position, sample_position = current_position in
-        ignore
-          (Option.map out_channel#output_string
-             (s.encoder.hls.insert_id3 ~frame_position ~sample_position m)));
+        match s.encoder.hls.insert_id3 ~frame_position ~sample_position m with
+          | None -> ()
+          | Some s -> out_channel#output_string s);
       if discontinuous then s.discontinuity_count <- s.discontinuity_count + 1
+
+    method reopen_segment ~position:(len, offset) =
+      function
+      | {
+          current_segment =
+            Some
+              ({ len = current_len; out_channel = Some oc } as current_segment);
+        } as s ->
+          let rem = oc#read offset (oc#position - offset) in
+          current_segment.len <- len;
+          oc#truncate offset;
+          self#close_segment s;
+          self#open_segment s;
+          let segment = Option.get s.current_segment in
+          let oc = Option.get segment.out_channel in
+          oc#output_string rem;
+          segment.len <- current_len - len
+      | _ -> assert false
 
     method private cleanup_streams =
       List.iter
@@ -838,7 +893,7 @@ class hls_output p =
       self#toggle_state `Stop;
       (try
          let data =
-           List.map (fun s -> (None, s.encoder.Encoder.stop ())) streams
+           List.map (fun s -> (0, None, s.encoder.Encoder.stop ())) streams
          in
          self#send data
        with _ -> ());
@@ -955,19 +1010,22 @@ class hls_output p =
         ( true,
           Printf.sprintf
             "Terminating current segment on stream %s to insert new metadata"
-            s.name )
+            s.name,
+          false )
       else if Atomic.get s.pending_extra_tags <> [] then
         ( true,
           Printf.sprintf
             "Terminating current segment on stream %s to insert pending extra \
              tags"
-            s.name )
+            s.name,
+          false )
       else if segment.len + len > segment_main_duration then
         ( true,
           Printf.sprintf
             "Terminating current segment on stream %s to make expected length"
-            s.name )
-      else (false, "")
+            s.name,
+          true )
+      else (false, "", false)
 
     method encode frame ofs len =
       let frame_pos, samples_pos = current_position in
@@ -985,33 +1043,43 @@ class hls_output p =
                   Encoder.(s.encoder.hls.init_encode frame ofs len)
                 in
                 self#process_init ~init ~segment s;
-                (None, encoded)
-              with Encoder.Not_enough_data -> (None, Strings.empty))
+                (len, None, encoded)
+              with Encoder.Not_enough_data -> (len, None, Strings.empty))
             else (
-              let should_reopen, reason = self#should_reopen ~segment ~len s in
-              if should_reopen then (
-                match Encoder.(s.encoder.hls.split_encode frame ofs len) with
-                  | `Ok (flushed, encoded) ->
-                      self#log#info "%s" reason;
-                      (Some flushed, encoded)
-                  | `Nope encoded -> (None, encoded))
-              else (None, Encoder.(s.encoder.encode frame ofs len)))
+              match Encoder.(s.encoder.hls.split_encode frame ofs len) with
+                | `Ok (flushed, encoded) -> (len, Some flushed, encoded)
+                | `Nope encoded -> (len, None, encoded))
           in
           let segment = Option.get s.current_segment in
           segment.len <- segment.len + len;
           b)
         streams
 
-    method private write_pipe s (flushed, data) =
-      let { out_channel } = Option.get s.current_segment in
-      ignore
-        (Option.map
-           (fun b ->
-             let oc = Option.get out_channel in
-             Strings.iter oc#output_substring b;
-             self#close_segment s;
-             self#open_segment s)
-           flushed);
+    method private write_pipe s (len, flushed, data) =
+      let ({ out_channel } as segment) = Option.get s.current_segment in
+      let oc = Option.get out_channel in
+      (match flushed with
+        | None -> ()
+        | Some b ->
+            Strings.iter oc#output_substring b;
+            segment.last_segmentable_position <- Some (segment.len, oc#position));
+      (match
+         (self#should_reopen ~segment ~len s, segment.last_segmentable_position)
+       with
+        | (false, _, _), _ | (true, _, false), None -> ()
+        | (true, reason, _), position ->
+            let position =
+              match position with
+                | None ->
+                    self#log#important
+                      "Splitting segment without a new keyframe! You might \
+                       want to adjust your encoder's parameters to increase \
+                       the keyframe frequency!";
+                    (segment.len, oc#position)
+                | Some p -> p
+            in
+            self#log#info "%s" reason;
+            self#reopen_segment ~position s);
       let { out_channel } = Option.get s.current_segment in
       let oc = Option.get out_channel in
       Strings.iter oc#output_substring data

--- a/src/core/outputs/icecast2.ml
+++ b/src/core/outputs/icecast2.ml
@@ -480,7 +480,7 @@ class output p =
   let connection = Cry.create ~timeout ~transport ?connection_timeout () in
   object (self)
     inherit
-      Output.encoded
+      [Strings.t] Output.encoded
         ~output_kind:"output.icecast" ~infallible ~register_telnet ~autostart
           ~export_cover_metadata:false ~on_start ~on_stop ~name source
 

--- a/src/core/outputs/output.ml
+++ b/src/core/outputs/output.ml
@@ -231,7 +231,7 @@ let _ =
 
 (** More concrete abstract-class, which takes care of the #send_frame method for
     outputs based on encoders. *)
-class virtual encoded ~output_kind ~name ~infallible ~on_start ~on_stop
+class virtual ['a] encoded ~output_kind ~name ~infallible ~on_start ~on_stop
   ~register_telnet ~autostart ~export_cover_metadata source =
   object (self)
     inherit

--- a/src/core/outputs/output.mli
+++ b/src/core/outputs/output.mli
@@ -58,7 +58,7 @@ class virtual output :
 (** Default methods on output values. *)
 val meth : (string * Lang.scheme * string * (output -> Lang.value)) list
 
-class virtual encoded :
+class virtual ['a] encoded :
   output_kind:string
   -> name:string
   -> infallible:bool

--- a/src/core/outputs/pipe_output.ml
+++ b/src/core/outputs/pipe_output.ml
@@ -60,7 +60,7 @@ class virtual base ~source ~name p =
   in
   object (self)
     inherit
-      Output.encoded
+      [Strings.t] Output.encoded
         ~infallible ~register_telnet ~on_start ~on_stop ~autostart
           ~export_cover_metadata ~output_kind:"output.file" ~name source
 

--- a/tests/core/output_encoded_test.ml
+++ b/tests/core/output_encoded_test.ml
@@ -7,7 +7,7 @@ let send_called = ref false
 class encoded_test =
   object (self)
     inherit
-      Output.encoded
+      [unit] Output.encoded
         ~output_kind:"foo" ~name:"encoded_test" ~infallible:false
           ~register_telnet:false
         ~on_start:(fun _ -> ())

--- a/tests/media/ffmpeg_raw_hls.liq
+++ b/tests/media/ffmpeg_raw_hls.liq
@@ -9,26 +9,24 @@ debian_version =
   )
 
 if debian_version == "10" then test.skip() end
+
 raw_encoder = %ffmpeg(%audio.raw, %video.raw)
+
 mpegts =
   %ffmpeg(
     format = "mpegts",
     %audio.raw(codec = "aac", b = "128k", channels = 2, ar = 44100),
-    %video.raw(codec = "libx264", b = "5M", flags = "+global_header")
+    %video.raw(codec = "libx264", x264opts = "keyint=12:min-keyint=12")
   )
 
-mp4 =
-  %ffmpeg(
-    format = "mp4",
-    movflags = "+dash+skip_sidx+skip_trailer+frag_custom",
-    frag_duration = 2,
-    %audio.raw(codec = "aac", b = "128k", channels = 2, ar = 44100),
-    %video.raw(codec = "libx264", b = "5M", flags = "+global_header")
-  )
+a = source.tracks(sine(duration=10.)).audio
+v = source.tracks(video.testsrc.ffmpeg(duration=10.)).video
 
-s = noise()
+s = source({audio=a, video=v})
+
 raw = ffmpeg.raw.encode.audio_video(raw_encoder, s)
-streams = [("mp4", mp4), ("mpegts", mpegts)]
+
+streams = [("mpegts", mpegts)]
 output_dir = file.temp_dir("liq", "hls")
 
 def cleanup() =
@@ -50,7 +48,7 @@ def check_stream() =
       process.read(
         "ffprobe -v quiet -print_format json -show_streams #{
           output_dir
-        }/mp4.m3u8"
+        }/mpegts.m3u8"
       )
 
     let json.parse (parsed :
@@ -101,7 +99,7 @@ def segment_name(~position, ~extname, stream_name) =
   "#{stream_name}_#{timestamp}_#{position}.#{extname}"
 end
 
-##clock.assign_new(sync='none',[raw])
+clock.assign_new(sync='none', [raw])
 output.file.hls(
   playlist="live.m3u8",
   segment_duration=2.0,


### PR DESCRIPTION
This PR changes the HLS segment splitting logic to be compliant with the HLS spec[^1]. When reaching the value specified for `EXT-X-TARGETDURATION`, the segment will be forced to be split.

In this case, the split will occur at the latest keyframe in the current segment. If no such keyframe is available, the split occurs right away and a warning is emitted.

It is, thus, recommended to fix the keyframe frequency to a value that will ensure at least one keyframe per segment.

Metadata and new tag splits do not force a segment split. It is expected that setting a correct keyframe frequency w.r.t. segment length will also produce an appropriate keyframe interval for those splits.

Fixes: #3630

[^1]: https://datatracker.ietf.org/doc/html/rfc8216#section-4.3.3.1 