### PR TITLE
chore(ci): Update CI scripts to use ubuntu_noble

### DIFF
--- a/.github/scripts/build-details.sh
+++ b/.github/scripts/build-details.sh
@@ -22,7 +22,7 @@ if [[ "${IS_FORK}" != "true" && ("${BRANCH}" =~ ^rolling-release\-v[0-9]\.[0-9]\
   IS_RELEASE=true
 
   echo "Building on all architectures"
-  BUILD_OS='["debian_trixie", "debian_bookworm", "debian_bullseye", "ubuntu_jammy", "ubuntu_lunar", "alpine"]'
+  BUILD_OS='["debian_trixie", "debian_bookworm", "debian_bullseye", "ubuntu_jammy", "ubuntu_noble", "alpine"]'
   BUILD_PLATFORM='["amd64", "arm64", "armhf"]'
   BUILD_INCLUDE='[{"platform": "amd64", "runs-on": "ubuntu-latest", "alpine-arch": "x86_64", "docker-platform": "linux/amd64", "docker-debian-os": "trixie"}, {"platform": "arm64", "runs-on": ["self-hosted", "build"], "alpine-arch": "aarch64", "docker-platform": "linux/arm64", "docker-debian-os": "trixie"}, {"platform": "armhf", "runs-on": ["self-hosted", "build"], "alpine-arch": "armv7", "docker-platform": "linux/arm/v7", "docker-debian-os": "bullseye"}]'
 
@@ -33,7 +33,7 @@ else
   IS_RELEASE=
 
   echo "Building on amd64 only"
-  BUILD_OS='["debian_trixie", "debian_bookworm", "ubuntu_jammy", "ubuntu_lunar", "alpine"]'
+  BUILD_OS='["debian_trixie", "debian_bookworm", "ubuntu_jammy", "ubuntu_noble", "alpine"]'
   BUILD_PLATFORM='["amd64"]'
   BUILD_INCLUDE='[{"platform": "amd64", "runs-on": "ubuntu-latest", "alpine-arch": "x86_64", "docker-platform": "linux/amd64", "docker-debian-os": "trixie"}]'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -380,7 +380,7 @@ jobs:
             platform: armhf
           - os: ubuntu_jammy
             platform: armhf
-          - os: ubuntu_lunar
+          - os: ubuntu_noble
             platform: armhf
     container:
       image: savonet/liquidsoap-ci:${{ matrix.os }}_${{ matrix.platform }}


### PR DESCRIPTION
## Summary

Update CI scripts to utilize the `ubuntu_noble` environment for building Debian packages.

## Details

This pull request modifies the CI scripts to switch from the deprecated `ubuntu_lunar` environment to the `ubuntu_noble` environment. The transition is essential for building Debian packages tailored for the corresponding release.
While `ubuntu_lunar` reached its End-of-Life (EOL) on the 20th of January 2024, `ubuntu_noble`, released on the 25th of April 2024, serves as the latest Long-Term Support (LTS) version.