### PR TITLE
refactor(prometheus): Change prometheus port

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -54,6 +54,7 @@ Changed:
 - Added `parents` option of `file.mkdir` (#3600, #3601).
 - Added `forced_major_collections` record field to the result of `runtime.gc.stat()` and
   `runtime.gc.quick_stat()` (#3783).
+- Changed the port for the built-in Prometheus exporter to `9599` (#3801).
 
 ---
 

--- a/doc/content/liq/prometheus-settings.liq
+++ b/doc/content/liq/prometheus-settings.liq
@@ -1,3 +1,3 @@
 # Prometheus settings
 settings.prometheus.server := true
-settings.prometheus.server.port := 9090
+settings.prometheus.server.port := 9599

--- a/doc/content/migrating.md
+++ b/doc/content/migrating.md
@@ -60,6 +60,11 @@ end
 unwanted requests before consuming process time. If you need to see the request's metadata or if the request resolves
 into a valid tile, however, you might need to call `request.resolve` inside your `check_next` script.
 
+### Prometheus
+
+The default port for the Prometheus metrics exporter has changed from `9090` to `9599`.
+As before, you can change it with `settings.prometheus.server.port := <your port value>`.
+
 ## From 2.1.x to 2.2.x
 
 ### References

--- a/src/core/tools/liq_prometheus.ml
+++ b/src/core/tools/liq_prometheus.ml
@@ -37,7 +37,7 @@ let conf_server =
     ~d:false "Enable the prometheus server."
 
 let conf_port =
-  Dtools.Conf.int ~p:(conf_server#plug "port") ~d:9090
+  Dtools.Conf.int ~p:(conf_server#plug "port") ~d:9599
     "Port to run the server on."
 
 let server () =


### PR DESCRIPTION
## Summary

It's good practice to allocate a specific port for each individual Prometheus metrics exporter.
This commit changes port `9090`, which is used by the prometheus server itself, to `9599`, which is used by an unavailable https://github.com/marco-m/pirograph exporter.

After merging this PR, the next step will be to change the wiki page https://github.com/prometheus/prometheus/wiki/Default-port-allocations.
## Additional
#3772