### PR TITLE
Autocue - Introducing sustained ending support

### DIFF
--- a/src/libs/autocue.liq
+++ b/src/libs/autocue.liq
@@ -258,11 +258,34 @@ def autocue.internal.implementation(uri) =
 
     # Extract timestamps for cue points
     # Iterate over loudness data frames and set cue points based on db thresholds
-    cue_in_found = ref(false)
     last_ts = ref(0.)
     current_ts = ref(0.)
+    cue_found = ref(false)
+    cross_start_idx = ref(0.)
+    cross_stop_idx = ref(0.)
+    cross_mid_idx = ref(0.)
+    cross_frame_length = ref(0.)
+    ending_fst_db = ref(0.)
+    ending_snd_db = ref(0.)
+    reset_iter_values = ref(true)
+  
+    frames_rev = list.rev(frames)
+    total_frames_length = float_of_int(list.length(frames))
+    frame_idx = ref(total_frames_length - 1.)
+    lufs_cross_threshold_sustained = ref(lufs_cross_threshold)
+    lufs_cue_out_threshold_sustained = ref(lufs_cue_out_threshold)
 
-    def find_cues(frame) =
+    err = error.register("assoc")
+    def find_cues(frame, ~reverse_order=false,~sustained_ending_check=false,~sustained_ending_recalc=false) =
+
+      if
+        reset_iter_values()
+      then
+        last_ts := 0.
+        current_ts := 0.
+        cue_found := false            
+      end
+          
       # Get current frame loudness level and timestamp
       db_level = list.assoc(default="nan", string("lavfi.r128.M"), frame)
       current_ts :=
@@ -275,31 +298,219 @@ def autocue.internal.implementation(uri) =
         db_level = float_of_string(db_level)
 
         if
-          db_level > lufs_cue_in_threshold and cue_in_found() == false
+          not sustained_ending_check and
+          not sustained_ending_recalc
         then
-          # First time exceeding threshold. Set cue in to timestamp of previous frame.
-          cue_in := last_ts()
-          cue_in_found := true
-        end
-        if
-          db_level > lufs_cue_out_threshold
+          # Run regular cue point calc
+          reset_iter_values := false
+          if
+            not reverse_order
+          then
+            # Search for cue in
+            if
+              db_level > lufs_cue_in_threshold
+            then
+              # First time exceeding threshold
+              cue_in := last_ts()
+              # Break
+              error.raise(err,"break list.iter")
+            end
+          else
+            # Search for cue out and crossfade point starting from the end (reversed)
+            if
+              db_level > lufs_cue_out_threshold and
+              not cue_found()
+            then
+              # Cue out
+              cue_out := last_ts()
+              cross_stop_idx := frame_idx()
+              cue_found := true
+            elsif
+              db_level > lufs_cross_threshold
+            then
+              # Absolute crossfade cue
+              cross_cue := last_ts()
+              cross_start_idx := frame_idx()
+              # Break            
+              error.raise(err,"break list.iter")
+            end
+            frame_idx := frame_idx() - 1.
+          end
+        elsif
+          sustained_ending_check
         then
-          # Cue out: Stick with the latest timestamp where level still exceeds threshold
-          cue_out := current_ts()
-        end
-        if
-          db_level > lufs_cross_threshold
+          # Check regular crossfade data for sustained ending
+          if
+            reset_iter_values()
+          then      
+            frame_idx := total_frames_length - 1.
+            cross_frame_length := cross_stop_idx() - cross_start_idx()
+            cross_start_idx := cross_start_idx() + 5.
+            cross_stop_idx := cross_stop_idx() - 5.  
+            cross_mid_idx := total_frames_length - (cross_frame_length() / 2.)
+          end
+          reset_iter_values := false
+        
+          if
+            frame_idx() < cross_start_idx()
+          then
+            # Break iteration if relevant frames were analysed
+            error.raise(err,"break list.iter")
+          end
+
+          if
+            frame_idx() < cross_stop_idx() and
+            frame_idx() > cross_mid_idx()
+          then
+            ending_snd_db := (ending_snd_db() + db_level) / 2.
+          end
+
+          if
+            frame_idx() > cross_start_idx() and
+            frame_idx() < cross_mid_idx()
+          then
+            ending_fst_db := (ending_fst_db() + db_level) / 2.
+          end
+          frame_idx := frame_idx() - 1.
+        elsif
+          sustained_ending_recalc
         then
-          # Absolute crossfade cue: Stick with the latest timestamp where level still exceeds threshold
-          cross_cue := current_ts()
+          # Recalculate crossfade on sustained ending
+          if
+            reset_iter_values()
+          then       
+            cue_out := 0.
+            cross_cue := 0.             
+          end
+          reset_iter_values := false
+          if
+            db_level > lufs_cue_out_threshold_sustained() and
+            not cue_found()
+          then
+            # Cue out
+            cue_out := last_ts()
+            cue_found := true
+          end
+          if
+            db_level > lufs_cross_threshold_sustained()
+          then
+            # Absolute crossfade cue
+            cross_cue := last_ts()
+            error.raise(err,"break list.iter")
+          end          
         end
+      
+        # Update last timestamp value with current
+        last_ts := current_ts()         
       end
-
-      # Update last timestamp value with current
-      last_ts := current_ts()
     end
-    list.iter(find_cues, frames)
 
+    # Search for cue_in first
+    reset_iter_values := true
+    def cue_iter_fwd(frame) =
+      find_cues(frame)
+    end
+    try
+      list.iter(cue_iter_fwd, frames)
+    catch _ do
+      log(
+        level=4,
+        label="autocue.internal",
+        "cue_iter_fwd completed."
+      )
+    end
+
+    # Reverse frames and search in reverse order for cross_cue and cue_out
+    reset_iter_values := true
+    def cue_iter_rev(frame) =
+      find_cues(frame,reverse_order=true)
+    end
+    try
+      list.iter(cue_iter_rev, frames_rev)
+    catch _ do
+      log(
+        level=4,
+        label="autocue.internal",
+        "cue_iter_rev completed."
+      )
+    end
+
+    # Check for sustained ending
+    reset_iter_values := true
+    def sustained_ending_check_iter(frame) =
+      find_cues(frame,sustained_ending_check=true)
+    end
+    try
+      list.iter(sustained_ending_check_iter, frames_rev)
+    catch _ do
+      log(
+        level=4,
+        label="autocue.internal",
+        "sustained_ending_check_iter completed."
+      )
+    end  
+
+    log(level=4, label="autocue.internal.sustained_end", "Ending analysis start frame: #{cross_start_idx()}")
+    log(level=4, label="autocue.internal.sustained_end", "Ending analysis stop frame: #{cross_stop_idx()}")
+    log(level=4, label="autocue.internal.sustained_end", "Analysis frame length: #{cross_frame_length()}")
+    log(level=4, label="autocue.internal.sustained_end", "Avg. ending dB level (1st half): #{ending_fst_db()}")
+    log(level=4, label="autocue.internal.sustained_end", "Avg. ending dB level (2nd half): #{ending_snd_db()}")
+
+    if
+      ending_fst_db() < 0.
+    then
+      ending_db_slope = ref(0.)
+      if
+        ending_snd_db() < 0.
+      then
+        ending_db_slope := ending_fst_db() / ending_snd_db()
+      end
+      log(level=4, label="autocue.internal.sustained_end", "Slope: #{ending_db_slope()}")
+      if
+        ending_db_slope() > 0.7 or ending_fst_db() > lufs_cross_threshold * 1.2
+      then
+        log(level=3, label="autocue.internal.sustained_end", "Sustained ending detected. Adjusting crossfade! Use Log Level 4 for more detailed information.")  
+      
+        if
+          ending_db_slope() > 0.7
+        then
+          lufs_cross_threshold_sustained := ending_snd_db() - 1.
+        else
+          lufs_cross_threshold_sustained := ending_fst_db() - 1.
+        end
+      
+        lufs_cue_out_threshold_sustained = ref(
+          lufs_cue_out_threshold + (lufs_cross_threshold_sustained() - lufs_cross_threshold)
+        )
+
+        log(level=4, label="autocue.internal.sustained_end", "Changed crossfade threshold: #{lufs_cross_threshold} => #{lufs_cross_threshold_sustained()}")
+        log(level=4, label="autocue.internal.sustained_end", "Changed cue out threshold: #{lufs_cue_out_threshold} => #{lufs_cue_out_threshold_sustained()}") 
+
+        cross_cue_init = cross_cue()
+        cue_out_init = cue_out()
+      
+        reset_iter_values := true
+        def sustained_ending_recalc_iter(frame) =
+          find_cues(frame,sustained_ending_recalc=true)
+        end
+        try
+          list.iter(sustained_ending_recalc_iter, frames_rev)
+        catch _ do
+          log(
+            level=4,
+            label="autocue.internal",
+            "sustained_ending_recalc_iter completed."
+          )
+        end
+        log(level=4, label="autocue.internal.sustained_end", "Changed crossfade point: #{cross_cue_init} => #{cross_cue()}")
+        log(level=4, label="autocue.internal.sustained_end", "Changed cue out point:  #{cue_out_init} => #{cue_out()}")   
+      end
+    end
+  
+    ##########################
+    # END: Sustained endings #
+    ##########################
+  
     # Get very last frame for precise track duration
     frame = list.last(frames)
     duration =
@@ -468,9 +679,6 @@ def enable_autocue_metadata() =
   settings.crossfade.assume_autocue := true
 
   def autocue_metadata(~metadata, fname) =
-    print(
-      "fname: #{fname}, metadata: #{metadata}"
-    )
     metadata_overrides = settings.autocue.metadata_override()
 
     if

--- a/src/libs/autocue.liq
+++ b/src/libs/autocue.liq
@@ -35,8 +35,8 @@ let settings.autocue.amplify_behavior =
   settings.make(
     description=
       "How to proceed with amplify data when `\"liq_amplify\"` is set. One of: \
-       `\"keep\"` (prefer user-provided value), `\"override\"` (always override with \
-       computed value), `\"ignore\"` (ignore/suppress loudness adjustment).",
+       `\"keep\"` (keep user-provided value), `\"override\"` (override with \
+       computed value) or `\"disable\"` (disable `autocue` altogether).",
     "keep"
   )
 
@@ -179,6 +179,12 @@ def autocue.internal.implementation(uri) =
   ratio = settings.autocue.internal.ratio()
   timeout = settings.autocue.internal.timeout()
 
+  log(
+    level=4,
+    label="autocue.internal",
+    "Starting to process #{path.basename(uri)}"
+  )
+
   frames = autocue.internal.ebur128(ratio=ratio, timeout=timeout, uri)
 
   if
@@ -207,6 +213,12 @@ def autocue.internal.implementation(uri) =
     lufs_cue_in_threshold = lufs + cue_in_threshold
     lufs_cue_out_threshold = lufs + cue_out_threshold
     lufs_cross_threshold = lufs + cross_threshold
+
+    log(
+      level=4,
+      label="autocue.internal",
+      "Processing results for #{path.basename(uri)}"
+    )
 
     log(
       level=4,
@@ -502,7 +514,7 @@ def enable_autocue_metadata() =
         level=4,
         label="autocue.metadata",
         "#{autocue_metadata_response()}"
-      )   
+      )
       autocue_metadata_response()
     end
   end

--- a/src/libs/autocue.liq
+++ b/src/libs/autocue.liq
@@ -106,6 +106,20 @@ let settings.autocue.internal.sustained_endings_slope =
     20.0
   )
 
+let settings.autocue.internal.sustained_endings_min_duration =
+  settings.make(
+    description=
+      "Minimum duration to consider it the ending as sustained [seconds]",
+    1.0
+  )
+
+let settings.autocue.internal.sustained_endings_threshold_limit =
+  settings.make(
+    description=
+      "Max reduction of dB thresholds compared to initial value [multiplying factor]",
+    2.0
+  )
+
 let settings.autocue.internal.ratio =
   settings.make(
     description=
@@ -210,6 +224,8 @@ def autocue.internal.implementation(uri) =
   sustained_endings_enabled = settings.autocue.internal.sustained_endings_enabled()
   sustained_endings_dropoff = settings.autocue.internal.sustained_endings_dropoff()
   sustained_endings_slope = settings.autocue.internal.sustained_endings_slope()
+  sustained_endings_min_duration = settings.autocue.internal.sustained_endings_min_duration()
+  sustained_endings_threshold_limit = settings.autocue.internal.sustained_endings_threshold_limit()
   ratio = settings.autocue.internal.ratio()
   timeout = settings.autocue.internal.timeout()
 
@@ -383,7 +399,7 @@ def autocue.internal.implementation(uri) =
 
           if
             frame_idx() < cross_start_idx() or
-            cross_frame_length() < 5.
+            cross_frame_length() < sustained_endings_min_duration * 10.
           then
             error.raise(err,"break list.iter")
           end
@@ -549,12 +565,23 @@ def autocue.internal.implementation(uri) =
           if
             detect_slope
           then
-            lufs_cross_threshold_sustained := ending_snd_db() - 0.5
+            lufs_cross_threshold_sustained :=
+              max(
+                lufs_cross_threshold * sustained_endings_threshold_limit,
+                ending_snd_db() - 0.5
+              )
           else
-            lufs_cross_threshold_sustained := ending_fst_db() - 0.5
+            lufs_cross_threshold_sustained :=
+              max(
+                lufs_cross_threshold * sustained_endings_threshold_limit,
+                ending_fst_db() - 0.5
+              )
           end
           lufs_cue_out_threshold_sustained = ref(
-            lufs_cue_out_threshold + (lufs_cross_threshold_sustained() - lufs_cross_threshold)
+            max(
+              lufs_cue_out_threshold * sustained_endings_threshold_limit,
+              lufs_cue_out_threshold + (lufs_cross_threshold_sustained() - lufs_cross_threshold)
+             )
           )
 
           log(

--- a/src/libs/autocue.liq
+++ b/src/libs/autocue.liq
@@ -83,11 +83,27 @@ let settings.autocue.internal.max_overlap =
     6.0
   )
 
-let settings.autocue.internal.sustained_endings =
+let settings.autocue.internal.sustained_endings_enabled =
   settings.make(
     description=
       "Try to optimize crossfade point on sustained endings",
     true
+  )
+
+let settings.autocue.internal.sustained_endings_dropoff =
+  settings.make(
+    description=
+      "Max. loudness drop off immediately after crossfade point to consider it \
+      as relevant ending [percentage]",
+    10.0
+  )
+
+let settings.autocue.internal.sustained_endings_slope =
+  settings.make(
+    description=
+      "Max. loudness difference between crossfade point and cue out to consider \
+      it as relevant ending [percentage]",
+    20.0
   )
 
 let settings.autocue.internal.ratio =
@@ -191,7 +207,9 @@ def autocue.internal.implementation(uri) =
   cue_out_threshold = settings.autocue.internal.cue_out_threshold()
   cross_threshold = settings.autocue.internal.cross_threshold()
   max_overlap = settings.autocue.internal.max_overlap()
-  sustained_endings = settings.autocue.internal.sustained_endings()
+  sustained_endings_enabled = settings.autocue.internal.sustained_endings_enabled()
+  sustained_endings_dropoff = settings.autocue.internal.sustained_endings_dropoff()
+  sustained_endings_slope = settings.autocue.internal.sustained_endings_slope()
   ratio = settings.autocue.internal.ratio()
   timeout = settings.autocue.internal.timeout()
 
@@ -448,7 +466,7 @@ def autocue.internal.implementation(uri) =
     end
 
     if
-      sustained_endings
+      sustained_endings_enabled
     then
       log(
         level=4,
@@ -486,32 +504,36 @@ def autocue.internal.implementation(uri) =
       if
         ending_fst_db() < 0.
       then
-        ending_db_slope = ref(0.)
+        slope = ref(0.)
 
         if
           ending_snd_db() < 0.
         then
-          ending_db_slope := ending_fst_db() / ending_snd_db()
+          slope := ending_fst_db() / ending_snd_db()
         end
 
         log(
           level=4,
           label="autocue.internal.sustained_ending",
-          "Slope: #{ending_db_slope()}"
+          "Slope: #{slope()} (#{
+            (1. - slope()) * 100.
+          }%)"
         )
 
+        detect_slope = slope() > 1. - sustained_endings_slope / 100.
+        detect_dropoff = ending_fst_db() > lufs_cross_threshold * sustained_endings_dropoff / 100. + 1.
         if
-          ending_db_slope() > 0.8 or
-          ending_fst_db() > (lufs_cross_threshold * 1.1)
+          detect_slope or
+          detect_dropoff
         then
           log(
             level=3,
             label="autocue.internal.sustained_ending",
-            "Sustained ending detected."
+            "Sustained ending detected (drop off: #{detect_dropoff} / slope: #{detect_slope})"
           )
 
           if
-            ending_db_slope() > 0.8
+            detect_slope
           then
             lufs_cross_threshold_sustained := ending_snd_db() - 0.5
           else

--- a/src/libs/autocue.liq
+++ b/src/libs/autocue.liq
@@ -503,7 +503,7 @@ def autocue.internal.implementation(uri) =
       log(
         level=4,
         label="autocue.internal.sustained_ending",
-        "Avg. ending dB level: 1st half => #{ending_fst_db()} / 2nd half => #{ending_snd_db()}"
+        "Avg. ending loudness: #{ending_fst_db()} => #{ending_snd_db()}"
       )
 
       # Check whether data indicate a sustained ending
@@ -511,6 +511,7 @@ def autocue.internal.implementation(uri) =
         ending_fst_db() < 0.
       then
         slope = ref(0.)
+        dropoff = lufs_cross_threshold / ending_fst_db()
 
         if
           ending_snd_db() < 0.
@@ -521,13 +522,20 @@ def autocue.internal.implementation(uri) =
         log(
           level=4,
           label="autocue.internal.sustained_ending",
-          "Slope: #{slope()} (#{
+          "Drop off: #{
+            (1. - dropoff) * 100.
+          }%"
+        )
+        log(
+          level=4,
+          label="autocue.internal.sustained_ending",
+          "Slope: #{
             (1. - slope()) * 100.
-          }%)"
+          }%"
         )
 
         detect_slope = slope() > 1. - sustained_endings_slope / 100.
-        detect_dropoff = ending_fst_db() > lufs_cross_threshold * sustained_endings_dropoff / 100. + 1.
+        detect_dropoff = ending_fst_db() > lufs_cross_threshold * (sustained_endings_dropoff / 100. + 1.)
         if
           detect_slope or
           detect_dropoff

--- a/src/libs/autocue.liq
+++ b/src/libs/autocue.liq
@@ -268,7 +268,7 @@ def autocue.internal.implementation(uri) =
     ending_fst_db = ref(0.)
     ending_snd_db = ref(0.)
     reset_iter_values = ref(true)
-  
+ 
     frames_rev = list.rev(frames)
     total_frames_length = float_of_int(list.length(frames))
     frame_idx = ref(total_frames_length - 1.)
@@ -287,9 +287,9 @@ def autocue.internal.implementation(uri) =
       then
         last_ts := 0.
         current_ts := 0.
-        cue_found := false            
+        cue_found := false           
       end
-          
+         
       # Get current frame loudness level and timestamp
       db_level = list.assoc(default="nan", string("lavfi.r128.M"), frame)
       current_ts :=
@@ -335,7 +335,7 @@ def autocue.internal.implementation(uri) =
               # Absolute crossfade cue
               cross_cue := last_ts()
               cross_start_idx := frame_idx()
-              # Break            
+              # Break           
               error.raise(err,"break list.iter")
             end
             frame_idx := frame_idx() - 1.
@@ -346,15 +346,15 @@ def autocue.internal.implementation(uri) =
           # Check regular crossfade data for sustained ending
           if
             reset_iter_values()
-          then      
+          then     
             frame_idx := total_frames_length - 1.
             cross_frame_length := cross_stop_idx() - cross_start_idx()
             cross_start_idx := cross_start_idx() + 5.
-            cross_stop_idx := cross_stop_idx() - 5.  
+            cross_stop_idx := cross_stop_idx() - 5. 
             cross_mid_idx := total_frames_length - (cross_frame_length() / 2.)
           end
           reset_iter_values := false
-        
+       
           if
             frame_idx() < cross_start_idx()
           then
@@ -382,9 +382,9 @@ def autocue.internal.implementation(uri) =
           # Recalculate crossfade on sustained ending
           if
             reset_iter_values()
-          then       
+          then      
             cue_out := 0.
-            cross_cue := 0.             
+            cross_cue := 0.            
           end
           reset_iter_values := false
           if
@@ -401,11 +401,11 @@ def autocue.internal.implementation(uri) =
             # Absolute crossfade cue
             cross_cue := last_ts()
             error.raise(err,"break list.iter")
-          end          
+          end         
         end
-      
+     
         # Update last timestamp value with current
-        last_ts := current_ts()         
+        last_ts := current_ts()        
       end
     end
 
@@ -452,29 +452,47 @@ def autocue.internal.implementation(uri) =
         label="autocue.internal",
         "sustained_ending_check_iter completed."
       )
-    end  
+    end 
 
-    log(level=4, label="autocue.internal.sustained_end", "Ending analysis start frame: #{cross_start_idx()}")
-    log(level=4, label="autocue.internal.sustained_end", "Ending analysis stop frame: #{cross_stop_idx()}")
-    log(level=4, label="autocue.internal.sustained_end", "Analysis frame length: #{cross_frame_length()}")
-    log(level=4, label="autocue.internal.sustained_end", "Avg. ending dB level (1st half): #{ending_fst_db()}")
-    log(level=4, label="autocue.internal.sustained_end", "Avg. ending dB level (2nd half): #{ending_snd_db()}")
-
+    log(
+      level=4,
+       label="autocue.internal.sustained_end",
+       "Analysis frame length: #{cross_frame_length()}"
+    )
+    log(
+      level=4,
+      label="autocue.internal.sustained_end",
+      "Avg. ending dB level: 1st half => #{ending_fst_db()} / 2nd half => #{ending_snd_db()}"
+    )
+   
+    # Check whether data indicate a sustained ending
     if
       ending_fst_db() < 0.
     then
       ending_db_slope = ref(0.)
+
       if
         ending_snd_db() < 0.
       then
         ending_db_slope := ending_fst_db() / ending_snd_db()
       end
-      log(level=4, label="autocue.internal.sustained_end", "Slope: #{ending_db_slope()}")
+     
+      log(
+        level=4,
+        label="autocue.internal.sustained_end",
+        "Slope: #{ending_db_slope()}"
+      )
+     
       if
-        ending_db_slope() > 0.7 or ending_fst_db() > lufs_cross_threshold * 1.2
+        ending_db_slope() > 0.7 or
+        ending_fst_db() > lufs_cross_threshold * 1.2
       then
-        log(level=3, label="autocue.internal.sustained_end", "Sustained ending detected. Adjusting crossfade! Use Log Level 4 for more detailed information.")  
-      
+        log(
+          level=3,
+          label="autocue.internal.sustained_end",
+          "Sustained ending detected."
+        ) 
+
         if
           ending_db_slope() > 0.7
         then
@@ -482,17 +500,24 @@ def autocue.internal.implementation(uri) =
         else
           lufs_cross_threshold_sustained := ending_fst_db() - 1.
         end
-      
         lufs_cue_out_threshold_sustained = ref(
           lufs_cue_out_threshold + (lufs_cross_threshold_sustained() - lufs_cross_threshold)
         )
 
-        log(level=4, label="autocue.internal.sustained_end", "Changed crossfade threshold: #{lufs_cross_threshold} => #{lufs_cross_threshold_sustained()}")
-        log(level=4, label="autocue.internal.sustained_end", "Changed cue out threshold: #{lufs_cue_out_threshold} => #{lufs_cue_out_threshold_sustained()}") 
+        log(
+          level=4,
+          label="autocue.internal.sustained_end",
+          "Changed crossfade threshold: #{lufs_cross_threshold} => #{lufs_cross_threshold_sustained()}"
+        )
+        log(
+          level=4,
+          label="autocue.internal.sustained_end",
+          "Changed cue out threshold: #{lufs_cue_out_threshold} => #{lufs_cue_out_threshold_sustained()}"
+        )
 
         cross_cue_init = cross_cue()
         cue_out_init = cue_out()
-      
+       
         reset_iter_values := true
         def sustained_ending_recalc_iter(frame) =
           find_cues(frame,sustained_ending_recalc=true)
@@ -506,15 +531,20 @@ def autocue.internal.implementation(uri) =
             "sustained_ending_recalc_iter completed."
           )
         end
-        log(level=4, label="autocue.internal.sustained_end", "Changed crossfade point: #{cross_cue_init} => #{cross_cue()}")
-        log(level=4, label="autocue.internal.sustained_end", "Changed cue out point:  #{cue_out_init} => #{cue_out()}")   
+       
+        log(
+          level=4,
+          label="autocue.internal.sustained_end",
+          "Changed crossfade point: #{cross_cue_init} => #{cross_cue()}"
+        )
+        log(
+          level=4,
+          label="autocue.internal.sustained_end",
+          "Changed cue out point:  #{cue_out_init} => #{cue_out()}"
+        )
       end
     end
-  
-    ##########################
-    # END: Sustained endings #
-    ##########################
-  
+
     # Get very last frame for precise track duration
     frame = list.last(frames)
     duration =

--- a/src/libs/autocue.liq
+++ b/src/libs/autocue.liq
@@ -35,8 +35,8 @@ let settings.autocue.amplify_behavior =
   settings.make(
     description=
       "How to proceed with amplify data when `\"liq_amplify\"` is set. One of: \
-       `\"keep\"` (prefer user-provided value), `\"override\"` (always override with \
-       computed value), `\"ignore\"` (ignore/suppress loudness adjustment).",
+       `\"keep\"` (keep user-provided value), `\"override\"` (override with \
+       computed value) or `\"disable\"` (disable `autocue` altogether).",
     "keep"
   )
 
@@ -455,16 +455,12 @@ def enable_autocue_metadata() =
       []
     else
       autocue_metadata = file.autocue.metadata(fname)
+      autocue_metadata_response = ref(autocue_metadata)
 
       if
         settings.autocue.amplify_behavior() == "ignore"
       then
-        log(
-          level=3,
-          label="autocue.metadata",
-          "Ignoring loudness adjustment... Removing `\"liq_amplify\"`."
-        )
-        [
+        autocue_metadata_response := [
           ...list.assoc.remove("liq_amplify", autocue_metadata)
         ]
       else
@@ -479,7 +475,7 @@ def enable_autocue_metadata() =
               label="autocue.metadata",
               "Keeping user-provided `\"liq_amplify\"` value."
             )
-            [
+            autocue_metadata_response := [
               ...list.assoc.remove("liq_amplify", autocue_metadata),
               ("liq_amplify", metadata["liq_amplify"])
             ]
@@ -502,7 +498,12 @@ def enable_autocue_metadata() =
           end
         end
       end
-      autocue_metadata
+      log(
+        level=4,
+        label="autocue.metadata",
+        "#{autocue_metadata_response()}"
+      )   
+      autocue_metadata_response()
     end
   end
   decoder.metadata.add("autocue", autocue_metadata)

--- a/src/libs/autocue.liq
+++ b/src/libs/autocue.liq
@@ -95,7 +95,7 @@ let settings.autocue.internal.sustained_endings_dropoff =
     description=
       "Max. loudness drop off immediately after crossfade point to consider it \
       as relevant ending [percentage]",
-    10.0
+    15.0
   )
 
 let settings.autocue.internal.sustained_endings_slope =
@@ -262,17 +262,17 @@ def autocue.internal.implementation(uri) =
     log(
       level=4,
       label="autocue.internal",
-      "adj_cue_in_threshold: #{lufs_cue_in_threshold}"
+      "lufs_cue_in_threshold: #{lufs_cue_in_threshold}"
     )
     log(
       level=4,
       label="autocue.internal",
-      "adj_cue_out_threshold: #{lufs_cue_out_threshold}"
+      "lufs_cue_out_threshold: #{lufs_cue_out_threshold}"
     )
     log(
       level=4,
       label="autocue.internal",
-      "adj_cross_threshold: #{lufs_cross_threshold}"
+      "lufs_cross_threshold: #{lufs_cross_threshold}"
     )
 
     # Set cue/fade defaults
@@ -374,17 +374,17 @@ def autocue.internal.implementation(uri) =
             reset_iter_values()
           then
             frame_idx := total_frames_length - 1.
-            cross_frame_length := cross_stop_idx() - cross_start_idx()
             cross_start_idx := cross_start_idx() + 5.
             cross_stop_idx := cross_stop_idx() - 5.
-            cross_mid_idx := total_frames_length - (cross_frame_length() / 2.)
+            cross_frame_length := cross_stop_idx() - cross_start_idx()
+            cross_mid_idx := cross_stop_idx() - (cross_frame_length() / 2.)
           end
           reset_iter_values := false
 
           if
-            frame_idx() < cross_start_idx()
+            frame_idx() < cross_start_idx() or
+            cross_frame_length() < 5.
           then
-            # Break iteration if relevant frames were analysed
             error.raise(err,"break list.iter")
           end
 
@@ -392,14 +392,26 @@ def autocue.internal.implementation(uri) =
             frame_idx() < cross_stop_idx() and
             frame_idx() > cross_mid_idx()
           then
-            ending_snd_db := (ending_snd_db() + db_level) / 2.
+            if
+              ending_snd_db() < 0.
+            then
+              ending_snd_db := (ending_snd_db() + db_level) / 2.
+            else
+              ending_snd_db := db_level
+            end
           end
 
           if
             frame_idx() > cross_start_idx() and
             frame_idx() < cross_mid_idx()
           then
-            ending_fst_db := (ending_fst_db() + db_level) / 2.
+            if
+              ending_fst_db() < 0.
+            then
+              ending_fst_db := (ending_fst_db() + db_level) / 2.
+            else
+              ending_fst_db := db_level
+            end
           end
           frame_idx := frame_idx() - 1.
         elsif
@@ -468,12 +480,6 @@ def autocue.internal.implementation(uri) =
     if
       sustained_endings_enabled
     then
-      log(
-        level=4,
-        label="autocue.internal.sustained_ending",
-        "Checking for sustained ending."
-      )
-
       # Check for sustained ending
       reset_iter_values := true
       def sustained_ending_check_iter(frame) =
@@ -581,7 +587,19 @@ def autocue.internal.implementation(uri) =
             label="autocue.internal.sustained_ending",
             "Changed cue out point:  #{cue_out_init} => #{cue_out()}"
           )
+        else
+          log(
+            level=3,
+            label="autocue.internal.sustained_ending",
+            "No sustained ending detected."
+          )
         end
+      else
+        log(
+          level=3,
+          label="autocue.internal.sustained_ending",
+          "No sustained ending detected."
+        )
       end
     end
 

--- a/src/libs/autocue.liq
+++ b/src/libs/autocue.liq
@@ -35,8 +35,8 @@ let settings.autocue.amplify_behavior =
   settings.make(
     description=
       "How to proceed with amplify data when `\"liq_amplify\"` is set. One of: \
-       `\"keep\"` (keep user-provided value), `\"override\"` (override with \
-       computed value) or `\"disable\"` (disable `autocue` altogether).",
+       `\"keep\"` (prefer user-provided value), `\"override\"` (always override with \
+       computed value), `\"ignore\"` (ignore/suppress loudness adjustment).",
     "keep"
   )
 

--- a/src/libs/autocue.liq
+++ b/src/libs/autocue.liq
@@ -225,7 +225,7 @@ def autocue.internal.implementation(uri) =
     )
     log(
       level=4,
-      label="autocue",
+      label="autocue.internal",
       "adj_cross_threshold: #{lufs_cross_threshold}"
     )
 

--- a/src/libs/autocue.liq
+++ b/src/libs/autocue.liq
@@ -268,7 +268,7 @@ def autocue.internal.implementation(uri) =
     ending_fst_db = ref(0.)
     ending_snd_db = ref(0.)
     reset_iter_values = ref(true)
- 
+
     frames_rev = list.rev(frames)
     total_frames_length = float_of_int(list.length(frames))
     frame_idx = ref(total_frames_length - 1.)
@@ -287,9 +287,9 @@ def autocue.internal.implementation(uri) =
       then
         last_ts := 0.
         current_ts := 0.
-        cue_found := false           
+        cue_found := false
       end
-         
+
       # Get current frame loudness level and timestamp
       db_level = list.assoc(default="nan", string("lavfi.r128.M"), frame)
       current_ts :=
@@ -335,7 +335,7 @@ def autocue.internal.implementation(uri) =
               # Absolute crossfade cue
               cross_cue := last_ts()
               cross_start_idx := frame_idx()
-              # Break           
+              # Break
               error.raise(err,"break list.iter")
             end
             frame_idx := frame_idx() - 1.
@@ -346,15 +346,15 @@ def autocue.internal.implementation(uri) =
           # Check regular crossfade data for sustained ending
           if
             reset_iter_values()
-          then     
+          then
             frame_idx := total_frames_length - 1.
             cross_frame_length := cross_stop_idx() - cross_start_idx()
             cross_start_idx := cross_start_idx() + 5.
-            cross_stop_idx := cross_stop_idx() - 5. 
+            cross_stop_idx := cross_stop_idx() - 5.
             cross_mid_idx := total_frames_length - (cross_frame_length() / 2.)
           end
           reset_iter_values := false
-       
+
           if
             frame_idx() < cross_start_idx()
           then
@@ -382,9 +382,9 @@ def autocue.internal.implementation(uri) =
           # Recalculate crossfade on sustained ending
           if
             reset_iter_values()
-          then      
+          then
             cue_out := 0.
-            cross_cue := 0.            
+            cross_cue := 0.
           end
           reset_iter_values := false
           if
@@ -401,11 +401,11 @@ def autocue.internal.implementation(uri) =
             # Absolute crossfade cue
             cross_cue := last_ts()
             error.raise(err,"break list.iter")
-          end         
+          end
         end
-     
+
         # Update last timestamp value with current
-        last_ts := current_ts()        
+        last_ts := current_ts()
       end
     end
 
@@ -452,19 +452,19 @@ def autocue.internal.implementation(uri) =
         label="autocue.internal",
         "sustained_ending_check_iter completed."
       )
-    end 
+    end
 
     log(
       level=4,
-       label="autocue.internal.sustained_end",
-       "Analysis frame length: #{cross_frame_length()}"
+      label="autocue.internal.sustained_end",
+      "Analysis frame length: #{cross_frame_length()}"
     )
     log(
       level=4,
       label="autocue.internal.sustained_end",
       "Avg. ending dB level: 1st half => #{ending_fst_db()} / 2nd half => #{ending_snd_db()}"
     )
-   
+
     # Check whether data indicate a sustained ending
     if
       ending_fst_db() < 0.
@@ -476,13 +476,13 @@ def autocue.internal.implementation(uri) =
       then
         ending_db_slope := ending_fst_db() / ending_snd_db()
       end
-     
+
       log(
         level=4,
         label="autocue.internal.sustained_end",
         "Slope: #{ending_db_slope()}"
       )
-     
+
       if
         ending_db_slope() > 0.7 or
         ending_fst_db() > lufs_cross_threshold * 1.2
@@ -491,7 +491,7 @@ def autocue.internal.implementation(uri) =
           level=3,
           label="autocue.internal.sustained_end",
           "Sustained ending detected."
-        ) 
+        )
 
         if
           ending_db_slope() > 0.7
@@ -517,7 +517,7 @@ def autocue.internal.implementation(uri) =
 
         cross_cue_init = cross_cue()
         cue_out_init = cue_out()
-       
+
         reset_iter_values := true
         def sustained_ending_recalc_iter(frame) =
           find_cues(frame,sustained_ending_recalc=true)
@@ -531,7 +531,7 @@ def autocue.internal.implementation(uri) =
             "sustained_ending_recalc_iter completed."
           )
         end
-       
+
         log(
           level=4,
           label="autocue.internal.sustained_end",

--- a/src/libs/autocue.liq
+++ b/src/libs/autocue.liq
@@ -446,7 +446,7 @@ def autocue.internal.implementation(uri) =
             not cue_found()
           then
             # Cue out
-            cue_out := current_ts()
+            cue_out := last_ts()
             cue_found := true
           end
           if

--- a/src/libs/autocue.liq
+++ b/src/libs/autocue.liq
@@ -446,14 +446,14 @@ def autocue.internal.implementation(uri) =
             not cue_found()
           then
             # Cue out
-            cue_out := last_ts()
+            cue_out := current_ts()
             cue_found := true
           end
           if
             db_level > lufs_cross_threshold_sustained()
           then
             # Absolute crossfade cue
-            cross_cue := last_ts()
+            cross_cue := current_ts()
             error.raise(err,"break list.iter")
           end
         end

--- a/src/libs/autocue.liq
+++ b/src/libs/autocue.liq
@@ -83,6 +83,13 @@ let settings.autocue.internal.max_overlap =
     6.0
   )
 
+let settings.autocue.internal.sustained_endings =
+  settings.make(
+    description=
+      "Try to optimize crossfade point on sustained endings",
+    true
+  )
+
 let settings.autocue.internal.ratio =
   settings.make(
     description=
@@ -184,6 +191,7 @@ def autocue.internal.implementation(uri) =
   cue_out_threshold = settings.autocue.internal.cue_out_threshold()
   cross_threshold = settings.autocue.internal.cross_threshold()
   max_overlap = settings.autocue.internal.max_overlap()
+  sustained_endings = settings.autocue.internal.sustained_endings()
   ratio = settings.autocue.internal.ratio()
   timeout = settings.autocue.internal.timeout()
 
@@ -439,109 +447,119 @@ def autocue.internal.implementation(uri) =
       )
     end
 
-    # Check for sustained ending
-    reset_iter_values := true
-    def sustained_ending_check_iter(frame) =
-      find_cues(frame,sustained_ending_check=true)
-    end
-    try
-      list.iter(sustained_ending_check_iter, frames_rev)
-    catch _ do
+    if
+      sustained_endings
+    then
       log(
         level=4,
-        label="autocue.internal",
-        "sustained_ending_check_iter completed."
+        label="autocue.internal.sustained_ending",
+        "Checking for sustained ending."
       )
-    end
 
-    log(
-      level=4,
-      label="autocue.internal.sustained_end",
-      "Analysis frame length: #{cross_frame_length()}"
-    )
-    log(
-      level=4,
-      label="autocue.internal.sustained_end",
-      "Avg. ending dB level: 1st half => #{ending_fst_db()} / 2nd half => #{ending_snd_db()}"
-    )
-
-    # Check whether data indicate a sustained ending
-    if
-      ending_fst_db() < 0.
-    then
-      ending_db_slope = ref(0.)
-
-      if
-        ending_snd_db() < 0.
-      then
-        ending_db_slope := ending_fst_db() / ending_snd_db()
+      # Check for sustained ending
+      reset_iter_values := true
+      def sustained_ending_check_iter(frame) =
+        find_cues(frame,sustained_ending_check=true)
+      end
+      try
+        list.iter(sustained_ending_check_iter, frames_rev)
+      catch _ do
+        log(
+          level=4,
+          label="autocue.internal.sustained_ending",
+          "sustained_ending_check_iter completed."
+        )
       end
 
       log(
         level=4,
-        label="autocue.internal.sustained_end",
-        "Slope: #{ending_db_slope()}"
+        label="autocue.internal.sustained_ending",
+        "Analysis frame length: #{cross_frame_length()}"
+      )
+      log(
+        level=4,
+        label="autocue.internal.sustained_ending",
+        "Avg. ending dB level: 1st half => #{ending_fst_db()} / 2nd half => #{ending_snd_db()}"
       )
 
+      # Check whether data indicate a sustained ending
       if
-        ending_db_slope() > 0.7 or
-        ending_fst_db() > lufs_cross_threshold * 1.2
+        ending_fst_db() < 0.
       then
+        ending_db_slope = ref(0.)
+
+        if
+          ending_snd_db() < 0.
+        then
+          ending_db_slope := ending_fst_db() / ending_snd_db()
+        end
+
         log(
-          level=3,
-          label="autocue.internal.sustained_end",
-          "Sustained ending detected."
+          level=4,
+          label="autocue.internal.sustained_ending",
+          "Slope: #{ending_db_slope()}"
         )
 
         if
-          ending_db_slope() > 0.7
+          ending_db_slope() > 0.8 or
+          ending_fst_db() > (lufs_cross_threshold * 1.1)
         then
-          lufs_cross_threshold_sustained := ending_snd_db() - 1.
-        else
-          lufs_cross_threshold_sustained := ending_fst_db() - 1.
-        end
-        lufs_cue_out_threshold_sustained = ref(
-          lufs_cue_out_threshold + (lufs_cross_threshold_sustained() - lufs_cross_threshold)
-        )
+          log(
+            level=3,
+            label="autocue.internal.sustained_ending",
+            "Sustained ending detected."
+          )
 
-        log(
-          level=4,
-          label="autocue.internal.sustained_end",
-          "Changed crossfade threshold: #{lufs_cross_threshold} => #{lufs_cross_threshold_sustained()}"
-        )
-        log(
-          level=4,
-          label="autocue.internal.sustained_end",
-          "Changed cue out threshold: #{lufs_cue_out_threshold} => #{lufs_cue_out_threshold_sustained()}"
-        )
+          if
+            ending_db_slope() > 0.8
+          then
+            lufs_cross_threshold_sustained := ending_snd_db() - 0.5
+          else
+            lufs_cross_threshold_sustained := ending_fst_db() - 0.5
+          end
+          lufs_cue_out_threshold_sustained = ref(
+            lufs_cue_out_threshold + (lufs_cross_threshold_sustained() - lufs_cross_threshold)
+          )
 
-        cross_cue_init = cross_cue()
-        cue_out_init = cue_out()
-
-        reset_iter_values := true
-        def sustained_ending_recalc_iter(frame) =
-          find_cues(frame,sustained_ending_recalc=true)
-        end
-        try
-          list.iter(sustained_ending_recalc_iter, frames_rev)
-        catch _ do
           log(
             level=4,
-            label="autocue.internal",
-            "sustained_ending_recalc_iter completed."
+            label="autocue.internal.sustained_ending",
+            "Changed crossfade threshold: #{lufs_cross_threshold} => #{lufs_cross_threshold_sustained()}"
+          )
+          log(
+            level=4,
+            label="autocue.internal.sustained_ending",
+            "Changed cue out threshold: #{lufs_cue_out_threshold} => #{lufs_cue_out_threshold_sustained()}"
+          )
+
+          cross_cue_init = cross_cue()
+          cue_out_init = cue_out()
+
+          reset_iter_values := true
+          def sustained_ending_recalc_iter(frame) =
+            find_cues(frame,sustained_ending_recalc=true)
+          end
+          try
+            list.iter(sustained_ending_recalc_iter, frames_rev)
+          catch _ do
+            log(
+              level=4,
+              label="autocue.internal",
+              "sustained_ending_recalc_iter completed."
+            )
+          end
+
+          log(
+            level=4,
+            label="autocue.internal.sustained_ending",
+            "Changed crossfade point: #{cross_cue_init} => #{cross_cue()}"
+          )
+          log(
+            level=4,
+            label="autocue.internal.sustained_ending",
+            "Changed cue out point:  #{cue_out_init} => #{cue_out()}"
           )
         end
-
-        log(
-          level=4,
-          label="autocue.internal.sustained_end",
-          "Changed crossfade point: #{cross_cue_init} => #{cross_cue()}"
-        )
-        log(
-          level=4,
-          label="autocue.internal.sustained_end",
-          "Changed cue out point:  #{cue_out_init} => #{cue_out()}"
-        )
       end
     end
 

--- a/src/libs/autocue.liq
+++ b/src/libs/autocue.liq
@@ -276,8 +276,12 @@ def autocue.internal.implementation(uri) =
     lufs_cue_out_threshold_sustained = ref(lufs_cue_out_threshold)
 
     err = error.register("assoc")
-    def find_cues(frame, ~reverse_order=false,~sustained_ending_check=false,~sustained_ending_recalc=false) =
-
+    def find_cues(
+      frame,
+      ~reverse_order=false,
+      ~sustained_ending_check=false,
+      ~sustained_ending_recalc=false
+    ) =
       if
         reset_iter_values()
       then

--- a/src/libs/autocue.liq
+++ b/src/libs/autocue.liq
@@ -35,8 +35,9 @@ let settings.autocue.amplify_behavior =
   settings.make(
     description=
       "How to proceed with amplify data when `\"liq_amplify\"` is set. One of: \
-       `\"keep\"` (prefer user-provided value), `\"override\"` (always override with \
-       computed value), `\"ignore\"` (ignore/suppress loudness adjustment).",
+       `\"keep\"` (prefer user-provided value), `\"override\"` (always override \
+       with computed value), `\"ignore\"` (ignore/suppress loudness \
+       adjustment).",
     "keep"
   )
 
@@ -454,6 +455,7 @@ def enable_autocue_metadata() =
   settings.crossfade.assume_autocue := true
 
   def autocue_metadata(~metadata, fname) =
+  print("fname: #{fname}, metadata: #{metadata}")
     metadata_overrides = settings.autocue.metadata_override()
 
     if
@@ -467,55 +469,53 @@ def enable_autocue_metadata() =
       []
     else
       autocue_metadata = file.autocue.metadata(fname)
-      autocue_metadata_response = ref(autocue_metadata)
 
-      if
-        settings.autocue.amplify_behavior() == "ignore"
-      then
-        autocue_metadata_response := [
-          ...list.assoc.remove("liq_amplify", autocue_metadata)
-        ]
-      else
+      autocue_metadata =
         if
-          list.assoc.mem("liq_amplify", metadata)
+          settings.autocue.amplify_behavior() == "ignore"
         then
+          [...list.assoc.remove("liq_amplify", autocue_metadata)]
+        else
           if
-            settings.autocue.amplify_behavior() == "keep"
+            list.assoc.mem("liq_amplify", metadata)
           then
-            log(
-              level=3,
-              label="autocue.metadata",
-              "Keeping user-provided `\"liq_amplify\"` value."
-            )
-            autocue_metadata_response := [
-              ...list.assoc.remove("liq_amplify", autocue_metadata),
-              ("liq_amplify", metadata["liq_amplify"])
-            ]
-          elsif
-            settings.autocue.amplify_behavior() == "override"
-          then
-            log(
-              level=3,
-              label="autocue.metadata",
-              "Overriding user-provided `\"liq_amplify\"` value."
-            )
+            if
+              settings.autocue.amplify_behavior() == "keep"
+            then
+              log(
+                level=3,
+                label="autocue.metadata",
+                "Keeping user-provided `\"liq_amplify\"` value."
+              )
+              [
+                ...list.assoc.remove("liq_amplify", autocue_metadata),
+                ("liq_amplify", metadata["liq_amplify"])
+              ]
+            elsif
+              settings.autocue.amplify_behavior() == "override"
+            then
+              log(
+                level=3,
+                label="autocue.metadata",
+                "Overriding user-provided `\"liq_amplify\"` value."
+              )
+              autocue_metadata
+            else
+              log(
+                level=2,
+                label="autocue.metadata",
+                "Invalid value for `settings.autocue.amplify_behavior`: #{
+                  settings.autocue.amplify_behavior()
+                }"
+              )
+              autocue_metadata
+            end
           else
-            log(
-              level=2,
-              label="autocue.metadata",
-              "Invalid value for `settings.autocue.amplify_behavior`: #{
-                settings.autocue.amplify_behavior()
-              }"
-            )
+            autocue_metadata
           end
         end
-      end
-      log(
-        level=4,
-        label="autocue.metadata",
-        "#{autocue_metadata_response()}"
-      )
-      autocue_metadata_response()
+      log(level=4, label="autocue.metadata", "#{autocue_metadata}")
+      autocue_metadata
     end
   end
   decoder.metadata.add("autocue", autocue_metadata)

--- a/src/libs/autocue.liq
+++ b/src/libs/autocue.liq
@@ -28,7 +28,14 @@ let settings.autocue.metadata_override =
   settings.make(
     description=
       "Disable processing when one of these metadata is found",
-    ["liq_cue_in", "liq_cue_out", "liq_fade_in", "liq_fade_out"]
+    [
+      "liq_cue_in",
+      "liq_cue_out",
+      "liq_fade_in",
+      "liq_fade_in_delay",
+      "liq_fade_out",
+      "liq_fade_out_delay"
+    ]
   )
 
 let settings.autocue.amplify_behavior =
@@ -429,6 +436,7 @@ def file.autocue.metadata(uri) =
       ("liq_cue_out", string(cue_out)),
       ("liq_cross_duration", string(cross_duration)),
       ("liq_fade_in", string(fade_in)),
+      ("liq_fade_in_delay", "0."),
       ("liq_fade_out", string(fade_out)),
       ("liq_fade_out_delay", string(fade_out_delay)),
       ...extra_metadata
@@ -455,7 +463,9 @@ def enable_autocue_metadata() =
   settings.crossfade.assume_autocue := true
 
   def autocue_metadata(~metadata, fname) =
-  print("fname: #{fname}, metadata: #{metadata}")
+    print(
+      "fname: #{fname}, metadata: #{metadata}"
+    )
     metadata_overrides = settings.autocue.metadata_override()
 
     if

--- a/src/libs/autocue.liq
+++ b/src/libs/autocue.liq
@@ -35,8 +35,9 @@ let settings.autocue.amplify_behavior =
   settings.make(
     description=
       "How to proceed with amplify data when `\"liq_amplify\"` is set. One of: \
-       `\"keep\"` (keep user-provided value), `\"override\"` (override with \
-       computed value) or `\"disable\"` (disable `autocue` altogether).",
+       `\"keep\"` (prefer user-provided value), `\"override\"` (always override with \
+       computed value), `\"cancel\"` (skip `autocue` on user-provided value), \
+       `\"disable\"` (ignore `amplify` entirely).",
     "keep"
   )
 
@@ -465,33 +466,41 @@ def enable_autocue_metadata() =
       autocue_metadata = file.autocue.metadata(fname)
 
       if
-        list.assoc.mem("liq_amplify", metadata)
+        settings.autocue.amplify_behavior() == "disable"
       then
+        log(
+          level=3,
+          label="autocue.metadata",
+          "Removing `\"liq_amplify\"` (disable amplify)."
+        )
+        [
+          ...list.assoc.remove("liq_amplify", autocue_metadata)
+        ]
+      else
         if
-          settings.autocue.amplify_behavior() == "keep"
+          list.assoc.mem("liq_amplify", metadata)
         then
-          log(
-            level=3,
-            label="autocue.metadata",
-            "Keeping user-provided `\"liq_amplify\"` value."
-          )
-          [
-            ...list.assoc.remove("liq_amplify", autocue_metadata),
-            ("liq_amplify", metadata["liq_amplify"])
-          ]
-        elsif
-          settings.autocue.amplify_behavior() == "override"
-        then
-          log(
-            level=3,
-            label="autocue.metadata",
-            "Overriding user-provided `\"liq_amplify\"` value."
-          )
-          autocue_metadata
-        else
           if
-            settings.autocue.amplify_behavior() != "cancel"
+            settings.autocue.amplify_behavior() == "keep"
           then
+            log(
+              level=3,
+              label="autocue.metadata",
+              "Keeping user-provided `\"liq_amplify\"` value."
+            )
+            [
+              ...list.assoc.remove("liq_amplify", autocue_metadata),
+              ("liq_amplify", metadata["liq_amplify"])
+            ]
+          elsif
+            settings.autocue.amplify_behavior() == "override"
+          then
+            log(
+              level=3,
+              label="autocue.metadata",
+              "Overriding user-provided `\"liq_amplify\"` value."
+            )
+          else
             log(
               level=2,
               label="autocue.metadata",
@@ -500,11 +509,9 @@ def enable_autocue_metadata() =
               }"
             )
           end
-          autocue_metadata
         end
-      else
-        autocue_metadata
       end
+      autocue_metadata
     end
   end
   decoder.metadata.add("autocue", autocue_metadata)

--- a/src/libs/autocue.liq
+++ b/src/libs/autocue.liq
@@ -36,8 +36,7 @@ let settings.autocue.amplify_behavior =
     description=
       "How to proceed with amplify data when `\"liq_amplify\"` is set. One of: \
        `\"keep\"` (prefer user-provided value), `\"override\"` (always override with \
-       computed value), `\"cancel\"` (skip `autocue` on user-provided value), \
-       `\"disable\"` (ignore `amplify` entirely).",
+       computed value), `\"ignore\"` (ignore/suppress loudness adjustment).",
     "keep"
   )
 
@@ -444,14 +443,6 @@ def enable_autocue_metadata() =
 
   def autocue_metadata(~metadata, fname) =
     metadata_overrides = settings.autocue.metadata_override()
-    metadata_overrides =
-      if
-        settings.autocue.amplify_behavior() == "cancel"
-      then
-        [...metadata_overrides, "liq_amplify"]
-      else
-        metadata_overrides
-      end
 
     if
       list.exists(fun (el) -> list.mem(fst(el), metadata_overrides), metadata)
@@ -466,12 +457,12 @@ def enable_autocue_metadata() =
       autocue_metadata = file.autocue.metadata(fname)
 
       if
-        settings.autocue.amplify_behavior() == "disable"
+        settings.autocue.amplify_behavior() == "ignore"
       then
         log(
           level=3,
           label="autocue.metadata",
-          "Removing `\"liq_amplify\"` (disable amplify)."
+          "Ignoring loudness adjustment... Removing `\"liq_amplify\"`."
         )
         [
           ...list.assoc.remove("liq_amplify", autocue_metadata)


### PR DESCRIPTION
This is an improvement of autocue to optimize crossfade and cue out points in case of sustained endings. This new algorithm is analysing the loudness behavior after the initially calculated crossfade and cue out point. If it's still a part of the song that is likely to be of relevance, the crossfade is recalculated based on that data.

The relevance is determined on the basis of the loudness reduction immediately after the original crossfade point and a possible "plateau" (i.e. no continuous fade-out).