### PR TITLE
Bring back `image/jpg` to cover manager

### DIFF
--- a/src/libs/extra/metadata.liq
+++ b/src/libs/extra/metadata.liq
@@ -11,6 +11,7 @@ def file.cover.manager(
   ~id=null(),
   ~mime_types=[
     ("image/gif", "gif"),
+    ("image/jpg", "jpeg"),
     ("image/jpeg", "jpeg"),
     ("image/png", "png"),
     ("image/webp", "webp")

--- a/src/libs/extra/video.liq
+++ b/src/libs/extra/video.liq
@@ -17,6 +17,7 @@ def video.add_cover(
   ~y=getter(0),
   ~mime_types=[
     ("image/gif", "gif"),
+    ("image/jpg", "jpeg"),
     ("image/jpeg", "jpeg"),
     ("image/png", "png"),
     ("image/webp", "webp")


### PR DESCRIPTION
It has been brought to our attention that `image/jpg` mais actually exist in the wild. Indeed, I can see some example of it at different places online.

I also learned of the [Postel's law](https://en.wikipedia.org/wiki/Robustness_principle):
> Be conservative in what you send, be liberal in what you accept

So let's just do that!