### PR TITLE
Fix sync_source check errors, improve errors

### DIFF
--- a/src/core/builtins/builtins_clock.ml
+++ b/src/core/builtins/builtins_clock.ml
@@ -79,5 +79,5 @@ let _ =
                  "Invalid sync mode! Should be one of: `\"auto\"`, `\"CPU\"`, \
                   `\"unsynced\"` or `\"passive\"`" ))
       in
-      let pos = match Lang.pos p with p :: _ -> Some p | [] -> None in
-      Lang_source.ClockValue.to_value (Clock.create ?pos ?on_error ?id ~sync ()))
+      Lang_source.ClockValue.to_value
+        (Clock.create ~stack:(Lang.pos p) ?on_error ?id ~sync ()))

--- a/src/core/builtins/builtins_ffmpeg_decoder.ml
+++ b/src/core/builtins/builtins_ffmpeg_decoder.ml
@@ -436,11 +436,6 @@ let mk_decoder mode =
            Lang.to_default_option ~default:name Lang.to_string
              (List.assoc "id" p)
          in
-         let pos =
-           match Liquidsoap_lang.Lang_core.pos p with
-             | [] -> None
-             | p :: _ -> Some p
-         in
          let field, source = Lang.to_track (List.assoc "" p) in
 
          let mk_decode_frame generator =
@@ -492,7 +487,8 @@ let mk_decoder mode =
              ~always_enabled:true ~write_frame:decode_frame
              ~name:(id ^ ".consumer") ~source:(Lang.source source) ()
          in
-         consumer#set_pos pos;
+         let stack = Liquidsoap_lang.Lang_core.pos p in
+         consumer#set_stack stack;
 
          let input_frame_t = Type.fresh input_frame_t in
          Typing.(
@@ -503,7 +499,7 @@ let mk_decoder mode =
          ( field,
            new Producer_consumer.producer
            (* We are expecting real-rate with a couple of hickups.. *)
-             ?pos ~check_self_sync:false ~consumers:[consumer]
+             ~stack ~check_self_sync:false ~consumers:[consumer]
              ~name:(id ^ ".producer") () )))
 
 let () =

--- a/src/core/builtins/builtins_ffmpeg_encoder.ml
+++ b/src/core/builtins/builtins_ffmpeg_encoder.ml
@@ -427,11 +427,6 @@ let mk_encoder mode =
            Lang.to_default_option ~default:name Lang.to_string
              (List.assoc "id" p)
          in
-         let pos =
-           match Liquidsoap_lang.Lang_core.pos p with
-             | [] -> None
-             | p :: _ -> Some p
-         in
          let format_val = Lang.assoc "" 1 p in
          let format =
            match Lang.to_format format_val with
@@ -557,7 +552,8 @@ let mk_encoder mode =
              ~write_frame:encode_frame ~name:(id ^ ".consumer")
              ~source:(Lang.source source) ()
          in
-         consumer#set_pos pos;
+         let stack = Liquidsoap_lang.Lang_core.pos p in
+         consumer#set_stack stack;
 
          let input_frame_t = Type.fresh input_frame_t in
          Typing.(
@@ -568,7 +564,7 @@ let mk_encoder mode =
          ( field,
            new Producer_consumer.producer
            (* We are expecting real-rate with a couple of hickups.. *)
-             ?pos ~check_self_sync:false ~consumers:[consumer]
+             ~stack ~check_self_sync:false ~consumers:[consumer]
              ~name:(id ^ ".producer") () )))
 
 let () =

--- a/src/core/clock_base.ml
+++ b/src/core/clock_base.ml
@@ -1,0 +1,169 @@
+(*****************************************************************************
+
+  Liquidsoap, a programmable stream generator.
+  Copyright 2003-2024 Savonet team
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details, fully stated in the COPYING
+  file at the root of the liquidsoap distribution.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA
+
+ *****************************************************************************)
+
+exception Invalid_state
+
+module Evaluation = Liquidsoap_lang.Evaluation
+
+type active_source = < reset : unit ; output : unit >
+
+type source_type =
+  [ `Passive | `Active of active_source | `Output of active_source ]
+
+type sync_source = ..
+type self_sync = [ `Static | `Dynamic ] * sync_source option
+
+module Queue = struct
+  include Liquidsoap_lang.Queues.Queue
+
+  let push q v = if not (exists q (fun v' -> v == v')) then push q v
+end
+
+module WeakQueue = struct
+  include Liquidsoap_lang.Queues.WeakQueue
+
+  let push q v = if not (exists q (fun v' -> v == v')) then push q v
+end
+
+exception Sync_source_name of string
+
+let sync_sources_handlers = Queue.create ()
+
+let string_of_sync_source s =
+  try
+    Queue.iter sync_sources_handlers (fun fn -> fn s);
+    assert false
+  with Sync_source_name s -> s
+
+module type SyncSource = sig
+  type t
+
+  val to_string : t -> string
+end
+
+module MkSyncSource (S : SyncSource) = struct
+  type sync_source += Sync_source of S.t
+
+  let make v = Sync_source v
+
+  let () =
+    Queue.push sync_sources_handlers (function
+      | Sync_source v -> raise (Sync_source_name (S.to_string v))
+      | _ -> ())
+end
+
+type sync_source_entry = {
+  name : string;
+  sync_source : sync_source;
+  stack : Pos.t list;
+}
+
+type clock_sync_error = {
+  name : string;
+  stack : Pos.t list;
+  sync_sources : sync_source_entry list;
+}
+
+exception Sync_error of clock_sync_error
+
+module SelfSyncSet = Set.Make (struct
+  type t = sync_source_entry
+
+  let compare { sync_source = a } { sync_source = b } = Stdlib.compare a b
+end)
+
+let () =
+  Printexc.register_printer (function
+    | Sync_error { name; stack; sync_sources } ->
+        let buf = Buffer.create 1024 in
+        let formatter = Format.formatter_of_buffer buf in
+        let open Liquidsoap_lang in
+        let print_stack = function
+          | [] -> " Unknown position"
+          | l ->
+              let l = List.init (min (List.length l) 3) (List.nth l) in
+              String.concat "\n"
+                (List.map (fun p -> " " ^ Liquidsoap_lang.Pos.to_string p) l)
+        in
+        ignore (print_stack []);
+        let pos = match stack with [] -> None | p :: _ -> Some p in
+        Runtime.error_header ~formatter 17 pos;
+        Format.fprintf formatter
+          "%s has multiple synchronization sources. Do you need to set \
+           self_sync=false?@."
+          name;
+        Format.fprintf formatter "\nSync sources:\n";
+        List.iter
+          (fun { name; sync_source } ->
+            Format.fprintf formatter " %s from source %s\n"
+              (string_of_sync_source sync_source)
+              name)
+          sync_sources;
+        Format.fprintf formatter "\nStack traces:\n";
+        Format.fprintf formatter "%s:\n%s\n\n" name (print_stack stack);
+        List.iter
+          (fun { name; stack; sync_source = _ } ->
+            Format.fprintf formatter "%s:\n%s\n\n" name (print_stack stack))
+          sync_sources;
+        Format.fprintf formatter "@]@.";
+        Format.pp_print_flush formatter ();
+        Some (Buffer.contents buf)
+    | _ -> None)
+
+type source =
+  < id : string
+  ; stack : Pos.t list
+  ; self_sync : self_sync
+  ; source_type : source_type
+  ; active : bool
+  ; wake_up : unit
+  ; force_sleep : unit
+  ; is_ready : bool
+  ; get_frame : Frame.t >
+
+let self_sync_type sources =
+  Lazy.from_fun (fun () ->
+      if List.exists (fun s -> fst s#self_sync = `Dynamic) sources then `Dynamic
+      else `Static)
+
+let self_sync sources =
+  let self_sync_type = self_sync_type sources in
+  fun ~source () ->
+    let sync_sources =
+      List.fold_left
+        (fun sync_sources s ->
+          if s#is_ready then (
+            match s#self_sync with
+              | _, Some sync_source ->
+                  SelfSyncSet.add
+                    { name = s#id; stack = s#stack; sync_source }
+                    sync_sources
+              | _ -> sync_sources)
+          else sync_sources)
+        SelfSyncSet.empty sources
+    in
+    match SelfSyncSet.elements sync_sources with
+      | [] -> (Lazy.force self_sync_type, None)
+      | [{ sync_source }] -> (Lazy.force self_sync_type, Some sync_source)
+      | sync_sources ->
+          raise
+            (Sync_error { name = source#id; stack = source#stack; sync_sources })

--- a/src/core/dune
+++ b/src/core/dune
@@ -65,6 +65,7 @@
   chord
   clip
   clock
+  clock_base
   comb
   compand
   compress

--- a/src/core/io/ffmpeg_filter_io.ml
+++ b/src/core/io/ffmpeg_filter_io.ml
@@ -233,7 +233,7 @@ class virtual ['a] input_base ~name ~pass_metadata ~self_sync ~is_ready ~pull
               self#put_data ~length frames
           | None -> ()
 
-    method self_sync : Clock.self_sync = self_sync ()
+    method self_sync : Clock.self_sync = self_sync self
 
     method pull =
       try

--- a/src/core/lang.mli
+++ b/src/core/lang.mli
@@ -88,7 +88,7 @@ val iter_sources :
 
 (** {2 Computation} *)
 
-val apply_fun : (?pos:Liquidsoap_lang.Pos.t -> value -> env -> value) ref
+val apply_fun : (?pos:Liquidsoap_lang.Pos.t list -> value -> env -> value) ref
 
 (** Multiapply a value to arguments. The argument [t] is the type of the result
    of the application. *)

--- a/src/core/lang_source.ml
+++ b/src/core/lang_source.ml
@@ -589,14 +589,9 @@ let add_operator ~(category : Doc.Value.source) ~descr ?(flags = [])
     :: List.stable_sort compare arguments
   in
   let f env =
-    let pos =
-      match Liquidsoap_lang.Lang_core.pos env with
-        | [] -> None
-        | p :: _ -> Some p
-    in
     let return_t, env = check_arguments ~return_t ~env arguments in
     let src : < Source.source ; .. > = f env in
-    src#set_pos pos;
+    src#set_stack (Liquidsoap_lang.Lang_core.pos env);
     Typing.(src#frame_type <: return_t);
     ignore
       (Option.map
@@ -629,14 +624,9 @@ let add_track_operator ~(category : Doc.Value.source) ~descr ?(flags = [])
     :: arguments
   in
   let f env =
-    let pos =
-      match Liquidsoap_lang.Lang_core.pos env with
-        | [] -> None
-        | p :: _ -> Some p
-    in
     let return_t, env = check_arguments ~return_t ~env arguments in
     let field, (src : < Source.source ; .. >) = f env in
-    src#set_pos pos;
+    src#set_stack (Liquidsoap_lang.Lang_core.pos env);
     (if field <> Frame.Fields.track_marks && field <> Frame.Fields.metadata then
        Typing.(
          src#frame_type

--- a/src/core/operators/frei0r_op.ml
+++ b/src/core/operators/frei0r_op.ml
@@ -85,7 +85,7 @@ class frei0r_filter ~name bgra instance params (source : source) =
 class frei0r_mixer ~name bgra instance params (source : source) source2 =
   let fps = Lazy.force Frame.video_rate in
   let dt = 1. /. float fps in
-  let self_sync = Utils.self_sync [source; source2] in
+  let self_sync = Clock_base.self_sync [source; source2] in
   object (self)
     inherit operator ~name:("frei0r." ^ name) [source; source2]
     method seek_source = (self :> Source.source)
@@ -97,7 +97,7 @@ class frei0r_mixer ~name bgra instance params (source : source) source2 =
         | x, y -> min x y
 
     method private can_generate_frame = source#is_ready && source2#is_ready
-    method self_sync = self_sync ()
+    method self_sync = self_sync ~source:self ()
 
     method abort_track =
       source#abort_track;

--- a/src/core/operators/muxer.ml
+++ b/src/core/operators/muxer.ml
@@ -36,7 +36,7 @@ class muxer tracks =
       [] tracks
   in
   let fallible = List.exists (fun s -> s#fallible) sources in
-  let self_sync = Utils.self_sync sources in
+  let self_sync = Clock_base.self_sync sources in
   object (self)
     (* Pass duplicated list to operator to make sure caching is properly enabled. *)
     inherit
@@ -44,7 +44,7 @@ class muxer tracks =
         ~name:"source"
         (List.map (fun { source } -> source) tracks)
 
-    method self_sync = self_sync ()
+    method self_sync = self_sync ~source:self ()
     method fallible = fallible
     method abort_track = List.iter (fun s -> s#abort_track) sources
     method private sources_ready = List.for_all (fun s -> s#is_ready) sources

--- a/src/core/operators/sequence.ml
+++ b/src/core/operators/sequence.ml
@@ -28,7 +28,7 @@ open Source
   * while looping on the last source -- this behavior would not be suited
   * to the current use of [sequence] in transitions. *)
 class sequence ?(merge = false) ?(single_track = true) sources =
-  let self_sync_type = Utils.self_sync_type sources in
+  let self_sync_type = Clock_base.self_sync_type sources in
   let seq_sources = Atomic.make sources in
   object (self)
     inherit operator ~name:"sequence" sources

--- a/src/core/operators/switch.ml
+++ b/src/core/operators/switch.ml
@@ -80,7 +80,8 @@ class switch ~all_predicates ~override_meta ~transition_length ~replay_meta
       (List.map (fun c -> c.transition) cases)
   in
   let self_sync_type =
-    if !failed then Lazy.from_val `Dynamic else Utils.self_sync_type !sources
+    if !failed then Lazy.from_val `Dynamic
+    else Clock_base.self_sync_type !sources
   in
   object (self)
     inherit operator ~name:"switch" (List.map (fun x -> x.source) cases)

--- a/src/core/operators/track/merge_metadata.ml
+++ b/src/core/operators/track/merge_metadata.ml
@@ -22,11 +22,11 @@
 
 class merge_metadata tracks =
   let sources = List.map snd tracks in
-  let self_sync = Utils.self_sync sources in
+  let self_sync = Clock_base.self_sync sources in
   object (self)
     inherit Source.operator ~name:"track.metadata.merge" sources
     initializer Typing.(self#frame_type <: Lang.unit_t)
-    method self_sync = self_sync ()
+    method self_sync = self_sync ~source:self ()
     method fallible = false
     method abort_track = List.iter (fun s -> s#abort_track) sources
     method private ready_sources = List.filter (fun s -> s#is_ready) sources

--- a/src/core/source.ml
+++ b/src/core/source.ml
@@ -75,9 +75,9 @@ let sleep s =
       (Printf.sprintf "Error when leaving output %s: %s!" s#id
          (Printexc.to_string e))
 
-class virtual operator ?pos ?clock ?(name = "src") sources =
+class virtual operator ?(stack = []) ?clock ?(name = "src") sources =
   let frame_type = Type.var () in
-  let clock = match clock with Some c -> c | None -> Clock.create ?pos () in
+  let clock = match clock with Some c -> c | None -> Clock.create ~stack () in
   object (self)
     (** Monitoring *)
     val mutable watchers = []
@@ -90,12 +90,15 @@ class virtual operator ?pos ?clock ?(name = "src") sources =
       List.iter (fun s -> Clock.unify ~pos:self#pos self#clock s#clock) sources;
       Clock.attach self#clock (self :> Clock.source)
 
-    val mutable pos : Pos.Option.t = pos
-    method pos = pos
+    val stack = Unifier.make stack
+    method stack = Unifier.deref stack
 
-    method set_pos p =
-      pos <- p;
-      Clock.set_pos clock pos
+    method set_stack p =
+      Unifier.set stack p;
+      Clock.set_stack clock p
+
+    method stack_unifier = stack
+    method pos = match Unifier.deref stack with [] -> None | p :: _ -> Some p
 
     (** Logging and identification *)
 
@@ -542,9 +545,9 @@ class virtual operator ?pos ?clock ?(name = "src") sources =
   end
 
 (** Entry-point sources, which need to actively perform some task. *)
-and virtual active_operator ?pos ?clock ?name sources =
+and virtual active_operator ?stack ?clock ?name sources =
   object (self)
-    inherit operator ?pos ?clock ?name sources
+    inherit operator ?stack ?clock ?name sources
     method! source_type : source_type = `Active (self :> active)
 
     (** Do whatever needed when the latency gets too big and is reset. *)
@@ -553,14 +556,14 @@ and virtual active_operator ?pos ?clock ?name sources =
 
 (** Shortcuts for defining sources with no children *)
 
-and virtual source ?pos ?clock ?name () =
+and virtual source ?stack ?clock ?name () =
   object
-    inherit operator ?pos ?clock ?name []
+    inherit operator ?stack ?clock ?name []
   end
 
-class virtual active_source ?pos ?clock ?name () =
+class virtual active_source ?stack ?clock ?name () =
   object
-    inherit active_operator ?pos ?clock ?name []
+    inherit active_operator ?stack ?clock ?name []
   end
 
 (* Reselect type. This drives the choice of next source.

--- a/src/core/source.mli
+++ b/src/core/source.mli
@@ -74,7 +74,7 @@ type watcher = {
 
 (** The [source] use is to send data frames through the [get] method. *)
 class virtual source :
-  ?pos:Pos.t
+  ?stack:Pos.t list
   -> ?clock:Clock.t
   -> ?name:string
   -> unit
@@ -92,7 +92,9 @@ class virtual source :
        (** Position in script *)
        method pos : Pos.Option.t
 
-       method set_pos : Pos.Option.t -> unit
+       method stack : Pos.t list
+       method set_stack : Pos.t list -> unit
+       method stack_unifier : Pos.t list Unifier.t
 
        (** {1 Source characteristics} *)
 
@@ -319,7 +321,7 @@ class virtual source :
 
 (* Entry-points sources, which need to actively perform some task. *)
 and virtual active_source :
-  ?pos:Pos.t
+  ?stack:Pos.t list
   -> ?clock:Clock.t
   -> ?name:string
   -> unit
@@ -334,7 +336,7 @@ and virtual active_source :
 
 (* This is for defining a source which has children *)
 class virtual operator :
-  ?pos:Pos.t
+  ?stack:Pos.t list
   -> ?clock:Clock.t
   -> ?name:string
   -> source list
@@ -345,7 +347,7 @@ class virtual operator :
 (* Most usual active source: the active_operator, pulling one source's data
  * and outputting it. *)
 class virtual active_operator :
-  ?pos:Pos.t
+  ?stack:Pos.t list
   -> ?clock:Clock.t
   -> ?name:string
   -> source list

--- a/src/core/tools/utils.ml
+++ b/src/core/tools/utils.ml
@@ -431,29 +431,6 @@ let string_of_size n =
     Printf.sprintf "%.02f MiB" (float_of_int n /. float_of_int (1 lsl 20))
   else Printf.sprintf "%.02f GiB" (float_of_int n /. float_of_int (1 lsl 30))
 
-let self_sync_type sources =
-  Lazy.from_fun (fun () ->
-      if List.exists (fun s -> fst s#self_sync = `Dynamic) sources then `Dynamic
-      else `Static)
-
-let self_sync sources =
-  let self_sync_type = self_sync_type sources in
-  fun () ->
-    ( Lazy.force self_sync_type,
-      List.fold_left
-        (fun sync_source s ->
-          match (sync_source, s#is_ready) with
-            | Some _, true when snd s#self_sync <> None ->
-                Runtime_error.raise
-                  ~pos:(match s#pos with Some p -> [p] | None -> [])
-                  ~message:
-                    (Printf.sprintf
-                       "Source %s has multiple synchronization sources!" s#id)
-                  "source"
-            | None, true -> snd s#self_sync
-            | _ -> sync_source)
-        None sources )
-
 let var_script = ref "default"
 
 let substs =

--- a/src/lang/evaluation.ml
+++ b/src/lang/evaluation.ml
@@ -173,7 +173,8 @@ let rec prepare_fun fv ~eval_check p env =
   let env = Env.restrict env fv in
   (p, env)
 
-and apply ?pos ~eval_check f l =
+and apply ?(pos = []) ~eval_check f l =
+  let apply_pos = match pos with [] -> None | p :: _ -> Some p in
   (* Extract the components of the function, whether it's explicit or foreign. *)
   let p, f =
     match f.Value.value with
@@ -191,12 +192,12 @@ and apply ?pos ~eval_check f l =
       | Runtime_error.Runtime_error err ->
           let bt = Printexc.get_raw_backtrace () in
           Runtime_error.raise ~bt
-            ~pos:(Option.to_list pos @ err.pos)
+            ~pos:(Option.to_list apply_pos @ err.pos)
             ~message:err.Runtime_error.msg err.Runtime_error.kind
       | Internal_error (poss, e) ->
           let bt = Printexc.get_raw_backtrace () in
           Printexc.raise_with_backtrace
-            (Internal_error (Option.to_list pos @ poss, e))
+            (Internal_error (Option.to_list apply_pos @ poss, e))
             bt
   in
   (* Provide given arguments. *)
@@ -219,25 +220,18 @@ and apply ?pos ~eval_check f l =
              with the mount/name params of output.icecast.*, the printing of
              the error should succeed at getting a position information. *)
           let v = Option.get v in
-          { v with Value.pos } )
+          { v with Value.pos = apply_pos } )
         :: pe)
       pe p
   in
   (* Add position *)
-  let pe =
-    pe
-    @ [
-        ( Lang_core.pos_var,
-          Lang_core.Stacktrace.to_value
-            (match pos with None -> [] | Some p -> [p]) );
-      ]
-  in
+  let pe = pe @ [(Lang_core.pos_var, Lang_core.Stacktrace.to_value pos)] in
   let v = f pe in
   (* Similarly here, the result of an FFI call should have some position
      information. For example, if we build a fallible source and pass it to an
      operator that expects an infallible one, an error is issued about that
      FFI-made value and a position is needed. *)
-  { v with Value.pos }
+  { v with Value.pos = apply_pos }
 
 and eval_base_term ~eval_check (env : Env.t) tm =
   let mk v =
@@ -354,7 +348,19 @@ and eval_base_term ~eval_check (env : Env.t) tm =
         let ans () =
           let f = eval ~eval_check env f in
           let l = List.map (fun (l, t) -> (l, eval ~eval_check env t)) l in
-          apply ?pos:tm.t.Type.pos ~eval_check f l
+          let pos =
+            match tm.t.Type.pos with
+              | None -> []
+              | Some p ->
+                  p
+                  ::
+                  (try
+                     List.map Lang_core.Position.of_value
+                       (Lang_core.to_list
+                          (Lazy.force (List.assoc Lang_core.pos_var env)))
+                   with _ -> [])
+          in
+          apply ~pos ~eval_check f l
         in
         if !profile then (
           match f.term with

--- a/src/lang/evaluation.mli
+++ b/src/lang/evaluation.mli
@@ -27,7 +27,7 @@ val eval : ?env:(string * Value.t) list -> Term.t -> Value.t
 val eval_toplevel : ?interactive:bool -> Term.t -> Value.t
 
 (** Apply a function to arguments. *)
-val apply : ?pos:Pos.t -> Value.t -> (string * Value.t) list -> Value.t
+val apply : ?pos:Pos.t list -> Value.t -> (string * Value.t) list -> Value.t
 
 (** Register a function to be executed after the next runtime evaluation completes. *)
 val on_after_eval : (unit -> unit) -> unit

--- a/src/lang/lang.mli
+++ b/src/lang/lang.mli
@@ -80,7 +80,7 @@ val split_meths : value -> (string * value) list * value
 
 (** {2 Computation} *)
 
-val apply_fun : (?pos:Pos.t -> value -> env -> value) ref
+val apply_fun : (?pos:Pos.t list -> value -> env -> value) ref
 
 (** Multiapply a value to arguments. The argument [t] is the type of the result
    of the application. *)

--- a/src/lang/lang_core.ml
+++ b/src/lang/lang_core.ml
@@ -276,7 +276,7 @@ let add_module ?base name =
 let module_name name = name
 
 (* Delay this function in order not to have Lang depend on Evaluation. *)
-let apply_fun : (?pos:Pos.t -> value -> env -> value) ref =
+let apply_fun : (?pos:Pos.t list -> value -> env -> value) ref =
   ref (fun ?pos:_ _ -> assert false)
 
 let apply f p = !apply_fun f p


### PR DESCRIPTION
This PR fixes a logic issue when checking for sync sources.

Since sync sources are confusing errors, it also adds a proper error reporting:

<img width="754" alt="Screenshot 2024-04-19 at 11 00 39 AM" src="https://github.com/savonet/liquidsoap/assets/871060/085eaca3-ef74-4669-a5fe-a4ae11c8cd2f">

This required some legwork with position and stacks:
* Store the entire call stack when executing functions
* Store the call stack on functions