### PR TITLE
Factor out mutexify.

### DIFF
--- a/src/core/builtins/builtins_files.ml
+++ b/src/core/builtins/builtins_files.ml
@@ -657,13 +657,13 @@ let () =
   if not Sys.win32 then (
     let umask_m = Mutex.create () in
     let get_umask =
-      Tutils.mutexify umask_m (fun () ->
+      Mutex.mutexify umask_m (fun () ->
           let umask = Unix.umask 0 in
           ignore (Unix.umask umask);
           umask)
     in
     let set_umask =
-      Tutils.mutexify umask_m (fun umask -> ignore (Unix.umask umask))
+      Mutex.mutexify umask_m (fun umask -> ignore (Unix.umask umask))
     in
     let umask =
       Lang.add_builtin ~base:file "umask" ~category:`File

--- a/src/core/builtins/builtins_lo.ml
+++ b/src/core/builtins/builtins_lo.ml
@@ -95,13 +95,13 @@ let start_server () =
 
 let () =
   Lifecycle.on_start ~name:"lo initialization"
-    (Tutils.mutexify started_m (fun () ->
+    (Mutex.mutexify started_m (fun () ->
          if !should_start && !server = None then start_server ()
          else started := true))
 
 let () =
   Lifecycle.on_core_shutdown ~name:"lo shutdown"
-    (Tutils.mutexify started_m (fun () ->
+    (Mutex.mutexify started_m (fun () ->
          match !server with
            | Some s ->
                log#info "Stopping OSC server";
@@ -110,7 +110,7 @@ let () =
            | None -> ()))
 
 let start_server =
-  Tutils.mutexify started_m (fun () ->
+  Mutex.mutexify started_m (fun () ->
       if !started && !server = None then start_server ()
       else should_start := true)
 

--- a/src/core/builtins/builtins_osc.ml
+++ b/src/core/builtins/builtins_osc.ml
@@ -93,13 +93,13 @@ let start_server () =
 
 let () =
   Lifecycle.on_start ~name:"osc initialization"
-    (Tutils.mutexify started_m (fun () ->
+    (Mutex.mutexify started_m (fun () ->
          if !should_start && !server = None then start_server ()
          else started := true))
 
 let () =
   Lifecycle.on_core_shutdown ~name:"osc shutdown"
-    (Tutils.mutexify started_m (fun () ->
+    (Mutex.mutexify started_m (fun () ->
          match !server with
            | Some s ->
                log#info "Stopping OSC server";
@@ -108,7 +108,7 @@ let () =
            | None -> ()))
 
 let start_server =
-  Tutils.mutexify started_m (fun () ->
+  Mutex.mutexify started_m (fun () ->
       if !started && !server = None then start_server ()
       else should_start := true)
 

--- a/src/core/dune
+++ b/src/core/dune
@@ -175,6 +175,7 @@
   mp3_format
   mpd
   ms_stereo
+  mutex
   muxer
   native_audio_converter
   native_video_converter

--- a/src/core/encoder/encoder.ml
+++ b/src/core/encoder/encoder.ml
@@ -351,8 +351,8 @@ let get_factory fmt =
       in
       (* Protect all functions with a mutex. *)
       let m = Mutex.create () in
-      let insert_metadata = Tutils.mutexify m insert_metadata in
-      let header = Tutils.mutexify m header in
+      let insert_metadata = Mutex.mutexify m insert_metadata in
+      let header = Mutex.mutexify m header in
       let {
         init;
         init_encode;
@@ -365,22 +365,22 @@ let get_factory fmt =
         hls
       in
       let init ?id3_enabled ?id3_version () =
-        Tutils.mutexify m (fun () -> init ?id3_enabled ?id3_version ()) ()
+        Mutex.mutexify m (fun () -> init ?id3_enabled ?id3_version ()) ()
       in
       let init_encode frame ofs len =
-        Tutils.mutexify m (fun () -> init_encode frame ofs len) ()
+        Mutex.mutexify m (fun () -> init_encode frame ofs len) ()
       in
       let split_encode frame ofs len =
-        Tutils.mutexify m (fun () -> split_encode frame ofs len) ()
+        Mutex.mutexify m (fun () -> split_encode frame ofs len) ()
       in
-      let codec_attrs = Tutils.mutexify m codec_attrs in
+      let codec_attrs = Mutex.mutexify m codec_attrs in
       let insert_id3 ~frame_position ~sample_position meta =
-        Tutils.mutexify m
+        Mutex.mutexify m
           (fun () -> insert_id3 ~frame_position ~sample_position meta)
           ()
       in
-      let bitrate = Tutils.mutexify m bitrate in
-      let video_size = Tutils.mutexify m video_size in
+      let bitrate = Mutex.mutexify m bitrate in
+      let video_size = Mutex.mutexify m video_size in
       let hls =
         {
           init;
@@ -393,7 +393,7 @@ let get_factory fmt =
         }
       in
       let encode frame ofs len =
-        Tutils.mutexify m (fun () -> encode frame ofs len) ()
+        Mutex.mutexify m (fun () -> encode frame ofs len) ()
       in
-      let stop = Tutils.mutexify m stop in
+      let stop = Mutex.mutexify m stop in
       { insert_metadata; hls; encode; stop; header }

--- a/src/core/encoder/encoders/external_encoder.ml
+++ b/src/core/encoder/encoders/external_encoder.ml
@@ -35,7 +35,7 @@ let encoder id ext =
   let mutex = Mutex.create () in
   let condition = Condition.create () in
   let restart_decision =
-    Tutils.mutexify mutex (fun () ->
+    Mutex.mutexify mutex (fun () ->
         let decision =
           match (!is_metadata_restart, !is_stop) with
             | _, true -> false
@@ -92,7 +92,7 @@ let encoder id ext =
   in
   let log s = log#important "%s" s in
   let on_stdout =
-    Tutils.mutexify mutex (fun puller ->
+    Mutex.mutexify mutex (fun puller ->
         begin
           let len = puller bytes 0 Utils.pagesize in
           match len with
@@ -106,7 +106,7 @@ let encoder id ext =
       ext.process
   in
   let insert_metadata =
-    Tutils.mutexify mutex (fun _ ->
+    Mutex.mutexify mutex (fun _ ->
         if ext.restart = Metadata then (
           is_metadata_restart := true;
           Process_handler.stop process))
@@ -138,7 +138,7 @@ let encoder id ext =
         Audio.S16LE.of_audio b start sbuf 0 len;
         Strings.unsafe_of_bytes sbuf)
     in
-    Tutils.mutexify mutex
+    Mutex.mutexify mutex
       (fun () ->
         try
           Process_handler.on_stdin process (fun push ->
@@ -156,7 +156,7 @@ let encoder id ext =
     Strings.Mutable.flush buf
   in
   let stop =
-    Tutils.mutexify mutex (fun () ->
+    Mutex.mutexify mutex (fun () ->
         is_stop := true;
         Process_handler.stop process;
         Condition.wait condition mutex;

--- a/src/core/encoder/encoders/gstreamer_encoder.ml
+++ b/src/core/encoder/encoders/gstreamer_encoder.ml
@@ -42,8 +42,8 @@ let encoder ext =
   (* Here "samples" are the number of buffers available in the GStreamer
      appsink *)
   let samples = ref 0 in
-  let decr_samples = Tutils.mutexify mutex (fun () -> decr samples) in
-  let incr_samples = Tutils.mutexify mutex (fun () -> incr samples) in
+  let decr_samples = Mutex.mutexify mutex (fun () -> decr samples) in
+  let incr_samples = Mutex.mutexify mutex (fun () -> incr samples) in
   let on_sample () = incr_samples () in
   let gst =
     let pipeline =

--- a/src/core/file_watcher.inotify.ml
+++ b/src/core/file_watcher.inotify.ml
@@ -41,7 +41,7 @@ let m = Mutex.create ()
 let rec watchdog () =
   let fd = Option.get !fd in
   let handler =
-    Tutils.mutexify m (fun _ ->
+    Mutex.mutexify m (fun _ ->
         let events = Inotify.read fd in
         List.iter
           (fun (wd, _, _, _) ->
@@ -56,7 +56,7 @@ let rec watchdog () =
 let watch : watch =
  fun ~pos e file f ->
   if not (Sys.file_exists file) then Lang.raise_error ~pos "not_found";
-  Tutils.mutexify m
+  Mutex.mutexify m
     (fun () ->
       if !fd = None then (
         fd := Some (Inotify.create ());
@@ -76,7 +76,7 @@ let watch : watch =
       let wd = Inotify.add_watch fd file e in
       handlers := (wd, f) :: !handlers;
       let unwatch =
-        Tutils.mutexify m (fun () ->
+        Mutex.mutexify m (fun () ->
             Inotify.rm_watch fd wd;
             handlers := List.remove_assoc wd !handlers)
       in

--- a/src/core/file_watcher.mtime.ml
+++ b/src/core/file_watcher.mtime.ml
@@ -47,7 +47,7 @@ let m = Mutex.create ()
 let file_mtime file = (Unix.stat file).Unix.st_mtime
 
 let rec handler _ =
-  Tutils.mutexify m
+  Mutex.mutexify m
     (fun () ->
       List.iter
         (fun ({ file; callback; mtime } as w) ->
@@ -68,7 +68,7 @@ let watch : watch =
  fun ~pos e file callback ->
   if not (Sys.file_exists file) then Lang.raise_error ~pos "not_found";
   if List.mem `Modify e then
-    Tutils.mutexify m
+    Mutex.mutexify m
       (fun () ->
         if not !launched then begin
           launched := true;
@@ -82,7 +82,7 @@ let watch : watch =
         let mtime = try file_mtime file with _ -> 0. in
         watched := { file; mtime; callback } :: !watched;
         let unwatch =
-          Tutils.mutexify m (fun () ->
+          Mutex.mutexify m (fun () ->
               watched := List.filter (fun w -> w.file <> file) !watched)
         in
         unwatch)

--- a/src/core/io/gstreamer_io.ml
+++ b/src/core/io/gstreamer_io.ml
@@ -69,7 +69,7 @@ class virtual ['a, 'b] element_factory ~on_error =
     method virtual make_element : ('a, 'b) element
 
     method private get_element =
-      Tutils.mutexify element_m
+      Mutex.mutexify element_m
         (fun () ->
           match element with
             | Some el -> el
@@ -81,7 +81,7 @@ class virtual ['a, 'b] element_factory ~on_error =
 
     method private restart_task =
       let should_run =
-        Tutils.mutexify restart_m
+        Mutex.mutexify restart_m
           (fun () ->
             if not restarting then (
               restarting <- true;
@@ -92,7 +92,7 @@ class virtual ['a, 'b] element_factory ~on_error =
       if should_run then (
         try
           self#log#important "Restarting pipeline.";
-          Tutils.mutexify element_m
+          Mutex.mutexify element_m
             (fun () ->
               begin
                 match element with
@@ -110,7 +110,7 @@ class virtual ['a, 'b] element_factory ~on_error =
                 ~on_error:(fun err -> retry_in <- on_error (Flushing_error err))
                 el.bin)
             ();
-          Tutils.mutexify restart_m (fun () -> restarting <- false) ();
+          Mutex.mutexify restart_m (fun () -> restarting <- false) ();
           if retry_in >= 0. then
             self#log#info
               "An error occurred while restarting pipeline, will retry in %.02f"
@@ -124,12 +124,12 @@ class virtual ['a, 'b] element_factory ~on_error =
                (Printexc.to_string exn));
           retry_in <- on_error exn;
           self#log#important "Will retry again in %.02f" retry_in;
-          Tutils.mutexify restart_m (fun () -> restarting <- false) ();
+          Mutex.mutexify restart_m (fun () -> restarting <- false) ();
           retry_in)
       else -1.
 
     method private register_task ~priority scheduler =
-      Tutils.mutexify task_m
+      Mutex.mutexify task_m
         (fun () ->
           task <-
             Some
@@ -137,7 +137,7 @@ class virtual ['a, 'b] element_factory ~on_error =
         ()
 
     method private stop_task =
-      Tutils.mutexify task_m
+      Mutex.mutexify task_m
         (fun () ->
           match task with
             | None -> ()
@@ -147,7 +147,7 @@ class virtual ['a, 'b] element_factory ~on_error =
         ()
 
     method private restart =
-      Tutils.mutexify task_m
+      Mutex.mutexify task_m
         (fun () ->
           match task with None -> () | Some t -> Duppy.Async.wake_up t)
         ()
@@ -213,7 +213,7 @@ class output ~self_sync ~on_error ~infallible ~register_telnet ~on_start
       self#stop_task;
       started <- false;
       let todo =
-        Tutils.mutexify element_m
+        Mutex.mutexify element_m
           (fun () ->
             match element with
               | None -> fun () -> ()
@@ -530,7 +530,7 @@ class audio_video_input p (pipeline, audio_pipeline, video_pipeline) =
     method! sleep =
       self#stop_task;
       let todo =
-        Tutils.mutexify element_m
+        Mutex.mutexify element_m
           (fun () ->
             match element with
               | Some el ->
@@ -568,10 +568,10 @@ class audio_video_input p (pipeline, audio_pipeline, video_pipeline) =
         let m = Mutex.create () in
         let counter = ref 0 in
         App_sink.emit_signals sink;
-        App_sink.on_new_sample sink (Tutils.mutexify m (fun () -> incr counter));
-        let pending = Tutils.mutexify m (fun () -> !counter) in
+        App_sink.on_new_sample sink (Mutex.mutexify m (fun () -> incr counter));
+        let pending = Mutex.mutexify m (fun () -> !counter) in
         let pull =
-          Tutils.mutexify m (fun () ->
+          Mutex.mutexify m (fun () ->
               let b = pull sink in
               decr counter;
               b)

--- a/src/core/io/udp_io.ml
+++ b/src/core/io/udp_io.ml
@@ -41,11 +41,11 @@ module Tutils = struct
     let lock = Mutex.create () in
     let should_stop = ref false in
     let has_stopped = ref false in
-    let kill = mutexify lock (fun () -> should_stop := true) in
+    let kill = Mutex.mutexify lock (fun () -> should_stop := true) in
     let wait () = wait cond lock (fun () -> !has_stopped) in
-    let should_stop = mutexify lock (fun () -> !should_stop) in
+    let should_stop = Mutex.mutexify lock (fun () -> !should_stop) in
     let has_stopped =
-      mutexify lock (fun () ->
+      Mutex.mutexify lock (fun () ->
           has_stopped := true;
           Condition.signal cond)
     in

--- a/src/core/ogg_formats/ogg_flac_encoder.ml
+++ b/src/core/ogg_formats/ogg_flac_encoder.ml
@@ -38,9 +38,9 @@ let create_encoder ~flac ~comments () =
   let started = ref false in
   let m = Mutex.create () in
   let pages = ref [] in
-  let write_cb = Tutils.mutexify m (fun p -> pages := p :: !pages) in
+  let write_cb = Mutex.mutexify m (fun p -> pages := p :: !pages) in
   let flush_pages =
-    Tutils.mutexify m (fun () ->
+    Mutex.mutexify m (fun () ->
         let p = !pages in
         pages := [];
         List.rev p)

--- a/src/core/operators/pipe.ml
+++ b/src/core/operators/pipe.ml
@@ -79,7 +79,7 @@ class pipe ~replay_delay ~data_len ~process ~bufferize ~max ~restart
       if not !header_read then (
         let wav = Wav_aiff.read_header Wav_aiff.callback_ops pull in
         header_read := true;
-        Tutils.mutexify mutex
+        Mutex.mutexify mutex
           (fun () ->
             if Wav_aiff.channels wav <> self#audio_channels then
               failwith "Invalid channels from pipe process!";
@@ -100,7 +100,7 @@ class pipe ~replay_delay ~data_len ~process ~bufferize ~max ~restart
         Generator.put self#buffer Frame.Fields.audio
           (Content.Audio.lift_data ~offset ~length:duration data);
         let to_replay =
-          Tutils.mutexify mutex
+          Mutex.mutexify mutex
             (fun () ->
               let pending = !replay_pending in
               let to_replay, pending =
@@ -193,12 +193,12 @@ class pipe ~replay_delay ~data_len ~process ~bufferize ~max ~restart
         if ret = len then (
           let action =
             if next <> `Nothing && replay_delay >= 0 then (
-              Tutils.mutexify mutex
+              Mutex.mutexify mutex
                 (fun () -> replay_pending := (0, next) :: !replay_pending)
                 ();
               `Continue)
             else (
-              Tutils.mutexify mutex (fun () -> next_stop := next) ();
+              Mutex.mutexify mutex (fun () -> next_stop := next) ();
               if next <> `Nothing then `Stop else `Continue)
           in
           ignore (Queue.take to_write);
@@ -215,7 +215,7 @@ class pipe ~replay_delay ~data_len ~process ~bufferize ~max ~restart
       `Continue
 
     method private on_stop =
-      Tutils.mutexify mutex (fun e ->
+      Mutex.mutexify mutex (fun e ->
           let ret = !next_stop in
           next_stop := `Nothing;
           header_read := false;
@@ -259,7 +259,7 @@ class pipe ~replay_delay ~data_len ~process ~bufferize ~max ~restart
     method! abort_track = source#abort_track
 
     method! sleep =
-      Tutils.mutexify mutex
+      Mutex.mutexify mutex
         (fun () ->
           try
             next_stop := `Sleep;

--- a/src/core/operators/time_warp.ml
+++ b/src/core/operators/time_warp.ml
@@ -43,7 +43,7 @@ module Buffer = struct
     mutable abort : bool;
   }
 
-  let proceed control f = Tutils.mutexify control.lock f ()
+  let proceed control f = Mutex.mutexify control.lock f ()
 
   (** The source which produces data by reading the buffer. *)
   class producer ~id c =
@@ -220,7 +220,7 @@ module AdaptativeBuffer = struct
     mutable abort : bool; (* whether we asked to abort the current track *)
   }
 
-  let proceed control f = Tutils.mutexify control.lock f ()
+  let proceed control f = Mutex.mutexify control.lock f ()
 
   (** The source which produces data by reading the buffer. *)
   class producer ~pre_buffer ~averaging ~limit ~resample c =

--- a/src/core/operators/window_op.ml
+++ b/src/core/operators/window_op.ml
@@ -52,7 +52,7 @@ class window mode duration source =
           value <- Array.make channels 0.)
 
     val m = Mutex.create ()
-    method value = Tutils.mutexify m (fun () -> value) ()
+    method value = Mutex.mutexify m (fun () -> value) ()
 
     method private generate_frame =
       let frame = source#get_frame in
@@ -84,7 +84,7 @@ class window mode duration source =
                         v)
             in
             acc_dur <- 0;
-            Tutils.mutexify m (fun () -> value <- value') ())
+            Mutex.mutexify m (fun () -> value <- value') ())
         done);
       frame
   end

--- a/src/core/outputs/harbor_output.ml
+++ b/src/core/outputs/harbor_output.ml
@@ -232,7 +232,7 @@ let add_meta c data =
   in
   let get_meta () =
     let meta =
-      Tutils.mutexify c.meta.metadata_m
+      Mutex.mutexify c.meta.metadata_m
         (fun () ->
           let meta = c.meta.metadata in
           c.meta.metadata <- None;
@@ -260,7 +260,7 @@ let add_meta c data =
 let rec client_task c =
   let* data =
     Duppy.Monad.Io.exec ~priority:`Maybe_blocking c.handler
-      (Tutils.mutexify c.mutex
+      (Mutex.mutexify c.mutex
          (fun () ->
            let buflen = Strings.Mutable.length c.buffer in
            let data =
@@ -282,13 +282,13 @@ let rec client_task c =
   in
   let* state =
     Duppy.Monad.Io.exec ~priority:`Maybe_blocking c.handler
-      (let ret = Tutils.mutexify c.mutex (fun () -> c.state) () in
+      (let ret = Mutex.mutexify c.mutex (fun () -> c.state) () in
        Duppy.Monad.return ret)
   in
   if state <> Done then client_task c else Duppy.Monad.return ()
 
 let client_task c =
-  Tutils.mutexify c.mutex
+  Mutex.mutexify c.mutex
     (fun () ->
       assert (c.state = Hello);
       c.state <- Sending)
@@ -435,7 +435,7 @@ class output p =
     method insert_metadata m =
       let m = Frame.Metadata.Export.to_metadata m in
       let m = recode m in
-      Tutils.mutexify metadata.metadata_m
+      Mutex.mutexify metadata.metadata_m
         (fun () -> metadata.metadata <- Some m)
         ();
       (Option.get encoder).Encoder.insert_metadata
@@ -504,7 +504,7 @@ class output p =
               in
               Utils.log_exception ~log:self#log ~bt msg;
               self#log#info "Client %s disconnected" ip;
-              Tutils.mutexify client.mutex
+              Mutex.mutexify client.mutex
                 (fun () ->
                   client.state <- Done;
                   ignore (Strings.Mutable.flush client.buffer))
@@ -535,7 +535,7 @@ class output p =
       Duppy.Monad.Io.exec ~priority:`Maybe_blocking handler
         (Harbor.relayed reply (fun () ->
              self#log#info "Client %s connected" ip;
-             Tutils.mutexify clients_m (fun () -> Queue.push client clients) ();
+             Mutex.mutexify clients_m (fun () -> Queue.push client clients) ();
              on_connect ~protocol ~uri
                ~headers:(Frame.Metadata.from_list headers)
                ip))
@@ -556,12 +556,12 @@ class output p =
         (match dump with
           | Some s -> Strings.iter (output_substring s) b
           | None -> ());
-        Tutils.mutexify clients_m
+        Mutex.mutexify clients_m
           (fun () ->
             Queue.iter
               (fun c ->
                 let start =
-                  Tutils.mutexify c.mutex
+                  Mutex.mutexify c.mutex
                     (fun () ->
                       match c.state with
                         | Hello ->
@@ -607,11 +607,11 @@ class output p =
       encoder <- None;
       Harbor.remove_http_handler ~port ~verb:`Get ~uri ();
       let new_clients = Queue.create () in
-      Tutils.mutexify clients_m
+      Mutex.mutexify clients_m
         (fun () ->
           Queue.iter
             (fun c ->
-              Tutils.mutexify c.mutex
+              Mutex.mutexify c.mutex
                 (fun () ->
                   c.state <- Done;
                   Duppy.Monad.run

--- a/src/core/source.ml
+++ b/src/core/source.ml
@@ -126,7 +126,7 @@ class virtual operator ?pos ?clock ?(name = "src") sources =
     val mutex = Mutex.create ()
 
     method private mutexify : 'a 'b. ('a -> 'b) -> 'a -> 'b =
-      Tutils.mutexify mutex
+      Mutex.mutexify mutex
 
     method virtual fallible : bool
     method source_type : source_type = `Passive

--- a/src/core/sources/harbor_input.ml
+++ b/src/core/sources/harbor_input.ml
@@ -53,7 +53,7 @@ class http_input_server ~pos ~transport ~dumpfile ~logfile ~bufferize ~max ~icy
     val mutable logf = None
 
     method connected_client =
-      Tutils.mutexify relay_m
+      Mutex.mutexify relay_m
         (fun () -> Option.map address_resolver relay_socket)
         ()
 
@@ -97,7 +97,7 @@ class http_input_server ~pos ~transport ~dumpfile ~logfile ~bufferize ~max ~icy
       let read buf ofs len =
         let input =
           (fun buf len ->
-            let socket = Tutils.mutexify relay_m (fun () -> relay_socket) () in
+            let socket = Mutex.mutexify relay_m (fun () -> relay_socket) () in
             match socket with
               | None -> 0
               | Some socket -> (
@@ -143,7 +143,7 @@ class http_input_server ~pos ~transport ~dumpfile ~logfile ~bufferize ~max ~icy
       try
         let decoder, buffer = create_decoder input in
         while true do
-          Tutils.mutexify relay_m
+          Mutex.mutexify relay_m
             (fun () -> if relay_socket = None then failwith "relaying stopped")
             ();
           if Atomic.get should_shutdown then failwith "shutdown called";
@@ -191,7 +191,7 @@ class http_input_server ~pos ~transport ~dumpfile ~logfile ~bufferize ~max ~icy
 
     method relay stype (headers : (string * string) list) ?(read = Harbor.read)
         socket =
-      Tutils.mutexify relay_m
+      Mutex.mutexify relay_m
         (fun () ->
           if relay_socket <> None then raise Harbor.Mount_taken;
           self#register_decoder stype;
@@ -224,7 +224,7 @@ class http_input_server ~pos ~transport ~dumpfile ~logfile ~bufferize ~max ~icy
       relay_socket <- None
 
     method private disconnect_with_lock =
-      Tutils.mutexify relay_m (fun () -> self#disconnect_no_lock) ()
+      Mutex.mutexify relay_m (fun () -> self#disconnect_no_lock) ()
 
     method private after_disconnect =
       begin

--- a/src/core/sources/request_dynamic.ml
+++ b/src/core/sources/request_dynamic.ml
@@ -117,12 +117,12 @@ class dynamic ~retry_delay ~available (f : Lang.value) prefetch timeout =
                    {
                      req;
                      fread =
-                       Tutils.mutexify m (fun len ->
+                       Mutex.mutexify m (fun len ->
                            let buf = decoder.Decoder.fread len in
                            remaining <- decoder.Decoder.remaining ();
                            buf);
                      seek =
-                       Tutils.mutexify m (fun len -> decoder.Decoder.fseek len);
+                       Mutex.mutexify m (fun len -> decoder.Decoder.fseek len);
                      close = decoder.Decoder.close;
                    });
               remaining <- decoder.Decoder.remaining ();
@@ -259,7 +259,7 @@ class dynamic ~retry_delay ~available (f : Lang.value) prefetch timeout =
     initializer
       self#on_wake_up (fun () ->
           assert (task = None);
-          Tutils.mutexify state_lock
+          Mutex.mutexify state_lock
             (fun () ->
               assert (state = `Sleeping);
               let t =
@@ -289,7 +289,7 @@ class dynamic ~retry_delay ~available (f : Lang.value) prefetch timeout =
                if it's currently resolving a file or not.  So we first put the queue
                into an harmless state: we put the state to `Tired and wait for it to
                acknowledge it by setting it to `Sleeping. *)
-            Tutils.mutexify state_lock (fun () -> state <- `Tired) ();
+            Mutex.mutexify state_lock (fun () -> state <- `Tired) ();
 
             (* Make sure the task is awake so that it can see our signal. *)
             Duppy.Async.wake_up (Option.get task);
@@ -309,7 +309,7 @@ class dynamic ~retry_delay ~available (f : Lang.value) prefetch timeout =
       (* Avoid trying to wake up the task during the shutdown process where it
          might have been stopped already, in which case we'd get an
          exception. *)
-      Tutils.mutexify state_lock
+      Mutex.mutexify state_lock
         (fun () ->
           if state = `Running then Duppy.Async.wake_up (Option.get task))
         ()
@@ -336,7 +336,7 @@ class dynamic ~retry_delay ~available (f : Lang.value) prefetch timeout =
       if
         (* Is the source running? And does it need prefetching? If the test fails,
            the task sleeps. *)
-        Tutils.mutexify state_lock
+        Mutex.mutexify state_lock
           (fun () ->
             match state with
               | `Starting ->

--- a/src/core/stdlib/mutex.ml
+++ b/src/core/stdlib/mutex.ml
@@ -1,0 +1,13 @@
+include Mutex
+
+let mutexify m f x =
+  lock m;
+  match f x with
+    | exception exn ->
+        let bt = Printexc.get_raw_backtrace () in
+        unlock m;
+        Printexc.raise_with_backtrace exn bt
+    | v ->
+        unlock m;
+        v
+  [@@inline always]

--- a/src/core/stdlib/mutex.mli
+++ b/src/core/stdlib/mutex.mli
@@ -1,0 +1,7 @@
+type t = Stdlib.Mutex.t
+
+val create : unit -> t
+val lock : t -> unit
+val try_lock : t -> bool
+val unlock : t -> unit
+val mutexify : t -> ('a -> 'b) -> 'a -> 'b

--- a/src/core/synth/keyboard.ml
+++ b/src/core/synth/keyboard.ml
@@ -114,7 +114,7 @@ class keyboard =
               events = [`Read Unix.stdin];
             });
 
-      self#on_sleep (Tutils.mutexify lock (fun () -> run_id <- run_id + 1))
+      self#on_sleep (Mutex.mutexify lock (fun () -> run_id <- run_id + 1))
 
     method reset = ()
 

--- a/src/core/tools/process_handler.ml
+++ b/src/core/tools/process_handler.ml
@@ -72,7 +72,7 @@ let get_process { process; _ } =
   match process with Some process -> process | None -> raise Finished
 
 let set_priority t =
-  Tutils.mutexify t.mutex (fun priority ->
+  Mutex.mutexify t.mutex (fun priority ->
       match t.process with
         | None -> raise Finished
         | Some p -> p.priority <- priority)
@@ -82,7 +82,7 @@ let stop_c, kill_c, done_c =
   (fn '0', fn '1', fn '2')
 
 let stop t =
-  Tutils.mutexify t.mutex
+  Mutex.mutexify t.mutex
     (fun () ->
       match t.process with
         | None -> raise Finished
@@ -91,7 +91,7 @@ let stop t =
     ()
 
 let kill t =
-  Tutils.mutexify t.mutex
+  Mutex.mutexify t.mutex
     (fun () ->
       match t.process with
         | None -> raise Finished
@@ -100,7 +100,7 @@ let kill t =
     ()
 
 let send_stop ~log t =
-  Tutils.mutexify t.mutex
+  Mutex.mutexify t.mutex
     (fun () ->
       let process = get_process t in
       if not process.stopped then (
@@ -121,7 +121,7 @@ let _kill = function
   | None -> ()
 
 let cleanup ~log t =
-  Tutils.mutexify t.mutex
+  Mutex.mutexify t.mutex
     (fun () ->
       log "Cleaning up process";
       let { process; _ } = t in
@@ -157,7 +157,7 @@ let run ?priority ?env ?on_start ?on_stdin ?on_stdout ?on_stderr ?on_stop ?log
          (fun () ->
            try
              let _, status = wait p in
-             Tutils.mutexify mutex
+             Mutex.mutexify mutex
                (fun () ->
                  if process.status = None then (
                    process.status <- Some status;
@@ -170,7 +170,7 @@ let run ?priority ?env ?on_start ?on_stdin ?on_stdout ?on_stderr ?on_stop ?log
   let process = create () in
   let t = { mutex; process = Some process } in
   let create =
-    Tutils.mutexify t.mutex (fun () ->
+    Mutex.mutexify t.mutex (fun () ->
         _kill t.process;
         t.process <- Some (create ()))
   in
@@ -326,13 +326,13 @@ let really_write ?(offset = 0) ?length data push =
   f offset
 
 let on_stdout t fn =
-  let process = Tutils.mutexify t.mutex (fun () -> get_process t) () in
+  let process = Mutex.mutexify t.mutex (fun () -> get_process t) () in
   let fd = Unix.descr_of_in_channel process.p.stdout in
   fn (puller process.in_pipe fd)
 
 let on_stdin t fn =
   let process =
-    Tutils.mutexify t.mutex
+    Mutex.mutexify t.mutex
       (fun () ->
         match t.process with
           | Some process ->
@@ -345,11 +345,11 @@ let on_stdin t fn =
   fn (pusher fd)
 
 let on_stderr t fn =
-  let process = Tutils.mutexify t.mutex (fun () -> get_process t) () in
+  let process = Mutex.mutexify t.mutex (fun () -> get_process t) () in
   let fd = Unix.descr_of_in_channel process.p.stderr in
   fn (puller process.in_pipe fd)
 
 let stopped t =
-  Tutils.mutexify t.mutex
+  Mutex.mutexify t.mutex
     (fun () -> try (get_process t).stopped with Finished -> true)
     ()

--- a/src/core/tools/server.ml
+++ b/src/core/tools/server.ml
@@ -143,7 +143,7 @@ let prefix_ns cmd ns = to_string (ns @ [cmd])
 let add ~ns ?usage ~descr cmd handler =
   let usage = match usage with None -> cmd | Some u -> u in
   let usage = prefix_ns usage ns in
-  Tutils.mutexify lock
+  Mutex.mutexify lock
     (fun () ->
       let name = prefix_ns cmd ns in
       if Hashtbl.mem commands name then
@@ -156,7 +156,7 @@ let add ~ns ?usage ~descr cmd handler =
 
 (* ... and maybe remove them. *)
 let remove ~ns cmd =
-  Tutils.mutexify lock (fun () -> Hashtbl.remove commands (prefix_ns cmd ns)) ()
+  Mutex.mutexify lock (fun () -> Hashtbl.remove commands (prefix_ns cmd ns)) ()
 
 (* That's if you want to have your command wait. *)
 type condition = {
@@ -217,7 +217,7 @@ let read ~after payload = raise (Read { payload; after })
 (* The usage string sums up all the commands... *)
 let usage () =
   let l =
-    Tutils.mutexify lock
+    Mutex.mutexify lock
       (fun () -> Hashtbl.fold (fun k v l -> (k, v) :: l) commands [])
       ()
   in
@@ -238,7 +238,7 @@ let () =
         let args =
           Pcre.substitute ~rex:(Pcre.regexp "\\s*") ~subst:(fun _ -> "") args
         in
-        let _, us, d = Tutils.mutexify lock (Hashtbl.find commands) args in
+        let _, us, d = Mutex.mutexify lock (Hashtbl.find commands) args in
         Printf.sprintf "Usage: %s\r\n  %s" us d
       with Not_found ->
         (if args <> "" then "No such command: " ^ args ^ "\r\n" else "")
@@ -254,7 +254,7 @@ let exec s =
     with Not_found -> (s, "")
   in
   try
-    let command, _, _ = Tutils.mutexify lock (Hashtbl.find commands) s in
+    let command, _, _ = Mutex.mutexify lock (Hashtbl.find commands) s in
     command args
   with
     | Server_wait opts -> raise (Server_wait opts)

--- a/src/core/tools/strings.ml
+++ b/src/core/tools/strings.ml
@@ -157,87 +157,82 @@ module Mutable = struct
   let empty () = of_strings []
   let to_strings { strings } = strings
 
-  (* Copied from tutils.ml to avoid circular references. *)
-  let mutexify lock f x =
-    Mutex.lock lock;
-    try
-      let ans = f x in
-      Mutex.unlock lock;
-      ans
-    with e ->
-      Mutex.unlock lock;
-      raise e
-
-  let add m s = mutexify m.mutex (fun () -> m.strings <- add m.strings s) ()
+  let add m s =
+    Mutex.mutexify m.mutex (fun () -> m.strings <- add m.strings s) ()
 
   let add_substring m s ofs len =
-    mutexify m.mutex
+    Mutex.mutexify m.mutex
       (fun () -> m.strings <- add_substring m.strings s ofs len)
       ()
 
   let add_subbytes m b ofs len =
-    mutexify m.mutex
+    Mutex.mutexify m.mutex
       (fun () -> m.strings <- add_subbytes m.strings b ofs len)
       ()
 
   let unsafe_add_subbytes m b ofs len =
-    mutexify m.mutex
+    Mutex.mutexify m.mutex
       (fun () -> m.strings <- unsafe_add_subbytes m.strings b ofs len)
       ()
 
   let add_bytes t b = add_subbytes t b 0 (Bytes.length b)
   let unsafe_add_bytes t b = unsafe_add_subbytes t b 0 (Bytes.length b)
-  let dda s m = mutexify m.mutex (fun () -> m.strings <- dda s m.strings) ()
+
+  let dda s m =
+    Mutex.mutexify m.mutex (fun () -> m.strings <- dda s m.strings) ()
 
   let append_strings m t =
-    mutexify m.mutex (fun () -> m.strings <- append m.strings t) ()
+    Mutex.mutexify m.mutex (fun () -> m.strings <- append m.strings t) ()
 
   let drop m len =
-    mutexify m.mutex (fun () -> m.strings <- drop m.strings len) ()
+    Mutex.mutexify m.mutex (fun () -> m.strings <- drop m.strings len) ()
 
   let keep m len =
-    mutexify m.mutex (fun () -> m.strings <- keep m.strings len) ()
+    Mutex.mutexify m.mutex (fun () -> m.strings <- keep m.strings len) ()
 
   let append m m' =
-    mutexify m.mutex
+    Mutex.mutexify m.mutex
       (fun () ->
-        mutexify m'.mutex
+        Mutex.mutexify m'.mutex
           (fun () -> m.strings <- append m.strings m'.strings)
           ())
       ()
 
-  let iter_view fn m = mutexify m.mutex (fun () -> iter_view fn m.strings) ()
-  let iter fn m = mutexify m.mutex (fun () -> iter fn m.strings) ()
+  let iter_view fn m =
+    Mutex.mutexify m.mutex (fun () -> iter_view fn m.strings) ()
+
+  let iter fn m = Mutex.mutexify m.mutex (fun () -> iter fn m.strings) ()
 
   let map_view fn m =
-    mutexify m.mutex (fun () -> of_strings (map_view fn m.strings)) ()
+    Mutex.mutexify m.mutex (fun () -> of_strings (map_view fn m.strings)) ()
 
-  let map fn m = mutexify m.mutex (fun () -> of_strings (map fn m.strings)) ()
+  let map fn m =
+    Mutex.mutexify m.mutex (fun () -> of_strings (map fn m.strings)) ()
 
   let fold_view fn x0 m =
-    mutexify m.mutex (fun () -> fold_view fn x0 m.strings) ()
+    Mutex.mutexify m.mutex (fun () -> fold_view fn x0 m.strings) ()
 
-  let fold fn x0 m = mutexify m.mutex (fun () -> fold fn x0 m.strings) ()
+  let fold fn x0 m = Mutex.mutexify m.mutex (fun () -> fold fn x0 m.strings) ()
 
   let flush m =
-    mutexify m.mutex
+    Mutex.mutexify m.mutex
       (fun () ->
         let content = m.strings in
         m.strings <- [];
         content)
       ()
 
-  let is_empty m = mutexify m.mutex (fun () -> is_empty m.strings) ()
-  let length m = mutexify m.mutex (fun () -> length m.strings) ()
-  let to_bytes m = mutexify m.mutex (fun () -> to_bytes m.strings) ()
-  let to_string m = mutexify m.mutex (fun () -> to_string m.strings) ()
+  let is_empty m = Mutex.mutexify m.mutex (fun () -> is_empty m.strings) ()
+  let length m = Mutex.mutexify m.mutex (fun () -> length m.strings) ()
+  let to_bytes m = Mutex.mutexify m.mutex (fun () -> to_bytes m.strings) ()
+  let to_string m = Mutex.mutexify m.mutex (fun () -> to_string m.strings) ()
 
   let blit m mo b bo len =
-    mutexify m.mutex (fun () -> blit (sub m.strings mo len) b bo) ()
+    Mutex.mutexify m.mutex (fun () -> blit (sub m.strings mo len) b bo) ()
 
   let sub m ofs len =
-    mutexify m.mutex (fun () -> of_strings (sub m.strings ofs len)) ()
+    Mutex.mutexify m.mutex (fun () -> of_strings (sub m.strings ofs len)) ()
 
   let substring m ofs len =
-    mutexify m.mutex (fun () -> substring m.strings ofs len) ()
+    Mutex.mutexify m.mutex (fun () -> substring m.strings ofs len) ()
 end

--- a/src/core/tools/tutils.ml
+++ b/src/core/tools/tutils.ml
@@ -112,18 +112,6 @@ let scheduler_log =
     ~p:(conf_scheduler#plug "log")
     ~d:false "Log scheduler messages"
 
-let mutexify lock f x =
-  Mutex.lock lock;
-  try
-    let v = f x in
-    Mutex.unlock lock;
-    v
-  with exn ->
-    let bt = Printexc.get_raw_backtrace () in
-    Mutex.unlock lock;
-    Printexc.raise_with_backtrace exn bt
-  [@@inline always]
-
 let seems_locked =
   if Sys.win32 then fun _ -> true
   else fun m ->
@@ -151,7 +139,7 @@ let queues = ref Set.empty
 let join_all ~set () =
   let rec f () =
     try
-      mutexify lock
+      Mutex.mutexify lock
         (fun () ->
           let name, c = Set.choose !set in
           log#info "Waiting for thread %s to shutdown" name;
@@ -180,13 +168,13 @@ exception Exit
 let create ~queue f x s =
   let c = Condition.create () in
   let set = if queue then queues else all in
-  mutexify lock
+  Mutex.mutexify lock
     (fun () ->
       let id =
         let process x =
           try
             f x;
-            mutexify lock
+            Mutex.mutexify lock
               (fun () ->
                 set := Set.remove (s, c) !set;
                 log#info "Thread %S terminated (%d remaining)." s
@@ -220,7 +208,7 @@ let create ~queue f x s =
             with e ->
               let l = Pcre.split ~rex:(Pcre.regexp "\n") bt in
               List.iter (log#info "%s") l;
-              mutexify lock
+              Mutex.mutexify lock
                 (fun () ->
                   set := Set.remove (s, c) !set;
                   if
@@ -308,7 +296,7 @@ let start () =
 
 (** Waits for [f()] to become true on condition [c]. *)
 let wait c m f =
-  mutexify m
+  Mutex.mutexify m
     (fun () ->
       while not (f ()) do
         Condition.wait c m

--- a/src/core/tools/tutils.mli
+++ b/src/core/tools/tutils.mli
@@ -69,9 +69,6 @@ val scheduler : priority Duppy.scheduler
   * and after the call. *)
 val wait : Condition.t -> Mutex.t -> (unit -> bool) -> unit
 
-(** Make a function work in critical section, protected by a given lock. *)
-val mutexify : Mutex.t -> ('a -> 'b) -> 'a -> 'b
-
 exception Timeout of float
 
 type event =


### PR DESCRIPTION
This is another preliminary PR to prepare for concurrent clocks, this time abstracting away `mutexify` and placing in an extension of the `Mutex` module.