### PR TITLE
Fix duration computation in the presence of cue_in/cue_out metadata.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,6 +24,7 @@ Fixed:
 - Fixed issues with rendered id3v2 frame that contain binary data (#3817)
 - Fixed memory leaks with SRT listen socket polling callbacks.
 - Fixed `%ffmpeg` copy muxer logic with some audio/video streams (#3840)
+- Fixed `duration` metadata calculation in the presence of `cue_in`/`cue_out` metadata.
 
 ---
 

--- a/src/core/builtins/builtins_request.ml
+++ b/src/core/builtins/builtins_request.ml
@@ -210,6 +210,10 @@ let _ =
         Some (Lang.list []),
         Some "Optional metadata used to decode the file, e.g. `ffmpeg_options`."
       );
+      ( "timeout",
+        Lang.float_t,
+        Some (Lang.float 30.),
+        Some "Limit in seconds to the duration of the resolving." );
       ("", Lang.string_t, None, None);
     ]
     (Lang.nullable_t Lang.float_t)
@@ -219,8 +223,24 @@ let _ =
        typically if the file was not recognized as valid audio."
     (fun p ->
       let f = Lang.to_string (List.assoc "" p) in
-      let metadata = Lang.to_metadata (List.assoc "metadata" p) in
-      try Lang.float (Request.duration ~metadata f) with _ -> Lang.null)
+      let metadata = Lang.to_metadata_list (List.assoc "metadata" p) in
+      let timeout = Lang.to_float (List.assoc "timeout" p) in
+      let r =
+        Request.create ~resolve_metadata:true ~metadata ~cue_in_metadata:None
+          ~cue_out_metadata:None f
+      in
+      if Request.resolve ~ctype:None r timeout = Request.Resolved then (
+        match
+          Request.duration
+            ~metadata:(Request.get_all_metadata r)
+            (Option.get (Request.get_filename r))
+        with
+          | Some f -> Lang.float f
+          | None -> Lang.null
+          | exception exn ->
+              let bt = Printexc.get_raw_backtrace () in
+              Lang.raise_as_runtime ~bt ~kind:"failure" exn)
+      else Lang.null)
 
 let _ =
   Lang.add_builtin ~base:request "id" ~category:`Liquidsoap

--- a/src/core/request.mli
+++ b/src/core/request.mli
@@ -186,7 +186,7 @@ val is_on_air : t -> bool
 (** [duration ~metadata filename] computes the duration of audio data contained in
     [filename]. The computation may be expensive.
     @raise Not_found if no duration computation method is found. *)
-val duration : metadata:Frame.metadata -> string -> float
+val duration : metadata:Frame.metadata -> string -> float option
 
 (** Return a decoder if the file has been resolved, guaranteed to have
     available data to deliver. *)

--- a/src/core/tools/liqfm.ml
+++ b/src/core/tools/liqfm.ml
@@ -135,10 +135,14 @@ let init host =
                 match request with
                   | Some s -> (
                       match Request.get_filename s with
-                        | Some file ->
-                            Request.duration
-                              ~metadata:(Request.get_all_metadata s)
-                              file
+                        | Some file -> (
+                            match
+                              Request.duration
+                                ~metadata:(Request.get_all_metadata s)
+                                file
+                            with
+                              | Some f -> f
+                              | None -> raise Not_found)
                         | None -> raise Not_found)
                   | None -> raise Not_found
               with

--- a/src/runtime/main.ml
+++ b/src/runtime/main.ml
@@ -191,12 +191,14 @@ let process_request s =
         Printf.printf "%s\n" metadata;
         Printf.printf "duration = %!";
         begin
-          try
-            Printf.printf "%.2f s\n"
-              (Request.duration
-                 ~metadata:(Request.get_all_metadata req)
-                 (Option.get (Request.get_filename req)))
-          with Not_found -> Printf.printf "failed\n"
+          match
+            Request.duration
+              ~metadata:(Request.get_all_metadata req)
+              (Option.get (Request.get_filename req))
+          with
+            | Some f -> Printf.printf "%.2f s\n" f
+            | None -> Printf.printf "n/a\n"
+            | exception Not_found -> Printf.printf "failed\n"
         end;
         Request.destroy req
 

--- a/tests/streams/request.liq
+++ b/tests/streams/request.liq
@@ -4,10 +4,10 @@ settings.log.level.set(4)
 
 test.check(fun () ->
   begin
-    test.almost_equal(digits=1, request.duration("file1.mp3"), 5.0)
-    test.almost_equal(digits=1, request.duration("annotate:cue_out=1.1:file1.mp3"), 1.1)
-    test.almost_equal(digits=1, request.duration("annotate:cue_in=1.041:file1.mp3"), 4.)
-    test.almost_equal(digits=1, request.duration("annotate:cue_in=1.00,cue_out=3.1:file1.mp3"), 2.1)
+    test.almost_equal(digits=1, request.duration("file1.mp3") ?? 0., 5.06)
+    test.almost_equal(digits=1, request.duration("annotate:cue_out=1.1:file1.mp3") ?? 0., 1.1)
+    test.almost_equal(digits=1, request.duration("annotate:cue_in=1.06:file1.mp3") ?? 0., 4.)
+    test.almost_equal(digits=1, request.duration("annotate:cue_in=1.00,cue_out=3.1:file1.mp3") ?? 0., 2.1)
 
     r = request.dynamic(prefetch=1, fun () -> request.create("invalid"))
 

--- a/tests/streams/request.liq
+++ b/tests/streams/request.liq
@@ -4,10 +4,10 @@ settings.log.level.set(4)
 
 test.check(fun () ->
   begin
-    test.equal(request.duration("file1.mp3"), 5.041)
-    test.equal(request.duration("annotate:cue_out=1.1:file1.mp3"), 1.1)
-    test.equal(request.duration("annotate:cue_in=1.041:file1.mp3"), 4.)
-    test.equal(request.duration("annotate:cue_in=1.00,cue_out=3.1:file1.mp3"), 2.1)
+    test.almost_equal(digits=1, request.duration("file1.mp3"), 5.0)
+    test.almost_equal(digits=1, request.duration("annotate:cue_out=1.1:file1.mp3"), 1.1)
+    test.almost_equal(digits=1, request.duration("annotate:cue_in=1.041:file1.mp3"), 4.)
+    test.almost_equal(digits=1, request.duration("annotate:cue_in=1.00,cue_out=3.1:file1.mp3"), 2.1)
 
     r = request.dynamic(prefetch=1, fun () -> request.create("invalid"))
 

--- a/tests/streams/request.liq
+++ b/tests/streams/request.liq
@@ -4,10 +4,10 @@ settings.log.level.set(4)
 
 test.check(fun () ->
   begin
-    if request.duration("file1.mp3") != 5.06 then
-      print("Invalid duration!")
-      test.fail()
-    end
+    test.equal(request.duration("file1.mp3"), 5.041)
+    test.equal(request.duration("annotate:cue_out=1.1:file1.mp3"), 1.1)
+    test.equal(request.duration("annotate:cue_in=1.041:file1.mp3"), 4.)
+    test.equal(request.duration("annotate:cue_in=1.00,cue_out=3.1:file1.mp3"), 2.1)
 
     r = request.dynamic(prefetch=1, fun () -> request.create("invalid"))
 

--- a/tests/test.liq
+++ b/tests/test.liq
@@ -88,6 +88,60 @@ def test.not.equal(v, v') =
   end
 end
 
+# Compares two float values for approximate equality.
+# Values are considered almost equal if their difference
+# is within 10^-digits.
+# @param ~digits The number of decimal digits to compare. Default is 7.
+# @flag hidden
+def test._almost_equal(~digits=7, first, second) =
+  diff = abs(float(first) - float(second))
+  if
+    diff * float(pow(10, digits)) < 0.5
+  then
+    true.{diff=diff}
+  else
+    false.{diff=diff}
+  end
+end
+
+# Compares two float values for approximate equality.
+# Values are considered almost equal if their difference
+# is within 10^-digits.
+# @param ~digits The number of decimal digits to compare. Default is 7.
+def test.almost_equal(~digits=7, first, second) =
+  is_almost_equal = test._almost_equal(digits=digits, first, second)
+  if
+    not is_almost_equal
+  then
+    error.raise(
+      error.failure,
+      "#{string.quote(string(first))} != #{string.quote(string(second))} \
+       up to #{digits} digits, diff = #{is_almost_equal.diff}."
+    )
+
+    test.fail()
+  end
+end
+
+# Compares two float values for approximate inequality.
+# Values are considered not almost equal if their difference
+# is greater than 10^-digits.
+# @param ~digits The number of decimal digits to compare. Default is 7.
+def test.not_almost_equal(~digits=7, first, second) =
+  is_almost_equal = test._almost_equal(digits=digits, first, second)
+  if
+    is_almost_equal
+  then
+    error.raise(
+      error.failure,
+      "#{string.quote(string(first))} == #{string.quote(string(second))} \
+       up to #{digits} digits, diff = #{is_almost_equal.diff}."
+    )
+
+    test.fail()
+  end
+end
+
 # Asynchronous test handler with dummy output
 # Best practice is to run all manual tests
 # through this one.


### PR DESCRIPTION
Fix duration metadata computation in the following order of operation:
* Use `cue_in`/`cue_out` when both present and make them take precedence over `duration`
* If `cue_out` is present with no `cue_in`, use it as `duration`
* If `duration` is present, use it
* Last resort: compute `duration` and potentially substract `cue_in`.