### PR TITLE
chore(readme): Change badges in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,11 @@ tradition of simple strong components working together.
 
 Copyright 2003-2024 Savonet team
 
-[![GPL license](https://img.shields.io/badge/License-GPL-green.svg)](https://github.com/savonet/liquidsoap/blob/master/COPYING)
+[![GPL license](https://img.shields.io/github/license/savonet/liquidsoap)](https://github.com/savonet/liquidsoap/blob/master/COPYING)
 ![CI](https://github.com/savonet/liquidsoap/workflows/CI/badge.svg)
 [![GitHub release](https://img.shields.io/github/release/savonet/liquidsoap.svg)](https://GitHub.com/savonet/liquidsoap/releases/)
-[![Install with Opam !](https://img.shields.io/badge/Install%20with-Opam-1abc9c.svg)](http://opam.ocaml.org/packages/liquidsoap/)
-[![Chat on slack !](https://img.shields.io/badge/Chat%20on-Discogs-1a1f9c.svg)](http://chat.liquidsoap.info/)
+[![Install with Opam!](https://img.shields.io/badge/Install%20with-Opam-1abc9c.svg)](http://opam.ocaml.org/packages/liquidsoap/)
+[![Chat on Discord!](https://img.shields.io/badge/Chat%20on-Discord-5865f2.svg)](http://chat.liquidsoap.info/)
 
 |                           |                                                                         |
 | ------------------------- | ----------------------------------------------------------------------- |


### PR DESCRIPTION
## Summary
- Use the license badge, which will automatically retrieve the correct license version from the GitHub repository.
  ![GPL license](https://img.shields.io/github/license/savonet/liquidsoap)
- Replace Discogs with Discord and use the branding color for the badge.
  ![Chat on Discord!](https://img.shields.io/badge/Chat%20on-Discord-5865f2.svg)

## Additionally

I don't like discord because of its invasive paranoia and lack of anonymous read-only mode, but it is possible to track the number of members in bagde: https://shields.io/badges/discord.
Something like this ![Discord](https://img.shields.io/discord/102860784329052160).
