### PR TITLE
Adapt to new channel layout.

### DIFF
--- a/.github/docker/Dockerfile.production
+++ b/.github/docker/Dockerfile.production
@@ -1,4 +1,4 @@
-FROM debian:trixie-slim
+FROM debian:bookworm-slim
 
 ARG DEB_FILE
 ARG DEB_DEBUG_FILE
@@ -16,7 +16,7 @@ RUN addgroup --gid 10001 --system liquidsoap && \
 
 # For ffmpeg with libfdk-aac
 RUN apt-get update && apt install -y ca-certificates && \
-    echo "deb https://www.deb-multimedia.org trixie main non-free" >> /etc/apt/sources.list && \
+    echo "deb https://www.deb-multimedia.org bookworm main non-free" >> /etc/apt/sources.list && \
     apt-get update -oAcquire::AllowInsecureRepositories=true && \
     apt-get install -y --allow-unauthenticated deb-multimedia-keyring
 

--- a/.github/scripts/build-details.sh
+++ b/.github/scripts/build-details.sh
@@ -22,9 +22,9 @@ if [[ "${IS_FORK}" != "true" && ("${BRANCH}" =~ ^rolling-release\-v[0-9]\.[0-9]\
   IS_RELEASE=true
 
   echo "Building on all architectures"
-  BUILD_OS='["debian_trixie", "debian_bookworm", "debian_bullseye", "ubuntu_jammy", "ubuntu_noble", "alpine"]'
+  BUILD_OS='["debian_trixie", "debian_bookworm", "debian_bullseye", "ubuntu_oracular", "ubuntu_noble", "alpine"]'
   BUILD_PLATFORM='["amd64", "arm64", "armhf"]'
-  BUILD_INCLUDE='[{"platform": "amd64", "runs-on": "ubuntu-latest", "alpine-arch": "x86_64", "docker-platform": "linux/amd64", "docker-debian-os": "trixie"}, {"platform": "arm64", "runs-on": ["self-hosted", "build"], "alpine-arch": "aarch64", "docker-platform": "linux/arm64", "docker-debian-os": "trixie"}, {"platform": "armhf", "runs-on": ["self-hosted", "build"], "alpine-arch": "armv7", "docker-platform": "linux/arm/v7", "docker-debian-os": "bullseye"}]'
+  BUILD_INCLUDE='[{"platform": "amd64", "runs-on": "ubuntu-latest", "alpine-arch": "x86_64", "docker-platform": "linux/amd64", "docker-debian-os": "bookworm"}, {"platform": "arm64", "runs-on": ["self-hosted", "build"], "alpine-arch": "aarch64", "docker-platform": "linux/arm64", "docker-debian-os": "bookworm"}, {"platform": "armhf", "runs-on": ["self-hosted", "build"], "alpine-arch": "armv7", "docker-platform": "linux/arm/v7", "docker-debian-os": "bullseye"}]'
 
   echo "Branch has a docker release"
   DOCKER_RELEASE=true
@@ -33,9 +33,9 @@ else
   IS_RELEASE=
 
   echo "Building on amd64 only"
-  BUILD_OS='["debian_trixie", "debian_bookworm", "ubuntu_jammy", "ubuntu_noble", "alpine"]'
+  BUILD_OS='["debian_trixie", "debian_bookworm", "ubuntu_oracular", "ubuntu_noble", "alpine"]'
   BUILD_PLATFORM='["amd64"]'
-  BUILD_INCLUDE='[{"platform": "amd64", "runs-on": "ubuntu-latest", "alpine-arch": "x86_64", "docker-platform": "linux/amd64", "docker-debian-os": "trixie"}]'
+  BUILD_INCLUDE='[{"platform": "amd64", "runs-on": "ubuntu-latest", "alpine-arch": "x86_64", "docker-platform": "linux/amd64", "docker-debian-os": "bookworm"}]'
 
   echo "Branch does not have a docker release"
   DOCKER_RELEASE=

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -378,7 +378,7 @@ jobs:
             platform: armhf
           - os: debian_trixie
             platform: armhf
-          - os: ubuntu_jammy
+          - os: ubuntu_oracular
             platform: armhf
           - os: ubuntu_noble
             platform: armhf

--- a/src/core/builtins/builtins_ffmpeg_encoder.ml
+++ b/src/core/builtins/builtins_ffmpeg_encoder.ml
@@ -76,7 +76,7 @@ let encode_audio_frame ~source_idx ~type_t ~mode ~opts ?codec ~format
 
           let encoder =
             Avcodec.Audio.create_encoder ~opts
-              ~channel_layout:target_channel_layout ~channels:target_channels
+              ~channel_layout:target_channel_layout
               ~sample_format:target_sample_format ~sample_rate:target_samplerate
               ~time_base:target_time_base codec
           in

--- a/src/core/decoder/ffmpeg_internal_decoder.ml
+++ b/src/core/decoder/ffmpeg_internal_decoder.ml
@@ -104,7 +104,9 @@ let mk_audio_decoder ~channels ~stream ~field ~pcm_kind codec =
         in
         if
           !in_sample_rate <> frame_in_sample_rate
-          || !in_channel_layout <> frame_in_channel_layout
+          || (not
+                (Avutil.Channel_layout.compare !in_channel_layout
+                   frame_in_channel_layout))
           || !in_sample_format <> frame_in_sample_format
         then (
           log#important "Frame format change detected!";

--- a/src/core/encoder/encoders/ffmpeg_encoder_common.ml
+++ b/src/core/encoder/encoders/ffmpeg_encoder_common.ml
@@ -115,7 +115,8 @@ let convert_options opts =
     | `String fmt -> `Int Avutil.Sample_format.(get_id (find fmt))
     | _ -> assert false);
   convert "channel_layout" (function
-    | `String layout -> `Int64 Avutil.Channel_layout.(get_id (find layout))
+    | `String layout ->
+        `String Avutil.Channel_layout.(get_description (find layout))
     | _ -> assert false)
 
 let encoder ~pos ~on_keyframe ~keyframes ~mk_streams ffmpeg meta =

--- a/src/core/encoder/encoders/ffmpeg_internal_encoder.ml
+++ b/src/core/encoder/encoders/ffmpeg_internal_encoder.ml
@@ -194,7 +194,9 @@ let mk_audio ~pos ~on_keyframe ~mode ~codec ~params ~options ~field output =
               let f =
                 if
                   src_samplerate <> target_samplerate
-                  || src_channel_layout <> target_channel_layout
+                  || (not
+                        (Avutil.Channel_layout.compare src_channel_layout
+                           target_channel_layout))
                   || src_sample_format <> target_sample_format
                 then (
                   let fn =

--- a/src/core/encoder/encoders/ffmpeg_internal_encoder.ml
+++ b/src/core/encoder/encoders/ffmpeg_internal_encoder.ml
@@ -35,10 +35,10 @@ module type InternalResampler_type = sig
 
   val create :
     ?options:Swresample.options list ->
-    Avutil__Channel_layout.t ->
+    Avutil.Channel_layout.t ->
     ?in_sample_format:Avutil__Sample_format.t ->
     int ->
-    Avutil__Channel_layout.t ->
+    Avutil.Channel_layout.t ->
     ?out_sample_format:Avutil__Sample_format.t ->
     int ->
     t

--- a/src/core/stream/content.mli
+++ b/src/core/stream/content.mli
@@ -220,5 +220,10 @@ module Track_marks : sig
 end
 
 (* Some tools *)
-val merge_param : name:string -> 'a option * 'a option -> 'a option
+val merge_param :
+  ?compare:('a -> 'a -> bool) ->
+  name:string ->
+  'a option * 'a option ->
+  'a option
+
 val print_optional : (string * string option) list -> string

--- a/src/core/stream/content_base.ml
+++ b/src/core/stream/content_base.ml
@@ -39,10 +39,10 @@ module Contents = struct
     !_type
 end
 
-let merge_param ~name = function
+let merge_param ?(compare = fun x x' -> x = x') ~name = function
   | None, None -> None
   | None, Some p | Some p, None -> Some p
-  | Some p, Some p' when p = p' -> Some p
+  | Some p, Some p' when compare p p' -> Some p
   | _ -> failwith ("Incompatible " ^ name)
 
 let print_optional l =

--- a/src/core/stream/ffmpeg_copy_content.ml
+++ b/src/core/stream/ffmpeg_copy_content.ml
@@ -120,7 +120,9 @@ module Specs = struct
       | Some (`Audio p), Some (`Audio p') ->
           Audio.get_params_id p = Audio.get_params_id p'
           && (conf_ffmpeg_copy_relaxed#get
-             || Audio.get_channel_layout p = Audio.get_channel_layout p'
+             || Avutil.Channel_layout.compare
+                  (Audio.get_channel_layout p)
+                  (Audio.get_channel_layout p')
                 && Audio.get_sample_format p = Audio.get_sample_format p'
                 && Audio.get_sample_rate p = Audio.get_sample_rate p')
       | Some (`Video p), Some (`Video p') ->

--- a/src/core/stream/ffmpeg_raw_content.ml
+++ b/src/core/stream/ffmpeg_raw_content.ml
@@ -81,9 +81,7 @@ module AudioSpecs = struct
     Content.print_optional
       [
         ( "channel_layout",
-          Option.map
-            (Channel_layout.get_description ?channels:None)
-            channel_layout );
+          Option.map Channel_layout.get_description channel_layout );
         ( "sample_format",
           Option.map
             (fun p ->
@@ -118,15 +116,20 @@ module AudioSpecs = struct
       | _ -> None
 
   let compatible p p' =
-    let c = function None, _ | _, None -> true | Some p, Some p' -> p = p' in
-    c (p.channel_layout, p'.channel_layout)
+    let c ?(compare = fun x x' -> x = x') = function
+      | None, _ | _, None -> true
+      | Some p, Some p' -> compare p p'
+    in
+    c ~compare:Avutil.Channel_layout.compare
+      (p.channel_layout, p'.channel_layout)
     && c (p.sample_format, p'.sample_format)
     && c (p.sample_rate, p'.sample_rate)
 
   let merge p p' =
     {
       channel_layout =
-        Content.merge_param ~name:"channel_layout"
+        Content.merge_param ~compare:Avutil.Channel_layout.compare
+          ~name:"channel_layout"
           (p.channel_layout, p'.channel_layout);
       sample_format =
         Content.merge_param ~name:"sample_format"

--- a/tests/media/dune.inc
+++ b/tests/media/dune.inc
@@ -1503,7 +1503,7 @@
   (:test_liq ../test.liq)
   (:run_test ../run_test.exe))
  (action
-  (run %{run_test} "FFmpeg raw decoder test test for @ffmpeg[format='mp4',@audio[codec='aac',channels=1],@video[codec='libx264']].mp4" liquidsoap %{test_liq} ffmpeg_raw_decoder.liq -- "@ffmpeg[format='mp4',@audio[codec='aac',channels=1],@video[codec='libx264']].mp4")))
+  (run %{run_test} "FFmpeg raw decoder test for @ffmpeg[format='mp4',@audio[codec='aac',channels=1],@video[codec='libx264']].mp4" liquidsoap %{test_liq} ffmpeg_raw_decoder.liq -- "@ffmpeg[format='mp4',@audio[codec='aac',channels=1],@video[codec='libx264']].mp4")))
 (rule
  (alias mediatest)
  (package liquidsoap)
@@ -1607,7 +1607,7 @@
   (:test_liq ../test.liq)
   (:run_test ../run_test.exe))
  (action
-  (run %{run_test} "FFmpeg raw decoder test test for @ffmpeg[format='mp4',@audio[codec='aac',channels=2],@video[codec='libx264']].mp4" liquidsoap %{test_liq} ffmpeg_raw_decoder.liq -- "@ffmpeg[format='mp4',@audio[codec='aac',channels=2],@video[codec='libx264']].mp4")))
+  (run %{run_test} "FFmpeg raw decoder test for @ffmpeg[format='mp4',@audio[codec='aac',channels=2],@video[codec='libx264']].mp4" liquidsoap %{test_liq} ffmpeg_raw_decoder.liq -- "@ffmpeg[format='mp4',@audio[codec='aac',channels=2],@video[codec='libx264']].mp4")))
 (rule
  (alias mediatest)
  (package liquidsoap)
@@ -1711,7 +1711,7 @@
   (:test_liq ../test.liq)
   (:run_test ../run_test.exe))
  (action
-  (run %{run_test} "FFmpeg raw decoder test test for @ffmpeg[format='mp4',@audio[codec='aac',channels=2],@video[codec='libx264',r=12]].mp4" liquidsoap %{test_liq} ffmpeg_raw_decoder.liq -- "@ffmpeg[format='mp4',@audio[codec='aac',channels=2],@video[codec='libx264',r=12]].mp4")))
+  (run %{run_test} "FFmpeg raw decoder test for @ffmpeg[format='mp4',@audio[codec='aac',channels=2],@video[codec='libx264',r=12]].mp4" liquidsoap %{test_liq} ffmpeg_raw_decoder.liq -- "@ffmpeg[format='mp4',@audio[codec='aac',channels=2],@video[codec='libx264',r=12]].mp4")))
 (rule
  (alias mediatest)
  (package liquidsoap)

--- a/tests/media/gen_dune.ml
+++ b/tests/media/gen_dune.ml
@@ -18,7 +18,7 @@ let audio_video_decoding_tests =
     ("FFmpeg copy+encode decode", "ffmpeg_copy_and_encode_decoder.liq");
     ("FFmpeg filter", "ffmpeg_filter.liq");
     ("FFmpeg bitstream filter", "ffmpeg_bitstream_filter.liq");
-    ("FFmpeg raw decoder test", "ffmpeg_raw_decoder.liq");
+    ("FFmpeg raw decoder", "ffmpeg_raw_decoder.liq");
     ("FFmpeg raw+encode decoder", "ffmpeg_raw_and_encode_decoder.liq");
     ("FFmpeg raw+copy decoder", "ffmpeg_raw_and_copy_decoder.liq");
   ]


### PR DESCRIPTION
This PR switches to the new ffmpeg channel API.

It is a breaking change from the build perspective but shouldn't break anything from the user side.

It is required because ffmpeg has picked up the dev pace, which is great, but is also now moving fast with new API. `6.x` has a backward compatible API for channels but `7.0` was just released without it and, soon, most recent platform/OS will only ship `7.0` so we have to move on with it.

On the plus side, our `ffmpeg` binding now compiles without a single warning!

On the down side, this forces the use of backports for OS/platforms that do not yet have at least ffmpeg `6.0`. This is the case for debian `bookworm` which will now build and ship packages relying on [deb-multimedia.org](https://www.deb-multimedia.org/) to get a recent ffmpeg version.

Likewise, the ubuntu platforms are bumped to `noble` (latest LTS) and `oracular` (latest release).