### PR TITLE
Abstract lazy

### DIFF
--- a/src/core/encoder/encoder.ml
+++ b/src/core/encoder/encoder.ml
@@ -97,7 +97,7 @@ let type_of_format f =
                     let params =
                       {
                         Content.Audio.channel_layout =
-                          lazy
+                          Lazy.from_val
                             (Audio_converter.Channel_layout.layout_of_channels
                                channels);
                       }

--- a/src/core/encoder/encoder_utils.ml
+++ b/src/core/encoder/encoder_utils.ml
@@ -24,9 +24,9 @@
 let render_mpeg2_timestamp =
   let mpeg2_timestamp_unit = 90000. in
   let frame_len =
-    lazy
-      (Int64.of_float
-         (Frame.seconds_of_main (Lazy.force Frame.size) *. mpeg2_timestamp_unit))
+    Lazy.from_fun (fun () ->
+        Int64.of_float
+          (Frame.seconds_of_main (Lazy.force Frame.size) *. mpeg2_timestamp_unit))
   in
   fun ~frame_position ~sample_position () ->
     let buf = Buffer.create 10 in

--- a/src/core/encoder/lang/lang_fdkaac.ml
+++ b/src/core/encoder/lang/lang_fdkaac.ml
@@ -45,15 +45,15 @@ let make params =
     ]
   in
   let check_samplerate ~pos i =
-    lazy
-      (let i = Lazy.force i in
-       if not (List.mem i valid_samplerates) then (
-         let err =
-           Printf.sprintf "invalid samplerate value. Possible values: %s"
-             (String.concat ", " (List.map string_of_int valid_samplerates))
-         in
-         Lang_encoder.raise_error ~pos err);
-       i)
+    Lazy.from_fun (fun () ->
+        let i = Lazy.force i in
+        if not (List.mem i valid_samplerates) then (
+          let err =
+            Printf.sprintf "invalid samplerate value. Possible values: %s"
+              (String.concat ", " (List.map string_of_int valid_samplerates))
+          in
+          Lang_encoder.raise_error ~pos err);
+        i)
   in
   let defaults =
     {

--- a/src/core/encoder/lang/lang_mp3.ml
+++ b/src/core/encoder/lang/lang_mp3.ml
@@ -33,14 +33,14 @@ let allowed_bitrates =
   ]
 
 let check_samplerate ~pos i =
-  lazy
-    (let i = Lazy.force i in
-     let allowed =
-       [8000; 11025; 12000; 16000; 22050; 24000; 32000; 44100; 48000]
-     in
-     if not (List.mem i allowed) then
-       Lang_encoder.raise_error ~pos "invalid samplerate value";
-     i)
+  Lazy.from_fun (fun () ->
+      let i = Lazy.force i in
+      let allowed =
+        [8000; 11025; 12000; 16000; 22050; 24000; 32000; 44100; 48000]
+      in
+      if not (List.mem i allowed) then
+        Lang_encoder.raise_error ~pos "invalid samplerate value";
+      i)
 
 let mp3_base_defaults () =
   {

--- a/src/core/encoder/lang/lang_theora.ml
+++ b/src/core/encoder/lang/lang_theora.ml
@@ -60,25 +60,33 @@ let make params =
           if i mod 16 <> 0 || i >= 1048576 then
             Lang_encoder.raise_error ~pos
               "invalid frame width value (should be a multiple of 16)";
-          { f with Theora_format.width = lazy i; picture_width = lazy i }
+          {
+            f with
+            Theora_format.width = Lazy.from_val i;
+            picture_width = Lazy.from_val i;
+          }
       | `Labelled ("height", { value = Ground (Int i); pos }) ->
           (* According to the doc: must be a multiple of 16, and less than 1048576. *)
           if i mod 16 <> 0 || i >= 1048576 then
             Lang_encoder.raise_error ~pos
               "invalid frame height value (should be a multiple of 16)";
-          { f with Theora_format.height = lazy i; picture_height = lazy i }
+          {
+            f with
+            Theora_format.height = Lazy.from_val i;
+            picture_height = Lazy.from_val i;
+          }
       | `Labelled ("picture_width", { value = Ground (Int i); pos }) ->
           (* According to the doc: must not be larger than width. *)
           if i > Lazy.force f.Theora_format.width then
             Lang_encoder.raise_error ~pos
               "picture width must not be larger than width";
-          { f with Theora_format.picture_width = lazy i }
+          { f with Theora_format.picture_width = Lazy.from_val i }
       | `Labelled ("picture_height", { value = Ground (Int i); pos }) ->
           (* According to the doc: must not be larger than height. *)
           if i > Lazy.force f.Theora_format.height then
             Lang_encoder.raise_error ~pos
               "picture height must not be larger than height";
-          { f with Theora_format.picture_height = lazy i }
+          { f with Theora_format.picture_height = Lazy.from_val i }
       | `Labelled ("picture_x", { value = Ground (Int i); pos }) ->
           (* According to the doc: must be no larger than width-picture_width
            * or 255, whichever is smaller. *)

--- a/src/core/harbor/harbor.ml
+++ b/src/core/harbor/harbor.ml
@@ -792,7 +792,10 @@ module Make (T : Transport_t) : T with type socket = T.socket = struct
     let { handler; _ } = find_handler port in
     let f (verb, regex, handler) =
       let rex = regex.Liquidsoap_lang.Builtins_regexp.regexp in
-      let sub = lazy (try Some (Re.Pcre.exec ~rex base_uri) with _ -> None) in
+      let sub =
+        Lazy.from_fun (fun () ->
+            try Some (Re.Pcre.exec ~rex base_uri) with _ -> None)
+      in
       if (verb :> verb) = hmethod && Lazy.force sub <> None then (
         let sub = Option.get (Lazy.force sub) in
         let groups =

--- a/src/core/lang.mli
+++ b/src/core/lang.mli
@@ -58,7 +58,7 @@ type value = Liquidsoap_lang.Value.t = {
 }
 
 and env = (string * value) list
-and lazy_env = (string * value Lazy.t) list
+and lazy_env = (string * value Stdlib.Lazy.t) list
 
 and ffi = Liquidsoap_lang.Value.ffi = {
   ffi_args : (string * string * value option) list;

--- a/src/core/lang_source.ml
+++ b/src/core/lang_source.ml
@@ -680,8 +680,8 @@ let iter_sources ?(on_imprecise = fun () -> ()) f v =
               (* TODO since inner-bound variables don't mask outer ones in [env],
                *   we are actually checking values that may be out of reach. *)
               let v = List.assoc v env in
-              if Lazy.is_val v then (
-                let v = Lazy.force v in
+              if Stdlib.Lazy.is_val v then (
+                let v = Stdlib.Lazy.force v in
                 iter_value v)
               else ()
             with Not_found -> ())

--- a/src/core/operators/stereotool_op.ml
+++ b/src/core/operators/stereotool_op.ml
@@ -33,22 +33,22 @@ class stereotool ~field ~handler source =
     inherit Source.operator ~name:"stereotool" [source]
 
     val config =
-      lazy
-        ((* This is computed first to inject some audio data. *)
-         let latency =
-           Frame.seconds_of_audio
-             (Stereotool.latency
-                ~samplerate:(Lazy.force Frame.audio_rate)
-                ~feed_silence:true handler)
-         in
-         {
-           unlincensed_used_features =
-             Stereotool.unlincensed_used_features handler;
-           valid_license = Stereotool.valid_license handler;
-           latency;
-           api_version = Stereotool.api_version handler;
-           software_version = Stereotool.software_version handler;
-         })
+      Lazy.from_fun (fun () ->
+          (* This is computed first to inject some audio data. *)
+          let latency =
+            Frame.seconds_of_audio
+              (Stereotool.latency
+                 ~samplerate:(Lazy.force Frame.audio_rate)
+                 ~feed_silence:true handler)
+          in
+          {
+            unlincensed_used_features =
+              Stereotool.unlincensed_used_features handler;
+            valid_license = Stereotool.valid_license handler;
+            latency;
+            api_version = Stereotool.api_version handler;
+            software_version = Stereotool.software_version handler;
+          })
 
     method config = Lazy.force config
 

--- a/src/core/operators/switch.ml
+++ b/src/core/operators/switch.ml
@@ -80,7 +80,7 @@ class switch ~all_predicates ~override_meta ~transition_length ~replay_meta
       (List.map (fun c -> c.transition) cases)
   in
   let self_sync_type =
-    if !failed then lazy `Dynamic else Utils.self_sync_type !sources
+    if !failed then Lazy.from_val `Dynamic else Utils.self_sync_type !sources
   in
   object (self)
     inherit operator ~name:"switch" (List.map (fun x -> x.source) cases)

--- a/src/core/operators/time_warp.ml
+++ b/src/core/operators/time_warp.ml
@@ -115,7 +115,8 @@ module Buffer = struct
     let control =
       {
         generator =
-          lazy (Generator.create (Lang.to_source source_val)#content_type);
+          Lazy.from_fun (fun () ->
+              Generator.create (Lang.to_source source_val)#content_type);
         lock = Mutex.create ();
         buffering = true;
         abort = false;

--- a/src/core/stream/content.ml
+++ b/src/core/stream/content.ml
@@ -64,7 +64,11 @@ module Video = struct
     lift_data
       {
         length = Frame_settings.main_of_video 1;
-        params = { height = Some (lazy height); width = Some (lazy width) };
+        params =
+          {
+            height = Some (Lazy.from_val height);
+            width = Some (Lazy.from_val width);
+          };
         data = [(0, img)];
       }
 
@@ -98,8 +102,8 @@ module Video = struct
     {
       params =
         {
-          Content_video.Specs.width = Some (lazy width);
-          height = Some (lazy height);
+          Content_video.Specs.width = Some (Lazy.from_val width);
+          height = Some (Lazy.from_val height);
         };
       width;
       height;

--- a/src/core/stream/content_audio.ml
+++ b/src/core/stream/content_audio.ml
@@ -61,9 +61,9 @@ module Specs = struct
   let copy d = Audio.copy d 0 (Audio.length d)
 
   let param_of_channels = function
-    | 1 -> { channel_layout = lazy `Mono }
-    | 2 -> { channel_layout = lazy `Stereo }
-    | 6 -> { channel_layout = lazy `Five_point_one }
+    | 1 -> { channel_layout = Lazy.from_val `Mono }
+    | 2 -> { channel_layout = Lazy.from_val `Stereo }
+    | 6 -> { channel_layout = Lazy.from_val `Five_point_one }
     | _ -> raise Invalid
 
   let channels_of_param = function
@@ -73,9 +73,9 @@ module Specs = struct
 
   let parse_param label value =
     match (label, value) with
-      | "", "mono" -> Some { channel_layout = lazy `Mono }
-      | "", "stereo" -> Some { channel_layout = lazy `Stereo }
-      | "", "5.1" -> Some { channel_layout = lazy `Five_point_one }
+      | "", "mono" -> Some { channel_layout = Lazy.from_val `Mono }
+      | "", "stereo" -> Some { channel_layout = Lazy.from_val `Stereo }
+      | "", "5.1" -> Some { channel_layout = Lazy.from_val `Five_point_one }
       | _ -> None
 
   let params d = param_of_channels (Array.length d)
@@ -102,9 +102,9 @@ include MkContentBase (Specs)
 let kind = lift_kind `Pcm
 
 let format_of_channels = function
-  | 1 -> lift_params { channel_layout = lazy `Mono }
-  | 2 -> lift_params { channel_layout = lazy `Stereo }
-  | 6 -> lift_params { channel_layout = lazy `Five_point_one }
+  | 1 -> lift_params { channel_layout = Lazy.from_val `Mono }
+  | 2 -> lift_params { channel_layout = Lazy.from_val `Stereo }
+  | 6 -> lift_params { channel_layout = Lazy.from_val `Five_point_one }
   | _ -> raise Invalid
 
 let channels_of_format p =

--- a/src/core/stream/content_video.ml
+++ b/src/core/stream/content_video.ml
@@ -107,9 +107,17 @@ module Specs = struct
   let parse_param label value =
     match label with
       | "width" ->
-          Some { width = Some (lazy (int_of_string value)); height = None }
+          Some
+            {
+              width = Some (Lazy.from_val (int_of_string value));
+              height = None;
+            }
       | "height" ->
-          Some { width = None; height = Some (lazy (int_of_string value)) }
+          Some
+            {
+              width = None;
+              height = Some (Lazy.from_val (int_of_string value));
+            }
       | _ -> None
 
   let merge p p' =
@@ -164,8 +172,8 @@ let lift_canvas ?(offset = 0) ?length data =
       | [] -> { Specs.width = None; height = None }
       | (_, i) :: _ ->
           {
-            Specs.width = Some (lazy (Video.Canvas.Image.width i));
-            height = Some (lazy (Video.Canvas.Image.height i));
+            Specs.width = Some (Lazy.from_val (Video.Canvas.Image.width i));
+            height = Some (Lazy.from_val (Video.Canvas.Image.height i));
           }
   in
   let length =

--- a/src/core/stream/frame_base.ml
+++ b/src/core/stream/frame_base.ml
@@ -122,7 +122,7 @@ let format_of_channels ~pcm_kind n =
   audio_format ~pcm_kind
     {
       Content_audio.Specs.channel_layout =
-        lazy (Audio_converter.Channel_layout.layout_of_channels n);
+        Lazy.from_val (Audio_converter.Channel_layout.layout_of_channels n);
     }
 
 let add_timed_content ?length content =

--- a/src/core/stream/frame_settings.ml
+++ b/src/core/stream/frame_settings.ml
@@ -110,7 +110,7 @@ let lazy_config_eval = ref false
 let delayed_eval = Queue.create ()
 
 let delayed f =
-  let ret = lazy (f ()) in
+  let ret = Lazy.from_fun f in
   Queue.push (fun () -> ignore (Lazy.force ret)) delayed_eval;
   ret
 

--- a/src/core/tools/sandbox.ml
+++ b/src/core/tools/sandbox.ml
@@ -84,7 +84,8 @@ let conf_shell_path =
      otherwise."
 
 let has_binary =
-  lazy (Utils.which_opt ~path:(Configure.path ()) conf_binary#get <> None)
+  Lazy.from_fun (fun () ->
+      Utils.which_opt ~path:(Configure.path ()) conf_binary#get <> None)
 
 let () =
   Lifecycle.before_start ~name:"sandbox start" (fun () ->

--- a/src/core/tools/tutils.ml
+++ b/src/core/tools/tutils.ml
@@ -387,18 +387,6 @@ let cleanup () =
   join_all ();
   log#important "Main threads terminated."
 
-(** Thread-safe lazy cell. *)
-let lazy_cell f =
-  let lock = Mutex.create () in
-  let c = ref None in
-  mutexify lock (fun () ->
-      match !c with
-        | Some v -> v
-        | None ->
-            let v = f () in
-            c := Some v;
-            v)
-
 let write_all ?timeout fd b =
   let rec f ofs len =
     (match timeout with

--- a/src/core/tools/tutils.mli
+++ b/src/core/tools/tutils.mli
@@ -89,7 +89,4 @@ val wait_for : ?log:(string -> unit) -> event -> float -> unit
   * This is meant to be used for assertions. *)
 val seems_locked : Mutex.t -> bool
 
-(** Thread-safe equivalent to Lazy.from_fun. *)
-val lazy_cell : (unit -> 'a) -> unit -> 'a
-
 val write_all : ?timeout:float -> Unix.file_descr -> bytes -> unit

--- a/src/core/tools/utils.ml
+++ b/src/core/tools/utils.ml
@@ -432,9 +432,9 @@ let string_of_size n =
   else Printf.sprintf "%.02f GiB" (float_of_int n /. float_of_int (1 lsl 30))
 
 let self_sync_type sources =
-  lazy
-    (if List.exists (fun s -> fst s#self_sync = `Dynamic) sources then `Dynamic
-     else `Static)
+  Lazy.from_fun (fun () ->
+      if List.exists (fun s -> fst s#self_sync = `Dynamic) sources then `Dynamic
+      else `Static)
 
 let self_sync sources =
   let self_sync_type = self_sync_type sources in
@@ -596,6 +596,6 @@ let id3v2_of_metadata ~version m =
   Metadata.ID3v2.make ~version frames
 
 let is_docker =
-  lazy
-    (Sys.unix
-    && Sys.command "grep 'docker\\|lxc' /proc/1/cgroup >/dev/null 2>&1" = 0)
+  Lazy.from_fun (fun () ->
+      Sys.unix
+      && Sys.command "grep 'docker\\|lxc' /proc/1/cgroup >/dev/null 2>&1" = 0)

--- a/src/core/types/format_type.ml
+++ b/src/core/types/format_type.ml
@@ -310,7 +310,8 @@ let audio_n ?(pcm_kind = Content_audio.kind) n =
          (Frame_base.audio_format ~pcm_kind
             {
               channel_layout =
-                lazy (Audio_converter.Channel_layout.layout_of_channels n);
+                Lazy.from_val
+                  (Audio_converter.Channel_layout.layout_of_channels n);
             })))
 
 let audio_mono ?pcm_kind () = audio_n ?pcm_kind 1

--- a/src/runtime/main.ml
+++ b/src/runtime/main.ml
@@ -93,7 +93,7 @@ let load_libs =
   Lifecycle.load ();
   (* Register settings module. Needs to be done last to make sure every
      dependent OCaml module has been linked. *)
-  Lazy.force Builtins_settings.settings_module;
+  Stdlib.Lazy.force Builtins_settings.settings_module;
   let loaded = ref false in
   fun () ->
     if !stdlib && not !loaded then (

--- a/tests/core/decoder_test.ml
+++ b/tests/core/decoder_test.ml
@@ -4,14 +4,17 @@ let () =
 
 let () =
   let mono =
-    Content.(Audio.lift_params { Content.Audio.channel_layout = lazy `Mono })
+    Content.(
+      Audio.lift_params { Content.Audio.channel_layout = Lazy.from_val `Mono })
   in
   let stereo =
-    Content.(Audio.lift_params { Content.Audio.channel_layout = lazy `Stereo })
+    Content.(
+      Audio.lift_params { Content.Audio.channel_layout = Lazy.from_val `Stereo })
   in
   let five_point_one =
     Content.(
-      Audio.lift_params { Content.Audio.channel_layout = lazy `Five_point_one })
+      Audio.lift_params
+        { Content.Audio.channel_layout = Lazy.from_val `Five_point_one })
   in
   let canvas = Content.default_format Content_video.kind in
   let midi = Content.(Midi.lift_params { Content.Midi.channels = 1 }) in


### PR DESCRIPTION
This is a preliminary PR for the switch to concurrent clocks that abstracts away all the lazy calls so that the main module can be later switched to a concurrent implementation.