### PR TITLE
Make mem_usage required.

### DIFF
--- a/.github/scripts/build-posix.sh
+++ b/.github/scripts/build-posix.sh
@@ -45,7 +45,7 @@ cd /tmp/liquidsoap-full/liquidsoap
 ./.github/scripts/checkout-deps.sh
 
 opam update
-opam install -y saturn_lockfree magic-mime
+opam install -y saturn_lockfree magic-mime mem_usage
 
 cd /tmp/liquidsoap-full
 

--- a/.github/scripts/stats-posix.sh
+++ b/.github/scripts/stats-posix.sh
@@ -8,7 +8,7 @@ OCAMLPATH="$(cat ../.ocamlpath)"
 export OCAMLPATH
 
 printf "Memory usage before loading all libraries: "
-dune exec --display=quiet -- src/bin/liquidsoap.exe --no-stdlib --check 'runtime.gc.full_major() print(runtime.mem_usage.prettify_bytes(runtime.mem_usage().process_physical_memory))'
+dune exec --display=quiet -- src/bin/liquidsoap.exe --no-stdlib --check 'runtime.gc.full_major() print(runtime.memory.prettify_bytes(runtime.memory().process_physical_memory))'
 
 printf "Memory usage after loading all libraries: "
 dune exec --display=quiet -- src/bin/liquidsoap.exe --check 'runtime.gc.full_major() print(runtime.memory().pretty.process_physical_memory)'

--- a/dune-project
+++ b/dune-project
@@ -55,6 +55,7 @@
     uri
     fileutils
     menhirLib
+    mem_usage
     (saturn_lockfree (>= 0.4.1))
     (metadata (>= 0.2.0))
     magic-mime
@@ -87,7 +88,6 @@
     lo
     mad
     memtrace
-    mem_usage
     ogg
     opus
     osc-unix
@@ -129,7 +129,6 @@
     (lo (< 0.2.0))
     (mad (< 0.5.0))
     (magic (< 0.6))
-    (mem_usage (< 0.0.3))
     (ogg (< 0.7.4))
     (opus (< 0.2.0))
     (portaudio (< 0.2.0))

--- a/liquidsoap-core.opam
+++ b/liquidsoap-core.opam
@@ -20,6 +20,7 @@ depends: [
   "uri"
   "fileutils"
   "menhirLib"
+  "mem_usage"
   "saturn_lockfree" {>= "0.4.1"}
   "metadata" {>= "0.2.0"}
   "magic-mime"
@@ -54,7 +55,6 @@ depopts: [
   "lo"
   "mad"
   "memtrace"
-  "mem_usage"
   "ogg"
   "opus"
   "osc-unix"
@@ -97,7 +97,6 @@ conflicts: [
   "lo" {< "0.2.0"}
   "mad" {< "0.5.0"}
   "magic" {< "0.6"}
-  "mem_usage" {< "0.0.3"}
   "ogg" {< "0.7.4"}
   "opus" {< "0.2.0"}
   "portaudio" {< "0.2.0"}

--- a/src/config/mem_usage_option.disabled.ml
+++ b/src/config/mem_usage_option.disabled.ml
@@ -1,2 +1,0 @@
-let detected = "no (requires mem_usage)"
-let enabled = false

--- a/src/config/mem_usage_option.enabled.ml
+++ b/src/config/mem_usage_option.enabled.ml
@@ -1,1 +1,0 @@
-noop.enabled.ml

--- a/src/core/builtins/builtins_mem_usage.ml
+++ b/src/core/builtins/builtins_mem_usage.ml
@@ -52,10 +52,9 @@ let _ =
       ]
   in
   let runtime_mem_usage =
-    Lang.add_builtin ~base:Modules.runtime "mem_usage" ~category:`System
-      ~flags:[`Hidden]
-      ~descr:"Return stats about the system and process memory." [] mem_usage_t
-      (fun _ -> mem_usage (Mem_usage.info ()))
+    Lang.add_builtin ~base:Modules.runtime "memory" ~category:`System
+      ~descr:"Returns information about the system and process' memory." []
+      mem_usage_t (fun _ -> mem_usage (Mem_usage.info ()))
   in
   Lang.add_builtin ~base:runtime_mem_usage "prettify_bytes" ~category:`String
     ~descr:"Returns a human-redable description of an amount of bytes."

--- a/src/core/builtins/builtins_optionals.ml
+++ b/src/core/builtins/builtins_optionals.ml
@@ -34,7 +34,6 @@ let () =
       ("lilv", Lilv_option.enabled);
       ("lo", Lo_option.enabled);
       ("mad", Mad_option.enabled);
-      ("mem_usage", Mem_usage_option.enabled);
       ("memtrace", Memtrace_option.enabled);
       ("ogg", Ogg_option.enabled);
       ("opus", Opus_option.enabled);

--- a/src/core/dune
+++ b/src/core/dune
@@ -33,6 +33,7 @@
   uri
   saturn_lockfree
   metadata
+  mem_usage
   magic-mime
   (select
    file_watcher.ml
@@ -275,6 +276,7 @@
   builtins_harbor
   builtins_http
   builtins_metadata
+  builtins_mem_usage
   builtins_process
   builtins_request
   builtins_resolvers
@@ -320,14 +322,6 @@
  (wrapped false)
  (optional)
  (modules camlimages_decoder))
-
-(library
- (name liquidsoap_mem_usage)
- (libraries mem_usage liquidsoap_core)
- (library_flags -linkall)
- (wrapped false)
- (optional)
- (modules builtins_mem_usage))
 
 (library
  (name liquidsoap_memtrace)
@@ -767,7 +761,6 @@
   lilv_option
   lo_option
   mad_option
-  mem_usage_option
   memtrace_option
   ogg_option
   opus_option
@@ -910,11 +903,6 @@
    from
    (liquidsoap_mad -> mad_option.enabled.ml)
    (-> mad_option.disabled.ml))
-  (select
-   mem_usage_option.ml
-   from
-   (liquidsoap_mem_usage -> mem_usage_option.enabled.ml)
-   (-> mem_usage_option.disabled.ml))
   (select
    memtrace_option.ml
    from

--- a/src/libs/runtime.liq
+++ b/src/libs/runtime.liq
@@ -1,43 +1,29 @@
-# Returns information about the system and process' memory
-# usage. Requires `mem_usage` for a full report.
-# @category Liquidsoap
-def runtime.memory() =
+# @docof runtime.memory
+def replaces runtime.memory() =
   x =
     {
+      ...runtime.memory(),
       process_managed_memory=
         runtime.gc.quick_stat().heap_words * runtime.sys.word_size / 8
-    }
-
-%ifdef runtime.mem_usage
-  info = runtime.mem_usage()
-  x =
-    x.{
-      total_virtual_memory=info.total_virtual_memory,
-      total_physical_memory=info.total_physical_memory,
-      total_used_virtual_memory=info.total_used_virtual_memory,
-      total_used_physical_memory=info.total_used_physical_memory,
-      process_virtual_memory=info.process_virtual_memory,
-      process_physical_memory=info.process_physical_memory
     }
 
   let x.pretty =
     {
       process_managed_memory=
-        runtime.mem_usage.prettify_bytes(x.process_managed_memory),
+        runtime.memory.prettify_bytes(x.process_managed_memory),
       total_virtual_memory=
-        runtime.mem_usage.prettify_bytes(info.total_virtual_memory),
+        runtime.memory.prettify_bytes(x.total_virtual_memory),
       total_physical_memory=
-        runtime.mem_usage.prettify_bytes(info.total_physical_memory),
+        runtime.memory.prettify_bytes(x.total_physical_memory),
       total_used_virtual_memory=
-        runtime.mem_usage.prettify_bytes(info.total_used_virtual_memory),
+        runtime.memory.prettify_bytes(x.total_used_virtual_memory),
       total_used_physical_memory=
-        runtime.mem_usage.prettify_bytes(info.total_used_physical_memory),
+        runtime.memory.prettify_bytes(x.total_used_physical_memory),
       process_virtual_memory=
-        runtime.mem_usage.prettify_bytes(info.process_virtual_memory),
+        runtime.memory.prettify_bytes(x.process_virtual_memory),
       process_physical_memory=
-        runtime.mem_usage.prettify_bytes(info.process_physical_memory)
+        runtime.memory.prettify_bytes(x.process_physical_memory)
     }
-%endif
 
   x
 end

--- a/src/runtime/build_config.ml
+++ b/src/runtime/build_config.ml
@@ -116,7 +116,6 @@ let build_config =
    - lastfm            : %{Lastfm_option.detected}
    - lo                : %{Lo_option.detected}
    - memtrace          : %{Memtrace_option.detected}
-   - mem_usage         : %{Mem_usage_option.detected}
    - osc               : %{Osc_option.detected}
    - ssl               : %{Ssl_option.detected}
    - sqlite3           : %{Sqlite3_option.detected}

--- a/tests/language/mem_usage.liq
+++ b/tests/language/mem_usage.liq
@@ -1,7 +1,7 @@
 #!../../liquidsoap ../test.liq
 
 def f() =
-  mu = runtime.mem_usage()
+  mu = runtime.memory()
   print(
     "Memory usage:\n#{mu}"
   )
@@ -60,7 +60,7 @@ def f() =
   )
 
   # See #2427
-  thread.run({ignore(runtime.mem_usage())})
+  thread.run({ignore(runtime.memory())})
   test.pass()
 end
 


### PR DESCRIPTION
This simplifies the code and API. The underlying module is available on all platforms that we support without any external dependency.