### PR TITLE
Fix duration computation in the presence of cue_in/cue_out metadata.

### DIFF
--- a/src/core/request.mli
+++ b/src/core/request.mli
@@ -179,7 +179,7 @@ val is_on_air : t -> bool
 (** [duration ~metadata filename] computes the duration of audio data contained in
     [filename]. The computation may be expensive.
     @raise Not_found if no duration computation method is found. *)
-val duration : metadata:Frame.metadata -> string -> float
+val duration : metadata:Frame.metadata -> string -> float option
 
 (** Return a decoder if the file has been resolved, guaranteed to have
     available data to deliver. *)

--- a/src/core/tools/liqfm.ml
+++ b/src/core/tools/liqfm.ml
@@ -134,10 +134,14 @@ let init host =
                 match request with
                   | Some s -> (
                       match Request.get_filename s with
-                        | Some file ->
-                            Request.duration
-                              ~metadata:(Request.get_all_metadata s)
-                              file
+                        | Some file -> (
+                            match
+                              Request.duration
+                                ~metadata:(Request.get_all_metadata s)
+                                file
+                            with
+                              | Some f -> f
+                              | None -> raise Not_found)
                         | None -> raise Not_found)
                   | None -> raise Not_found
               with

--- a/src/runtime/main.ml
+++ b/src/runtime/main.ml
@@ -193,12 +193,14 @@ let process_request s =
         Printf.printf "%s\n" metadata;
         Printf.printf "duration = %!";
         begin
-          try
-            Printf.printf "%.2f s\n"
-              (Request.duration
-                 ~metadata:(Request.get_all_metadata req)
-                 (Option.get (Request.get_filename req)))
-          with Not_found -> Printf.printf "failed\n"
+          match
+            Request.duration
+              ~metadata:(Request.get_all_metadata req)
+              (Option.get (Request.get_filename req))
+          with
+            | Some f -> Printf.printf "%.2f s\n" f
+            | None -> Printf.printf "n/a\n"
+            | exception Not_found -> Printf.printf "failed\n"
         end;
         Request.destroy req
 

--- a/tests/language/math.liq
+++ b/tests/language/math.liq
@@ -3,8 +3,8 @@
 def test_db_lin() =
   x = 5.
 
-  test.almost_equals(dB_of_lin(lin_of_dB(x)), x)
-  test.almost_equals(lin_of_dB(dB_of_lin(x)), x)
+  test.almost_equal(dB_of_lin(lin_of_dB(x)), x)
+  test.almost_equal(lin_of_dB(dB_of_lin(x)), x)
 
   y = -x
   test.equal(y, -5.)

--- a/tests/streams/replaygain.liq
+++ b/tests/streams/replaygain.liq
@@ -3,39 +3,39 @@
 def test_file_replaygain() =
   g = file.replaygain("replaygain_track_gain.mp3")
   test.not.equal(g, null())
-  test.almost_equals(null.get(g), -32.)
+  test.almost_equal(null.get(g), -32.)
 
   g = file.replaygain("r128_track_gain.mp3")
   test.not.equal(g, null())
-  test.almost_equals(null.get(g), -16.)
+  test.almost_equal(null.get(g), -16.)
 
   g = file.replaygain("replaygain_r128_track_gain.mp3")
   test.not.equal(g, null())
-  test.almost_equals(null.get(g), -16.)
+  test.almost_equal(null.get(g), -16.)
 
   g = file.replaygain("replaygain_track_gain.opus")
   test.not.equal(g, null())
-  test.almost_equals(null.get(g), -32.)
+  test.almost_equal(null.get(g), -32.)
 
   g = file.replaygain("r128_track_gain.opus")
   test.not.equal(g, null())
-  test.almost_equals(null.get(g), -16.)
+  test.almost_equal(null.get(g), -16.)
 
   g = file.replaygain("replaygain_r128_track_gain.opus")
   test.not.equal(g, null())
-  test.almost_equals(null.get(g), -16.)
+  test.almost_equal(null.get(g), -16.)
 
   g = file.replaygain("replaygain_track_gain.mp3", compute=true)
   test.not.equal(g, null())
-  test.almost_equals(null.get(g), -32.)
+  test.almost_equal(null.get(g), -32.)
 
   g = file.replaygain("replaygain_track_gain.mp3", compute=false)
   test.not.equal(g, null())
-  test.almost_equals(null.get(g), -32.)
+  test.almost_equal(null.get(g), -32.)
 
   g = file.replaygain("without_replaygain_track_gain.mp3", compute=true)
   test.not.equal(g, null())
-  test.almost_equals(null.get(g), 7.39)
+  test.almost_equal(null.get(g), 7.39)
 
   g = file.replaygain("without_replaygain_track_gain.mp3", compute=false)
   test.equal(g, null())

--- a/tests/streams/request.liq
+++ b/tests/streams/request.liq
@@ -3,11 +3,17 @@ settings.log.level.set(4)
 test.check(
   fun () ->
     begin
-      test.equal(request.duration("file1.mp3"), 5.041)
-      test.equal(request.duration("annotate:cue_out=1.1:file1.mp3"), 1.1)
-      test.equal(request.duration("annotate:cue_in=1.041:file1.mp3"), 4.)
-      test.equal(
-        request.duration("annotate:cue_in=1.00,cue_out=3.1:file1.mp3"), 2.1
+      test.almost_equal(digits=1, request.duration("file1.mp3"), 5.)
+      test.almost_equal(
+        digits=1, request.duration("annotate:cue_out=1.1:file1.mp3"), 1.1
+      )
+      test.almost_equal(
+        digits=1, request.duration("annotate:cue_in=1.041:file1.mp3"), 4.
+      )
+      test.almost_equal(
+        digits=1,
+        request.duration("annotate:cue_in=1.00,cue_out=3.1:file1.mp3"),
+        2.1
       )
 
       r = request.dynamic(prefetch=1, fun () -> request.create("invalid"))

--- a/tests/streams/request.liq
+++ b/tests/streams/request.liq
@@ -3,16 +3,16 @@ settings.log.level.set(4)
 test.check(
   fun () ->
     begin
-      test.almost_equal(digits=1, request.duration("file1.mp3"), 5.)
+      test.almost_equal(digits=1, request.duration("file1.mp3") ?? 0., 5.)
       test.almost_equal(
-        digits=1, request.duration("annotate:cue_out=1.1:file1.mp3"), 1.1
+        digits=1, request.duration("annotate:cue_out=1.1:file1.mp3") ?? 0., 1.1
       )
       test.almost_equal(
-        digits=1, request.duration("annotate:cue_in=1.041:file1.mp3"), 4.
+        digits=1, request.duration("annotate:cue_in=1.041:file1.mp3") ?? 0., 4.
       )
       test.almost_equal(
         digits=1,
-        request.duration("annotate:cue_in=1.00,cue_out=3.1:file1.mp3"),
+        request.duration("annotate:cue_in=1.00,cue_out=3.1:file1.mp3") ?? 0.,
         2.1
       )
 

--- a/tests/streams/request.liq
+++ b/tests/streams/request.liq
@@ -3,14 +3,12 @@ settings.log.level.set(4)
 test.check(
   fun () ->
     begin
-      if
-        request.duration("file1.mp3") != 5.06
-      then
-        print(
-          "Invalid duration!"
-        )
-        test.fail()
-      end
+      test.equal(request.duration("file1.mp3"), 5.041)
+      test.equal(request.duration("annotate:cue_out=1.1:file1.mp3"), 1.1)
+      test.equal(request.duration("annotate:cue_in=1.041:file1.mp3"), 4.)
+      test.equal(
+        request.duration("annotate:cue_in=1.00,cue_out=3.1:file1.mp3"), 2.1
+      )
 
       r = request.dynamic(prefetch=1, fun () -> request.create("invalid"))
       if

--- a/tests/streams/request.liq
+++ b/tests/streams/request.liq
@@ -3,12 +3,12 @@ settings.log.level.set(4)
 test.check(
   fun () ->
     begin
-      test.almost_equal(digits=1, request.duration("file1.mp3") ?? 0., 5.)
+      test.almost_equal(digits=1, request.duration("file1.mp3") ?? 0., 5.06)
       test.almost_equal(
         digits=1, request.duration("annotate:cue_out=1.1:file1.mp3") ?? 0., 1.1
       )
       test.almost_equal(
-        digits=1, request.duration("annotate:cue_in=1.041:file1.mp3") ?? 0., 4.
+        digits=1, request.duration("annotate:cue_in=1.06:file1.mp3") ?? 0., 4.
       )
       test.almost_equal(
         digits=1,

--- a/tests/test.liq
+++ b/tests/test.liq
@@ -138,7 +138,7 @@ end
 # is within 10^-digits.
 # @param ~digits The number of decimal digits to compare. Default is 7.
 # @flag hidden
-def test._almost_equals(~digits=7, first, second) =
+def test._almost_equal(~digits=7, first, second) =
   diff = abs(float(first) - float(second))
   if
     diff * float(pow(10, digits)) < 0.5
@@ -153,17 +153,17 @@ end
 # Values are considered almost equal if their difference
 # is within 10^-digits.
 # @param ~digits The number of decimal digits to compare. Default is 7.
-def test.almost_equals(~digits=7, first, second) =
-  is_almost_equals = test._almost_equals(digits=digits, first, second)
+def test.almost_equal(~digits=7, first, second) =
+  is_almost_equal = test._almost_equal(digits=digits, first, second)
   if
-    not is_almost_equals
+    not is_almost_equal
   then
     error.raise(
       error.failure,
       "#{string.quote(string(first))} != #{
         string.quote(string(second))
       }
-       up to #{digits} digits, diff = #{is_almost_equals.diff}."
+       up to #{digits} digits, diff = #{is_almost_equal.diff}."
     )
 
     test.fail()
@@ -174,17 +174,17 @@ end
 # Values are considered not almost equal if their difference
 # is greater than 10^-digits.
 # @param ~digits The number of decimal digits to compare. Default is 7.
-def test.not_almost_equals(~digits=7, first, second) =
-  is_almost_equals = test._almost_equals(digits=digits, first, second)
+def test.not_almost_equal(~digits=7, first, second) =
+  is_almost_equal = test._almost_equal(digits=digits, first, second)
   if
-    is_almost_equals
+    is_almost_equal
   then
     error.raise(
       error.failure,
       "#{string.quote(string(first))} == #{
         string.quote(string(second))
       }
-       up to #{digits} digits, diff = #{is_almost_equals.diff}."
+       up to #{digits} digits, diff = #{is_almost_equal.diff}."
     )
 
     test.fail()


### PR DESCRIPTION
Same as https://github.com/savonet/liquidsoap/pull/3889 but for `main`.