### PR TITLE
Add priority to metadata decoders.

### DIFF
--- a/src/core/builtins/builtins_resolvers.ml
+++ b/src/core/builtins/builtins_resolvers.ml
@@ -31,6 +31,10 @@ let _ =
   Lang.add_builtin ~base:decoder_metadata "add" ~category:`Liquidsoap
     ~descr:"Register an external file metadata decoder."
     [
+      ( "priority",
+        Lang.getter_t Lang.int_t,
+        Some (Lang.int 1),
+        Some "Resolver's priority." );
       ("", Lang.string_t, None, Some "Format/resolver's name.");
       ( "",
         resolver_t,
@@ -43,6 +47,7 @@ let _ =
     (fun p ->
       let format = Lang.to_string (Lang.assoc "" 1 p) in
       let f = Lang.assoc "" 2 p in
+      let priority = Lang.to_int_getter (List.assoc "priority" p) in
       let resolver ~metadata ~extension:_ ~mime:_ name =
         let ret =
           Lang.apply f
@@ -55,7 +60,8 @@ let _ =
         in
         ret
       in
-      Plug.register Request.mresolvers format ~doc:"" resolver;
+      Plug.register Request.mresolvers format ~doc:""
+        { Request.priority; resolver };
       Lang.unit)
 
 let add_playlist_parser ~format name (parser : Playlist_parser.parser) =

--- a/src/core/decoder/aac_decoder.ml
+++ b/src/core/decoder/aac_decoder.ml
@@ -288,4 +288,14 @@ let get_tags ~metadata:_ ~extension ~mime file =
       let mp4 = Faad.Mp4.openfile_fd fd in
       Array.to_list (Faad.Mp4.metadata mp4))
 
-let () = Plug.register Request.mresolvers "mp4" ~doc:"MP4 tag decoder." get_tags
+let mp4_metadata_decoder_priority =
+  Dtools.Conf.int
+    ~p:(Request.conf_metadata_decoder_priorities#plug "mp4")
+    "Priority for the mp4 metadata decoder" ~d:1
+
+let () =
+  Plug.register Request.mresolvers "mp4" ~doc:"MP4 tag decoder."
+    {
+      Request.priority = (fun () -> mp4_metadata_decoder_priority#get);
+      resolver = get_tags;
+    }

--- a/src/core/decoder/ffmpeg_decoder.ml
+++ b/src/core/decoder/ffmpeg_decoder.ml
@@ -600,7 +600,17 @@ let get_tags ~metadata ~extension ~mime file =
              (Printexc.to_string e));
         raise Not_found
 
-let () = Plug.register Request.mresolvers "ffmpeg" ~doc:"" get_tags
+let metadata_decoder_priority =
+  Dtools.Conf.int
+    ~p:(Request.conf_metadata_decoder_priorities#plug "ffmpeg")
+    "Priority for the ffmpeg metadata decoder" ~d:1
+
+let () =
+  Plug.register Request.mresolvers "ffmpeg" ~doc:""
+    {
+      Request.priority = (fun () -> metadata_decoder_priority#get);
+      resolver = get_tags;
+    }
 
 (* Get the type of an input container. *)
 let get_type ~ctype ~format ~url container =

--- a/src/core/decoder/flac_metadata_plug.ml
+++ b/src/core/decoder/flac_metadata_plug.ml
@@ -39,6 +39,11 @@ let file_extensions =
     "File extensions used for decoding metadata using native FLAC parser."
     ~d:["flac"]
 
+let priority =
+  Dtools.Conf.int
+    ~p:(Request.conf_metadata_decoder_priorities#plug "flac_native")
+    "Priority for the flac native decoder" ~d:1
+
 let get_tags ~metadata:_ ~extension ~mime parse fname =
   try
     if
@@ -59,4 +64,7 @@ let get_tags ~metadata:_ ~extension ~mime parse fname =
 let () =
   Plug.register Request.mresolvers "flac_native"
     ~doc:"Native FLAC metadata resolver."
-    (get_tags Metadata.FLAC.parse_file)
+    {
+      Request.priority = (fun () -> priority#get);
+      resolver = get_tags Metadata.FLAC.parse_file;
+    }

--- a/src/core/decoder/gstreamer_decoder.ml
+++ b/src/core/decoder/gstreamer_decoder.ml
@@ -346,6 +346,14 @@ let get_tags ~metadata:_ file =
     GU.flush ~log bin;
     List.rev !ans
 
+let metadata_decoder_priority =
+  Dtools.Conf.int
+    ~p:(Request.conf_metadata_decoder_priorities#plug "gstreamer")
+    "Priority for the gstreamer metadata decoder" ~d:1
+
 let () =
   Plug.register Request.mresolvers "gstreamer" ~doc:"Read tags using GStreamer."
-    get_tags
+    {
+      Request.priority = (fun () -> metadata_decoder_priority#get);
+      resolver = get_tags;
+    }

--- a/src/core/decoder/id3_plug.ml
+++ b/src/core/decoder/id3_plug.ml
@@ -56,6 +56,21 @@ let file_extensions =
      parser"
     ~d:["mp3"; "wav"]
 
+let priority =
+  Dtools.Conf.int
+    ~p:(Request.conf_metadata_decoder_priorities#plug "id3")
+    "Priority for the native ID3 metadata decoder" ~d:1
+
+let priority_v1 =
+  Dtools.Conf.int
+    ~p:(Request.conf_metadata_decoder_priorities#plug "id3v1")
+    "Priority for the native ID3v1 metadata decoder" ~d:1
+
+let priority_v2 =
+  Dtools.Conf.int
+    ~p:(Request.conf_metadata_decoder_priorities#plug "id3v2")
+    "Priority for the native ID3v2 metadata decoder" ~d:1
+
 let get_tags ~metadata:_ ~extension ~mime parse fname =
   try
     if
@@ -75,12 +90,21 @@ let get_tags ~metadata:_ ~extension ~mime parse fname =
 
 let () =
   Plug.register Request.mresolvers "ID3" ~doc:"Native decoder for ID3 tags."
-    (get_tags Metadata.ID3.parse_file)
+    {
+      Request.priority = (fun () -> priority#get);
+      resolver = get_tags Metadata.ID3.parse_file;
+    }
 
 let () =
   Plug.register Request.mresolvers "ID3v1" ~doc:"Native decoder for ID3v1 tags."
-    (get_tags Metadata.ID3v1.parse_file)
+    {
+      Request.priority = (fun () -> priority_v1#get);
+      resolver = get_tags Metadata.ID3v1.parse_file;
+    }
 
 let () =
   Plug.register Request.mresolvers "ID3v2" ~doc:"Native decode for ID3v2 tags."
-    (get_tags Metadata.ID3v2.parse_file)
+    {
+      Request.priority = (fun () -> priority_v2#get);
+      resolver = get_tags Metadata.ID3v2.parse_file;
+    }

--- a/src/core/decoder/image_plug.ml
+++ b/src/core/decoder/image_plug.ml
@@ -40,6 +40,11 @@ let file_extensions =
     "File extensions used for decoding metadata using native parser."
     ~d:["png"; "jpg"; "jpeg"]
 
+let priority =
+  Dtools.Conf.int
+    ~p:(Request.conf_metadata_decoder_priorities#plug "image_metadata")
+    "Priority for the image metadata decoder" ~d:1
+
 let get_tags ~metadata:_ ~extension ~mime fname =
   try
     if
@@ -59,4 +64,5 @@ let get_tags ~metadata:_ ~extension ~mime fname =
 
 let () =
   Plug.register Request.mresolvers "image"
-    ~doc:"Native decoder for image metadata." get_tags
+    ~doc:"Native decoder for image metadata."
+    { Request.priority = (fun () -> priority#get); resolver = get_tags }

--- a/src/core/decoder/liq_flac_decoder.ml
+++ b/src/core/decoder/liq_flac_decoder.ml
@@ -163,7 +163,17 @@ let get_tags ~metadata:_ ~extension ~mime file =
       let h = Flac.Decoder.File.create_from_fd write fd in
       match h.Flac.Decoder.File.comments with Some (_, m) -> m | None -> [])
 
-let () = Plug.register Request.mresolvers "flac" ~doc:"" get_tags
+let metadata_decoder_priority =
+  Dtools.Conf.int
+    ~p:(Request.conf_metadata_decoder_priorities#plug "flac")
+    "Priority for the flac metadata decoder" ~d:1
+
+let () =
+  Plug.register Request.mresolvers "flac" ~doc:""
+    {
+      Request.priority = (fun () -> metadata_decoder_priority#get);
+      resolver = get_tags;
+    }
 
 let check filename =
   List.mem (Magic_mime.lookup filename) mime_types#get

--- a/src/core/decoder/liq_ogg_decoder.ml
+++ b/src/core/decoder/liq_ogg_decoder.ml
@@ -320,4 +320,14 @@ let get_tags ~metadata:_ ~extension ~mime file =
       get Ogg_decoder.audio_info tracks.Ogg_decoder.audio_track
       @ get Ogg_decoder.video_info tracks.Ogg_decoder.video_track)
 
-let () = Plug.register Request.mresolvers "ogg" ~doc:"" get_tags
+let metadata_decoder_priority =
+  Dtools.Conf.int
+    ~p:(Request.conf_metadata_decoder_priorities#plug "ogg")
+    "Priority for the ogg metadata decoder" ~d:1
+
+let () =
+  Plug.register Request.mresolvers "ogg" ~doc:""
+    {
+      Request.priority = (fun () -> metadata_decoder_priority#get);
+      resolver = get_tags;
+    }

--- a/src/core/decoder/ogg_metadata_plug.ml
+++ b/src/core/decoder/ogg_metadata_plug.ml
@@ -39,6 +39,11 @@ let file_extensions =
     "File extensions used for decoding metadata using native ogg parser."
     ~d:["ogg"]
 
+let priority =
+  Dtools.Conf.int
+    ~p:(Request.conf_metadata_decoder_priorities#plug "ogg_metadata")
+    "Priority for the native ogg metadata decoder" ~d:1
+
 let get_tags ~metadata:_ ~extension ~mime parse fname =
   try
     if
@@ -59,4 +64,7 @@ let get_tags ~metadata:_ ~extension ~mime parse fname =
 let () =
   Plug.register Request.mresolvers "ogg_native"
     ~doc:"Native ogg metadata resolver."
-    (get_tags Metadata.OGG.parse_file)
+    {
+      Request.priority = (fun () -> priority#get);
+      resolver = get_tags Metadata.OGG.parse_file;
+    }

--- a/src/core/decoder/taglib_plug.ml
+++ b/src/core/decoder/taglib_plug.ml
@@ -44,6 +44,11 @@ let mime_types =
 let conf_taglib =
   Dtools.Conf.void ~p:(Decoder.conf_decoder#plug "taglib") "Taglib settings"
 
+let priority =
+  Dtools.Conf.int
+    ~p:(Request.conf_metadata_decoder_priorities#plug "taglib")
+    "Priority for the taglib metadata decoder" ~d:1
+
 let file_extensions =
   Dtools.Conf.list
     ~p:(Decoder.conf_file_extensions#plug "taglib")
@@ -99,4 +104,6 @@ let get_tags ~metadata:_ ~extension ~mime fname =
              (Printexc.to_string e));
         raise Not_found
 
-let () = Plug.register Request.mresolvers "taglib" ~doc:"" get_tags
+let () =
+  Plug.register Request.mresolvers "taglib" ~doc:""
+    { Request.priority = (fun () -> priority#get); resolver = get_tags }

--- a/src/core/decoder/video_plug.ml
+++ b/src/core/decoder/video_plug.ml
@@ -40,6 +40,11 @@ let file_extensions =
     "File extensions used for decoding metadata using native parser."
     ~d:["avi"; "mp4"]
 
+let priority =
+  Dtools.Conf.int
+    ~p:(Request.conf_metadata_decoder_priorities#plug "video_metadata")
+    "Priority for the native video metadata decoder" ~d:1
+
 let get_tags ~metadata:_ ~extension ~mime fname =
   try
     if
@@ -59,4 +64,5 @@ let get_tags ~metadata:_ ~extension ~mime fname =
 
 let () =
   Plug.register Request.mresolvers "video-metadata"
-    ~doc:"Native metadata decoder for videos." get_tags
+    ~doc:"Native metadata decoder for videos."
+    { Request.priority = (fun () -> priority#get); resolver = get_tags }

--- a/src/core/request.ml
+++ b/src/core/request.ml
@@ -49,6 +49,16 @@ let parse_uri uri =
       (String.sub uri 0 i, String.sub uri (i + 1) (String.length uri - (i + 1)))
   with _ -> None
 
+type metadata_resolver = {
+  priority : unit -> int;
+  resolver :
+    metadata:Frame.metadata ->
+    extension:string option ->
+    mime:string ->
+    string ->
+    (string * string) list;
+}
+
 (** Log *)
 
 type log = (Unix.tm * string) Queue.t
@@ -246,6 +256,18 @@ let conf_metadata_decoders =
     ~p:(conf#plug "metadata_decoders")
     ~d:[] "Decoders and order used to decode files' metadata."
 
+let conf_metadata_decoder_priorities =
+  Dtools.Conf.void
+    ~p:(conf_metadata_decoders#plug "priorities")
+    "Priorities used for applying metadata decoders. Decoder with the highest \
+     priority take precedence."
+
+let conf_request_metadata_priority =
+  Dtools.Conf.int ~d:5
+    ~p:(conf_metadata_decoder_priorities#plug "request_metadata")
+    "Priority for the request metadata. This include metadata set via \
+     `annotate`."
+
 let f c v =
   match c#get_d with
     | None -> c#set_d (Some [v])
@@ -259,7 +281,9 @@ let get_decoders conf decoders =
           log#severe "Cannot find decoder %s" name;
           cur
   in
-  List.fold_left f [] (List.rev conf#get)
+  List.sort
+    (fun (_, d) (_, d') -> Stdlib.compare (d'.priority ()) (d.priority ()))
+    (List.fold_left f [] (List.rev conf#get))
 
 let mresolvers_doc = "Methods to extract metadata from a file."
 
@@ -267,13 +291,6 @@ let mresolvers =
   Plug.create
     ~register_hook:(fun name _ -> f conf_metadata_decoders name)
     ~doc:mresolvers_doc "metadata formats"
-
-let conf_override_metadata =
-  Dtools.Conf.bool
-    ~p:(conf_metadata_decoders#plug "override")
-    ~d:false
-    "Allow metadata resolvers to override metadata already set through \
-     annotate: or playlist resolution for instance."
 
 let conf_duration =
   Dtools.Conf.bool
@@ -294,6 +311,57 @@ let conf_recode_excluded =
     ~d:["apic"; "metadata_block_picture"; "coverart"]
     ~p:(conf_recode#plug "exclude")
     "Exclude these metadata from automatic recording."
+
+let resolve_metadata ~initial_metadata ~excluded name =
+  let decoders = get_decoders conf_metadata_decoders mresolvers in
+  let decoders =
+    List.filter (fun (name, _) -> not (List.mem name excluded)) decoders
+  in
+  let high_priority_decoders, low_priority_decoders =
+    List.partition
+      (fun (_, { priority }) ->
+        conf_request_metadata_priority#get < priority ())
+      decoders
+  in
+  let convert =
+    if conf_recode#get then (
+      let excluded = conf_recode_excluded#get in
+      fun k v -> if not (List.mem k excluded) then Charset.convert v else v)
+    else fun _ x -> x
+  in
+  let extension = try Some (Utils.get_ext name) with _ -> None in
+  let mime = Magic_mime.lookup name in
+  let get_metadata ~metadata decoders =
+    List.fold_left
+      (fun metadata (_, { resolver }) ->
+        try
+          let ans = resolver ~metadata:initial_metadata ~extension ~mime name in
+          List.fold_left
+            (fun metadata (k, v) ->
+              let k = String.lowercase_ascii (convert k k) in
+              let v = convert k v in
+              if not (Frame.Metadata.mem k metadata) then
+                Frame.Metadata.add k v metadata
+              else metadata)
+            metadata ans
+        with _ -> metadata)
+      metadata decoders
+  in
+  let metadata =
+    get_metadata ~metadata:Frame.Metadata.empty high_priority_decoders
+  in
+  let metadata =
+    get_metadata
+      ~metadata:(Frame.Metadata.append initial_metadata metadata)
+      low_priority_decoders
+  in
+  if conf_duration#get && not (Frame.Metadata.mem "duration" metadata) then (
+    try
+      Frame.Metadata.add "duration"
+        (string_of_float (duration ~metadata name))
+        metadata
+    with Not_found -> metadata)
+  else metadata
 
 (** Sys.file_exists doesn't make a difference between existing files and files
     without enough permissions to list their attributes, for example when they
@@ -325,44 +393,11 @@ let read_metadata t =
       log#important "Read permission denied for %s!"
         (Lang_string.quote_string name)
     else (
-      let convert =
-        if conf_recode#get then (
-          let excluded = conf_recode_excluded#get in
-          fun k v -> if not (List.mem k excluded) then Charset.convert v else v)
-        else fun _ x -> x
+      let metadata =
+        resolve_metadata ~initial_metadata:(get_all_metadata t)
+          ~excluded:t.excluded_metadata_resolvers name
       in
-      let extension = try Some (Utils.get_ext name) with _ -> None in
-      let mime = Magic_mime.lookup name in
-      let decoders = get_decoders conf_metadata_decoders mresolvers in
-      let decoders =
-        List.filter
-          (fun (name, _) -> not (List.mem name t.excluded_metadata_resolvers))
-          decoders
-      in
-      List.iter
-        (fun (_, resolver) ->
-          try
-            let ans =
-              resolver ~metadata:indicator.metadata ~extension ~mime name
-            in
-            List.iter
-              (fun (k, v) ->
-                let k = String.lowercase_ascii (convert k k) in
-                let v = convert k v in
-                if conf_override_metadata#get || get_metadata t k = None then
-                  indicator.metadata <-
-                    Frame.Metadata.add k v indicator.metadata)
-              ans;
-            if conf_duration#get && get_metadata t "duration" = None then (
-              try
-                indicator.metadata <-
-                  Frame.Metadata.add "duration"
-                    (string_of_float
-                       (duration ~metadata:indicator.metadata name))
-                    indicator.metadata
-              with Not_found -> ())
-          with _ -> ())
-        decoders))
+      indicator.metadata <- Frame.Metadata.append indicator.metadata metadata))
 
 let local_check t =
   read_metadata t;

--- a/src/core/request.mli
+++ b/src/core/request.mli
@@ -114,6 +114,9 @@ val is_static : string -> bool
   * audio file, or simply because there was no enough time left. *)
 type resolve_flag = Resolved | Failed | Timeout
 
+(** Metadata resolvers priorities. *)
+val conf_metadata_decoder_priorities : Dtools.Conf.ut
+
 (** Read the metadata for the toplevel indicator of the request. This is usually
     performed automatically by [resolve] so that you do not have to use this,
     excepting when the [ctype] is [None]. *)
@@ -188,15 +191,29 @@ val get_decoder : t -> Decoder.file_decoder_ops option
 (** Functions for computing duration. *)
 val dresolvers : (metadata:Frame.metadata -> string -> float) Plug.t
 
+(** Type for a metadata resolver. Resolvers are executed in priority
+    order and the first returned metadata take precedence over any other
+    one later returned. *)
+type metadata_resolver = {
+  priority : unit -> int;
+  resolver :
+    metadata:Frame.metadata ->
+    extension:string option ->
+    mime:string ->
+    string ->
+    (string * string) list;
+}
+
 (** Functions for resolving metadata. Metadata filling isn't included in Decoder
     because we want it to occur immediately after request resolution. *)
-val mresolvers :
-  (metadata:Frame.metadata ->
-  extension:string option ->
-  mime:string ->
+val mresolvers : metadata_resolver Plug.t
+
+(** Resolve metadata for a local file: *)
+val resolve_metadata :
+  initial_metadata:Frame.metadata ->
+  excluded:string list ->
   string ->
-  (string * string) list)
-  Plug.t
+  Frame.metadata
 
 (** Functions for resolving URIs. *)
 val protocols : protocol Plug.t

--- a/src/lang/methods.ml
+++ b/src/lang/methods.ml
@@ -24,7 +24,6 @@
 
 type ('a, 'b) t = ('a * 'b) list
 
-let from_list l = l
 let is_empty h = h = []
 let bindings h = h
 let empty = []
@@ -36,9 +35,10 @@ let mem = List.mem_assoc
 let mapi fn = List.map (fun (k, v) -> (k, fn k v))
 let map fn = List.map (fun (k, v) -> (k, fn v))
 let filter fn = List.filter (fun (k, v) -> fn k v)
-let remove k h = List.remove_assoc k h
+let remove k h = List.filter (fun (k', _) -> k <> k') h
 let add k v h = (k, v) :: remove k h
 let append l l' = List.fold_left (fun m (k, v) -> add k v m) l l'
+let from_list l = append [] l
 let iter fn = List.iter (fun (k, v) -> fn k v)
 let for_all fn = List.for_all (fun (k, v) -> fn k v)
 let exists fn = List.exists (fun (k, v) -> fn k v)

--- a/tests/streams/dune
+++ b/tests/streams/dune
@@ -37,6 +37,8 @@
    "sine=frequency=220:duration=5"
    -ac
    2
+   -metadata
+   "title=Test Title"
    %{target})))
 
 (rule

--- a/tests/streams/dune.inc
+++ b/tests/streams/dune.inc
@@ -933,6 +933,37 @@
  (alias citest)
  (package liquidsoap)
  (deps
+  metadata-override.liq
+  ./file1.mp3
+  ./file2.mp3
+  ./file3.mp3
+  ./jingle1.mp3
+  ./jingle2.mp3
+  ./jingle3.mp3
+  ./file1.png
+  ./file2.png
+  ./jingles
+  ./playlist
+  ./huge_playlist
+  ./replaygain_track_gain.mp3
+  ./r128_track_gain.mp3
+  ./replaygain_r128_track_gain.mp3
+  ./replaygain_track_gain.opus
+  ./r128_track_gain.opus
+  ./replaygain_r128_track_gain.opus
+  ./without_replaygain_track_gain.mp3
+  ./crossfade-plot.old.txt
+  ./crossfade-plot.new.txt
+  ../../src/bin/liquidsoap.exe
+  (package liquidsoap)
+  (:test_liq ../test.liq)
+  (:run_test ../run_test.exe))
+ (action (run %{run_test} metadata-override.liq liquidsoap %{test_liq} metadata-override.liq)))
+
+(rule
+ (alias citest)
+ (package liquidsoap)
+ (deps
   never.liq
   ./file1.mp3
   ./file2.mp3

--- a/tests/streams/metadata-override.liq
+++ b/tests/streams/metadata-override.liq
@@ -1,0 +1,139 @@
+def filter_meta(meta) =
+  [("title", meta["title"])]
+end
+
+def f() =
+  fname = "file1.mp3"
+  meta = file.metadata(fname)
+  test.equal(
+    filter_meta(meta),
+    [
+      (
+        "title",
+        "Test Title"
+      )
+    ]
+  )
+
+  r =
+    request.create(
+      "annotate:title=\"Annotate Override\":#{fname}"
+    )
+  test.equal(request.resolve(r), true)
+  test.equal(
+    filter_meta(request.metadata(r)),
+    [
+      (
+        "title",
+        "Annotate Override"
+      )
+    ]
+  )
+
+  decoder.metadata.add(
+    priority=-1,
+    "test-no-override",
+    fun (~metadata=_, _) ->
+      [
+        (
+          "title",
+          "Metadata decoder no override"
+        )
+      ]
+  )
+
+  meta = file.metadata(fname)
+  test.equal(
+    filter_meta(meta),
+    [
+      (
+        "title",
+        "Test Title"
+      )
+    ]
+  )
+
+  r =
+    request.create(
+      "annotate:title=\"Annotate Override\":#{fname}"
+    )
+  test.equal(request.resolve(r), true)
+  test.equal(
+    filter_meta(request.metadata(r)),
+    [
+      (
+        "title",
+        "Annotate Override"
+      )
+    ]
+  )
+
+  decoder.metadata.add(
+    priority=4,
+    "test-override",
+    fun (~metadata=_, _) ->
+      [
+        (
+          "title",
+          "Metadata decoder override"
+        )
+      ]
+  )
+
+  meta = file.metadata(fname)
+  test.equal(
+    filter_meta(meta),
+    [
+      (
+        "title",
+        "Metadata decoder override"
+      )
+    ]
+  )
+
+  r =
+    request.create(
+      "annotate:title=\"Annotate Override\":#{fname}"
+    )
+  test.equal(request.resolve(r), true)
+  test.equal(
+    filter_meta(request.metadata(r)),
+    [
+      (
+        "title",
+        "Annotate Override"
+      )
+    ]
+  )
+
+  decoder.metadata.add(
+    priority=10,
+    "test-override-annotate",
+    fun (~metadata=_, _) ->
+      [
+        (
+          "title",
+          "Metadata decoder annotate override"
+        )
+      ]
+  )
+
+  r =
+    request.create(
+      "annotate:title=\"Annotate Override\":#{fname}"
+    )
+  test.equal(request.resolve(r), true)
+  test.equal(
+    filter_meta(request.metadata(r)),
+    [
+      (
+        "title",
+        "Metadata decoder annotate override"
+      )
+    ]
+  )
+
+  test.pass()
+end
+
+test.check(f)

--- a/tests/test.liq
+++ b/tests/test.liq
@@ -33,7 +33,7 @@ def test.fail(reason=null()) =
   print(
     "Test failed#{reason}"
   )
-  shutdown(code=1)
+  exit(1)
 end
 
 # End test with signal 2
@@ -101,11 +101,13 @@ def test.equal(v, v') =
   if
     v != v'
   then
-    print(
+    msg =
       "expected:\r\n#{string.quote(string(v'))}\r\ngot:\r\n#{
         string.quote(string(v))
       }"
-    )
+    print(msg)
+
+    error.raise(error.failure, msg)
 
     test.fail()
   end
@@ -117,13 +119,15 @@ def test.not.equal(first, second) =
   if
     first == second
   then
-    error.raise(
-      error.failure,
+    msg =
       "expected\r\n
       #{string.quote(string(first))}\r\nto differ from:\r\n#{
         string.quote(string(second))
       }"
-    )
+
+    print(msg)
+
+    error.raise(error.failure, msg)
 
     test.fail()
   end


### PR DESCRIPTION
This PR adds priorities to metadata decoders. Decoders with the highest priority take precedence over decoders with lower priorities. Request metadata are part of this workflow and assigned their own priority. Decoder with priority above that are able to override request metadata. This should, of course, be handled with care.