### PR TITLE
`autocue` improvements in crossfade

### DIFF
--- a/.github/scripts/build-apk.sh
+++ b/.github/scripts/build-apk.sh
@@ -17,6 +17,7 @@ APK_VERSION=$(opam show -f version ./liquidsoap.opam | cut -d'-' -f 1)
 COMMIT_SHORT=$(echo "${GITHUB_SHA}" | cut -c-7)
 
 export LIQUIDSOAP_BUILD_TARGET=posix
+export ABUILD_APK_INDEX_OPTS="--allow-untrusted"
 
 if [ -n "${IS_ROLLING_RELEASE}" ]; then
   APK_PACKAGE="liquidsoap-${COMMIT_SHORT}-${ALPINE_ARCH}"

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ New:
 - Added `enable_autocue_metadata` and `autocue:` protocol to automatically compute cue points and crossfade parameters (#3753, @RM-FM and @Moonbase59)
 - Added `db_levels` method to `blank.*` sources (#3790)
 - Added `excluded_metadata_resolvers` to `request.create` to make it possible to selectively disable specific metadata resolvers when resolving requests.
+- Added optional `reconcile_duration` option to crossfade operator to make handle new tracks shorter than the crossfade duration.
 
 Changed:
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,7 +6,7 @@ New:
 - Added `enable_autocue_metadata` and `autocue:` protocol to automatically compute cue points and crossfade parameters (#3753, @RM-FM and @Moonbase59)
 - Added `db_levels` method to `blank.*` sources (#3790)
 - Added `excluded_metadata_resolvers` to `request.create` to make it possible to selectively disable specific metadata resolvers when resolving requests.
-- Added optional `reconcile_duration` option to crossfade operator to make handle new tracks shorter than the crossfade duration.
+- Added optional `autocue` option to crossfade operator to make handle new tracks shorter than the crossfade duration.
 
 Changed:
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,7 +6,7 @@ New:
 - Added `enable_autocue_metadata` and `autocue:` protocol to automatically compute cue points and crossfade parameters (#3753, @RM-FM and @Moonbase59)
 - Added `db_levels` method to `blank.*` sources (#3790)
 - Added `excluded_metadata_resolvers` to `request.create` to make it possible to selectively disable specific metadata resolvers when resolving requests.
-- Added optional `autocue` option to crossfade operator to make handle new tracks shorter than the crossfade duration.
+- Normalized expected API from `autocue`, allow multiple implementation and adapt `cross`/`crossfade` to work with it out of the box with workaround for short tracks.
 
 Changed:
 

--- a/src/core/operators/cross.ml
+++ b/src/core/operators/cross.ml
@@ -367,10 +367,12 @@ class cross val_source ~duration_getter ~autocue ~override_duration
                   float_of_string (Hashtbl.find before_metadata "liq_fade_out")
                 in
                 let fade_out = min new_cross_duration fade_out in
-                let fade_out_delay = min (new_cross_duration -. fade_out) 0. in
+                let fade_out_delay = max (new_cross_duration -. fade_out) 0. in
                 Hashtbl.replace before_metadata "liq_fade_out"
                   (string_of_float fade_out);
-                Hashtbl.replace after_metadata "liq_fade_out_delay"
+                Hashtbl.replace before_metadata "liq_fade_out_delay"
+                  (string_of_float fade_out_delay);
+                Hashtbl.replace after_metadata "liq_fade_in_delay"
                   (string_of_float fade_out_delay)));
             let before_head =
               if (not autocue) && buffered < buffered_before then (

--- a/src/core/operators/cross.ml
+++ b/src/core/operators/cross.ml
@@ -299,9 +299,12 @@ class cross val_source ~duration_getter ~reconcile_duration ~override_cue_in
     (* Analyze the beginning of a new track. *)
     method private analyze_after =
       let buf_frame = self#buf_frame in
-      let len_before = Generator.length gen_before in
+      let before_len = Generator.length gen_before in
       let rec f () =
-        let buffer_len = self#safe_cross_len len_before in
+        let buffer_len =
+          if reconcile_duration then self#safe_cross_len before_len
+          else before_len
+        in
         let start = AFrame.position buf_frame in
         let stop =
           self#child_get source buf_frame;

--- a/src/core/operators/cross.ml
+++ b/src/core/operators/cross.ml
@@ -23,19 +23,6 @@
 open Mm
 open Source
 
-let conf_crossfade =
-  Dtools.Conf.void ~p:(Configure.conf#plug "crossfade") "Crossfade settings"
-
-let conf_fade_in_duration =
-  Dtools.Conf.float ~d:3.
-    ~p:(conf_crossfade#plug "fade_in_duration")
-    "Default `fade.in` duration"
-
-let conf_fade_out_duration =
-  Dtools.Conf.float ~d:3.
-    ~p:(conf_crossfade#plug "fade_out_duration")
-    "Default `fade.out` duration"
-
 let finalise_child_clock child_clock source =
   Clock.forget source#clock child_clock
 

--- a/src/core/operators/cross.ml
+++ b/src/core/operators/cross.ml
@@ -100,7 +100,7 @@ class cross val_source ~duration_getter ~reconcile_duration ~override_cue_in
             float_of_string
               (Hashtbl.find after_metadata override_track_duration)
         in
-        let safe_max = (stop -. start) /. 2. in
+        let safe_max = stop -. start -. self#cross_duration in
         min expected (Frame.main_of_seconds safe_max)
       with _ -> Frame.main_of_seconds self#cross_duration
 

--- a/src/core/operators/cross.ml
+++ b/src/core/operators/cross.ml
@@ -364,23 +364,16 @@ class cross val_source ~duration_getter ~reconcile_duration ~override_cue_in
             let before_metadata = metadata before_metadata in
             let after_metadata = metadata after_metadata in
             if reconcile_duration then (
-              let fade_in_delay =
-                try
-                  float_of_string
-                    (Hashtbl.find after_metadata override_fade_in_delay)
-                with _ -> 0.
-              in
               let missing_cross_duration =
-                self#cross_duration -. Frame.seconds_of_main buffered_after
+                Frame.seconds_of_main (buffered_before - buffered_after)
               in
-              if 0. < fade_in_delay && 0. < missing_cross_duration then (
-                let new_delay = fade_in_delay -. missing_cross_duration in
+              if 0. < missing_cross_duration then (
                 self#log#info
                   "Adding %.2f fade-in delay to match the ending track's \
                    buffer."
-                  new_delay;
+                  missing_cross_duration;
                 Hashtbl.replace after_metadata override_fade_in_delay
-                  (string_of_float new_delay)));
+                  (string_of_float missing_cross_duration)));
             let before_head =
               if (not reconcile_duration) && buffered < buffered_before then (
                 let head =

--- a/src/core/operators/cross.ml
+++ b/src/core/operators/cross.ml
@@ -23,14 +23,28 @@
 open Mm
 open Source
 
+let conf_crossfade =
+  Dtools.Conf.void ~p:(Configure.conf#plug "crossfade") "Crossfade settings"
+
+let conf_fade_in_duration =
+  Dtools.Conf.float ~d:3.
+    ~p:(conf_crossfade#plug "fade_in_duration")
+    "Default `fade.in` duration"
+
+let conf_fade_out_duration =
+  Dtools.Conf.float ~d:3.
+    ~p:(conf_crossfade#plug "fade_out_duration")
+    "Default `fade.out` duration"
+
 let finalise_child_clock child_clock source =
   Clock.forget source#clock child_clock
 
 (** [rms_width] and [minimum_length] are all in samples.
   * [cross_length] is in ticks (like #remaining estimations).
   * We are assuming a fixed audio kind -- at least for now. *)
-class cross val_source ~duration_getter ~override_duration ~persist_override
-  ~rms_width ~minimum_length ~conservative transition =
+class cross val_source ~duration_getter ~reconcile_duration
+  ~override_fade_in_delay ~override_fade_out_duration ~override_duration
+  ~persist_override ~rms_width ~minimum_length ~conservative transition =
   let s = Lang.to_source val_source in
   let original_duration_getter = duration_getter in
   object (self)
@@ -279,8 +293,11 @@ class cross val_source ~duration_getter ~override_duration ~persist_override
     (* Analyze the beginning of a new track. *)
     method private analyze_after =
       let buf_frame = self#buf_frame in
-      let before_len = Generator.length gen_before in
       let rec f () =
+        let before_len =
+          if reconcile_duration then Frame.main_of_seconds self#cross_duration
+          else Generator.length gen_before
+        in
         let start = AFrame.position buf_frame in
         let stop =
           self#child_get source buf_frame;
@@ -329,8 +346,28 @@ class cross val_source ~duration_getter ~override_duration ~persist_override
             let metadata = function None -> Hashtbl.create 0 | Some m -> m in
             let before_metadata = metadata before_metadata in
             let after_metadata = metadata after_metadata in
+            if reconcile_duration then (
+              let ending_fade_out =
+                try
+                  float_of_string
+                    (Option.get
+                       (Hashtbl.find_opt after_metadata
+                          override_fade_out_duration))
+                with _ -> conf_fade_out_duration#get
+              in
+              let missing_buffer_delay =
+                if buffered_after < buffered_before then
+                  Frame.seconds_of_main (buffered_before - buffered_after)
+                else 0.
+              in
+              let new_delay = ending_fade_out +. missing_buffer_delay in
+              self#log#info
+                "Adding %.2f fade-in delay to match the ending track's buffer."
+                new_delay;
+              Hashtbl.replace after_metadata override_fade_in_delay
+                (string_of_float new_delay));
             let before_head =
-              if buffered < buffered_before then (
+              if (not reconcile_duration) && buffered < buffered_before then (
                 let head =
                   Generator.get ~length:(buffered_before - buffered) gen_before
                 in
@@ -351,7 +388,7 @@ class cross val_source ~duration_getter ~override_duration ~persist_override
             in
             Typing.(before#frame_type <: self#frame_type);
             let after_tail =
-              if buffered < buffered_after then (
+              if (not reconcile_duration) && buffered < buffered_after then (
                 let head = Generator.get ~length:buffered gen_after in
                 let head_gen =
                   Generator.create ~content:head
@@ -400,10 +437,17 @@ class cross val_source ~duration_getter ~override_duration ~persist_override
                 (Frame.seconds_of_main buffered_before)
                 (Frame.seconds_of_main buffered_after);
               if Frame.main_of_audio minimum_length < buffered then (
-                self#log#important
-                  "Computing crossfade duration over overlapping %.2fs \
-                   buffered data at start and end."
-                  (Frame.seconds_of_main buffered);
+                if reconcile_duration then
+                  self#log#important
+                    "Computing crossfade transition over reconciled duration \
+                     with %.2fs ending and %.2fs starting buffered data."
+                    (Frame.seconds_of_main buffered_before)
+                    (Frame.seconds_of_main buffered_after)
+                else
+                  self#log#important
+                    "Computing crossfade transition over overlapping %.2fs \
+                     buffered data at start and end."
+                    (Frame.seconds_of_main buffered);
                 f before after)
               else (
                 self#log#important "Not enough data for crossing.";
@@ -482,6 +526,25 @@ let _ =
         Some
           "Metadata field which, if present and containing a float, overrides \
            the 'duration' parameter for current track." );
+      ( "reconcile_duration",
+        Lang.bool_t,
+        Some (Lang.bool false),
+        Some
+          "When set to `true`, if duration for the new track is shorter than \
+           the ending duration, a `liq_fade_in_delay` metadata is \
+           automatically injected to make crossfades match." );
+      ( "override_fade_in_delay",
+        Lang.string_t,
+        Some (Lang.string "liq_fade_in_delay"),
+        Some
+          "Metadata field which used to inject metadata overriding fade-in \
+           delay when reconciling crossfade duration." );
+      ( "override_fade_out_duration",
+        Lang.string_t,
+        Some (Lang.string "liq_fade_out"),
+        Some
+          "Metadata field which used to inject metadata overriding fade-out \
+           duration when reconciling crossfade duration." );
       ( "persist_override",
         Lang.bool_t,
         Some (Lang.bool false),
@@ -536,6 +599,15 @@ let _ =
       let override_duration =
         Lang.to_string (List.assoc "override_duration" p)
       in
+      let reconcile_duration =
+        Lang.to_bool (List.assoc "reconcile_duration" p)
+      in
+      let override_fade_in_delay =
+        Lang.to_string (List.assoc "override_fade_in_delay" p)
+      in
+      let override_fade_out_duration =
+        Lang.to_string (List.assoc "override_fade_out_duration" p)
+      in
       let persist_override = Lang.to_bool (List.assoc "persist_override" p) in
       let minimum = Lang.to_float (List.assoc "minimum" p) in
       let minimum_length = Frame.audio_of_seconds minimum in
@@ -545,5 +617,6 @@ let _ =
       let conservative = Lang.to_bool (List.assoc "conservative" p) in
       let source = Lang.assoc "" 2 p in
       new cross
-        source transition ~conservative ~duration_getter ~rms_width
+        source transition ~conservative ~duration_getter ~reconcile_duration
+        ~override_fade_in_delay ~override_fade_out_duration ~rms_width
         ~minimum_length ~override_duration ~persist_override)

--- a/src/core/request.ml
+++ b/src/core/request.ml
@@ -649,8 +649,10 @@ let get_decoder r =
                     if cue_out <= new_pos then (
                       r.logger#info "Cueing out at position: %.02f"
                         (Frame.seconds_of_main cue_out);
-                      Frame.set_breaks frame
-                        ((start + (cue_out - old_pos)) :: breaks);
+                      (* Don't add a break if there is already one. *)
+                      let break = start + (cue_out - old_pos) in
+                      if not (List.mem break breaks) then
+                        Frame.set_breaks frame (break :: breaks);
                       0)
                     else (
                       if Frame.is_partial frame then

--- a/src/core/request.mli
+++ b/src/core/request.mli
@@ -30,6 +30,9 @@ type metadata = (string, string) Hashtbl.t
     deleting a local file). *)
 type indicator
 
+(** Root configuration node. *)
+val conf : Dtools.Conf.ut
+
 (** Create an indicator. *)
 val indicator : ?metadata:metadata -> ?temporary:bool -> string -> indicator
 

--- a/src/core/stream/generator.ml
+++ b/src/core/stream/generator.ml
@@ -111,6 +111,16 @@ let _truncate gen len =
        (Atomic.get gen.content))
 
 let truncate gen = Tutils.mutexify gen.lock (_truncate gen)
+
+let _keep gen len =
+  Atomic.set gen.content
+    (Frame_base.Fields.map
+       (fun content ->
+         assert (len <= Content.length content);
+         Content.sub content 0 len)
+       (Atomic.get gen.content))
+
+let keep gen = Tutils.mutexify gen.lock (_keep gen)
 let clear gen = Atomic.set gen.content (make_content ~length:0 gen.content_type)
 
 let _set_metadata gen =

--- a/src/core/stream/generator.mli
+++ b/src/core/stream/generator.mli
@@ -70,6 +70,9 @@ val remaining : t -> int
 (* Drop given length of content at the beginning of the generator. *)
 val truncate : t -> int -> unit
 
+(* Keep only the given length of data from the beginning of the generator. *)
+val keep : t -> int -> unit
+
 (* Empty the generator. *)
 val clear : t -> unit
 

--- a/src/libs/autocue.liq
+++ b/src/libs/autocue.liq
@@ -329,7 +329,7 @@ def autocue.internal.implementation(uri) =
 
     (
       {
-        amplify=lufs_correction,
+        amplify=lin_of_dB(lufs_correction),
         cue_in=cue_in(),
         cue_out=cue_out(),
         fade_in=fade_in(),
@@ -411,17 +411,7 @@ def file.autocue.metadata(uri) =
       if fade_out < cross_duration then cross_duration - fade_out else 0. end
 
     [
-      ...(
-        null.defined(amplify)
-        ?
-          [
-            (
-              "liq_amplify",
-              "#{null.get(amplify)} dB"
-            )
-          ]
-        : []
-      ),
+      ...(null.defined(amplify) ? [("liq_amplify", string(amplify))] : [] ),
       ("liq_cue_in", string(cue_in)),
       ("liq_cue_out", string(cue_out)),
       ("liq_cross_duration", string(cross_duration)),

--- a/src/libs/autocue.liq
+++ b/src/libs/autocue.liq
@@ -389,11 +389,8 @@ end
 # Enable autocue metadata resolver. This resolver will process any file
 # decoded by Liquidsoap and add cue-in/out and crossfade metadata when these
 # values can be computed. For a finer-grained processing, use the `autocue:` protocol.
-# This also sets `settings.crossfade.autocue` to `true`.
 # @category Liquidsoap
 def enable_autocue_metadata() =
-  settings.crossfade.autocue := true
-
   def autocue_metadata(~metadata, fname) =
     metadata_overrides =
       ["liq_amplify", "liq_cue_in", "liq_cue_out", "liq_fade_in", "liq_fade_out"

--- a/src/libs/autocue.liq
+++ b/src/libs/autocue.liq
@@ -360,8 +360,6 @@ def file.autocue.metadata(uri) =
     # Make sure cross_duration is never 0.
     cross_duration = max(cross_duration, 0.1)
 
-    fade_in_delay =
-      if fade_in < cross_duration then cross_duration - fade_in else 0. end
     fade_out_delay =
       if fade_out < cross_duration then cross_duration - fade_out else 0. end
 
@@ -375,7 +373,6 @@ def file.autocue.metadata(uri) =
       ("liq_cue_out", string(cue_out)),
       ("liq_cross_duration", string(cross_duration)),
       ("liq_fade_in", string(fade_in)),
-      ("liq_fade_in_delay", string(fade_in_delay)),
       ("liq_fade_out", string(fade_out)),
       ("liq_fade_out_delay", string(fade_out_delay))
     ]

--- a/src/libs/autocue.liq
+++ b/src/libs/autocue.liq
@@ -292,7 +292,15 @@ def autocue.internal.implementation(uri) =
 
     # Limit overlap duration to maximum
     if max_overlap < fade_in() then fade_in := max_overlap end
-    if max_overlap < fade_out() then fade_out := max_overlap end
+
+    if
+      max_overlap < fade_out()
+    then
+      cue_shift = fade_out() - max_overlap
+      cue_out := cue_out() - cue_shift
+      fade_out := max_overlap
+      fade_out := max_overlap
+    end
 
     {
       amplify=lufs_correction,

--- a/src/libs/autocue.liq
+++ b/src/libs/autocue.liq
@@ -473,7 +473,10 @@ def enable_autocue_metadata() =
             label="autocue.metadata",
             "Keeping user-provided `\"liq_amplify\"` value."
           )
-          [...autocue_metadata, ("liq_amplify", metadata["amplify"])]
+          [
+            ...list.assoc.remove("liq_amplify", autocue_metadata),
+            ("liq_amplify", metadata["liq_amplify"])
+          ]
         elsif
           settings.autocue.amplify_behavior() == "override"
         then

--- a/src/libs/autocue.liq
+++ b/src/libs/autocue.liq
@@ -1,74 +1,80 @@
-# Initialize settings for autocue protocol
-let settings.autocue = ()
+# Initialize settings for autocue
+let settings.autocue = {internal=()}
 
-let settings.autocue.lufs_target =
+let settings.autocue.implementations =
+  settings.make(
+    description=
+      "All available autocue implementations",
+    []
+  )
+
+let settings.autocue.preferred =
+  settings.make(
+    description=
+      "Preferred autocue",
+    "internal"
+  )
+
+let settings.autocue.internal.lufs_target =
   settings.make(
     description=
       "Loudness target",
     -16.0
   )
 
-let settings.autocue.cue_in_threshold =
+let settings.autocue.internal.cue_in_threshold =
   settings.make(
     description=
       "Cue in threshold",
     -34.0
   )
 
-let settings.autocue.cue_out_threshold =
+let settings.autocue.internal.cue_out_threshold =
   settings.make(
     description=
       "Cue out threshold",
     -42.0
   )
 
-let settings.autocue.cross_threshold =
-  settings.make(
-    description=
-      "Crossfade start threshold",
-    -7.0
-  )
-
-let settings.autocue.max_overlap =
+let settings.autocue.internal.max_overlap =
   settings.make(
     description=
       "Maximum allowed overlap/crossfade in seconds",
     6.0
   )
 
-let settings.autocue.ratio =
+let settings.autocue.internal.ratio =
   settings.make(
     description=
       "Maximum real time ratio to control speed of LUFS data analysis",
     50.
   )
 
-let settings.autocue.timeout =
+let settings.autocue.internal.timeout =
   settings.make(
     description=
       "Maximum allowed processing time (estimated)",
     10.
   )
 
-let settings.autocue.metadata_overrides =
-  settings.make(
-    description=
-      "Existing metadata causing autocue to skip",
-    [
-      "liq_amplify",
-      "liq_cue_in",
-      "liq_cue_out",
-      "liq_cross_duration",
-      "liq_fade_in",
-      "liq_fade_out"
-    ]
-  )
+let autocue = {internal=()}
 
-let file.autocue = ()
+def autocue.register(~name, fn) =
+  current_implementations = settings.autocue.implementations()
+  if
+    list.assoc.mem(name, current_implementations)
+  then
+    error.raise(
+      error.invalid,
+      "Autocue implementation #{name} already exists!"
+    )
+  end
+  settings.autocue.implementations := [(name, fn), ...current_implementations]
+end
 
 # Get frames from ffmpeg.filter.ebur128
 # @flag hidden
-def file.autocue.ebur128(~ratio=50.,~timeout=10.,uri) =
+def autocue.internal.ebur128(~ratio=50., ~timeout=10., uri) =
   r = request.create(resolve_metadata=false, uri)
   s = request.once(r)
 
@@ -76,8 +82,7 @@ def file.autocue.ebur128(~ratio=50.,~timeout=10.,uri) =
     s.resolve()
   then
 %ifdef ffmpeg.filter.ebur128
-
-    duration = null.get(default=0.,request.duration(uri))
+    duration = null.get(default=0., request.duration(uri))
     estimated_processing_time = duration / ratio
 
     if
@@ -85,8 +90,11 @@ def file.autocue.ebur128(~ratio=50.,~timeout=10.,uri) =
     then
       log(
         level=2,
-        label="autocue",
-        "Estimated processing duration is too long, autocue disabled! #{duration} / #{ratio} = #{estimated_processing_time} (Duration / Ratio = Processing duration; max. allowed: #{timeout})"
+        label="autocue.internal",
+        "Estimated processing duration is too long, autocue disabled! #{
+          duration
+        } / #{ratio} = #{estimated_processing_time} (Duration / Ratio = \
+         Processing duration; max. allowed: #{timeout})"
       )
       []
     else
@@ -113,7 +121,7 @@ def file.autocue.ebur128(~ratio=50.,~timeout=10.,uri) =
 %else
     log(
       level=2,
-      label="autofocus",
+      label="autocue.internal",
       "ffmpeg.filter.ebur128 is not available, autocue disabled!"
     )
     []
@@ -121,7 +129,7 @@ def file.autocue.ebur128(~ratio=50.,~timeout=10.,uri) =
   else
     log(
       level=2,
-      label="autocue",
+      label="autocue.internal",
       "Couldn't resolve source for uri: #{uri}"
     )
     []
@@ -129,40 +137,23 @@ def file.autocue.ebur128(~ratio=50.,~timeout=10.,uri) =
 end
 
 # Compute autocue data
-# @flag extra
-# @category Source / Audio processing
-# @param ~lufs_target Loudness target in LUFS
-# @param ~cue_in_threshold Cue in threshold
-# @param ~cue_out_threshold Cue out threshold
-# @param ~cross_threshold Crossfade start threshold
-# @param ~max_overlap Maximum allowed overlap/crossfade in seconds
-# @param ~ratio Decoding ratio. A value of `50.` means try to decode the file `50x` faster than real time, if possible. Use this setting to lower CPU peaks when computing autocue data.
-def replaces file.autocue(
-  ~lufs_target=null(),
-  ~cue_in_threshold=null(),
-  ~cue_out_threshold=null(),
-  ~cross_threshold=null(),
-  ~max_overlap=null(),
-  ~ratio=null(),
-  ~timeout=null(),
-  uri
-) =
-  lufs_target = lufs_target ?? settings.autocue.lufs_target()
-  cue_in_threshold = cue_in_threshold ?? settings.autocue.cue_in_threshold()
-  cue_out_threshold = cue_out_threshold ?? settings.autocue.cue_out_threshold()
-  cross_threshold = cross_threshold ?? settings.autocue.cross_threshold()
-  max_overlap = max_overlap ?? settings.autocue.max_overlap()
-  ratio = ratio ?? settings.autocue.ratio()
-  timeout = timeout ?? settings.autocue.timeout()
+# @flag hidden
+def autocue.internal.implementation(uri) =
+  lufs_target = settings.autocue.internal.lufs_target()
+  cue_in_threshold = settings.autocue.internal.cue_in_threshold()
+  cue_out_threshold = settings.autocue.internal.cue_out_threshold()
+  max_overlap = settings.autocue.internal.max_overlap()
+  ratio = settings.autocue.internal.ratio()
+  timeout = settings.autocue.internal.timeout()
 
-  frames = file.autocue.ebur128(ratio=ratio, timeout=timeout, uri)
+  frames = autocue.internal.ebur128(ratio=ratio, timeout=timeout, uri)
 
   if
-    frames == []
+    list.length(frames) < 2
   then
     log(
       level=2,
-      label="autocue",
+      label="autocue.internal",
       "Autocue computation failed!"
     )
     null()
@@ -182,36 +173,28 @@ def replaces file.autocue(
     # Create dB thresholds relative to LUFS target
     lufs_cue_in_threshold = lufs + cue_in_threshold
     lufs_cue_out_threshold = lufs + cue_out_threshold
-    lufs_cross_threshold = lufs + cross_threshold
 
     log(
       level=4,
-      label="autocue",
+      label="autocue.internal",
       "lufs_correction: #{lufs_correction}"
     )
     log(
       level=4,
-      label="autocue",
+      label="autocue.internal",
       "adj_cue_in_threshold: #{lufs_cue_in_threshold}"
     )
     log(
       level=4,
-      label="autocue",
+      label="autocue.internal",
       "adj_cue_out_threshold: #{lufs_cue_out_threshold}"
-    )
-    log(
-      level=4,
-      label="autocue",
-      "adj_cross_threshold: #{lufs_cross_threshold}"
     )
 
     # Set cue/fade defaults
     cue_in = ref(0.)
     cue_out = ref(0.)
-    cross_cue = ref(0.)
     fade_in = ref(0.)
     fade_out = ref(0.)
-    cross_duration = ref(0.)
 
     # Extract timestamps for cue points
     # Iterate over loudness data frames and set cue points based on db thresholds
@@ -244,12 +227,6 @@ def replaces file.autocue(
           # Cue out: Stick with the latest timestamp where level still exceeds threshold
           cue_out := current_ts()
         end
-        if
-          db_level > lufs_cross_threshold
-        then
-          # Absolute crossfade cue: Stick with the latest timestamp where level still exceeds threshold
-          cross_cue := current_ts()
-        end
       end
 
       # Update last timestamp value with current
@@ -264,19 +241,6 @@ def replaces file.autocue(
         float_of_string(list.assoc(default="0.", "lavfi.liq.duration", frame))
 
     # Finalize cue/cross/fade values now...
-
-    # Calc cross/overlap duration
-    if
-      cross_cue() + 0.1 < duration
-    then
-      if
-        cue_out() > 0.
-      then
-        cross_duration := cue_out() - cross_cue()
-      else
-        cross_duration := duration - cross_cue()
-      end
-    end
 
     # Add some margin to cue in
     cue_in := cue_in() - 0.1
@@ -297,73 +261,76 @@ def replaces file.autocue(
       cue_in := 0.
     end
 
+    # Limit overlap duration to maximum
+    if max_overlap < cue_in() then cue_in := cue_in() - max_overlap end
+
+    if max_overlap < cue_out() then cue_out := cue_out() - max_overlap end
+
     # Catch invalid cue out values
     if cue_out() <= cue_in() then cue_out := 0. end
-
-    # Set fade out equal to crossfade/overlap
-    if cross_duration() > 0. then fade_out := cross_duration() end
-
-    # Limit overlap duration to maximum
-    if
-      cross_duration() > max_overlap
-    then
-      cue_shift = cross_duration() - max_overlap
-      cue_out := cue_out() - cue_shift
-      cross_duration := max_overlap
-      fade_out := max_overlap
-    end
 
     {
       amplify=lufs_correction,
       cue_in=(cue_in() > 0. ? cue_in() : null() ),
       cue_out=(cue_out() > 0. ? cue_out() : null() ),
-      cross_duration=cross_duration(),
       fade_in=fade_in(),
       fade_out=fade_out()
     }
   end
 end
 
+autocue.register(name="internal", autocue.internal.implementation)
+
+let file.autocue = ()
+
 # Return the file's autocue values as metadata suitable for metadata override.
-# @flag extra
 # @category Source / Audio processing
-# @param ~lufs_target Loudness target in LUFS
-# @param ~cue_in_threshold Cue in threshold
-# @param ~cue_out_threshold Cue out threshold
-# @param ~cross_threshold Crossfade start threshold
-# @param ~max_overlap Maximum allowed overlap/crossfade in seconds
-# @param ~ratio Decoding ratio. A value of `50.` means try to decode the file `50x` faster than real time, if possible. Use this setting to lower CPU peaks when computing autocue data.
-def file.autocue.metadata(
-  ~lufs_target=null(),
-  ~cue_in_threshold=null(),
-  ~cue_out_threshold=null(),
-  ~cross_threshold=null(),
-  ~max_overlap=null(),
-  ~ratio=null(),
-  uri
-) =
-  let autocue =
-    file.autocue(
-      lufs_target=lufs_target,
-      cue_in_threshold=cue_in_threshold,
-      cue_out_threshold=cue_out_threshold,
-      cross_threshold=cross_threshold,
-      max_overlap=max_overlap,
-      ratio=ratio,
-      uri
-    )
+def file.autocue.metadata(uri) =
+  preferred_implementation = settings.autocue.preferred()
+  implementations = settings.autocue.implementations()
+  implementation =
+    if
+      list.assoc.mem(preferred_implementation, implementations)
+    then
+      log(
+        level=4,
+        label="autocue",
+        "Using preferred #{preferred_implementation} autocue implementation."
+      )
+      list.assoc(preferred_implementation, implementations)
+    elsif
+      list.length(implementations) > 0
+    then
+      let [(name, implementation)] = implementations
+      log(
+        level=4,
+        label="autocue",
+        "Using first available #{name} autocue implementation."
+      )
+      implementation
+    else
+      error.raise(
+        error.not_found,
+        "No autocue implementation found!"
+      )
+    end
+
+  autocue = implementation(uri)
 
   if
     null.defined(autocue)
   then
-    let {
-      amplify,
-      cue_in,
-      cue_out,
-      cross_duration,
-      fade_in,
-      fade_out
-    } = null.get(autocue)
+    let {amplify, cue_in, cue_out, fade_in, fade_out} = null.get(autocue)
+
+    cross_duration = max(fade_in, fade_out)
+
+    # Make sure cross_duration is never 0.
+    cross_duration = max(cross_duration, 0.1)
+
+    fade_in_delay =
+      if fade_in < cross_duration then cross_duration - fade_in else 0. end
+    fade_out_delay =
+      if fade_out < cross_duration then cross_duration - fade_out else 0. end
 
     [
       ("liq_autocue", "true"),
@@ -381,7 +348,9 @@ def file.autocue.metadata(
 
       ("liq_cross_duration", string(cross_duration)),
       ("liq_fade_in", string(fade_in)),
-      ("liq_fade_out", string(fade_out))
+      ("liq_fade_in_delay", string(fade_in_delay)),
+      ("liq_fade_out", string(fade_out)),
+      ("liq_fade_out_delay", string(fade_out_delay))
     ]
   else
     log(
@@ -396,11 +365,15 @@ end
 # Enable autocue metadata resolver. This resolver will process any file
 # decoded by Liquidsoap and add cue-in/out and crossfade metadata when these
 # values can be computed. For a finer-grained processing, use the `autocue:` protocol.
+# This also sets `settings.crossfade.reconcile_duration` to `true`.
 # @category Liquidsoap
 def enable_autocue_metadata() =
-  def autocue_metadata(~metadata, fname) =
+  settings.crossfade.reconcile_duration := true
 
-    metadata_overrides = settings.autocue.metadata_overrides()
+  def autocue_metadata(~metadata, fname) =
+    metadata_overrides =
+      ["liq_amplify", "liq_cue_in", "liq_cue_out", "liq_fade_in", "liq_fade_out"
+      ]
 
     if
       list.exists(fun (el) -> list.mem(fst(el), metadata_overrides), metadata)
@@ -434,7 +407,7 @@ def protocol.autocue(~rlog=_, ~maxtime=_, arg) =
     log(
       level=2,
       label="autocue.protocol",
-      "No autofocus data found for URI #{arg}!"
+      "No autocue data found for URI #{arg}!"
     )
     [arg]
   end

--- a/src/libs/autocue.liq
+++ b/src/libs/autocue.liq
@@ -24,19 +24,19 @@ let settings.autocue.preferred =
     "internal"
   )
 
-let settings.autocue.internal.metadata_override =
+let settings.autocue.metadata_override =
   settings.make(
     description=
       "Disable processing when one of these metadata is found",
     ["liq_cue_in", "liq_cue_out", "liq_fade_in", "liq_fade_out"]
   )
 
-let settings.autocue.internal.amplify_behavior =
+let settings.autocue.amplify_behavior =
   settings.make(
     description=
       "How to proceed with amplify data when `\"liq_amplify\"` is set. One of: \
        `\"keep\"` (keep user-provided value), `\"override\"` (override with \
-       computed value) or `\"disable\`\" (disable `autocue` altogether).",
+       computed value) or `\"disable\"` (disable `autocue` altogether).",
     "keep"
   )
 
@@ -327,13 +327,25 @@ def autocue.internal.implementation(uri) =
       fade_out := max_overlap
     end
 
-    {
-      amplify=lufs_correction,
-      cue_in=cue_in(),
-      cue_out=cue_out(),
-      fade_in=fade_in(),
-      fade_out=fade_out()
-    }
+    (
+      {
+        amplify=lufs_correction,
+        cue_in=cue_in(),
+        cue_out=cue_out(),
+        fade_in=fade_in(),
+        fade_out=fade_out(),
+        extra_metadata=[("liq_autocue", "internal")]
+      }
+    :
+      {
+        amplify?: float,
+        cue_in: float,
+        cue_out: float,
+        fade_in: float,
+        fade_out: float,
+        extra_metadata?: [(string*string)]
+      }
+    )
   end
 end
 
@@ -378,7 +390,10 @@ def file.autocue.metadata(uri) =
   if
     null.defined(autocue)
   then
-    let {amplify, cue_in, cue_out, fade_in, fade_out} = null.get(autocue)
+    autocue = null.get(autocue)
+    let {cue_in, cue_out, fade_in, fade_out} = autocue
+    extra_metadata = autocue.extra_metadata ?? []
+    amplify = autocue?.amplify
 
     cross_duration =
       if
@@ -396,17 +411,24 @@ def file.autocue.metadata(uri) =
       if fade_out < cross_duration then cross_duration - fade_out else 0. end
 
     [
-      ("liq_autocue", "true"),
-      (
-        "liq_amplify",
-        "#{amplify} dB"
+      ...(
+        null.defined(amplify)
+        ?
+          [
+            (
+              "liq_amplify",
+              "#{null.get(amplify)} dB"
+            )
+          ]
+        : []
       ),
       ("liq_cue_in", string(cue_in)),
       ("liq_cue_out", string(cue_out)),
       ("liq_cross_duration", string(cross_duration)),
       ("liq_fade_in", string(fade_in)),
       ("liq_fade_out", string(fade_out)),
-      ("liq_fade_out_delay", string(fade_out_delay))
+      ("liq_fade_out_delay", string(fade_out_delay)),
+      ...extra_metadata
     ]
   else
     log(
@@ -428,10 +450,10 @@ def enable_autocue_metadata() =
   if settings.request.prefetch() == 1 then settings.request.prefetch := 2 end
 
   def autocue_metadata(~metadata, fname) =
-    metadata_overrides = settings.autocue.internal.metadata_override()
+    metadata_overrides = settings.autocue.metadata_override()
     metadata_overrides =
       if
-        settings.autocue.internal.amplify_behavior() == "cancel"
+        settings.autocue.amplify_behavior() == "cancel"
       then
         [...metadata_overrides, "liq_amplify"]
       else
@@ -454,7 +476,7 @@ def enable_autocue_metadata() =
         list.assoc.mem("liq_amplify", metadata)
       then
         if
-          settings.autocue.internal.amplify_behavior() == "keep"
+          settings.autocue.amplify_behavior() == "keep"
         then
           log(
             level=3,
@@ -463,7 +485,7 @@ def enable_autocue_metadata() =
           )
           [...autocue_metadata, ("liq_amplify", metadata["amplify"])]
         elsif
-          settings.autocue.internal.amplify_behavior() == "override"
+          settings.autocue.amplify_behavior() == "override"
         then
           log(
             level=3,
@@ -473,13 +495,13 @@ def enable_autocue_metadata() =
           autocue_metadata
         else
           if
-            settings.autocue.internal.amplify_behavior() != "cancel"
+            settings.autocue.amplify_behavior() != "cancel"
           then
             log(
               level=2,
               label="autocue.metadata",
-              "Invalid value for `settings.autocue.internal.amplify_behavior`: #{
-                settings.autocue.internal.amplify_behavior()
+              "Invalid value for `settings.autocue.amplify_behavior`: #{
+                settings.autocue.amplify_behavior()
               }"
             )
           end

--- a/src/libs/autocue.liq
+++ b/src/libs/autocue.liq
@@ -389,10 +389,10 @@ end
 # Enable autocue metadata resolver. This resolver will process any file
 # decoded by Liquidsoap and add cue-in/out and crossfade metadata when these
 # values can be computed. For a finer-grained processing, use the `autocue:` protocol.
-# This also sets `settings.crossfade.reconcile_duration` to `true`.
+# This also sets `settings.crossfade.autocue` to `true`.
 # @category Liquidsoap
 def enable_autocue_metadata() =
-  settings.crossfade.reconcile_duration := true
+  settings.crossfade.autocue := true
 
   def autocue_metadata(~metadata, fname) =
     metadata_overrides =

--- a/src/libs/autocue.liq
+++ b/src/libs/autocue.liq
@@ -434,10 +434,12 @@ end
 # decoded by Liquidsoap and add cue-in/out and crossfade metadata when these
 # values can be computed. This function sets `settings.request.prefetch` to `2`
 # to account for the latency introduced by the `autocue` computation when resolving
-# reausts. For a finer-grained processing, use the `autocue:` protocol.
+# reausts and sets `settings.crossfade.assume_autocue` to `true` as well. For a
+# finer-grained processing, use the `autocue:` protocol.
 # @category Liquidsoap
 def enable_autocue_metadata() =
   if settings.request.prefetch() == 1 then settings.request.prefetch := 2 end
+  settings.crossfade.assume_autocue := true
 
   def autocue_metadata(~metadata, fname) =
     metadata_overrides = settings.autocue.metadata_override()

--- a/src/libs/autocue.liq
+++ b/src/libs/autocue.liq
@@ -45,7 +45,7 @@ let settings.autocue.internal.cue_out_threshold =
     -42.0
   )
 
-let settings.autocue.cross_threshold =
+let settings.autocue.internal.cross_threshold =
   settings.make(
     description=
       "Crossfade start threshold",
@@ -158,7 +158,7 @@ def autocue.internal.implementation(uri) =
   lufs_target = settings.autocue.internal.lufs_target()
   cue_in_threshold = settings.autocue.internal.cue_in_threshold()
   cue_out_threshold = settings.autocue.internal.cue_out_threshold()
-  cross_threshold = settings.autocue.cross_threshold()
+  cross_threshold = settings.autocue.internal.cross_threshold()
   max_overlap = settings.autocue.internal.max_overlap()
   ratio = settings.autocue.internal.ratio()
   timeout = settings.autocue.internal.timeout()

--- a/src/libs/autocue.liq
+++ b/src/libs/autocue.liq
@@ -204,7 +204,6 @@ def autocue.internal.implementation(uri) =
       "adj_cross_threshold: #{lufs_cross_threshold}"
     )
 
-
     # Set cue/fade defaults
     cue_in = ref(0.)
     cue_out = ref(0.)
@@ -263,17 +262,13 @@ def autocue.internal.implementation(uri) =
         float_of_string(list.assoc(default="0.", "lavfi.liq.duration", frame))
 
     # Finalize cue/cross/fade values now...
+    if cue_out() == 0. then cue_out := duration end
+
     # Calc cross/overlap duration
     if
-      cross_cue() + 0.1 < duration
+      cross_cue() + 0.1 < cue_out()
     then
-      if
-        cue_out() > 0.
-      then
-        fade_out := cue_out() - cross_cue()
-      else
-        fade_out := duration - cross_cue()
-      end
+      fade_out := cue_out() - cross_cue()
     end
 
     # Add some margin to cue in
@@ -297,20 +292,12 @@ def autocue.internal.implementation(uri) =
 
     # Limit overlap duration to maximum
     if max_overlap < fade_in() then fade_in := max_overlap end
-
-    if max_overlap < fade_out() then
-      cue_shift = fade_out() - max_overlap
-      cue_out := cue_out() - cue_shift
-      fade_out := max_overlap
-    end
-
-    # Catch invalid cue out values
-    if cue_out() <= cue_in() then cue_out := 0. end
+    if max_overlap < fade_out() then fade_out := max_overlap end
 
     {
       amplify=lufs_correction,
-      cue_in=(cue_in() > 0. ? cue_in() : null() ),
-      cue_out=(cue_out() > 0. ? cue_out() : null() ),
+      cue_in=cue_in(),
+      cue_out=cue_out(),
       fade_in=fade_in(),
       fade_out=fade_out()
     }
@@ -376,14 +363,8 @@ def file.autocue.metadata(uri) =
         "liq_amplify",
         "#{amplify} dB"
       ),
-      ...(
-        null.defined(cue_in) ? [("liq_cue_in", string(null.get(cue_in)))] : []
-      ),
-      ...(
-        null.defined(cue_out)
-        ? [("liq_cue_out", string(null.get(cue_out)))] : []
-      ),
-
+      ("liq_cue_in", string(cue_in)),
+      ("liq_cue_out", string(cue_out)),
       ("liq_cross_duration", string(cross_duration)),
       ("liq_fade_in", string(fade_in)),
       ("liq_fade_in_delay", string(fade_in_delay)),

--- a/src/libs/autocue.liq
+++ b/src/libs/autocue.liq
@@ -298,7 +298,11 @@ def autocue.internal.implementation(uri) =
     # Limit overlap duration to maximum
     if max_overlap < fade_in() then fade_in := max_overlap end
 
-    if max_overlap < fade_out() then fade_out := max_overlap end
+    if max_overlap < fade_out() then
+      cue_shift = fade_out() - max_overlap
+      cue_out := cue_out() - cue_shift
+      fade_out := max_overlap
+    end
 
     # Catch invalid cue out values
     if cue_out() <= cue_in() then cue_out := 0. end

--- a/src/libs/autocue.liq
+++ b/src/libs/autocue.liq
@@ -404,9 +404,13 @@ end
 
 # Enable autocue metadata resolver. This resolver will process any file
 # decoded by Liquidsoap and add cue-in/out and crossfade metadata when these
-# values can be computed. For a finer-grained processing, use the `autocue:` protocol.
+# values can be computed. This function sets `settings.request.prefetch` to `2`
+# to account for the latency introduced by the `autocue` computation when resolving
+# reausts. For a finer-grained processing, use the `autocue:` protocol.
 # @category Liquidsoap
 def enable_autocue_metadata() =
+  if settings.request.prefetch() == 1 then settings.request.prefetch := 2 end
+
   def autocue_metadata(~metadata, fname) =
     metadata_overrides =
       ["liq_amplify", "liq_cue_in", "liq_cue_out", "liq_fade_in", "liq_fade_out"

--- a/src/libs/autocue.liq
+++ b/src/libs/autocue.liq
@@ -24,6 +24,22 @@ let settings.autocue.preferred =
     "internal"
   )
 
+let settings.autocue.internal.metadata_override =
+  settings.make(
+    description=
+      "Disable processing when one of these metadata is found",
+    ["liq_cue_in", "liq_cue_out", "liq_fade_in", "liq_fade_out"]
+  )
+
+let settings.autocue.internal.amplify_behavior =
+  settings.make(
+    description=
+      "How to proceed with amplify data when `\"liq_amplify\"` is set. One of: \
+       `\"keep\"` (keep user-provided value), `\"override\"` (override with \
+       computed value) or `\"disable\`\" (disable `autocue` altogether).",
+    "keep"
+  )
+
 let settings.autocue.internal.lufs_target =
   settings.make(
     description=
@@ -412,9 +428,15 @@ def enable_autocue_metadata() =
   if settings.request.prefetch() == 1 then settings.request.prefetch := 2 end
 
   def autocue_metadata(~metadata, fname) =
+    metadata_overrides = settings.autocue.internal.metadata_override()
     metadata_overrides =
-      ["liq_amplify", "liq_cue_in", "liq_cue_out", "liq_fade_in", "liq_fade_out"
-      ]
+      if
+        settings.autocue.internal.amplify_behavior() == "cancel"
+      then
+        [...metadata_overrides, "liq_amplify"]
+      else
+        metadata_overrides
+      end
 
     if
       list.exists(fun (el) -> list.mem(fst(el), metadata_overrides), metadata)
@@ -426,7 +448,46 @@ def enable_autocue_metadata() =
       )
       []
     else
-      file.autocue.metadata(fname)
+      autocue_metadata = file.autocue.metadata(fname)
+
+      if
+        list.assoc.mem("liq_amplify", metadata)
+      then
+        if
+          settings.autocue.internal.amplify_behavior() == "keep"
+        then
+          log(
+            level=3,
+            label="autocue.metadata",
+            "Keeping user-provided `\"liq_amplify\"` value."
+          )
+          [...autocue_metadata, ("liq_amplify", metadata["amplify"])]
+        elsif
+          settings.autocue.internal.amplify_behavior() == "override"
+        then
+          log(
+            level=3,
+            label="autocue.metadata",
+            "Overriding user-provided `\"liq_amplify\"` value."
+          )
+          autocue_metadata
+        else
+          if
+            settings.autocue.internal.amplify_behavior() != "cancel"
+          then
+            log(
+              level=2,
+              label="autocue.metadata",
+              "Invalid value for `settings.autocue.internal.amplify_behavior`: #{
+                settings.autocue.internal.amplify_behavior()
+              }"
+            )
+          end
+          autocue_metadata
+        end
+      else
+        autocue_metadata
+      end
     end
   end
   decoder.metadata.add("autocue", autocue_metadata)

--- a/src/libs/autocue.liq
+++ b/src/libs/autocue.liq
@@ -8,6 +8,15 @@ let settings.autocue.implementations =
     []
   )
 
+let settings.autocue.target_cross_duration =
+  settings.make(
+    description=
+      "How much data should be buffer from each track when computing crossfade \
+       transitions. This will be shorter if one of the track is shorter than \
+       that.",
+    3.
+  )
+
 let settings.autocue.preferred =
   settings.make(
     description=
@@ -355,7 +364,14 @@ def file.autocue.metadata(uri) =
   then
     let {amplify, cue_in, cue_out, fade_in, fade_out} = null.get(autocue)
 
-    cross_duration = max(fade_in, fade_out)
+    cross_duration =
+      if
+        cue_out - cue_in < settings.autocue.target_cross_duration() * 2.
+      then
+        max(fade_in, fade_out)
+      else
+        settings.autocue.target_cross_duration()
+      end
 
     # Make sure cross_duration is never 0.
     cross_duration = max(cross_duration, 0.1)

--- a/src/libs/autocue.liq
+++ b/src/libs/autocue.liq
@@ -262,9 +262,9 @@ def autocue.internal.implementation(uri) =
     end
 
     # Limit overlap duration to maximum
-    if max_overlap < cue_in() then cue_in := cue_in() - max_overlap end
+    if max_overlap < fade_in() then fade_in := max_overlap end
 
-    if max_overlap < cue_out() then cue_out := cue_out() - max_overlap end
+    if max_overlap < fade_out() then fade_out := max_overlap end
 
     # Catch invalid cue out values
     if cue_out() <= cue_in() then cue_out := 0. end

--- a/src/libs/autocue.liq
+++ b/src/libs/autocue.liq
@@ -36,6 +36,13 @@ let settings.autocue.internal.cue_out_threshold =
     -42.0
   )
 
+let settings.autocue.cross_threshold =
+  settings.make(
+    description=
+      "Crossfade start threshold",
+    -7.0
+  )
+
 let settings.autocue.internal.max_overlap =
   settings.make(
     description=
@@ -142,6 +149,7 @@ def autocue.internal.implementation(uri) =
   lufs_target = settings.autocue.internal.lufs_target()
   cue_in_threshold = settings.autocue.internal.cue_in_threshold()
   cue_out_threshold = settings.autocue.internal.cue_out_threshold()
+  cross_threshold = settings.autocue.cross_threshold()
   max_overlap = settings.autocue.internal.max_overlap()
   ratio = settings.autocue.internal.ratio()
   timeout = settings.autocue.internal.timeout()
@@ -173,6 +181,7 @@ def autocue.internal.implementation(uri) =
     # Create dB thresholds relative to LUFS target
     lufs_cue_in_threshold = lufs + cue_in_threshold
     lufs_cue_out_threshold = lufs + cue_out_threshold
+    lufs_cross_threshold = lufs + cross_threshold
 
     log(
       level=4,
@@ -189,10 +198,17 @@ def autocue.internal.implementation(uri) =
       label="autocue.internal",
       "adj_cue_out_threshold: #{lufs_cue_out_threshold}"
     )
+    log(
+      level=4,
+      label="autocue",
+      "adj_cross_threshold: #{lufs_cross_threshold}"
+    )
+
 
     # Set cue/fade defaults
     cue_in = ref(0.)
     cue_out = ref(0.)
+    cross_cue = ref(0.)
     fade_in = ref(0.)
     fade_out = ref(0.)
 
@@ -227,6 +243,12 @@ def autocue.internal.implementation(uri) =
           # Cue out: Stick with the latest timestamp where level still exceeds threshold
           cue_out := current_ts()
         end
+        if
+          db_level > lufs_cross_threshold
+        then
+          # Absolute crossfade cue: Stick with the latest timestamp where level still exceeds threshold
+          cross_cue := current_ts()
+        end
       end
 
       # Update last timestamp value with current
@@ -241,6 +263,18 @@ def autocue.internal.implementation(uri) =
         float_of_string(list.assoc(default="0.", "lavfi.liq.duration", frame))
 
     # Finalize cue/cross/fade values now...
+    # Calc cross/overlap duration
+    if
+      cross_cue() + 0.1 < duration
+    then
+      if
+        cue_out() > 0.
+      then
+        fade_out := cue_out() - cross_cue()
+      else
+        fade_out := duration - cross_cue()
+      end
+    end
 
     # Add some margin to cue in
     cue_in := cue_in() - 0.1

--- a/src/libs/extra/deprecations.liq
+++ b/src/libs/extra/deprecations.liq
@@ -84,7 +84,7 @@ end
 # `reload_mode` argument to `"never"` and `loop` to `false`.
 # @flag deprecated
 def playlist.once(~id=null(),~random=false,~reload_mode="",
-                  ~prefetch=1,~filter=fun(_)->true,uri)
+                  ~prefetch=null(),~filter=fun(_)->true,uri)
   deprecated("playlist.once", "playlist")
   mode = if random then "randomize" else "normal" end
   reload_mode = if reload_mode == "" then "never" else reload_mode end

--- a/src/libs/fades.liq
+++ b/src/libs/fades.liq
@@ -1,9 +1,12 @@
+let settings.crossfade = settings.make.void("Crossfqde settings")
+
 let settings.crossfade.reconcile_duration =
   settings.make(
     description=
       "Default value for `reconcile_duration`",
     false
   )
+
 
 fade = ()
 
@@ -110,8 +113,7 @@ end
 # Fade the end of tracks.
 # @category Source / Fade
 # @param ~id Force the value of the source ID.
-# @param ~duration Duration of the fading. This value can be set on a per-file basis using the metadata field passed as override. \
-#                  Defaults to `settings.crossfade.fade_out_duration` if `null`.
+# @param ~duration Duration of the fading. This value can be set on a per-file basis using the metadata field passed as override.
 # @param ~delay Initial delay before starting fade.
 # @param ~curve Fade curve. Default if `null`.
 # @param ~override_duration Metadata field which, if present and containing a float, overrides the 'duration' parameter for the current track.
@@ -125,7 +127,7 @@ end
 # @param ~type Fader shape (lin|sin|log|exp): linear, sinusoidal, logarithmic or exponential.
 def fade.out(
   ~id="fade.out",
-  ~duration=null(),
+  ~duration=3.,
   ~delay=0.,
   ~curve=null(),
   ~override_duration="liq_fade_out",
@@ -147,7 +149,6 @@ def fade.out(
   type = ref(type)
   original_curve = curve
   curve = ref(curve)
-  duration = duration ?? settings.crossfade.fade_out_duration()
   original_duration = duration
   duration = ref(duration)
   original_delay = delay
@@ -282,9 +283,8 @@ def fade.out(
       not persist_overrides
     then
       log(
-        "Setting fade out to default duration: #{original_duration}s, delay: #{
-          original_delay
-        }s, type: #{original_type}, curve: #{original_curve}"
+        "Setting fade out to default duration: #{original_duration}s, delay: \
+        #{original_delay}s, type: #{original_type}, curve: #{original_curve}"
       )
       duration := original_duration
       delay := original_delay
@@ -449,9 +449,8 @@ def fade.skip(
       not persist_overrides
     then
       log(
-        "Setting fade skip to default duration: #{original_duration}s, type: #{
-          original_type
-        }, curve: #{original_curve}"
+        "Setting fade skip to default duration: #{original_duration}s, \
+        type: #{original_type}, curve: #{original_curve}"
       )
       duration := original_duration
       type := original_type
@@ -462,14 +461,16 @@ def fade.skip(
   s = source.on_track(s, reset_overrides)
   s = source.on_metadata(s, update_fade)
   s = source.on_track(s, stop_fade)
-  fade.scale(id=id, apply, s).{fade_duration={duration()}, fade_type={type()}}
+  fade.scale(id=id, apply, s).{
+    fade_duration={duration()},
+    fade_type={type()}
+  }
 end
 
 # Fade the beginning of tracks.
 # @category Source / Fade
 # @param ~id Force the value of the source ID.
-# @param ~duration Duration of the fading. This value can be set on a per-file basis using the metadata field passed as override.\
-#                  Defaults to `settings.crossfade.fade_in_duration` if `null`.
+# @param ~duration Duration of the fading. This value can be set on a per-file basis using the metadata field passed as override.
 # @param ~delay Initial delay before starting fade.
 # @param ~curve Fade curve. Default if `null`.
 # @param ~override_duration Metadata field which, if present and containing a float, overrides the 'duration' parameter for the current track.
@@ -483,7 +484,7 @@ end
 # @param ~type Fader shape (lin|sin|log|exp): linear, sinusoidal, logarithmic or exponential.
 def fade.in(
   ~id="fade.in",
-  ~duration=null(),
+  ~duration=3.,
   ~delay=0.,
   ~curve=null(),
   ~override_duration="liq_fade_in",
@@ -501,7 +502,6 @@ def fade.in(
   end
 
   fn = ref(fun () -> 0.)
-  duration = duration ?? settings.crossfade.fade_in_duration()
   original_duration = duration
   duration = ref(duration)
   original_delay = delay
@@ -521,14 +521,12 @@ def fade.in(
     curve_log =
       if null.defined(curve()) then string(null.get(curve())) else "default" end
 
-    duration =
-      if
-        source.remaining(s) < duration()
-      then
-        source.remaining(s)
-      else
-        duration()
-      end
+     duration =
+       if source.remaining(s) < duration() then
+         source.remaining(s)
+       else
+         duration()
+        end
 
     log(
       "Fading in with type: #{type()}, curve: #{curve_log}, delay: #{delay()}s \
@@ -626,9 +624,8 @@ def fade.in(
       not persist_overrides
     then
       log(
-        "Setting fade in to default duration: #{original_duration}s, delay: #{
-          original_delay
-        }s, type: #{original_type}, curve: #{original_curve}"
+        "Setting fade in to default duration: #{original_duration}s, \
+        delay: #{original_delay}s, type: #{original_type}, curve: #{original_curve}"
       )
       duration := original_duration
       delay := original_delay
@@ -700,7 +697,7 @@ end
 # @param ~high     Value, in dB, for loud sound level.
 # @param ~medium   Value, in dB, for medium sound level.
 # @param ~margin   Margin to detect sources that have too different sound level for crossing.
-# @param ~default Smart crossfade: transition used when no rule applies (default: sequence).
+# @param ~default Smartcrossfade: transition used when no rule applies (default: sequence).
 # @param a Ending track
 # @param b Starting track
 def cross.smart(
@@ -837,6 +834,13 @@ end
 # @param ~fade_out     Fade-out duration, if any.
 # @param ~width        Width of the volume analysis window.
 # @param ~conservative Always prepare for a premature end-of-track.
+# @param ~reconcile_duration \
+#                      When set to `true`, if duration for the new track is shorter than the ending \
+#                      duration, a `liq_fade_in_delay` metadata is automatically injected to make \
+#                      crossfades match. Defaults to `settings.crossfade.reconcile_duration` if `null`.
+# @param ~override_fade_in_delay \
+#                      Metadata field used to inject metadata overriding fade-in delay \
+#                      when reonciling crossfade duration.
 # @param ~minimum      Minimum duration (in sec.) for a cross: \
 #                      If the track ends without any warning (e.g. in case of skip) \
 #                      there may not be enough data for a decent composition. \
@@ -845,13 +849,6 @@ end
 #                      With a negative default, transitions always occur.
 # @param ~default      Smart crossfade: transition used when no rule applies \
 #                      (default: sequence).
-# @param ~reconcile_duration \
-#                      When set to `true`, if duration for the new track is shorter than the ending \
-#                      duration, a `liq_fade_in_delay` metadata is automatically injected to make \
-#                      crossfades match. Defaults to `settings.crossfade.reconcile_duration` if `null`.
-# @param ~override_fade_in_delay \
-#                      Metadata field used to inject metadata overriding fade-in delay \
-#                      when reonciling crossfade duration.
 # @param ~smart        Enable smart crossfading
 # @param ~high         Smart crossfade: value, in dB, for loud sound level.
 # @param ~medium       Smart crossfade: value, in dB, for medium sound level.

--- a/src/libs/fades.liq
+++ b/src/libs/fades.liq
@@ -832,6 +832,10 @@ end
 #                      With a negative default, transitions always occur.
 # @param ~default      Smart crossfade: transition used when no rule applies \
 #                      (default: sequence).
+# @param ~assume_autocue \
+#                      Assume that a track has autocue enabled when all four cue in/out \
+#                      and fade in/out override metadata are present. Defaults to \
+#                      `settings.crossfade.assume_autocue` when `null`.
 # @param ~smart        Enable smart crossfading
 # @param ~high         Smart crossfade: value, in dB, for loud sound level.
 # @param ~medium       Smart crossfade: value, in dB, for medium sound level.
@@ -849,6 +853,7 @@ def crossfade(
   ~fade_out=3.,
   ~smart=false,
   ~default=(fun (a, b) -> (sequence([a, b]) : source)),
+  ~assume_autocue=null(),
   ~high=-15.,
   ~medium=-32.,
   ~margin=4.,
@@ -938,6 +943,7 @@ def crossfade(
       persist_override=persist_override,
       override_duration=override_duration,
       conservative=conservative,
+      assume_autocue=assume_autocue,
       minimum=minimum,
       transition,
       s

--- a/src/libs/fades.liq
+++ b/src/libs/fades.liq
@@ -1,3 +1,6 @@
+let settings.crossfade.reconcile_duration = settings.make(
+  description="Default value for `reconcile_duration`", false)
+
 fade = ()
 
 # Make a fade function based on a source's clock.
@@ -103,7 +106,8 @@ end
 # Fade the end of tracks.
 # @category Source / Fade
 # @param ~id Force the value of the source ID.
-# @param ~duration Duration of the fading. This value can be set on a per-file basis using the metadata field passed as override.
+# @param ~duration Duration of the fading. This value can be set on a per-file basis using the metadata field passed as override. \
+#                  Defaults to `settings.crossfade.fade_out_duration` if `null`.
 # @param ~delay Initial delay before starting fade.
 # @param ~curve Fade curve. Default if `null`.
 # @param ~override_duration Metadata field which, if present and containing a float, overrides the 'duration' parameter for the current track.
@@ -117,7 +121,7 @@ end
 # @param ~type Fader shape (lin|sin|log|exp): linear, sinusoidal, logarithmic or exponential.
 def fade.out(
   ~id="fade.out",
-  ~duration=3.,
+  ~duration=null(),
   ~delay=0.,
   ~curve=null(),
   ~override_duration="liq_fade_out",
@@ -139,6 +143,7 @@ def fade.out(
   type = ref(type)
   original_curve = curve
   curve = ref(curve)
+  duration = duration ?? settings.crossfade.fade_out_duration()
   original_duration = duration
   duration = ref(duration)
   original_delay = delay
@@ -460,7 +465,8 @@ end
 # Fade the beginning of tracks.
 # @category Source / Fade
 # @param ~id Force the value of the source ID.
-# @param ~duration Duration of the fading. This value can be set on a per-file basis using the metadata field passed as override.
+# @param ~duration Duration of the fading. This value can be set on a per-file basis using the metadata field passed as override.\
+#                  Defaults to `settings.crossfade.fade_in_duration` if `null`.
 # @param ~delay Initial delay before starting fade.
 # @param ~curve Fade curve. Default if `null`.
 # @param ~override_duration Metadata field which, if present and containing a float, overrides the 'duration' parameter for the current track.
@@ -474,7 +480,7 @@ end
 # @param ~type Fader shape (lin|sin|log|exp): linear, sinusoidal, logarithmic or exponential.
 def fade.in(
   ~id="fade.in",
-  ~duration=3.,
+  ~duration=null(),
   ~delay=0.,
   ~curve=null(),
   ~override_duration="liq_fade_in",
@@ -492,6 +498,7 @@ def fade.in(
   end
 
   fn = ref(fun () -> 0.)
+  duration = duration ?? settings.crossfade.fade_in_duration()
   original_duration = duration
   duration = ref(duration)
   original_delay = delay
@@ -809,6 +816,8 @@ def cross.smart(
   end
 end
 
+
+
 # Crossfade between tracks, taking the respective volume levels into account in
 # the choice of the transition.
 # @category Source / Fade
@@ -832,6 +841,13 @@ end
 #                      With a negative default, transitions always occur.
 # @param ~default      Smart crossfade: transition used when no rule applies \
 #                      (default: sequence).
+# @param ~reconcile_duration \
+#                      When set to `true`, if duration for the new track is shorter than the ending \
+#                      duration, a `liq_fade_in_delay` metadata is automatically injected to make \
+#                      crossfades match. Defaults to `settings.crossfade.reconcile_duration` if `null`.
+# @param ~override_fade_in_delay \
+#                      Metadata field used to inject metadata overriding fade-in delay \
+#                      when reonciling crossfade duration.
 # @param ~smart        Enable smart crossfading
 # @param ~high         Smart crossfade: value, in dB, for loud sound level.
 # @param ~medium       Smart crossfade: value, in dB, for medium sound level.
@@ -844,6 +860,8 @@ def crossfade(
   ~id=null(),
   ~duration=5.,
   ~override_duration="liq_cross_duration",
+  ~reconcile_duration=null(),
+  ~override_fade_in_delay="liq_fade_in_delay",
   ~persist_override=false,
   ~fade_in=3.,
   ~fade_out=3.,
@@ -859,6 +877,8 @@ def crossfade(
   s
 ) =
   id = string.id.default(default="crossfade", id)
+  reconcile_duration = reconcile_duration ?? settings.crossfade.reconcile_duration()
+
   def log(~level=3, x) =
     log(label=id, level=level, x)
   end
@@ -936,6 +956,8 @@ def crossfade(
       width=width,
       duration=duration,
       persist_override=persist_override,
+      reconcile_duration=reconcile_duration,
+      override_fade_in_delay=override_fade_in_delay,
       override_duration=override_duration,
       conservative=conservative,
       minimum=minimum,

--- a/src/libs/fades.liq
+++ b/src/libs/fades.liq
@@ -1,5 +1,9 @@
-let settings.crossfade.reconcile_duration = settings.make(
-  description="Default value for `reconcile_duration`", false)
+let settings.crossfade.reconcile_duration =
+  settings.make(
+    description=
+      "Default value for `reconcile_duration`",
+    false
+  )
 
 fade = ()
 
@@ -278,8 +282,9 @@ def fade.out(
       not persist_overrides
     then
       log(
-        "Setting fade out to default duration: #{original_duration}s, delay: \
-        #{original_delay}s, type: #{original_type}, curve: #{original_curve}"
+        "Setting fade out to default duration: #{original_duration}s, delay: #{
+          original_delay
+        }s, type: #{original_type}, curve: #{original_curve}"
       )
       duration := original_duration
       delay := original_delay
@@ -444,8 +449,9 @@ def fade.skip(
       not persist_overrides
     then
       log(
-        "Setting fade skip to default duration: #{original_duration}s, \
-        type: #{original_type}, curve: #{original_curve}"
+        "Setting fade skip to default duration: #{original_duration}s, type: #{
+          original_type
+        }, curve: #{original_curve}"
       )
       duration := original_duration
       type := original_type
@@ -456,10 +462,7 @@ def fade.skip(
   s = source.on_track(s, reset_overrides)
   s = source.on_metadata(s, update_fade)
   s = source.on_track(s, stop_fade)
-  fade.scale(id=id, apply, s).{
-    fade_duration={duration()},
-    fade_type={type()}
-  }
+  fade.scale(id=id, apply, s).{fade_duration={duration()}, fade_type={type()}}
 end
 
 # Fade the beginning of tracks.
@@ -518,12 +521,14 @@ def fade.in(
     curve_log =
       if null.defined(curve()) then string(null.get(curve())) else "default" end
 
-     duration =
-       if source.remaining(s) < duration() then
-         source.remaining(s)
-       else
-         duration()
-        end
+    duration =
+      if
+        source.remaining(s) < duration()
+      then
+        source.remaining(s)
+      else
+        duration()
+      end
 
     log(
       "Fading in with type: #{type()}, curve: #{curve_log}, delay: #{delay()}s \
@@ -621,8 +626,9 @@ def fade.in(
       not persist_overrides
     then
       log(
-        "Setting fade in to default duration: #{original_duration}s, \
-        delay: #{original_delay}s, type: #{original_type}, curve: #{original_curve}"
+        "Setting fade in to default duration: #{original_duration}s, delay: #{
+          original_delay
+        }s, type: #{original_type}, curve: #{original_curve}"
       )
       duration := original_duration
       delay := original_delay
@@ -816,8 +822,6 @@ def cross.smart(
   end
 end
 
-
-
 # Crossfade between tracks, taking the respective volume levels into account in
 # the choice of the transition.
 # @category Source / Fade
@@ -877,7 +881,8 @@ def crossfade(
   s
 ) =
   id = string.id.default(default="crossfade", id)
-  reconcile_duration = reconcile_duration ?? settings.crossfade.reconcile_duration()
+  reconcile_duration =
+    reconcile_duration ?? settings.crossfade.reconcile_duration()
 
   def log(~level=3, x) =
     log(label=id, level=level, x)

--- a/src/libs/fades.liq
+++ b/src/libs/fades.liq
@@ -1,9 +1,9 @@
 let settings.crossfade = settings.make.void("Crossfqde settings")
 
-let settings.crossfade.reconcile_duration =
+let settings.crossfade.autocue =
   settings.make(
     description=
-      "Default value for `reconcile_duration`",
+      "Default value for `autocue`",
     false
   )
 
@@ -834,13 +834,10 @@ end
 # @param ~fade_out     Fade-out duration, if any.
 # @param ~width        Width of the volume analysis window.
 # @param ~conservative Always prepare for a premature end-of-track.
-# @param ~reconcile_duration \
+# @param ~autocue \
 #                      When set to `true`, if duration for the new track is shorter than the ending \
 #                      duration, a `liq_fade_in_delay` metadata is automatically injected to make \
-#                      crossfades match. Defaults to `settings.crossfade.reconcile_duration` if `null`.
-# @param ~override_fade_in_delay \
-#                      Metadata field used to inject metadata overriding fade-in delay \
-#                      when reonciling crossfade duration.
+#                      crossfades match. Defaults to `settings.crossfade.autocue` if `null`.
 # @param ~minimum      Minimum duration (in sec.) for a cross: \
 #                      If the track ends without any warning (e.g. in case of skip) \
 #                      there may not be enough data for a decent composition. \
@@ -861,8 +858,7 @@ def crossfade(
   ~id=null(),
   ~duration=5.,
   ~override_duration="liq_cross_duration",
-  ~reconcile_duration=null(),
-  ~override_fade_in_delay="liq_fade_in_delay",
+  ~autocue=null(),
   ~persist_override=false,
   ~fade_in=3.,
   ~fade_out=3.,
@@ -878,8 +874,8 @@ def crossfade(
   s
 ) =
   id = string.id.default(default="crossfade", id)
-  reconcile_duration =
-    reconcile_duration ?? settings.crossfade.reconcile_duration()
+  autocue =
+    autocue ?? settings.crossfade.autocue()
 
   def log(~level=3, x) =
     log(label=id, level=level, x)
@@ -958,8 +954,7 @@ def crossfade(
       width=width,
       duration=duration,
       persist_override=persist_override,
-      reconcile_duration=reconcile_duration,
-      override_fade_in_delay=override_fade_in_delay,
+      autocue=autocue,
       override_duration=override_duration,
       conservative=conservative,
       minimum=minimum,

--- a/src/libs/fades.liq
+++ b/src/libs/fades.liq
@@ -1,13 +1,3 @@
-let settings.crossfade = settings.make.void("Crossfqde settings")
-
-let settings.crossfade.autocue =
-  settings.make(
-    description=
-      "Default value for `autocue`",
-    false
-  )
-
-
 fade = ()
 
 # Make a fade function based on a source's clock.
@@ -697,7 +687,7 @@ end
 # @param ~high     Value, in dB, for loud sound level.
 # @param ~medium   Value, in dB, for medium sound level.
 # @param ~margin   Margin to detect sources that have too different sound level for crossing.
-# @param ~default Smartcrossfade: transition used when no rule applies (default: sequence).
+# @param ~default Smart crossfade: transition used when no rule applies (default: sequence).
 # @param a Ending track
 # @param b Starting track
 def cross.smart(
@@ -834,10 +824,6 @@ end
 # @param ~fade_out     Fade-out duration, if any.
 # @param ~width        Width of the volume analysis window.
 # @param ~conservative Always prepare for a premature end-of-track.
-# @param ~autocue \
-#                      When set to `true`, if duration for the new track is shorter than the ending \
-#                      duration, a `liq_fade_in_delay` metadata is automatically injected to make \
-#                      crossfades match. Defaults to `settings.crossfade.autocue` if `null`.
 # @param ~minimum      Minimum duration (in sec.) for a cross: \
 #                      If the track ends without any warning (e.g. in case of skip) \
 #                      there may not be enough data for a decent composition. \
@@ -858,7 +844,6 @@ def crossfade(
   ~id=null(),
   ~duration=5.,
   ~override_duration="liq_cross_duration",
-  ~autocue=null(),
   ~persist_override=false,
   ~fade_in=3.,
   ~fade_out=3.,
@@ -874,9 +859,6 @@ def crossfade(
   s
 ) =
   id = string.id.default(default="crossfade", id)
-  autocue =
-    autocue ?? settings.crossfade.autocue()
-
   def log(~level=3, x) =
     log(label=id, level=level, x)
   end
@@ -954,7 +936,6 @@ def crossfade(
       width=width,
       duration=duration,
       persist_override=persist_override,
-      autocue=autocue,
       override_duration=override_duration,
       conservative=conservative,
       minimum=minimum,

--- a/src/libs/playlist.liq
+++ b/src/libs/playlist.liq
@@ -164,7 +164,7 @@ let stdlib_native = native
 # @param playlist Playlist.
 # @method reload Reload the playlist with given list of songs.
 # @method remaining_files Songs remaining to be played.
-def playlist.list(~id=null(), ~check_next=null(), ~prefetch=1, ~loop=true,
+def playlist.list(~id=null(), ~check_next=null(), ~prefetch=null(), ~loop=true,
                   ~mode="normal", ~native=false, ~on_loop={()}, ~on_done={()}, ~max_fail=10,
                   ~cue_in_metadata=null("liq_cue_in"), ~cue_out_metadata=null("liq_cue_out"),
                   ~on_fail=null(), ~timeout=20., playlist)
@@ -353,7 +353,7 @@ end
 def replaces playlist(
   ~id=null(),
   ~check_next=null(),
-  ~prefetch=1,
+  ~prefetch=null(),
   ~loop=true,
   ~mime_type=null(),
   ~mode="randomize",

--- a/src/libs/request.liq
+++ b/src/libs/request.liq
@@ -30,7 +30,7 @@ end
 # @method add This method is internal and should not be used. Consider using `push` instead.
 # @method push Push a request on the request queue.
 # @method length Length of the queue.
-def request.queue(~id=null(), ~interactive=true, ~prefetch=1, ~native=false, ~queue=[], ~timeout=20.)
+def request.queue(~id=null(), ~interactive=true, ~prefetch=null(), ~native=false, ~queue=[], ~timeout=20.)
   id = string.id.default(default="request.queue", id)
   ignore(native)
   queue = ref(queue)

--- a/src/libs/stdlib.liq
+++ b/src/libs/stdlib.liq
@@ -22,6 +22,7 @@
 %include "request.liq"
 %include "audio.liq"
 %include "fades.liq"
+%include "autocue.liq"
 %include "replaygain.liq"
 %include "http_codes.liq"
 %include "http.liq"
@@ -52,6 +53,5 @@
 %include_extra "extra/gstreamer.liq"
 %include_extra "extra/visualization.liq"
 %include_extra "extra/fades.liq"
-%include_extra "extra/autocue.liq"
 
 set_settings_ref(settings)


### PR DESCRIPTION
This PR includes patient and careful efforts coordinated with @RM-FM and @Moonbase59.

The changes include:
* A new `autocue` mode sets when all 4 standard cue in/out, fade in/out metadata are set
* A better handling of the starting track's buffer when it has autocue enabled using cue in/out values to prevent buffering too much data when the track is short
* A better handling of transitions when the starting track has autocue enabled did not buffer as much data as the ending track:
  * If the ending track is in `autocue` mode, assume a crossfade transition and shorten its ending to match the starting track's buffer length
  * In all cases, delay the starting track fade-in to start at the same time as the ending track's fade-out

`autocue` is now promoted to an officially supported API. It is also made modular so that other implementations can be provided/registered.

All autocue implementations should provide the following function:
```liquidsoap
fun (string) -> {
  amplify?: float,
  cue_in: float,
  cue_out: float,
  fade_in: float,
  fade_out: float,
  extra_metadata?: [(string*string)]
}?
```

The implementation takes a request URI and:
* Returns `null` when no data could be computed
* Otherwise always returns cue in/out and fade in/out
* Otherwise optionally can return `amplify` override and any arbitrary metadata to add to the request

There's some logic for overrides:
* Always disable is any of the cue in/out and fade in/out metadata is present
* Switch beteeen keeping user value, overriding user value or disabling the whole processing when amplify override metadata is present

These can be controlled via settings.

The changes also include a bugfix for a double `break` issue triggered when `cue_out` was set to exactly the same value as the track's duration.