### PR TITLE
Fix crossfade with short tracks:

### DIFF
--- a/src/core/stream/generator.ml
+++ b/src/core/stream/generator.ml
@@ -40,13 +40,18 @@ let add_timed_content content =
 let make_content ?length content_type =
   add_timed_content (Frame_base.Fields.map (Content.make ?length) content_type)
 
-let create ?(log = fun s -> log#info "%s" s) ?max_length ?length content_type =
+let create ?(log = fun s -> log#info "%s" s) ?max_length ?length ?content
+    content_type =
   {
     lock = Mutex.create ();
     max_length = Atomic.make max_length;
     log;
     content_type;
-    content = Atomic.make (make_content ?length content_type);
+    content =
+      Atomic.make
+        (match content with
+          | Some c -> c
+          | None -> make_content ?length content_type);
   }
 
 let get_field gen field = Frame_base.Fields.find field (Atomic.get gen.content)

--- a/src/core/stream/generator.mli
+++ b/src/core/stream/generator.mli
@@ -44,6 +44,7 @@ val create :
   ?log:(string -> unit) ->
   ?max_length:int ->
   ?length:int ->
+  ?content:Content.data Frame_base.Fields.t ->
   Frame_base.content_type ->
   t
 

--- a/tests/streams/crossfade.liq
+++ b/tests/streams/crossfade.liq
@@ -6,7 +6,9 @@ a = metadata.map(update=false, (fun (_) -> [("title","a1")]), a)
 b = sine(duration=20.,880.)
 b = metadata.map(update=false, (fun (_) -> [("title","b1")]), b)
 
-s = sequence([a,b])
+c= sine(duration=20.,880.)
+
+s = sequence([a,b, c])
 
 fa = crossfade(smart=true, deduplicate=true, s)
 
@@ -16,7 +18,11 @@ a = metadata.map(update=false, (fun (_) -> [("title","a2")]), a)
 b = sine(duration=20.,880.)
 b = metadata.map(update=false, (fun (_) -> [("title","b2")]), b)
 
-s = sequence([a,b])
+c= sine(duration=20.,880.)
+
+s = sequence([a,b, c])
+
+s = sequence([a,b, c])
 
 fb = crossfade(smart=true, deduplicate=false, conservative=false, s)
 


### PR DESCRIPTION
* Make sure to stop on first track boundary when buffering next track
* Compute crossfade over the minimum common buffer.

Fixes: #3610