### PR TITLE
Enable FFmpeg non-interleaved API

### DIFF
--- a/.github/opam/liquidsoap-core-windows.opam
+++ b/.github/opam/liquidsoap-core-windows.opam
@@ -89,8 +89,8 @@ conflicts: [
   "dssi-windows" {< "0.1.3"}
   "faad-windows" {< "0.5.0"}
   "fdkaac-windows" {< "0.3.1"}
-  "ffmpeg-windows" {< "1.1.8"}
-  "ffmpeg-avutil-windows" {< "1.1.8"}
+  "ffmpeg-windows" {< "1.1.10"}
+  "ffmpeg-avutil-windows" {< "1.1.10"}
   "flac-windows" {< "0.3.0"}
   "frei0r-windows" {< "0.1.0"}
   "gstreamer-windows" {< "0.3.1"}

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,8 @@ New:
 - Allow frames smaller than one video frames, typically values under `0.04s`.
   Smaller frames means less latency and memory consumption at the expense of
   a higher CPU usage. See @TODO@ for more details (#3607)
+- Added non-interleaved API to `%ffmpeg` encoder, enabled by default when only
+  one stream is encoded.
 - Allow trailing commas in record definition (#3300).
 - Add `metadata.getter.source.float` (#3356).
 - Added optional `main_playlist_writer` to `output.file.hls` and

--- a/doc/content/ffmpeg_encoder.md
+++ b/doc/content/ffmpeg_encoder.md
@@ -5,6 +5,26 @@ and [encoders](https://www.ffmpeg.org/ffmpeg-codecs.html), including private con
 key/values, with values being of types: `string`, `int`, or `float`. If an option is not recognized (or: unused), it will raise an error
 during the instantiation of the encoder. Here are some configuration examples:
 
+### Interleaved muxing
+
+FFmpeg provides two different APIs for muxing data, interleaved or not. The interleaved API buffers packets waiting to be
+outputted to make sure that all streams, e.g. audio and video, have their packets as close to each other as possible. This
+ensures that for instance, the stream does not start with a long chunk of audio data without any video content. However, this
+can come with some increased memory usage due to buffering.
+
+On the other hand, the non-interleaved API allows to send encoded packets directly to the output without intermediate buffering.
+This can sometimes result in better latency and lower memory usage.
+
+The `%ffmpeg` encoder can use either API. By default, it uses the interleaved API when encoding more than one stream. You can also
+specify the interleaving mode by passing the `interleaved` parameter: `%ffmpeg(interleaved=<true|false|"default">, ...)`.
+
+You might also want to take this into consideration when setting your encoder's parameters. Some video encoders can buffer frames for
+a while before outputting the first encoded frame, which can also create issues even with the interleaved API enabled (the interleaving
+buffer has a max size too!). Typically, with `libx264`, you can set `tune = "zerolatency"` to make sure that the encoder starts outputting
+data right away.
+
+### Encoding examples
+
 - **AAC encoding at `22050kHz` using `fdk-aac` encoder and `mpegts` muxer**
 
 ```liquidsoap

--- a/src/core/encoder/encoders/ffmpeg_encoder_common.ml
+++ b/src/core/encoder/encoders/ffmpeg_encoder_common.ml
@@ -140,8 +140,10 @@ let encoder ~pos ~mk_streams ffmpeg meta =
                     Lang_encoder.raise_error ~pos
                       (Printf.sprintf
                          "No ffmpeg format could be found for format=%S" fmt));
-            Av.open_output_stream ~opts:options write (Option.get format)
-        | `Url url -> Av.open_output ?format ~opts:options url
+            Av.open_output_stream ~interleaved:false ~opts:options write
+              (Option.get format)
+        | `Url url ->
+            Av.open_output ?format ~interleaved:false ~opts:options url
     in
     let streams = mk_streams output in
     if Hashtbl.length options > 0 then
@@ -253,9 +255,11 @@ let encoder ~pos ~mk_streams ffmpeg meta =
           in
           Frame.Fields.iter
             (fun field c ->
-              let sent = Frame.Fields.find field sent in
-              let d = Content.sub c start len in
-              sent := !sent || not (Content.is_empty d))
+              match Frame.Fields.find_opt field sent with
+                | None -> ()
+                | Some sent ->
+                    let d = Content.sub c start len in
+                    sent := !sent || not (Content.is_empty d))
             frame;
           if Frame.Fields.exists (fun _ c -> not !c) sent then
             raise Encoder.Not_enough_data;

--- a/src/core/encoder/encoders/ffmpeg_encoder_common.ml
+++ b/src/core/encoder/encoders/ffmpeg_encoder_common.ml
@@ -130,6 +130,12 @@ let encoder ~pos ~mk_streams ffmpeg meta =
       len
     in
     let format = mk_format ffmpeg in
+    let interleaved =
+      match ffmpeg.interleaved with
+        | `Default -> 0 < List.length ffmpeg.streams
+        | `True -> true
+        | `False -> false
+    in
     let output =
       match ffmpeg.Ffmpeg_format.output with
         | `Stream ->
@@ -140,10 +146,9 @@ let encoder ~pos ~mk_streams ffmpeg meta =
                     Lang_encoder.raise_error ~pos
                       (Printf.sprintf
                          "No ffmpeg format could be found for format=%S" fmt));
-            Av.open_output_stream ~interleaved:false ~opts:options write
+            Av.open_output_stream ~interleaved ~opts:options write
               (Option.get format)
-        | `Url url ->
-            Av.open_output ?format ~interleaved:false ~opts:options url
+        | `Url url -> Av.open_output ?format ~interleaved ~opts:options url
     in
     let streams = mk_streams output in
     if Hashtbl.length options > 0 then

--- a/src/core/encoder/formats/ffmpeg_format.ml
+++ b/src/core/encoder/formats/ffmpeg_format.ml
@@ -69,6 +69,7 @@ type t = {
   format : string option;
   output : output;
   streams : (Frame.field * stream) list;
+  interleaved : [ `Default | `True | `False ];
   opts : opts;
 }
 
@@ -157,6 +158,14 @@ let to_string m =
                 (string_of_options stream_opts)
               :: opts)
       opts m.streams
+  in
+  let opts =
+    Printf.sprintf "interleaved=%s"
+      (match m.interleaved with
+        | `Default -> "\"default\""
+        | `True -> "true"
+        | `False -> "false")
+    :: opts
   in
   let opts =
     match m.format with

--- a/src/core/encoder/lang/lang_ffmpeg.ml
+++ b/src/core/encoder/lang/lang_ffmpeg.ml
@@ -298,6 +298,7 @@ let ffmpeg_gen params =
       Ffmpeg_format.format = None;
       output = `Stream;
       streams = [];
+      interleaved = `Default;
       opts = Hashtbl.create 0;
     }
   in
@@ -504,6 +505,10 @@ let ffmpeg_gen params =
           { f with Ffmpeg_format.format = None }
       | `Option ("format", { value = Ground (String fmt); _ }) ->
           { f with Ffmpeg_format.format = Some fmt }
+      | `Option ("interleaved", { value = Ground (Bool b); _ }) ->
+          { f with Ffmpeg_format.interleaved = (if b then `True else `False) }
+      | `Option ("interleaved", { value = Ground (String "default"); _ }) ->
+          { f with Ffmpeg_format.interleaved = `Default }
       | `Option (k, { value = Ground (String s); _ }) ->
           Hashtbl.add f.Ffmpeg_format.opts k (`String s);
           f

--- a/tests/core/ffmpeg_quality.ml
+++ b/tests/core/ffmpeg_quality.ml
@@ -6,6 +6,7 @@ let () =
   let vorbis_enc =
     {
       format = Some "ogg";
+      interleaved = `Default;
       output = `Stream;
       streams =
         [
@@ -36,6 +37,7 @@ let () =
   let mixed_enc =
     {
       format = Some "ogg";
+      interleaved = `Default;
       output = `Stream;
       streams =
         [

--- a/tests/media/ffmpeg_raw_hls.liq
+++ b/tests/media/ffmpeg_raw_hls.liq
@@ -12,11 +12,16 @@ if debian_version == "10" then test.skip() end
 
 raw_encoder = %ffmpeg(%audio.raw, %video.raw)
 
-mpegts =
+mp4 =
   %ffmpeg(
-    format = "mpegts",
+    format = "mp4",
     %audio.raw(codec = "aac", b = "128k", channels = 2, ar = 44100),
-    %video.raw(codec = "libx264", x264opts = "keyint=12:min-keyint=12")
+    %video.raw(
+      codec = "libx264",
+      b = "5M",
+      tune = "zerolatency",
+      x264opts = "keyint=12:min-keyint=12"
+    )
   )
 
 a = source.tracks(sine(duration=10.)).audio
@@ -26,7 +31,7 @@ s = source({audio=a, video=v})
 
 raw = ffmpeg.raw.encode.audio_video(raw_encoder, s)
 
-streams = [("mpegts", mpegts)]
+streams = [("mp4", mp4)]
 output_dir = file.temp_dir("liq", "hls")
 
 def cleanup() =
@@ -48,7 +53,7 @@ def check_stream() =
       process.read(
         "ffprobe -v quiet -print_format json -show_streams #{
           output_dir
-        }/mpegts.m3u8"
+        }/mp4.m3u8"
       )
 
     let json.parse (parsed :


### PR DESCRIPTION
This PR adds support for non-interleaved encoding in the ffmpeg encoder and enables it by default when encoding only one stream.