### PR TITLE
Add virtual video.canvas for positioning video elements independently of the frame size.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,7 +28,7 @@ repos:
       - id: ocamlformat
 
   - repo: https://github.com/savonet/pre-commit-liquidsoap
-    rev: 5fadc94
+    rev: 1e33b9e
     hooks:
       - id: liquidsoap-prettier
 

--- a/doc/content/liq/video-canvas-example.liq
+++ b/doc/content/liq/video-canvas-example.liq
@@ -1,0 +1,28 @@
+# Change to video.canvas.virtual_10k.actual_720p etc.. to render
+# in different sizes without changing the values below!
+let {px, rem, vh, vw, width, height} = video.canvas.virtual_10k.actual_1080p
+
+video.frame.width := width
+video.frame.height := height
+
+background =
+  video.add_image(
+    x=0.3 @ vw,
+    y=0.01 @ vh,
+    width=1562 @ px,
+    height=1562 @ px,
+    file=cover_files,
+    background
+  )
+
+background =
+  video.add_text(
+    color=0xFCB900,
+    font=myfont,
+    speed=0,
+    x=234 @ px,
+    y=4437 @ px,
+    size=1.5 @ rem,
+    {nowplaying()},
+    background
+  )

--- a/doc/content/liq/video-canvas-example.liq
+++ b/doc/content/liq/video-canvas-example.liq
@@ -11,7 +11,7 @@ background =
     y=0.01 @ vh,
     width=1562 @ px,
     height=1562 @ px,
-    file=cover_files,
+    file="/path/to/cover.jpg",
     background
   )
 

--- a/doc/content/liq/video-canvas-example.liq
+++ b/doc/content/liq/video-canvas-example.liq
@@ -1,3 +1,6 @@
+background = blank()
+
+# BEGIN
 # Change to video.canvas.virtual_10k.actual_720p etc.. to render
 # in different sizes without changing the values below!
 let {px, rem, vh, vw, width, height} = video.canvas.virtual_10k.actual_1080p
@@ -18,11 +21,13 @@ background =
 background =
   video.add_text(
     color=0xFCB900,
-    font=myfont,
     speed=0,
     x=234 @ px,
     y=4437 @ px,
     size=1.5 @ rem,
-    {nowplaying()},
+    "Some text",
     background
   )
+# END
+
+output.dummy(fallible=true, background)

--- a/doc/content/liq/video-default-canvas.liq
+++ b/doc/content/liq/video-default-canvas.liq
@@ -1,0 +1,21 @@
+# Standard video canvas based off a `10k` virtual canvas.
+# @category Source / Video processing
+def video.canvas.virtual_10k =
+  def make(height, width) =
+    video.canvas.make(
+      virtual_height=10000,
+      actual_size={width=width, height=height},
+      font_size=160
+    )
+  end
+
+  {
+    actual_360p=make(640, 360),
+    actual_480p=make(640, 480),
+    actual_720p=make(1280, 720),
+    actual_1080p=make(1920, 1080),
+    actual_1440p=make(2560, 1440),
+    actual_4k=make(3840, 2160),
+    actual_8k=make(7680, 4320)
+  }
+end

--- a/doc/content/liq/video-default-canvas.liq
+++ b/doc/content/liq/video-default-canvas.liq
@@ -1,9 +1,9 @@
 # Standard video canvas based off a `10k` virtual canvas.
 # @category Source / Video processing
 def video.canvas.virtual_10k =
-  def make(height, width) =
+  def make(width, height) =
     video.canvas.make(
-      virtual_height=10000,
+      virtual_width=10000,
       actual_size={width=width, height=height},
       font_size=160
     )

--- a/doc/content/video.md
+++ b/doc/content/video.md
@@ -26,6 +26,39 @@ size of videos have a great impact on computations; if your machine cannot
 handle a stream (i.e. it's always catching up) you can try to encode to smaller
 videos for a start.
 
+### Setting up frame size and positions
+
+We provide an abstract API to specify video frame sizes and positions that is idependent
+from the actual rendered size. This way, you can define all your elements and have them
+being rendered at different frame size without having to change their placement or size values!
+
+This works by setting up a _virtual canvas_ that is larger than the _actual canvas_. You specify
+your positions, sizes etc. in terms of units for the larger canvas and they are translated automatically
+to values that apply for the actual canvas.
+
+We provide some default values. They are all `16:9` ratio using a virtual canvas of `10 000` pixels height:
+
+```{.liquidsoap include="video-default-canvas.liq"}
+
+```
+
+The returned canvas is a record with the following methods:
+
+- `width`/`height`: size of the actual frame
+- `px`: define values in terms of virtual pixels
+- `vw`/`vh`: define values in terms of percentage (between `0.` and `1.`) of, resp., the actual frame width and height
+- `rem`: define values in terms of percentage (between `0.` and `1.`) of the default font size
+
+All the positioning methods are functions. For convenience, you can use the infix operator `@` to make things more readable. For instance,
+instead of writing `px(120)` to define a size of `120px`, you can write: `120 @ px`. These two notations are equivalent but the second
+one is more readable in this context.
+
+Here's an example of how to use this:
+
+```{.liquidsoap include="video-canvas-example.liq"}
+
+```
+
 ### Encoding with FFmpeg
 
 The `%ffmpeg` encoder is the recommended encoder when working with video. Not only does it support a wide range

--- a/doc/dune
+++ b/doc/dune
@@ -3,10 +3,10 @@
 (include dune.inc)
 
 (rule
-  (alias dummytest)
-  (package liquidsoap)
-  (action (run %{bin:liquidsoap} --version))
-)
+ (alias dummytest)
+ (package liquidsoap)
+ (action
+  (run %{bin:liquidsoap} --version)))
 
 (executable
  (name gen_dune)

--- a/doc/dune.inc
+++ b/doc/dune.inc
@@ -179,6 +179,8 @@
     content/liq/transcoding.liq
     content/liq/video-anonymizer.liq
     content/liq/video-bluescreen.liq
+    content/liq/video-canvas-example.liq
+    content/liq/video-default-canvas.liq
     content/liq/video-in-video.liq
     content/liq/video-logo.liq
     content/liq/video-osc.liq
@@ -329,6 +331,8 @@
     content/liq/transcoding.liq
     content/liq/video-anonymizer.liq
     content/liq/video-bluescreen.liq
+    content/liq/video-canvas-example.liq
+    content/liq/video-default-canvas.liq
     content/liq/video-in-video.liq
     content/liq/video-logo.liq
     content/liq/video-osc.liq
@@ -479,6 +483,8 @@
     content/liq/transcoding.liq
     content/liq/video-anonymizer.liq
     content/liq/video-bluescreen.liq
+    content/liq/video-canvas-example.liq
+    content/liq/video-default-canvas.liq
     content/liq/video-in-video.liq
     content/liq/video-logo.liq
     content/liq/video-osc.liq
@@ -629,6 +635,8 @@
     content/liq/transcoding.liq
     content/liq/video-anonymizer.liq
     content/liq/video-bluescreen.liq
+    content/liq/video-canvas-example.liq
+    content/liq/video-default-canvas.liq
     content/liq/video-in-video.liq
     content/liq/video-logo.liq
     content/liq/video-osc.liq
@@ -779,6 +787,8 @@
     content/liq/transcoding.liq
     content/liq/video-anonymizer.liq
     content/liq/video-bluescreen.liq
+    content/liq/video-canvas-example.liq
+    content/liq/video-default-canvas.liq
     content/liq/video-in-video.liq
     content/liq/video-logo.liq
     content/liq/video-osc.liq
@@ -929,6 +939,8 @@
     content/liq/transcoding.liq
     content/liq/video-anonymizer.liq
     content/liq/video-bluescreen.liq
+    content/liq/video-canvas-example.liq
+    content/liq/video-default-canvas.liq
     content/liq/video-in-video.liq
     content/liq/video-logo.liq
     content/liq/video-osc.liq
@@ -1079,6 +1091,8 @@
     content/liq/transcoding.liq
     content/liq/video-anonymizer.liq
     content/liq/video-bluescreen.liq
+    content/liq/video-canvas-example.liq
+    content/liq/video-default-canvas.liq
     content/liq/video-in-video.liq
     content/liq/video-logo.liq
     content/liq/video-osc.liq
@@ -1229,6 +1243,8 @@
     content/liq/transcoding.liq
     content/liq/video-anonymizer.liq
     content/liq/video-bluescreen.liq
+    content/liq/video-canvas-example.liq
+    content/liq/video-default-canvas.liq
     content/liq/video-in-video.liq
     content/liq/video-logo.liq
     content/liq/video-osc.liq
@@ -1379,6 +1395,8 @@
     content/liq/transcoding.liq
     content/liq/video-anonymizer.liq
     content/liq/video-bluescreen.liq
+    content/liq/video-canvas-example.liq
+    content/liq/video-default-canvas.liq
     content/liq/video-in-video.liq
     content/liq/video-logo.liq
     content/liq/video-osc.liq
@@ -1529,6 +1547,8 @@
     content/liq/transcoding.liq
     content/liq/video-anonymizer.liq
     content/liq/video-bluescreen.liq
+    content/liq/video-canvas-example.liq
+    content/liq/video-default-canvas.liq
     content/liq/video-in-video.liq
     content/liq/video-logo.liq
     content/liq/video-osc.liq
@@ -1679,6 +1699,8 @@
     content/liq/transcoding.liq
     content/liq/video-anonymizer.liq
     content/liq/video-bluescreen.liq
+    content/liq/video-canvas-example.liq
+    content/liq/video-default-canvas.liq
     content/liq/video-in-video.liq
     content/liq/video-logo.liq
     content/liq/video-osc.liq
@@ -1829,6 +1851,8 @@
     content/liq/transcoding.liq
     content/liq/video-anonymizer.liq
     content/liq/video-bluescreen.liq
+    content/liq/video-canvas-example.liq
+    content/liq/video-default-canvas.liq
     content/liq/video-in-video.liq
     content/liq/video-logo.liq
     content/liq/video-osc.liq
@@ -1979,6 +2003,8 @@
     content/liq/transcoding.liq
     content/liq/video-anonymizer.liq
     content/liq/video-bluescreen.liq
+    content/liq/video-canvas-example.liq
+    content/liq/video-default-canvas.liq
     content/liq/video-in-video.liq
     content/liq/video-logo.liq
     content/liq/video-osc.liq
@@ -2129,6 +2155,8 @@
     content/liq/transcoding.liq
     content/liq/video-anonymizer.liq
     content/liq/video-bluescreen.liq
+    content/liq/video-canvas-example.liq
+    content/liq/video-default-canvas.liq
     content/liq/video-in-video.liq
     content/liq/video-logo.liq
     content/liq/video-osc.liq
@@ -2279,6 +2307,8 @@
     content/liq/transcoding.liq
     content/liq/video-anonymizer.liq
     content/liq/video-bluescreen.liq
+    content/liq/video-canvas-example.liq
+    content/liq/video-default-canvas.liq
     content/liq/video-in-video.liq
     content/liq/video-logo.liq
     content/liq/video-osc.liq
@@ -2429,6 +2459,8 @@
     content/liq/transcoding.liq
     content/liq/video-anonymizer.liq
     content/liq/video-bluescreen.liq
+    content/liq/video-canvas-example.liq
+    content/liq/video-default-canvas.liq
     content/liq/video-in-video.liq
     content/liq/video-logo.liq
     content/liq/video-osc.liq
@@ -2579,6 +2611,8 @@
     content/liq/transcoding.liq
     content/liq/video-anonymizer.liq
     content/liq/video-bluescreen.liq
+    content/liq/video-canvas-example.liq
+    content/liq/video-default-canvas.liq
     content/liq/video-in-video.liq
     content/liq/video-logo.liq
     content/liq/video-osc.liq
@@ -2729,6 +2763,8 @@
     content/liq/transcoding.liq
     content/liq/video-anonymizer.liq
     content/liq/video-bluescreen.liq
+    content/liq/video-canvas-example.liq
+    content/liq/video-default-canvas.liq
     content/liq/video-in-video.liq
     content/liq/video-logo.liq
     content/liq/video-osc.liq
@@ -2879,6 +2915,8 @@
     content/liq/transcoding.liq
     content/liq/video-anonymizer.liq
     content/liq/video-bluescreen.liq
+    content/liq/video-canvas-example.liq
+    content/liq/video-default-canvas.liq
     content/liq/video-in-video.liq
     content/liq/video-logo.liq
     content/liq/video-osc.liq
@@ -3029,6 +3067,8 @@
     content/liq/transcoding.liq
     content/liq/video-anonymizer.liq
     content/liq/video-bluescreen.liq
+    content/liq/video-canvas-example.liq
+    content/liq/video-default-canvas.liq
     content/liq/video-in-video.liq
     content/liq/video-logo.liq
     content/liq/video-osc.liq
@@ -3179,6 +3219,8 @@
     content/liq/transcoding.liq
     content/liq/video-anonymizer.liq
     content/liq/video-bluescreen.liq
+    content/liq/video-canvas-example.liq
+    content/liq/video-default-canvas.liq
     content/liq/video-in-video.liq
     content/liq/video-logo.liq
     content/liq/video-osc.liq
@@ -3329,6 +3371,8 @@
     content/liq/transcoding.liq
     content/liq/video-anonymizer.liq
     content/liq/video-bluescreen.liq
+    content/liq/video-canvas-example.liq
+    content/liq/video-default-canvas.liq
     content/liq/video-in-video.liq
     content/liq/video-logo.liq
     content/liq/video-osc.liq
@@ -3479,6 +3523,8 @@
     content/liq/transcoding.liq
     content/liq/video-anonymizer.liq
     content/liq/video-bluescreen.liq
+    content/liq/video-canvas-example.liq
+    content/liq/video-default-canvas.liq
     content/liq/video-in-video.liq
     content/liq/video-logo.liq
     content/liq/video-osc.liq
@@ -3629,6 +3675,8 @@
     content/liq/transcoding.liq
     content/liq/video-anonymizer.liq
     content/liq/video-bluescreen.liq
+    content/liq/video-canvas-example.liq
+    content/liq/video-default-canvas.liq
     content/liq/video-in-video.liq
     content/liq/video-logo.liq
     content/liq/video-osc.liq
@@ -3779,6 +3827,8 @@
     content/liq/transcoding.liq
     content/liq/video-anonymizer.liq
     content/liq/video-bluescreen.liq
+    content/liq/video-canvas-example.liq
+    content/liq/video-default-canvas.liq
     content/liq/video-in-video.liq
     content/liq/video-logo.liq
     content/liq/video-osc.liq
@@ -3929,6 +3979,8 @@
     content/liq/transcoding.liq
     content/liq/video-anonymizer.liq
     content/liq/video-bluescreen.liq
+    content/liq/video-canvas-example.liq
+    content/liq/video-default-canvas.liq
     content/liq/video-in-video.liq
     content/liq/video-logo.liq
     content/liq/video-osc.liq
@@ -4079,6 +4131,8 @@
     content/liq/transcoding.liq
     content/liq/video-anonymizer.liq
     content/liq/video-bluescreen.liq
+    content/liq/video-canvas-example.liq
+    content/liq/video-default-canvas.liq
     content/liq/video-in-video.liq
     content/liq/video-logo.liq
     content/liq/video-osc.liq
@@ -4229,6 +4283,8 @@
     content/liq/transcoding.liq
     content/liq/video-anonymizer.liq
     content/liq/video-bluescreen.liq
+    content/liq/video-canvas-example.liq
+    content/liq/video-default-canvas.liq
     content/liq/video-in-video.liq
     content/liq/video-logo.liq
     content/liq/video-osc.liq
@@ -4379,6 +4435,8 @@
     content/liq/transcoding.liq
     content/liq/video-anonymizer.liq
     content/liq/video-bluescreen.liq
+    content/liq/video-canvas-example.liq
+    content/liq/video-default-canvas.liq
     content/liq/video-in-video.liq
     content/liq/video-logo.liq
     content/liq/video-osc.liq
@@ -4529,6 +4587,8 @@
     content/liq/transcoding.liq
     content/liq/video-anonymizer.liq
     content/liq/video-bluescreen.liq
+    content/liq/video-canvas-example.liq
+    content/liq/video-default-canvas.liq
     content/liq/video-in-video.liq
     content/liq/video-logo.liq
     content/liq/video-osc.liq
@@ -4679,6 +4739,8 @@
     content/liq/transcoding.liq
     content/liq/video-anonymizer.liq
     content/liq/video-bluescreen.liq
+    content/liq/video-canvas-example.liq
+    content/liq/video-default-canvas.liq
     content/liq/video-in-video.liq
     content/liq/video-logo.liq
     content/liq/video-osc.liq
@@ -4829,6 +4891,8 @@
     content/liq/transcoding.liq
     content/liq/video-anonymizer.liq
     content/liq/video-bluescreen.liq
+    content/liq/video-canvas-example.liq
+    content/liq/video-default-canvas.liq
     content/liq/video-in-video.liq
     content/liq/video-logo.liq
     content/liq/video-osc.liq
@@ -4979,6 +5043,8 @@
     content/liq/transcoding.liq
     content/liq/video-anonymizer.liq
     content/liq/video-bluescreen.liq
+    content/liq/video-canvas-example.liq
+    content/liq/video-default-canvas.liq
     content/liq/video-in-video.liq
     content/liq/video-logo.liq
     content/liq/video-osc.liq
@@ -5129,6 +5195,8 @@
     content/liq/transcoding.liq
     content/liq/video-anonymizer.liq
     content/liq/video-bluescreen.liq
+    content/liq/video-canvas-example.liq
+    content/liq/video-default-canvas.liq
     content/liq/video-in-video.liq
     content/liq/video-logo.liq
     content/liq/video-osc.liq
@@ -5279,6 +5347,8 @@
     content/liq/transcoding.liq
     content/liq/video-anonymizer.liq
     content/liq/video-bluescreen.liq
+    content/liq/video-canvas-example.liq
+    content/liq/video-default-canvas.liq
     content/liq/video-in-video.liq
     content/liq/video-logo.liq
     content/liq/video-osc.liq
@@ -5429,6 +5499,8 @@
     content/liq/transcoding.liq
     content/liq/video-anonymizer.liq
     content/liq/video-bluescreen.liq
+    content/liq/video-canvas-example.liq
+    content/liq/video-default-canvas.liq
     content/liq/video-in-video.liq
     content/liq/video-logo.liq
     content/liq/video-osc.liq
@@ -5579,6 +5651,8 @@
     content/liq/transcoding.liq
     content/liq/video-anonymizer.liq
     content/liq/video-bluescreen.liq
+    content/liq/video-canvas-example.liq
+    content/liq/video-default-canvas.liq
     content/liq/video-in-video.liq
     content/liq/video-logo.liq
     content/liq/video-osc.liq
@@ -5729,6 +5803,8 @@
     content/liq/transcoding.liq
     content/liq/video-anonymizer.liq
     content/liq/video-bluescreen.liq
+    content/liq/video-canvas-example.liq
+    content/liq/video-default-canvas.liq
     content/liq/video-in-video.liq
     content/liq/video-logo.liq
     content/liq/video-osc.liq
@@ -5879,6 +5955,8 @@
     content/liq/transcoding.liq
     content/liq/video-anonymizer.liq
     content/liq/video-bluescreen.liq
+    content/liq/video-canvas-example.liq
+    content/liq/video-default-canvas.liq
     content/liq/video-in-video.liq
     content/liq/video-logo.liq
     content/liq/video-osc.liq
@@ -6029,6 +6107,8 @@
     content/liq/transcoding.liq
     content/liq/video-anonymizer.liq
     content/liq/video-bluescreen.liq
+    content/liq/video-canvas-example.liq
+    content/liq/video-default-canvas.liq
     content/liq/video-in-video.liq
     content/liq/video-logo.liq
     content/liq/video-osc.liq
@@ -6179,6 +6259,8 @@
     content/liq/transcoding.liq
     content/liq/video-anonymizer.liq
     content/liq/video-bluescreen.liq
+    content/liq/video-canvas-example.liq
+    content/liq/video-default-canvas.liq
     content/liq/video-in-video.liq
     content/liq/video-logo.liq
     content/liq/video-osc.liq
@@ -6329,6 +6411,8 @@
     content/liq/transcoding.liq
     content/liq/video-anonymizer.liq
     content/liq/video-bluescreen.liq
+    content/liq/video-canvas-example.liq
+    content/liq/video-default-canvas.liq
     content/liq/video-in-video.liq
     content/liq/video-logo.liq
     content/liq/video-osc.liq
@@ -6479,6 +6563,8 @@
     content/liq/transcoding.liq
     content/liq/video-anonymizer.liq
     content/liq/video-bluescreen.liq
+    content/liq/video-canvas-example.liq
+    content/liq/video-default-canvas.liq
     content/liq/video-in-video.liq
     content/liq/video-logo.liq
     content/liq/video-osc.liq
@@ -6629,6 +6715,8 @@
     content/liq/transcoding.liq
     content/liq/video-anonymizer.liq
     content/liq/video-bluescreen.liq
+    content/liq/video-canvas-example.liq
+    content/liq/video-default-canvas.liq
     content/liq/video-in-video.liq
     content/liq/video-logo.liq
     content/liq/video-osc.liq
@@ -6779,6 +6867,8 @@
     content/liq/transcoding.liq
     content/liq/video-anonymizer.liq
     content/liq/video-bluescreen.liq
+    content/liq/video-canvas-example.liq
+    content/liq/video-default-canvas.liq
     content/liq/video-in-video.liq
     content/liq/video-logo.liq
     content/liq/video-osc.liq
@@ -6929,6 +7019,8 @@
     content/liq/transcoding.liq
     content/liq/video-anonymizer.liq
     content/liq/video-bluescreen.liq
+    content/liq/video-canvas-example.liq
+    content/liq/video-default-canvas.liq
     content/liq/video-in-video.liq
     content/liq/video-logo.liq
     content/liq/video-osc.liq
@@ -7079,6 +7171,8 @@
     content/liq/transcoding.liq
     content/liq/video-anonymizer.liq
     content/liq/video-bluescreen.liq
+    content/liq/video-canvas-example.liq
+    content/liq/video-default-canvas.liq
     content/liq/video-in-video.liq
     content/liq/video-logo.liq
     content/liq/video-osc.liq
@@ -7229,6 +7323,8 @@
     content/liq/transcoding.liq
     content/liq/video-anonymizer.liq
     content/liq/video-bluescreen.liq
+    content/liq/video-canvas-example.liq
+    content/liq/video-default-canvas.liq
     content/liq/video-in-video.liq
     content/liq/video-logo.liq
     content/liq/video-osc.liq
@@ -7379,6 +7475,8 @@
     content/liq/transcoding.liq
     content/liq/video-anonymizer.liq
     content/liq/video-bluescreen.liq
+    content/liq/video-canvas-example.liq
+    content/liq/video-default-canvas.liq
     content/liq/video-in-video.liq
     content/liq/video-logo.liq
     content/liq/video-osc.liq
@@ -7529,6 +7627,8 @@
     content/liq/transcoding.liq
     content/liq/video-anonymizer.liq
     content/liq/video-bluescreen.liq
+    content/liq/video-canvas-example.liq
+    content/liq/video-default-canvas.liq
     content/liq/video-in-video.liq
     content/liq/video-logo.liq
     content/liq/video-osc.liq
@@ -7679,6 +7779,8 @@
     content/liq/transcoding.liq
     content/liq/video-anonymizer.liq
     content/liq/video-bluescreen.liq
+    content/liq/video-canvas-example.liq
+    content/liq/video-default-canvas.liq
     content/liq/video-in-video.liq
     content/liq/video-logo.liq
     content/liq/video-osc.liq
@@ -7829,6 +7931,8 @@
     content/liq/transcoding.liq
     content/liq/video-anonymizer.liq
     content/liq/video-bluescreen.liq
+    content/liq/video-canvas-example.liq
+    content/liq/video-default-canvas.liq
     content/liq/video-in-video.liq
     content/liq/video-logo.liq
     content/liq/video-osc.liq
@@ -7979,6 +8083,8 @@
     content/liq/transcoding.liq
     content/liq/video-anonymizer.liq
     content/liq/video-bluescreen.liq
+    content/liq/video-canvas-example.liq
+    content/liq/video-default-canvas.liq
     content/liq/video-in-video.liq
     content/liq/video-logo.liq
     content/liq/video-osc.liq
@@ -8129,6 +8235,8 @@
     content/liq/transcoding.liq
     content/liq/video-anonymizer.liq
     content/liq/video-bluescreen.liq
+    content/liq/video-canvas-example.liq
+    content/liq/video-default-canvas.liq
     content/liq/video-in-video.liq
     content/liq/video-logo.liq
     content/liq/video-osc.liq
@@ -8279,6 +8387,8 @@
     content/liq/transcoding.liq
     content/liq/video-anonymizer.liq
     content/liq/video-bluescreen.liq
+    content/liq/video-canvas-example.liq
+    content/liq/video-default-canvas.liq
     content/liq/video-in-video.liq
     content/liq/video-logo.liq
     content/liq/video-osc.liq
@@ -8429,6 +8539,8 @@
     content/liq/transcoding.liq
     content/liq/video-anonymizer.liq
     content/liq/video-bluescreen.liq
+    content/liq/video-canvas-example.liq
+    content/liq/video-default-canvas.liq
     content/liq/video-in-video.liq
     content/liq/video-logo.liq
     content/liq/video-osc.liq
@@ -8579,6 +8691,8 @@
     content/liq/transcoding.liq
     content/liq/video-anonymizer.liq
     content/liq/video-bluescreen.liq
+    content/liq/video-canvas-example.liq
+    content/liq/video-default-canvas.liq
     content/liq/video-in-video.liq
     content/liq/video-logo.liq
     content/liq/video-osc.liq
@@ -8729,6 +8843,8 @@
     content/liq/transcoding.liq
     content/liq/video-anonymizer.liq
     content/liq/video-bluescreen.liq
+    content/liq/video-canvas-example.liq
+    content/liq/video-default-canvas.liq
     content/liq/video-in-video.liq
     content/liq/video-logo.liq
     content/liq/video-osc.liq
@@ -8879,6 +8995,8 @@
     content/liq/transcoding.liq
     content/liq/video-anonymizer.liq
     content/liq/video-bluescreen.liq
+    content/liq/video-canvas-example.liq
+    content/liq/video-default-canvas.liq
     content/liq/video-in-video.liq
     content/liq/video-logo.liq
     content/liq/video-osc.liq
@@ -9029,6 +9147,8 @@
     content/liq/transcoding.liq
     content/liq/video-anonymizer.liq
     content/liq/video-bluescreen.liq
+    content/liq/video-canvas-example.liq
+    content/liq/video-default-canvas.liq
     content/liq/video-in-video.liq
     content/liq/video-logo.liq
     content/liq/video-osc.liq
@@ -9179,6 +9299,8 @@
     content/liq/transcoding.liq
     content/liq/video-anonymizer.liq
     content/liq/video-bluescreen.liq
+    content/liq/video-canvas-example.liq
+    content/liq/video-default-canvas.liq
     content/liq/video-in-video.liq
     content/liq/video-logo.liq
     content/liq/video-osc.liq
@@ -9329,6 +9451,8 @@
     content/liq/transcoding.liq
     content/liq/video-anonymizer.liq
     content/liq/video-bluescreen.liq
+    content/liq/video-canvas-example.liq
+    content/liq/video-default-canvas.liq
     content/liq/video-in-video.liq
     content/liq/video-logo.liq
     content/liq/video-osc.liq
@@ -9479,6 +9603,8 @@
     content/liq/transcoding.liq
     content/liq/video-anonymizer.liq
     content/liq/video-bluescreen.liq
+    content/liq/video-canvas-example.liq
+    content/liq/video-default-canvas.liq
     content/liq/video-in-video.liq
     content/liq/video-logo.liq
     content/liq/video-osc.liq
@@ -9629,6 +9755,8 @@
     content/liq/transcoding.liq
     content/liq/video-anonymizer.liq
     content/liq/video-bluescreen.liq
+    content/liq/video-canvas-example.liq
+    content/liq/video-default-canvas.liq
     content/liq/video-in-video.liq
     content/liq/video-logo.liq
     content/liq/video-osc.liq
@@ -9779,6 +9907,8 @@
     content/liq/transcoding.liq
     content/liq/video-anonymizer.liq
     content/liq/video-bluescreen.liq
+    content/liq/video-canvas-example.liq
+    content/liq/video-default-canvas.liq
     content/liq/video-in-video.liq
     content/liq/video-logo.liq
     content/liq/video-osc.liq
@@ -9929,6 +10059,8 @@
     content/liq/transcoding.liq
     content/liq/video-anonymizer.liq
     content/liq/video-bluescreen.liq
+    content/liq/video-canvas-example.liq
+    content/liq/video-default-canvas.liq
     content/liq/video-in-video.liq
     content/liq/video-logo.liq
     content/liq/video-osc.liq
@@ -10079,6 +10211,8 @@
     content/liq/transcoding.liq
     content/liq/video-anonymizer.liq
     content/liq/video-bluescreen.liq
+    content/liq/video-canvas-example.liq
+    content/liq/video-default-canvas.liq
     content/liq/video-in-video.liq
     content/liq/video-logo.liq
     content/liq/video-osc.liq
@@ -10229,6 +10363,8 @@
     content/liq/transcoding.liq
     content/liq/video-anonymizer.liq
     content/liq/video-bluescreen.liq
+    content/liq/video-canvas-example.liq
+    content/liq/video-default-canvas.liq
     content/liq/video-in-video.liq
     content/liq/video-logo.liq
     content/liq/video-osc.liq
@@ -10379,6 +10515,8 @@
     content/liq/transcoding.liq
     content/liq/video-anonymizer.liq
     content/liq/video-bluescreen.liq
+    content/liq/video-canvas-example.liq
+    content/liq/video-default-canvas.liq
     content/liq/video-in-video.liq
     content/liq/video-logo.liq
     content/liq/video-osc.liq
@@ -10529,6 +10667,8 @@
     content/liq/transcoding.liq
     content/liq/video-anonymizer.liq
     content/liq/video-bluescreen.liq
+    content/liq/video-canvas-example.liq
+    content/liq/video-default-canvas.liq
     content/liq/video-in-video.liq
     content/liq/video-logo.liq
     content/liq/video-osc.liq
@@ -10679,6 +10819,8 @@
     content/liq/transcoding.liq
     content/liq/video-anonymizer.liq
     content/liq/video-bluescreen.liq
+    content/liq/video-canvas-example.liq
+    content/liq/video-default-canvas.liq
     content/liq/video-in-video.liq
     content/liq/video-logo.liq
     content/liq/video-osc.liq
@@ -10829,6 +10971,8 @@
     content/liq/transcoding.liq
     content/liq/video-anonymizer.liq
     content/liq/video-bluescreen.liq
+    content/liq/video-canvas-example.liq
+    content/liq/video-default-canvas.liq
     content/liq/video-in-video.liq
     content/liq/video-logo.liq
     content/liq/video-osc.liq
@@ -10979,6 +11123,8 @@
     content/liq/transcoding.liq
     content/liq/video-anonymizer.liq
     content/liq/video-bluescreen.liq
+    content/liq/video-canvas-example.liq
+    content/liq/video-default-canvas.liq
     content/liq/video-in-video.liq
     content/liq/video-logo.liq
     content/liq/video-osc.liq
@@ -11129,6 +11275,8 @@
     content/liq/transcoding.liq
     content/liq/video-anonymizer.liq
     content/liq/video-bluescreen.liq
+    content/liq/video-canvas-example.liq
+    content/liq/video-default-canvas.liq
     content/liq/video-in-video.liq
     content/liq/video-logo.liq
     content/liq/video-osc.liq
@@ -11279,6 +11427,8 @@
     content/liq/transcoding.liq
     content/liq/video-anonymizer.liq
     content/liq/video-bluescreen.liq
+    content/liq/video-canvas-example.liq
+    content/liq/video-default-canvas.liq
     content/liq/video-in-video.liq
     content/liq/video-logo.liq
     content/liq/video-osc.liq
@@ -11429,6 +11579,8 @@
     content/liq/transcoding.liq
     content/liq/video-anonymizer.liq
     content/liq/video-bluescreen.liq
+    content/liq/video-canvas-example.liq
+    content/liq/video-default-canvas.liq
     content/liq/video-in-video.liq
     content/liq/video-logo.liq
     content/liq/video-osc.liq
@@ -11579,6 +11731,8 @@
     content/liq/transcoding.liq
     content/liq/video-anonymizer.liq
     content/liq/video-bluescreen.liq
+    content/liq/video-canvas-example.liq
+    content/liq/video-default-canvas.liq
     content/liq/video-in-video.liq
     content/liq/video-logo.liq
     content/liq/video-osc.liq
@@ -17526,6 +17680,110 @@
     (:test_liq content/liq/video-bluescreen.liq)
   )
   (action (run %{bin:liquidsoap} --no-stdlib %{stdlib} --check --no-fallible-check content/liq/video-bluescreen.liq))
+)
+
+(rule
+  (alias doctest)
+  (package liquidsoap)
+  (deps
+    ../src/libs/audio.liq
+    ../src/libs/clock.liq
+    ../src/libs/error.liq
+    ../src/libs/fades.liq
+    ../src/libs/ffmpeg.liq
+    ../src/libs/file.liq
+    ../src/libs/getter.liq
+    ../src/libs/hls.liq
+    ../src/libs/http.liq
+    ../src/libs/http_codes.liq
+    ../src/libs/icecast.liq
+    ../src/libs/io.liq
+    ../src/libs/liquidsoap.liq
+    ../src/libs/list.liq
+    ../src/libs/log.liq
+    ../src/libs/math.liq
+    ../src/libs/medialib.liq
+    ../src/libs/metadata.liq
+    ../src/libs/null.liq
+    ../src/libs/playlist.liq
+    ../src/libs/predicate.liq
+    ../src/libs/process.liq
+    ../src/libs/profiler.liq
+    ../src/libs/protocols.liq
+    ../src/libs/ref.liq
+    ../src/libs/replaygain.liq
+    ../src/libs/request.liq
+    ../src/libs/resolvers.liq
+    ../src/libs/runtime.liq
+    ../src/libs/server.liq
+    ../src/libs/settings.liq
+    ../src/libs/socket.liq
+    ../src/libs/source.liq
+    ../src/libs/sqlite.liq
+    ../src/libs/stdlib.liq
+    ../src/libs/string.liq
+    ../src/libs/switches.liq
+    ../src/libs/testing.liq
+    ../src/libs/thread.liq
+    ../src/libs/tracks.liq
+    ../src/libs/utils.liq
+    ../src/libs/video.liq
+    (:stdlib ../src/libs/stdlib.liq)
+    (:test_liq content/liq/video-canvas-example.liq)
+  )
+  (action (run %{bin:liquidsoap} --no-stdlib %{stdlib} --check --no-fallible-check content/liq/video-canvas-example.liq))
+)
+
+(rule
+  (alias doctest)
+  (package liquidsoap)
+  (deps
+    ../src/libs/audio.liq
+    ../src/libs/clock.liq
+    ../src/libs/error.liq
+    ../src/libs/fades.liq
+    ../src/libs/ffmpeg.liq
+    ../src/libs/file.liq
+    ../src/libs/getter.liq
+    ../src/libs/hls.liq
+    ../src/libs/http.liq
+    ../src/libs/http_codes.liq
+    ../src/libs/icecast.liq
+    ../src/libs/io.liq
+    ../src/libs/liquidsoap.liq
+    ../src/libs/list.liq
+    ../src/libs/log.liq
+    ../src/libs/math.liq
+    ../src/libs/medialib.liq
+    ../src/libs/metadata.liq
+    ../src/libs/null.liq
+    ../src/libs/playlist.liq
+    ../src/libs/predicate.liq
+    ../src/libs/process.liq
+    ../src/libs/profiler.liq
+    ../src/libs/protocols.liq
+    ../src/libs/ref.liq
+    ../src/libs/replaygain.liq
+    ../src/libs/request.liq
+    ../src/libs/resolvers.liq
+    ../src/libs/runtime.liq
+    ../src/libs/server.liq
+    ../src/libs/settings.liq
+    ../src/libs/socket.liq
+    ../src/libs/source.liq
+    ../src/libs/sqlite.liq
+    ../src/libs/stdlib.liq
+    ../src/libs/string.liq
+    ../src/libs/switches.liq
+    ../src/libs/testing.liq
+    ../src/libs/thread.liq
+    ../src/libs/tracks.liq
+    ../src/libs/utils.liq
+    ../src/libs/video.liq
+    (:stdlib ../src/libs/stdlib.liq)
+    (:test_liq content/liq/video-default-canvas.liq)
+  )
+  (action (run %{bin:liquidsoap} --no-stdlib %{stdlib} --check --no-fallible-check content/liq/video-default-canvas.liq))
 )
 
 (rule

--- a/dune-project
+++ b/dune-project
@@ -167,7 +167,7 @@
     (ocaml (>= 4.14.0))
     (liquidsoap-lang (= :version))
     js_of_ocaml-ppx
-    js_of_ocaml)
+    (js_of_ocaml (< 5.6.0)))
   (conflicts
     (liquidsoap (<> :version)))
   (synopsis "Liquidsoap language - javascript wrapper"))

--- a/liquidsoap-js.opam
+++ b/liquidsoap-js.opam
@@ -12,7 +12,7 @@ depends: [
   "ocaml" {>= "4.14.0"}
   "liquidsoap-lang" {= version}
   "js_of_ocaml-ppx"
-  "js_of_ocaml"
+  "js_of_ocaml" {< "5.6.0"}
   "odoc" {with-doc}
 ]
 conflicts: [

--- a/src/core/operators/dyn_op.ml
+++ b/src/core/operators/dyn_op.ml
@@ -50,24 +50,30 @@ class dyn ~init ~track_sensitive ~infallible ~resurection_time ~self_sync f =
       if s#is_ready then Some s else None
 
     method private get_next reselect =
-      match Atomic.exchange proposed None with
-        | Some s -> self#prepare s
-        | None -> (
-            last_select <- Unix.gettimeofday ();
-            let s =
-              Lang.apply f [] |> Lang.to_option |> Option.map Lang.to_source
-            in
-            match s with
-              | None -> (
-                  match Atomic.get source with
-                    | Some s
-                      when self#can_reselect
-                             ~reselect:
-                               (match reselect with `Force -> `Ok | v -> v)
-                             s ->
-                        Some s
-                    | _ -> None)
-              | Some s -> self#prepare s)
+      (* Avoid that a new source gets assigned to the default clock. *)
+      Clock.collect_after
+        (self#mutexify (fun () ->
+             match Atomic.exchange proposed None with
+               | Some s -> self#prepare s
+               | None -> (
+                   last_select <- Unix.gettimeofday ();
+                   let s =
+                     Lang.apply f [] |> Lang.to_option
+                     |> Option.map Lang.to_source
+                   in
+                   match s with
+                     | None -> (
+                         match Atomic.get source with
+                           | Some s
+                             when self#can_reselect
+                                    ~reselect:
+                                      (match reselect with
+                                        | `Force -> `Ok
+                                        | v -> v)
+                                    s ->
+                               Some s
+                           | _ -> None)
+                     | Some s -> self#prepare s)))
 
     method private get_source ~reselect () =
       match (Atomic.get source, reselect) with

--- a/src/js/index.html
+++ b/src/js/index.html
@@ -22,7 +22,7 @@
         "@codemirror/state": "https://esm.sh/@codemirror/state@6.3.1",
         "@codemirror/language": "https://esm.sh/@codemirror/language@6.9.2",
         "@codemirror/view": "https://esm.sh/@codemirror/view@6.22.0",
-        "codemirror-lang-liquidsoap": "https://esm.sh/codemirror-lang-liquidsoap@0.2.9?external=@codemirror/state,@codemirror/language,@codemirror/view",
+        "codemirror-lang-liquidsoap": "https://esm.sh/codemirror-lang-liquidsoap@0.3.0?external=@codemirror/state,@codemirror/language,@codemirror/view",
         "prettier": "https://esm.sh/prettier@3.0.2/standalone.mjs",
         "liquidsoap-prettier": "https://esm.sh/liquidsoap-prettier@1.4.8/src/index.js"
       }

--- a/src/lang/lexer.ml
+++ b/src/lang/lexer.ml
@@ -245,6 +245,7 @@ let rec token lexbuf =
     | '{' -> LCUR
     | '}' -> RCUR
     | ',' -> COMMA
+    | '@' -> AT
     | "::" -> COLONCOLON
     | ':' -> COLON
     | ';' -> SEQ

--- a/src/lang/parser.mly
+++ b/src/lang/parser.mly
@@ -89,9 +89,9 @@ open Parser_helper
 %left OR
 %left QUESTION_DOT
 %nonassoc NOT
-%left BIN1
+%left BIN1 AT
 %left BIN2 MINUS
-%left BIN3 TIMES AT
+%left BIN3 TIMES
 %right COLONCOLON
 %nonassoc GET          (* (!x)+2 *)
 %left DOT

--- a/src/lang/parser.mly
+++ b/src/lang/parser.mly
@@ -63,6 +63,7 @@ open Parser_helper
 %token <string> BIN1
 %token <string> BIN2
 %token <string> BIN3
+%token AT
 %token TIMES
 %token MINUS UMINUS
 %token UNDERSCORE
@@ -90,7 +91,7 @@ open Parser_helper
 %nonassoc NOT
 %left BIN1
 %left BIN2 MINUS
-%left BIN3 TIMES
+%left BIN3 TIMES AT
 %right COLONCOLON
 %nonassoc GET          (* (!x)+2 *)
 %left DOT
@@ -281,6 +282,7 @@ expr:
   | expr BIN3 expr                 { mk ~pos:$loc (`Infix ($1, $2, $3)) }
   | expr TIMES expr                { mk ~pos:$loc (`Infix ($1, "*", $3)) }
   | expr MINUS expr                { mk ~pos:$loc (`Infix ($1, "-", $3)) }
+  | expr AT expr                   { mk ~pos:$loc (`At ($1, $3)) }
   | time_predicate                 { $1 }
 
 invoke:

--- a/src/lang/term/parsed_term.ml
+++ b/src/lang/term/parsed_term.ml
@@ -177,6 +177,7 @@ and parsed_ast =
   | `Infix of t * string * t
   | `Bool of string * t list
   | `Coalesce of t * t
+  | `At of t * t
   | `Simple_fun of t
   | `String_interpolation of char * string_interpolation list
   | `Include of inc
@@ -289,6 +290,9 @@ let rec iter_term fn ({ term } as tm) =
         iter_term fn tm'
     | `Bool (_, l) -> List.iter (iter_term fn) l
     | `Coalesce (tm, tm') ->
+        iter_term fn tm;
+        iter_term fn tm'
+    | `At (tm, tm') ->
         iter_term fn tm;
         iter_term fn tm'
     | `Simple_fun tm -> iter_term fn tm

--- a/src/lang/term/term_reducer.ml
+++ b/src/lang/term/term_reducer.ml
@@ -823,6 +823,7 @@ let rec to_ast ~pos : parsed_ast -> Term.runtime_ast = function
       to_ast ~pos (`App (op, [`Term ("", mk_parsed ~pos (`List l))]))
   | `Def p | `Let p | `Binding p -> mk_let ~pos ~to_term p
   | `Coalesce (t, default) -> mk_coalesce ~pos ~to_term ~default t
+  | `At (t, t') -> `App (to_term t', [("", to_term t)])
   | `Time t -> mk_time_pred ~pos (during ~pos t)
   | `Time_interval (t, t') -> mk_time_pred ~pos (between ~pos t t')
   | `Ground g -> `Ground g

--- a/src/libs/video.liq
+++ b/src/libs/video.liq
@@ -768,7 +768,7 @@ let video.canvas = ()
 # Create a virtual canvas that can be used to return video position and sizes
 # that are independent of the frame's dimensions.
 # @category Source / Video processing
-# @param ~virtual_height Virtual height, in pixels, of the canvas
+# @param ~virtual_width Virtual height, in pixels, of the canvas
 # @param ~actual_size Actual size, in pixels, of the canvas
 # @param ~font_size Font size, in virtual pixels.
 # @method ~px Map a virtual size in pixel to the actual size.
@@ -777,11 +777,11 @@ let video.canvas = ()
 #             of the canvas height
 # @method ~vw Return a position in percent (as a value between `0.` and `1.`) \
 #             of the canvas width
-def video.canvas.make(~virtual_height, ~actual_size, ~font_size) =
-  virtual_height = float(virtual_height)
+def video.canvas.make(~virtual_width, ~actual_size, ~font_size) =
+  virtual_width = float(virtual_width)
   actual_height = float(actual_size.height)
   actual_width = float(actual_size.width)
-  ratio = actual_height / virtual_height
+  ratio = actual_width / virtual_width
   font_ratio = float(font_size) * ratio
 
   def px((v:int)) =
@@ -806,9 +806,9 @@ end
 # Standard video canvas based off a `10k` virtual canvas.
 # @category Source / Video processing
 def video.canvas.virtual_10k =
-  def make(height, width) =
+  def make(width, height) =
     video.canvas.make(
-      virtual_height=10000,
+      virtual_width=10000,
       actual_size={width=width, height=height},
       font_size=160
     )

--- a/src/libs/video.liq
+++ b/src/libs/video.liq
@@ -779,7 +779,7 @@ def video.canvas.make(~virtualSize, ~actualSize, ~fontSize) =
   ratio = actualSize / virtualSize
   fontRatio = float(fontSize) * ratio
 
-  def px(v) =
+  def px((v:int)) =
     int_of_float(float(v) * ratio)
   end
 
@@ -792,6 +792,9 @@ end
 
 # Standard video canvas
 # @category Source / Video processing
+# @method seven_20p Standard 720p video canvas
+# @method ten_80p Standard 1080p video canvas
+# @method four_k Standard 4k video canvas
 def video.canvas.ten_k =
   {
     seven_20p=

--- a/src/libs/video.liq
+++ b/src/libs/video.liq
@@ -768,52 +768,59 @@ let video.canvas = ()
 # Create a virtual canvas that can be used to return video position and sizes
 # that are independent of the frame's dimensions.
 # @category Source / Video processing
-# @param ~virtualSize Virtual size, in pixels, of the canvas
-# @param ~actualSize Actual size, in pixels, of the canvas
-# @param ~fontSize Font size, in virtual pixels.
+# @param ~virtual_height Virtual height, in pixels, of the canvas
+# @param ~actual_size Actual size, in pixels, of the canvas
+# @param ~font_size Font size, in virtual pixels.
 # @method ~px Map a virtual size in pixel to the actual size.
 # @method ~rem Map a fraction of the virtual font size into an actual font size
-def video.canvas.make(~virtualSize, ~actualSize, ~fontSize) =
-  virtualSize = float(virtualSize)
-  actualSize = float(actualSize)
-  ratio = actualSize / virtualSize
-  fontRatio = float(fontSize) * ratio
+# @method ~vh Return a position in percent (as a value between `0.` and `1.`) \
+#             of the canvas height
+# @method ~vw Return a position in percent (as a value between `0.` and `1.`) \
+#             of the canvas width
+def video.canvas.make(~virtual_height, ~actual_size, ~font_size) =
+  virtual_height = float(virtual_height)
+  actual_height = float(actual_size.height)
+  actual_width = float(actual_size.width)
+  ratio = actual_height / virtual_height
+  font_ratio = float(font_size) * ratio
 
   def px((v:int)) =
     int_of_float(float(v) * ratio)
   end
 
-  def rem(v) =
-    int_of_float(v * fontRatio)
+  def vh(v) =
+    int_of_float(v * actual_height)
   end
 
-  {px=px, rem=rem}
+  def vw(v) =
+    int_of_float(v * (float(actual_width)))
+  end
+
+  def rem(v) =
+    int_of_float(v * font_ratio)
+  end
+
+  {px=px, rem=rem, vw=vw, vh=vh, ...actual_size}
 end
 
-# Standard video canvas
+# Standard video canvas based off a `10k` virtual canvas.
 # @category Source / Video processing
-# @method seven_20p Standard 720p video canvas
-# @method ten_80p Standard 1080p video canvas
-# @method four_k Standard 4k video canvas
-def video.canvas.ten_k =
+def video.canvas.virtual_10k =
+  def make(height, width) =
+    video.canvas.make(
+      virtual_height=10000,
+      actual_size={width=width, height=height},
+      font_size=156
+    )
+  end
+
   {
-    seven_20p=
-      {
-        width=1280,
-        height=720,
-        ...video.canvas.make(virtualSize=10000, actualSize=1280, fontSize=156)
-      },
-    ten_80p=
-      {
-        width=1920,
-        height=1080,
-        ...video.canvas.make(virtualSize=10000, actualSize=1920, fontSize=156)
-      },
-    four_k=
-      {
-        width=3840,
-        height=2160,
-        ...video.canvas.make(virtualSize=10000, actualSize=3840, fontSize=156)
-      }
+    actual_360p=make(640, 360),
+    actual_480p=make(640, 480),
+    actual_720p=make(1280, 720),
+    actual_1080p=make(1920, 1080),
+    actual_1440p=make(2560, 1440),
+    actual_4k=make(3840, 2160),
+    actual_8k=make(7680, 4320)
   }
 end

--- a/src/libs/video.liq
+++ b/src/libs/video.liq
@@ -810,7 +810,7 @@ def video.canvas.virtual_10k =
     video.canvas.make(
       virtual_height=10000,
       actual_size={width=width, height=height},
-      font_size=156
+      font_size=160
     )
   end
 

--- a/src/libs/video.liq
+++ b/src/libs/video.liq
@@ -762,3 +762,55 @@ def video.plot(~lines=true, ~min=0., ~max=1., ~speed=100., ~color=0xffffff, y) =
 
   source.on_frame(s', update)
 end
+
+let video.canvas = ()
+
+# Create a virtual canvas that can be used to return video position and sizes
+# that are independent of the frame's dimensions.
+# @category Source / Video processing
+# @param ~virtualSize Virtual size, in pixels, of the canvas
+# @param ~actualSize Actual size, in pixels, of the canvas
+# @param ~fontSize Font size, in virtual pixels.
+# @method ~px Map a virtual size in pixel to the actual size.
+# @method ~rem Map a fraction of the virtual font size into an actual font size
+def video.canvas.make(~virtualSize, ~actualSize, ~fontSize) =
+  virtualSize = float(virtualSize)
+  actualSize = float(actualSize)
+  ratio = actualSize / virtualSize
+  fontRatio = float(fontSize) * ratio
+
+  def px(v) =
+    int_of_float(float(v) * ratio)
+  end
+
+  def rem(v) =
+    int_of_float(v * fontRatio)
+  end
+
+  {px=px, rem=rem}
+end
+
+# Standard video canvas
+# @category Source / Video processing
+def video.canvas.ten_k =
+  {
+    seven_20p=
+      {
+        width=1280,
+        height=720,
+        ...video.canvas.make(virtualSize=10000, actualSize=1280, fontSize=156)
+      },
+    ten_80p=
+      {
+        width=1920,
+        height=1080,
+        ...video.canvas.make(virtualSize=10000, actualSize=1920, fontSize=156)
+      },
+    four_k=
+      {
+        width=3840,
+        height=2160,
+        ...video.canvas.make(virtualSize=10000, actualSize=3840, fontSize=156)
+      }
+  }
+end

--- a/src/tooling/parsed_json.ml
+++ b/src/tooling/parsed_json.ml
@@ -517,6 +517,9 @@ let rec to_ast_json ~to_json = function
       ast_node ~typ:"include_extra" [("value", `String inc_name)]
   | `Coalesce (t, t') ->
       ast_node ~typ:"coalesce" [("left", to_json t); ("right", to_json t')]
+  | `At (t, t') ->
+      ast_node ~typ:"infix"
+        [("left", to_json t); ("op", `String "@"); ("right", to_json t')]
   | `Var s -> ast_node ~typ:"var" [("value", `String s)]
   | `Seq (t, t') ->
       ast_node ~typ:"seq" [("left", to_json t); ("right", to_json t')]

--- a/tests/language/eval.liq
+++ b/tests/language/eval.liq
@@ -10,7 +10,15 @@ def echo(s) =
 end
 
 def t(lbl, f) =
-  if f() then echo(lbl) else echo("fail #{lbl}") end
+  if
+    f()
+  then
+    echo(lbl)
+  else
+    echo(
+      "fail #{lbl}"
+    )
+  end
 end
 
 def f() =
@@ -40,16 +48,19 @@ def f() =
   t("17", {"foo" == (false ? "bla" : "foo" )})
 
   # Generic eval
-  let eval x = "{foo = 123, gni = \"aabbcc\"}"
+  let eval x =
+    "{foo = 123, gni = \"aabbcc\"}"
   t("18", {x.foo == 123})
   t("19", {x.gni == "aabbcc"})
 
   # Eval with sources!
-  let eval x = "output.dummy(id='bla', blank())"
+  let eval x =
+    "output.dummy(id='bla', blank())"
   t("20", {x.id() == "bla"})
 
   # Eval with patterns
-  let eval {foo, gni = [x, y]} = "{foo = 123, gni = [1,2]}"
+  let eval {foo, gni = [x, y]} =
+    "{foo = 123, gni = [1,2]}"
   t("21", {foo == 123})
   t("22", {gni == [1, 2]})
   t("23", {x == 1})
@@ -60,8 +71,10 @@ def f() =
   t("25", {(x, y) == (123, 456)})
 
   # @ infix notation
-  def f(x) = 2 * x end
-  t("26", {2@f == 4})
+  def f(x) =
+    2 * x
+  end
+  t("26", {2 @ f == 4})
   if fail() then test.fail() else test.pass() end
 end
 

--- a/tests/language/eval.liq
+++ b/tests/language/eval.liq
@@ -58,6 +58,10 @@ def f() =
   # Eval with type cast
   let eval ([x, y] : [int]) = "[123,456]"
   t("25", {(x, y) == (123, 456)})
+
+  # @ infix notation
+  def f(x) = 2 * x end
+  t("26", {2@f == 4})
   if fail() then test.fail() else test.pass() end
 end
 


### PR DESCRIPTION
This PR adds a notion of virtual vs. actual video canvas that makes it possible to add video elements independently of the frame size.

Since there is no way of knowing how many pixel videos will have in the future, the general idea is to create a conversion from a higher number of virtual pixels to a smaller number of actual pixels. This is done via `video.canvas.make`.

We also add a **suggested** syntactic sugar: `x@y = y(x)` to make it more readable!

Then, we define standard canvas based on a `10k` virtual canvas for `720p`, `1080p` and `4k` resolutions. Those can be used as follows:

```liquidsoap
let {
  px,
  rem,
  vh,
  vw,
  width,
  height
} = video.canvas.virtual_10k.actual_1080p

video.frame.width := width
video.frame.height := height

background =
  video.add_image(
    x=0.3@vw, y=0.01@vh, width=1562@px, height=1562@px, file=cover_files, background
  )

background =
  video.add_text(
    color=0xFCB900,
    font=myfont,
    speed=0,
    x=234@px,
    y=4437@px,
    size=1.5@rem,
    {nowplaying()},
    background
  )
```

You can then change the actual resolution by using a different canvas on the top of the script!