### PR TITLE
[2.2] feat: Add `forced_major_collections` back to the GC stat record

### DIFF
--- a/src/core/builtins/builtins_runtime.ml
+++ b/src/core/builtins/builtins_runtime.ml
@@ -74,6 +74,7 @@ let _ =
         ("major_words", Lang.float_t);
         ("minor_collections", Lang.int_t);
         ("major_collections", Lang.int_t);
+        ("forced_major_collections", Lang.int_t);
         ("heap_words", Lang.int_t);
         ("heap_chunks", Lang.int_t);
         ("live_words", Lang.int_t);
@@ -94,6 +95,7 @@ let _ =
         major_words;
         minor_collections;
         major_collections;
+        forced_major_collections;
         heap_words;
         heap_chunks;
         live_words;
@@ -113,6 +115,7 @@ let _ =
         ("major_words", Lang.float major_words);
         ("minor_collections", Lang.int minor_collections);
         ("major_collections", Lang.int major_collections);
+        ("forced_major_collections", Lang.int forced_major_collections);
         ("heap_words", Lang.int heap_words);
         ("heap_chunks", Lang.int heap_chunks);
         ("live_words", Lang.int live_words);


### PR DESCRIPTION
## Summary
This commit adds `forced_major_collections` back to the `runtime.gc.stat()` and `runtime.gc.quick_stat()` results because the minimum required ocaml version is 4.14.
It was removed in 889cc4f8 to be compatible with ocaml 4.08.

Backport of #3783.