### PR TITLE
Fix ffmpeg copy encoder muxer logic

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,7 @@ Fixed:
 - Fixed streaming errors when disconnecting `input.harbor`.
 - Fixed issues with rendered id3v2 frame that contain binary data (#3817)
 - Fixed memory leaks with SRT listen socket polling callbacks.
+- Fixed `%ffmpeg` copy muxer logic with some audio/video streams (#3840)
 
 ---
 

--- a/src/core/encoder/encoders/ffmpeg_copy_encoder.ml
+++ b/src/core/encoder/encoders/ffmpeg_copy_encoder.ml
@@ -88,10 +88,13 @@ let mk_stream_copy ~get_stream ~remove_stream ~keyframe_opt ~field output =
         keyframe_opt = `Wait_for_keyframe && not !intra_only;
       remove_stream !current_stream;
       (* Mark the stream as ready if it is not waiting for keyframes. *)
-      current_stream :=
+      let stream =
         get_stream ~last_start:Int64.min_int
           ~ready:(not !waiting_for_keyframe)
-          stream_idx;
+          stream_idx
+      in
+      stream.ready <- not !waiting_for_keyframe;
+      current_stream := stream;
       stream_started := false);
     let is_keyframe = List.mem `Keyframe Avcodec.Packet.(get_flags packet) in
     if !waiting_for_keyframe then is_keyframe

--- a/src/libs/file.liq
+++ b/src/libs/file.liq
@@ -1,3 +1,19 @@
+# @docof file.temp
+# @param ~cleanup Delete the file on shutdown
+def file.temp(~cleanup=false, %argsof(file.temp), prefix, suffix) =
+  f = file.temp(%argsof(file.temp), prefix, suffix)
+  if cleanup then on_cleanup({file.remove(f)}) end
+  f
+end
+
+# @docof file.temp_dir
+# @param ~cleanup Delete the file on shutdown
+def file.temp_dir(~cleanup=false, prefix, suffix="") =
+  dir = file.temp_dir(prefix, suffix)
+  if cleanup then on_cleanup({file.rmdir(dir)}) end
+  dir
+end
+
 # Read the content of a file. Returns a function of type `()->string`. File is
 # done reading when function returns the empty string `""`.
 # @category File

--- a/tests/regression/GH3840.liq
+++ b/tests/regression/GH3840.liq
@@ -1,0 +1,36 @@
+out_file = file.temp(cleanup=true, "output", ".mp4")
+
+audio = once(single("../media/@shine[channels=2].mp3"))
+
+video =
+  single(
+    "../media/@ffmpeg[format='mp4',@audio[codec='aac',channels=1],@video[codec='libx264']].mp4"
+  )
+
+stream = source(source.tracks(audio).{video=source.tracks(video).video})
+
+clock.assign_new(sync='none', [stream])
+
+enc = %ffmpeg(%audio.copy, %video.copy)
+
+def on_stop() =
+  j =
+    process.read(
+      "ffprobe -v quiet -print_format json -show_streams #{out_file}"
+    )
+
+  let json.parse ({streams = [s1, s2]} : {streams: [{codec_name: string}]}) = j
+  if
+    not list.exists(fun (s) -> s.codec_name == "mp3", streams)
+  then
+    test.fail()
+  end
+  if
+    not list.exists(fun (s) -> s.codec_name == "h264", streams)
+  then
+    test.fail()
+  end
+  test.pass()
+end
+
+output.file(fallible=true, on_stop=on_stop, enc, out_file, stream)

--- a/tests/regression/dune.inc
+++ b/tests/regression/dune.inc
@@ -445,6 +445,19 @@
  (alias citest)
  (package liquidsoap)
  (deps
+  GH3840.liq
+  ../media/all_media_files
+  ../../src/bin/liquidsoap.exe
+  (package liquidsoap)
+  (:stdlib ../../src/libs/stdlib.liq)
+  (:test_liq ../test.liq)
+  (:run_test ../run_test.exe))
+ (action (run %{run_test} GH3840.liq liquidsoap %{test_liq} GH3840.liq)))
+
+(rule
+ (alias citest)
+ (package liquidsoap)
+ (deps
   LS268.liq
   ../media/all_media_files
   ../../src/bin/liquidsoap.exe


### PR DESCRIPTION
Backport of https://github.com/savonet/liquidsoap/pull/3841 for `rolling-release-v2.2.x`.

Fixes: #3840