### PR TITLE
Cache terms

### DIFF
--- a/.github/opam/liquidsoap-core-windows.opam
+++ b/.github/opam/liquidsoap-core-windows.opam
@@ -36,6 +36,8 @@ depends: [
   "dune-build-info-windows"
   "ppx_string" {build}
   "ppx_string-windows" {build}
+  "ppx_hash" {build}
+  "ppx_hash-windows" {build}
 ]
 depopts: [
   "alsa-windows"

--- a/.github/scripts/build-posix.sh
+++ b/.github/scripts/build-posix.sh
@@ -50,7 +50,7 @@ opam install -y .
 cd ..
 
 opam update
-opam install -y tls.0.17.4 saturn_lockfree.0.4.1
+opam install -y tls.0.17.4 saturn_lockfree.0.4.1 ppx_hash
 
 cd /tmp/liquidsoap-full
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,7 +92,7 @@ jobs:
           cp PACKAGES.minimal PACKAGES
           opam update
           opam pin -yn .
-          opam install -y saturn_lockfree.0.4.1
+          opam install -y saturn_lockfree.0.4.1 ppx_hash
           opam info -f "depopts:" liquidsoap-core | grep -v osx-secure-transport | xargs opam remove -y inotify ffmpeg-avutil cohttp-lwt-unix prometheus-app ${{ needs.build_details.outputs.minimal_exclude_deps }}
           opam install -y mem_usage
           echo "::endgroup::"

--- a/dune-project
+++ b/dune-project
@@ -155,6 +155,7 @@
     (saturn_lockfree (>= 0.4.1))
     (re (>= 1.11.0))
     (ppx_string :build)
+    (ppx_hash :build)
     (sedlex (>= 3.2))
     (menhir (>= 20180703))
   )

--- a/liquidsoap-lang.opam
+++ b/liquidsoap-lang.opam
@@ -14,6 +14,7 @@ depends: [
   "saturn_lockfree" {>= "0.4.1"}
   "re" {>= "1.11.0"}
   "ppx_string" {build}
+  "ppx_hash" {build}
   "sedlex" {>= "3.2"}
   "menhir" {>= "20180703"}
   "odoc" {with-doc}

--- a/scripts/gen_emacs_completion.ml
+++ b/scripts/gen_emacs_completion.ml
@@ -1,5 +1,6 @@
 open Liquidsoap_runtime
 
 let () =
-  Main.with_eval ~run_streams:false (fun () ->
+  Main.parse_options ();
+  Main.with_stdlib ~run_streams:false (fun () ->
       Lang_string.kprint_string ~pager:false Doc.Value.print_emacs_completions)

--- a/src/core/builtins/builtins_sys.ml
+++ b/src/core/builtins/builtins_sys.ml
@@ -53,12 +53,6 @@ let conf_strip_types_types =
     ~p:(conf_runtime#plug "strip_types")
     ~d:true "Strip runtime types whenever possible to optimize memory usage."
 
-let () =
-  Lifecycle.after_script_parse ~name:"strip types and cleanup memory" (fun () ->
-      if conf_strip_types_types#get then (
-        Liquidsoap_lang.Term.trim_runtime_types ();
-        Gc.full_major ()))
-
 let _ =
   let kind = Lang.univ_t () in
   Lang.add_builtin ~category:`Liquidsoap ~base:encoder "content_type"

--- a/src/core/harbor/harbor.ml
+++ b/src/core/harbor/harbor.ml
@@ -1131,7 +1131,7 @@ module Make (T : Transport_t) : T with type socket = T.socket = struct
   let get_handler ~pos ~transport ~icy port =
     try
       let { handler; fds; transport = t } = Hashtbl.find opened_ports port in
-      if transport != t then
+      if transport#name <> t#name then
         Lang.raise_error ~pos
           ~message:"Port is already opened with a different transport" "http";
       (* If we have only one socket and icy=true,

--- a/src/core/stream/content.mli
+++ b/src/core/stream/content.mli
@@ -48,6 +48,8 @@ module type ContentSpecs = sig
   type params
   type data
 
+  val name : string
+
   (** Data *)
 
   (* Length is in main ticks. *)

--- a/src/core/stream/content_audio.ml
+++ b/src/core/stream/content_audio.ml
@@ -34,6 +34,7 @@ module Specs = struct
 
   type data = Audio.Mono.buffer array
 
+  let name = "pcm"
   let string_of_kind = function `Pcm -> "pcm"
 
   let string_of_params { channel_layout } =

--- a/src/core/stream/content_midi.ml
+++ b/src/core/stream/content_midi.ml
@@ -30,6 +30,7 @@ module Specs = struct
   type params = { channels : int }
   type data = MIDI.Multitrack.t
 
+  let name = "midi"
   let internal_content_type = Some `Midi
   let string_of_kind = function `Midi -> "midi"
   let string_of_params { channels } = Printf.sprintf "channels=%d" channels

--- a/src/core/stream/content_pcm_f32.ml
+++ b/src/core/stream/content_pcm_f32.ml
@@ -33,6 +33,7 @@ module Specs = struct
   type data =
     (float, Bigarray.float32_elt, Bigarray.c_layout) Bigarray.Array1.t array
 
+  let name = "pcm_f32"
   let string_of_kind = function `Pcm_f32 -> "pcm_f32"
   let copy = copy ~fmt:Bigarray.float32
   let make = make ~fmt:Bigarray.float32

--- a/src/core/stream/content_pcm_s16.ml
+++ b/src/core/stream/content_pcm_s16.ml
@@ -33,6 +33,7 @@ module Specs = struct
   type data =
     (int, Bigarray.int16_signed_elt, Bigarray.c_layout) Bigarray.Array1.t array
 
+  let name = "pcm_s16"
   let string_of_kind = function `Pcm_s16 -> "pcm_s16"
   let copy = copy ~fmt:Bigarray.int16_signed
   let make = make ~fmt:Bigarray.int16_signed

--- a/src/core/stream/content_timed.ml
+++ b/src/core/stream/content_timed.ml
@@ -84,6 +84,7 @@ module Metadata_specs = struct
   type params = unit
   type data = Metadata_base.t content
 
+  let name = "metadata"
   let internal_content_type = None
   let kind = `Metadata
   let string_of_kind _ = "metadata"
@@ -126,6 +127,7 @@ module Track_marks_specs = struct
   type kind = [ `Track_marks ]
   type data = unit content
 
+  let name = "track_marks"
   let internal_content_type = None
   let kind = `Track_marks
   let string_of_kind _ = "track_marks"

--- a/src/core/stream/content_video.ml
+++ b/src/core/stream/content_video.ml
@@ -84,6 +84,7 @@ module Specs = struct
   type params = { width : int Lazy.t option; height : int Lazy.t option }
   type data = (params, Video.Canvas.image) content
 
+  let name = "canvas"
   let internal_content_type = Some `Video
   let string_of_kind = function `Canvas -> "canvas"
 

--- a/src/core/stream/ffmpeg_copy_content.ml
+++ b/src/core/stream/ffmpeg_copy_content.ml
@@ -54,6 +54,7 @@ module Specs = struct
   type params = params_payload option
   type data = (params, packet_payload) content
 
+  let name = "ffmpeg.copy"
   let kind = `Copy
   let parse_param _ _ = None
   let internal_content_type = None

--- a/src/core/stream/ffmpeg_raw_content.ml
+++ b/src/core/stream/ffmpeg_raw_content.ml
@@ -58,6 +58,8 @@ module AudioSpecs = struct
 
   type data = (params, audio frame) content
 
+  let name = "ffmpeg.raw.audio"
+
   let frame_params { frame } =
     {
       channel_layout = Some (Audio.frame_get_channel_layout frame);
@@ -154,6 +156,8 @@ module VideoSpecs = struct
   }
 
   type data = (params, video frame) content
+
+  let name = "ffmpeg.raw.video"
 
   let frame_params { frame } =
     {

--- a/src/js/interactive_js.ml
+++ b/src/js/interactive_js.ml
@@ -3,7 +3,7 @@ open Liquidsoap_lang
 
 let () =
   (Hooks.liq_libs_dir := fun () -> "/static");
-  Runtime.load_libs ~stdlib:"stdlib_js.liq" ()
+  Runtime.load_libs ()
 
 let execute ~throw expr =
   (try

--- a/src/lang/builtins_lang.ml
+++ b/src/lang/builtins_lang.ml
@@ -134,6 +134,21 @@ let _ =
 
 let liquidsoap = Modules.liquidsoap
 
+let liquidsoap_cache =
+  Lang.add_builtin ~category:`Configuration ~descr:"Liquidsoap cache directory."
+    ~base:liquidsoap "cache" [] (Lang.nullable_t Lang.string_t) (fun _ ->
+      match Term_cache.cache_dir () with
+        | None -> Lang.null
+        | Some dir -> Lang.string dir)
+
+let _ =
+  Lang.add_builtin ~category:`Configuration
+    ~descr:"Execute cache maintenance routine." ~base:liquidsoap_cache
+    "maintenance" [] Lang.unit_t (fun _ ->
+      let fn = !Hooks.cache_maintenance in
+      fn ();
+      Lang.unit)
+
 let liquidsoap_version =
   Lang.add_builtin_base ~category:`Configuration
     ~descr:"Liquidsoap version string." ~base:liquidsoap "version"

--- a/src/lang/dune
+++ b/src/lang/dune
@@ -81,8 +81,15 @@
  (name liquidsoap_lang)
  (public_name liquidsoap-lang)
  (preprocess
-  (pps sedlex.ppx ppx_string))
- (libraries liquidsoap-lang.console dune-site re saturn_lockfree str unix menhirLib)
+  (pps sedlex.ppx ppx_string ppx_hash))
+ (libraries
+  liquidsoap-lang.console
+  dune-site
+  re
+  saturn_lockfree
+  str
+  unix
+  menhirLib)
  (modules
   active_value
   build_config
@@ -134,8 +141,12 @@
   startup
   term
   term_base
+  term_cache
   term_custom
+  term_hash
+  term_preprocessor
   term_reducer
+  term_trim
   type
   type_base
   type_constraints

--- a/src/lang/hooks.ml
+++ b/src/lang/hooks.ml
@@ -13,6 +13,7 @@ let make_encoder =
 let has_encoder = ref (fun _ -> false)
 let liq_libs_dir = ref (fun () -> raise Not_found)
 let log_path = ref None
+let cache_maintenance = ref (fun () -> ())
 
 type log =
   < f : 'a. int -> ('a, unit, string, unit) format4 -> 'a

--- a/src/lang/hooks.mli
+++ b/src/lang/hooks.mli
@@ -12,6 +12,7 @@ val make_log : (string list -> log) ref
 val log : string list -> log
 val liq_libs_dir : (unit -> string) ref
 val log_path : string option ref
+val cache_maintenance : (unit -> unit) ref
 
 (* Media-specific dependencies. *)
 

--- a/src/lang/lang_string.ml
+++ b/src/lang/lang_string.ml
@@ -342,7 +342,9 @@ let kprint_string ?(pager = false) f =
 
 (** Operations on versions of Liquidsoap. *)
 module Version = struct
-  type t = int list * string
+  open Term_hash
+
+  type t = int list * string [@@deriving hash]
 
   (* We assume something like, 2.0.0+git@7e211ffd *)
   let of_string s : t =

--- a/src/lang/lang_string.mli
+++ b/src/lang/lang_string.mli
@@ -65,6 +65,7 @@ val kprint_string : ?pager:bool -> ((string -> unit) -> unit) -> unit
 module Version : sig
   type t = int list * string
 
+  val hash_fold_t : Term_hash.state -> t -> Term_hash.state
   val of_string : string -> t
   val to_string : t -> string
   val num : t -> int list

--- a/src/lang/repr.ml
+++ b/src/lang/repr.ml
@@ -493,7 +493,9 @@ let print_scheme f (generalized, t) =
   if !debug then
     List.iter
       (fun v ->
-        print f (make ~generalized (Type_base.make (Var (ref (Free v)))));
+        print f
+          (make ~generalized
+             (Type_base.make (Var { id = 0; contents = Free v })));
         Format.fprintf f ".")
       generalized;
   print f (make ~generalized t)

--- a/src/lang/runtime.mli
+++ b/src/lang/runtime.mli
@@ -24,25 +24,22 @@
 
 exception Error
 
+type eval_config = {
+  fetch_cache : bool;
+  save_cache : bool;
+  eval : [ `True | `False | `Toplevel ];
+}
+
+type eval_mode = [ `Parse_only | `Eval of eval_config ]
+
 (** Raise errors for warnings. *)
 val strict : bool ref
 
 (** Return the list of external libraries. *)
-val libs :
-  ?error_on_no_stdlib:bool ->
-  ?deprecated:bool ->
-  ?stdlib:string ->
-  unit ->
-  string list
+val libs : ?error_on_no_stdlib:bool -> ?deprecated:bool -> unit -> string list
 
 (** Load the external libraries. *)
-val load_libs :
-  ?error_on_no_stdlib:bool ->
-  ?parse_only:bool ->
-  ?deprecated:bool ->
-  ?stdlib:string ->
-  unit ->
-  unit
+val load_libs : unit -> unit
 
 (* Wrapper for format language errors. Re-raises [Error]
    after printing language errors. *)
@@ -57,14 +54,8 @@ val mk_expr :
   Sedlexing.lexbuf ->
   Term.t
 
-(** Evaluate a script from an [in_channel]. *)
-val from_in_channel : ?parse_only:bool -> lib:bool -> in_channel -> unit
-
-(** Evaluate a script from a file. *)
-val from_file : ?ns:string -> ?parse_only:bool -> lib:bool -> string -> unit
-
 (** Evaluate a script from a string. *)
-val from_string : ?parse_only:bool -> lib:bool -> string -> unit
+val from_string : eval_mode:eval_mode -> string -> unit
 
 (** Interactive loop: read from command line, eval, print and loop. *)
 val interactive : unit -> unit

--- a/src/lang/term.mli
+++ b/src/lang/term.mli
@@ -46,7 +46,6 @@ val to_string : t -> string
 val make :
   ?pos:Pos.t -> ?t:Type.t -> ?flags:int -> ?methods:t Methods.t -> ast -> t
 
-val trim_runtime_types : unit -> unit
 val free_vars_pat : pattern -> Vars.t
 val bound_vars_pat : pattern -> Vars.t
 val free_vars : ?bound:Vars.elt list -> t -> Vars.t
@@ -72,7 +71,6 @@ module type Custom = sig
   val is_custom : Custom.t -> bool
   val to_term : content -> t
   val of_term : t -> content
-  val is_term : t -> bool
 end
 
 module type CustomDef = sig

--- a/src/lang/term/runtime_term.ml
+++ b/src/lang/term/runtime_term.ml
@@ -1,3 +1,5 @@
+open Term_hash
+
 (** Sets of variables. *)
 module Vars = Set.Make (String)
 
@@ -8,16 +10,19 @@ module Methods = struct
   type 'a t = 'a typ
 end
 
-type custom = ..
+type custom [@@deriving hash]
 
 type custom_handler = {
-  to_string : custom -> string;
-  to_json : pos:Pos.t list -> custom -> Json.t;
-  compare : custom -> custom -> int;
-  typ : (module Type.Custom.Implementation);
+  name : string;
+  to_string : custom -> string; [@hash.ignore]
+  to_json : pos:Pos.t list -> custom -> Json.t; [@hash.ignore]
+  compare : custom -> custom -> int; [@hash.ignore]
+  typ : Type.t; [@hash.ignore]
 }
+[@@deriving hash]
 
 type custom_term = { value : custom; handler : custom_handler }
+[@@deriving hash]
 
 type pattern =
   [ `PVar of string list  (** a field *)
@@ -25,6 +30,7 @@ type pattern =
   | `PList of pattern list * string option * pattern list  (** a list *)
   | `PMeth of pattern option * (string * meth_term_default) list
     (** a value with methods *) ]
+[@@deriving hash]
 
 and meth_term_default = [ `Nullable | `Pattern of pattern | `None ]
 
@@ -38,7 +44,6 @@ type 'a term = {
   term : 'a;
   flags : flags;
   methods : 'a term Methods.t;
-  id : int;
 }
 
 let has_flag { flags } flag = flags land flag <> 0
@@ -50,6 +55,7 @@ type ('a, 'b) func_argument = {
   default : 'a option;
   typ : 'b;
 }
+[@@deriving hash]
 
 type ('a, 'b) func = {
   mutable free_vars : Vars.t option;
@@ -67,6 +73,7 @@ type 'a common_ast =
   | `Open of 'a * 'a
   | `Var of string
   | `Seq of 'a * 'a ]
+[@@deriving hash]
 
 type 'a invoke = { invoked : 'a; invoke_default : 'a option; meth : string }
 

--- a/src/lang/term/term_cache.ml
+++ b/src/lang/term/term_cache.ml
@@ -1,0 +1,103 @@
+let cache_enabled () =
+  try
+    let venv = Unix.getenv "LIQ_CACHE" in
+    venv = "1" || venv = "true"
+  with Not_found -> true
+
+let default_cache_dir =
+  ref (fun () ->
+      try
+        match Sys.os_type with
+          | "Win32" ->
+              let dir = Filename.dirname Sys.executable_name in
+              let cwd = Sys.getcwd () in
+              Sys.chdir dir;
+              let dir = Sys.getcwd () in
+              Sys.chdir cwd;
+              Some (Filename.concat dir ".cache")
+          | _ ->
+              Some
+                (Filename.concat
+                   (Filename.concat (Unix.getenv "HOME") ".cache")
+                   "liquidsoap")
+      with Not_found -> None)
+
+let cache_dir () =
+  if cache_enabled () then (
+    match
+      try Some (Unix.getenv "LIQ_CACHE_DIR")
+      with Not_found ->
+        let fn = !default_cache_dir in
+        fn ()
+    with
+      | None ->
+          Startup.message
+            "Could not find default cache directory! You can set it using the \
+             `$LIQ_CACHE_DIR` environment variable.";
+          None
+      | Some _ as v -> v)
+  else (
+    Startup.message "Cache disabled!";
+    None)
+
+let rec recmkdir dir =
+  if not (Sys.file_exists dir) then (
+    recmkdir (Filename.dirname dir);
+    Sys.mkdir dir 0o755)
+
+let cache_filename ~toplevel term =
+  match cache_dir () with
+    | None -> None
+    | Some dir ->
+        recmkdir dir;
+        let hash = Parsed_term.hash term in
+        let fname =
+          Printf.sprintf "%s%s.liq-cache" hash
+            (if toplevel then "-toplevel" else "")
+        in
+        Some (Filename.concat dir fname)
+
+let retrieve ~toplevel parsed_term : Term.t option =
+  Startup.time "Cache retrieval" (fun () ->
+      try
+        match cache_filename ~toplevel parsed_term with
+          | None -> None
+          | Some filename ->
+              if Sys.file_exists filename then (
+                let ic = open_in_bin filename in
+                Fun.protect
+                  ~finally:(fun () -> close_in ic)
+                  (fun () ->
+                    let term = Marshal.from_channel ic in
+                    Startup.message "Loading script from cache!";
+                    Some term))
+              else None
+      with
+        | Failure msg
+          when String.starts_with ~prefix:"input_value: unknown code module" msg
+          ->
+            Startup.message "Liquidsoap binary changed: cache invalidated!";
+            None
+        | exn ->
+            let bt = Printexc.get_backtrace () in
+            let exn = Printexc.to_string exn in
+            if Sys.getenv_opt "LIQ_DEBUG_CACHE" <> None then
+              Startup.message "Error while loading cache: %s\n%s" exn bt
+            else Startup.message "Error while loading cache: %s" exn;
+            None)
+
+let cache ~toplevel ~parsed_term term =
+  try
+    match cache_filename ~toplevel parsed_term with
+      | None -> ()
+      | Some filename ->
+          let oc = open_out filename in
+          Fun.protect
+            ~finally:(fun () -> close_out oc)
+            (fun () ->
+              let term = Marshal.to_channel oc term [Marshal.Closures] in
+              let fn = !Hooks.cache_maintenance in
+              fn ();
+              term)
+  with exn ->
+    Startup.message "Error while saving cache: %s" (Printexc.to_string exn)

--- a/src/lang/term/term_cache.mli
+++ b/src/lang/term/term_cache.mli
@@ -1,0 +1,4 @@
+val cache_enabled : unit -> bool
+val cache_dir : unit -> string option
+val retrieve : toplevel:bool -> Parsed_term.t -> Term.t option
+val cache : toplevel:bool -> parsed_term:Parsed_term.t -> Term.t -> unit

--- a/src/lang/term/term_custom.mli
+++ b/src/lang/term/term_custom.mli
@@ -20,21 +20,21 @@
 
  *****************************************************************************)
 
-type custom = Runtime_term.custom = ..
+type custom = Runtime_term.custom
 type t = Runtime_term.custom_term
 
 val to_string : t -> string
 val to_json : pos:Pos.t list -> t -> Json.t
-val to_descr : t -> Type_base.descr
 val compare : t -> t -> int
 
 module type Specs = sig
   type content
 
+  val name : string
+  val t : Type.t
   val to_string : content -> string
   val to_json : pos:Pos.t list -> content -> Json.t
   val compare : content -> content -> int
-  val typ : (module Type.Custom.Implementation)
 end
 
 module type Implementation = sig
@@ -43,7 +43,6 @@ module type Implementation = sig
   val to_custom : content -> t
   val of_custom : t -> content
   val is_custom : t -> bool
-  val descr : Type_base.descr
 end
 
 module Make (S : Specs) : Implementation with type content = S.content

--- a/src/lang/term/term_hash.ml
+++ b/src/lang/term/term_hash.ml
@@ -1,0 +1,33 @@
+module Specs = struct
+  let description = "md5"
+
+  type state = string
+
+  let fold_int s i = Digest.string (s ^ string_of_int i)
+  let fold_int64 s i = Digest.string (s ^ Int64.to_string i)
+  let fold_float s f = Digest.string (s ^ string_of_float f)
+  let fold_string s v = Digest.string (s ^ v)
+
+  type seed = string
+
+  let alloc () = ""
+  let reset ?(seed = "") _ = seed
+
+  type hash_value = string
+
+  let get_hash_value = Digest.to_hex
+
+  module For_tests = struct
+    let compare_state = Stdlib.compare
+    let state_to_string s = s
+  end
+end
+
+module Ppx_hash_lib = struct
+  module Std = struct
+    module Hash = Ppx_hash_lib.Std.Hash.F (Specs)
+  end
+end
+
+include Ppx_hash_lib.Std.Hash
+include Ppx_hash_lib.Std.Hash.Builtin

--- a/src/lang/term/term_hash.mli
+++ b/src/lang/term/term_hash.mli
@@ -1,0 +1,14 @@
+type state
+
+module Ppx_hash_lib : sig
+  module Std : sig
+    module Hash :
+      Ppx_hash_lib.Std.Hash.Full
+        with type state = state
+         and type seed = string
+         and type hash_value = string
+  end
+end
+
+include module type of Ppx_hash_lib.Std.Hash with type state := state
+include module type of Ppx_hash_lib.Std.Hash.Builtin

--- a/src/lang/term/term_preprocessor.ml
+++ b/src/lang/term/term_preprocessor.ml
@@ -1,0 +1,289 @@
+(*****************************************************************************
+
+  Liquidsoap, a programmable stream generator.
+  Copyright 2003-2024 Savonet team
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details, fully stated in the COPYING
+  file at the root of the liquidsoap distribution.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA
+
+ *****************************************************************************)
+
+open Parsed_term
+
+type processor =
+  ( Parser.token * Lexing.position * Lexing.position,
+    Parsed_term.t )
+  MenhirLib.Convert.revised
+
+let program = MenhirLib.Convert.Simplified.traditional2revised Parser.program
+
+let mk_expr ?fname processor lexbuf =
+  let tokenizer = Preprocessor.mk_tokenizer ?fname lexbuf in
+  Parser_helper.clear_comments ();
+  let parsed_term = processor tokenizer in
+  Parser_helper.attach_comments parsed_term;
+  parsed_term
+
+exception No_extra
+
+let rec concat_term (t : t) (t' : t) =
+  match t with
+    | { term = `Let (def, body) } ->
+        { t with term = `Let (def, concat_term body t') }
+    | { term = `Def (def, body) } ->
+        { t with term = `Def (def, concat_term body t') }
+    | { term = `Binding (def, body) } ->
+        { t with term = `Binding (def, concat_term body t') }
+    | { term = `Seq (t1, t2) } as tm ->
+        { tm with term = `Seq (t1, concat_term t2 t') }
+    | _ -> Parsed_term.make ~pos:t.Parsed_term.pos (`Seq (t, t'))
+
+let includer_reducer ~pos = function
+  | `Include { inc_type; inc_name; inc_pos } -> (
+      try
+        let fname =
+          match inc_type with
+            | `Lib -> Filename.concat (!Hooks.liq_libs_dir ()) inc_name
+            | v -> (
+                try
+                  let current_dir =
+                    Filename.dirname (fst inc_pos).Lexing.pos_fname
+                  in
+                  Utils.check_readable ~current_dir ~pos:[inc_pos] inc_name
+                with _ when v = `Extra -> raise No_extra)
+        in
+        let ic = if fname = "-" then stdin else open_in fname in
+        Fun.protect
+          ~finally:(fun () -> if fname <> "-" then close_in ic)
+          (fun () ->
+            let lexbuf = Sedlexing.Utf8.from_channel ic in
+            mk_expr ~fname program lexbuf)
+      with No_extra -> Parsed_term.make ~pos (`Tuple []))
+
+let rec expand_encoder (lbl, params) =
+  ( lbl,
+    List.map
+      (function
+        | `Encoder enc -> `Encoder (expand_encoder enc)
+        | `Labelled (lbl, t) -> `Labelled (lbl, expand_term t)
+        | `Anonymous _ as v -> v)
+      params )
+
+and expand_term tm =
+  let expand_decoration = function
+    | `None -> `None
+    | `Recursive -> `Recursive
+    | `Replaces -> `Replaces
+    | `Eval -> `Eval
+    | `Sqlite_query -> `Sqlite_query
+    | `Sqlite_row -> `Sqlite_row
+    | `Yaml_parse -> `Yaml_parse
+    | `Json_parse l ->
+        `Json_parse (List.map (fun (lbl, t) -> (lbl, expand_term t)) l)
+  in
+  let expand_func_arg ({ default } as arg) =
+    { arg with default = Option.map expand_term default }
+  in
+  let expand_arglist =
+    List.map (function
+      | `Term arg -> `Term (expand_func_arg arg)
+      | `Argsof _ as el -> el)
+  in
+  let expand_app_arg =
+    List.map (function
+      | `Argsof _ as el -> el
+      | `Term (lbl, t) -> `Term (lbl, expand_term t))
+  in
+  let expand_fun_args =
+    List.map (function
+      | `Term arg -> `Term (expand_func_arg arg)
+      | `Argsof _ as v -> v)
+  in
+  let term =
+    match tm.Parsed_term.term with
+      | `Include _ as ast ->
+          (expand_term (includer_reducer ~pos:tm.Parsed_term.pos ast)).term
+      | `Seq ({ pos; term = `Include _ as ast }, t') ->
+          let t = expand_term (includer_reducer ~pos ast) in
+          let t' = expand_term t' in
+          (concat_term t t').term
+      | `Seq (t, t') -> `Seq (expand_term t, expand_term t')
+      | `If_def ({ if_def_then; if_def_else } as if_def) ->
+          `If_def
+            {
+              if_def with
+              if_def_then = expand_term if_def_then;
+              if_def_else = Option.map expand_term if_def_else;
+            }
+      | `If_version ({ if_version_then; if_version_else } as if_version) ->
+          `If_version
+            {
+              if_version with
+              if_version_then = expand_term if_version_then;
+              if_version_else = Option.map expand_term if_version_else;
+            }
+      | `If_encoder ({ if_encoder_then; if_encoder_else } as if_encoder) ->
+          `If_encoder
+            {
+              if_encoder with
+              if_encoder_then = expand_term if_encoder_then;
+              if_encoder_else = Option.map expand_term if_encoder_else;
+            }
+      | `If { if_condition; if_then; if_elsif; if_else } ->
+          `If
+            {
+              if_condition = expand_term if_condition;
+              if_then = expand_term if_then;
+              if_elsif =
+                List.map
+                  (fun (t, t') -> (expand_term t, expand_term t'))
+                  if_elsif;
+              if_else = Option.map expand_term if_else;
+            }
+      | `Inline_if { if_condition; if_then; if_elsif; if_else } ->
+          `If
+            {
+              if_condition = expand_term if_condition;
+              if_then = expand_term if_then;
+              if_elsif =
+                List.map
+                  (fun (t, t') -> (expand_term t, expand_term t'))
+                  if_elsif;
+              if_else = Option.map expand_term if_else;
+            }
+      | `While { while_condition; while_loop } ->
+          `While
+            {
+              while_condition = expand_term while_condition;
+              while_loop = expand_term while_loop;
+            }
+      | `For ({ for_from; for_to; for_loop } as _for) ->
+          `For
+            {
+              _for with
+              for_from = expand_term for_from;
+              for_to = expand_term for_to;
+              for_loop = expand_term for_loop;
+            }
+      | `Iterable_for ({ iterable_for_iterator; iterable_for_loop } as _for) ->
+          `Iterable_for
+            {
+              _for with
+              iterable_for_iterator = expand_term iterable_for_iterator;
+              iterable_for_loop = expand_term iterable_for_loop;
+            }
+      | `List l ->
+          `List
+            (List.map
+               (function
+                 | `Term t -> `Term (expand_term t)
+                 | `Ellipsis t -> `Ellipsis (expand_term t))
+               l)
+      | `Try ({ try_body; try_errors_list; try_handler; try_finally } as _try)
+        ->
+          `Try
+            {
+              _try with
+              try_body = expand_term try_body;
+              try_errors_list = Option.map expand_term try_errors_list;
+              try_handler = Option.map expand_term try_handler;
+              try_finally = Option.map expand_term try_finally;
+            }
+      | `Regexp _ as ast -> ast
+      | `Time_interval _ as ast -> ast
+      | `Time _ as ast -> ast
+      | `Def (({ decoration; arglist; def } as _let), body) ->
+          `Def
+            ( {
+                _let with
+                decoration = expand_decoration decoration;
+                def = expand_term def;
+                arglist = Option.map expand_arglist arglist;
+              },
+              expand_term body )
+      | `Let (({ decoration; arglist; def } as _let), body) ->
+          `Let
+            ( {
+                _let with
+                decoration = expand_decoration decoration;
+                def = expand_term def;
+                arglist = Option.map expand_arglist arglist;
+              },
+              expand_term body )
+      | `Binding (({ decoration; arglist; def } as _let), body) ->
+          `Binding
+            ( {
+                _let with
+                decoration = expand_decoration decoration;
+                def = expand_term def;
+                arglist = Option.map expand_arglist arglist;
+              },
+              expand_term body )
+      | `Cast (t, typ) -> `Cast (expand_term t, typ)
+      | `App (t, app_arg) -> `App (expand_term t, expand_app_arg app_arg)
+      | `Invoke ({ invoked; meth } as invoke) ->
+          `Invoke
+            {
+              invoke with
+              invoked = expand_term invoked;
+              meth =
+                (match meth with
+                  | `String _ as s -> s
+                  | `App (n, app_arg) -> `App (n, expand_app_arg app_arg));
+            }
+      | `Fun (fun_args, t) -> `Fun (expand_fun_args fun_args, expand_term t)
+      | `RFun (name, fun_args, t) ->
+          `RFun (name, expand_fun_args fun_args, expand_term t)
+      | `Not t -> `Not (expand_term t)
+      | `Get t -> `Get (expand_term t)
+      | `Set (t, t') -> `Set (expand_term t, expand_term t')
+      | `Methods (t, methods) ->
+          `Methods
+            ( Option.map expand_term t,
+              List.map
+                (function
+                  | `Ellipsis t -> `Ellipsis (expand_term t)
+                  | `Method (name, t) -> `Method (name, expand_term t))
+                methods )
+      | `Negative t -> `Negative (expand_term t)
+      | `Append (t, t') -> `Append (expand_term t, expand_term t')
+      | `Assoc (t, t') -> `Assoc (expand_term t, expand_term t')
+      | `Infix (t, op, t') -> `Infix (expand_term t, op, expand_term t')
+      | `BoolOp (b, l) -> `BoolOp (b, List.map expand_term l)
+      | `Coalesce (t, t') -> `Coalesce (expand_term t, expand_term t')
+      | `At (t, t') -> `At (expand_term t, expand_term t')
+      | `Simple_fun t -> `Simple_fun (expand_term t)
+      | `String_interpolation (c, l) ->
+          `String_interpolation
+            ( c,
+              List.map
+                (function
+                  | `String _ as s -> s | `Term t -> `Term (expand_term t))
+                l )
+      | `Int _ as ast -> ast
+      | `Float _ as ast -> ast
+      | `String _ as ast -> ast
+      | `Bool _ as ast -> ast
+      | `Eof -> `Eof
+      | `Block t -> `Block (expand_term t)
+      | `Parenthesis t -> `Parenthesis (expand_term t)
+      | `Encoder enc -> `Encoder (expand_encoder enc)
+      | `Custom _ as ast -> ast
+      | `Open (t, t') -> `Open (expand_term t, expand_term t')
+      | `Tuple l -> `Tuple (List.map expand_term l)
+      | `Var _ as ast -> ast
+      | `Null -> `Null
+  in
+  { tm with Parsed_term.term }

--- a/src/lang/term/term_trim.ml
+++ b/src/lang/term/term_trim.ml
@@ -1,0 +1,45 @@
+open Runtime_term
+
+let rec trim_encoder_params params =
+  List.iter
+    (function
+      | `Anonymous _ -> ()
+      | `Encoder enc -> trim_encoder enc
+      | `Labelled (_, t) -> trim_term t)
+    params
+
+and trim_encoder (_, params) = trim_encoder_params params
+
+and trim_ast = function
+  | `Custom _ -> ()
+  | `Tuple l -> List.iter trim_term l
+  | `Null | `Int _ | `Float _ | `Bool _ | `String _ -> ()
+  | `Open (t, t') ->
+      trim_term t;
+      trim_term t'
+  | `Var _ -> ()
+  | `Seq (t, t') ->
+      trim_term t;
+      trim_term t'
+  | `Let { def; body } ->
+      trim_term def;
+      trim_term body
+  | `List l -> List.iter trim_term l
+  | `Cast (t, _) -> trim_term t
+  | `App (t, l) ->
+      trim_term t;
+      List.iter (fun (_, t) -> trim_term t) l
+  | `Invoke { invoked; invoke_default } -> (
+      trim_term invoked;
+      match invoke_default with None -> () | Some t -> trim_term t)
+  | `Encoder enc -> trim_encoder enc
+  | `Fun { body; arguments } ->
+      trim_term body;
+      List.iter
+        (function { default = Some t } -> trim_term t | _ -> ())
+        arguments
+
+and trim_term ({ term; methods } as tm) =
+  tm.t <- Type.deep_demeth tm.t;
+  trim_ast term;
+  Term.Methods.iter (fun _ t -> trim_term t) methods

--- a/src/lang/type.mli
+++ b/src/lang/type.mli
@@ -30,6 +30,22 @@ open Type_base
 
 type variance = [ `Covariant | `Invariant ]
 type t = Type_base.t = private { pos : Pos.Option.t; descr : descr }
+type custom = Type_base.custom
+
+type custom_handler = Type_base.custom_handler = {
+  typ : custom;
+  custom_name : string;
+  copy_with : (t -> t) -> custom -> custom;
+  occur_check : (t -> unit) -> custom -> unit;
+  filter_vars : (var list -> t -> var list) -> var list -> custom -> var list;
+  repr : (var list -> t -> constr R.t) -> var list -> custom -> constr R.t;
+  subtype : (t -> t -> unit) -> custom -> custom -> unit;
+  sup : (t -> t -> t) -> custom -> custom -> custom;
+  to_string : custom -> string;
+}
+
+type invar = Type_base.invar = Free of var | Link of variance * t
+type var_t = Type_base.var_t = { id : int; mutable contents : invar }
 
 type descr = Type_base.descr =
   | String
@@ -45,7 +61,7 @@ type descr = Type_base.descr =
   | Nullable of t  (** something that is either t or null *)
   | Meth of meth * t  (** t with a method added *)
   | Arrow of t argument list * t  (** a function *)
-  | Var of invar ref  (** a type variable *)
+  | Var of var_t  (** a type variable *)
 
 type constr = Type_base.constr = {
   constr_descr : string;
@@ -66,7 +82,6 @@ type var = Type_base.var = {
   mutable constraints : Constraints.t;
 }
 
-type invar = Type_base.invar = Free of var | Link of variance * t
 type scheme = var list * t
 
 type meth = Type_base.meth = {
@@ -85,19 +100,6 @@ val num_constr : constr
 val ord_constr : constr
 
 module R = Type_base.R
-
-type custom = Type_base.custom = ..
-
-type custom_handler = Type_base.custom_handler = {
-  typ : custom;
-  copy_with : (t -> t) -> custom -> custom;
-  occur_check : (t -> unit) -> custom -> unit;
-  filter_vars : (var list -> t -> var list) -> var list -> custom -> var list;
-  repr : (var list -> t -> Repr.t) -> var list -> custom -> Repr.t;
-  subtype : (t -> t -> unit) -> custom -> custom -> unit;
-  sup : (t -> t -> t) -> custom -> custom -> custom;
-  to_string : custom -> string;
-}
 
 type 'a argument = bool * string * 'a
 

--- a/src/lang/typechecking.ml
+++ b/src/lang/typechecking.ml
@@ -188,7 +188,7 @@ let rec check ?(print_toplevel = false) ~throw ~level ~(env : Typing.env) e =
       | `Float _ -> base_type >: mk Float
       | `String _ -> base_type >: mk String
       | `Bool _ -> base_type >: mk Bool
-      | `Custom g -> base_type >: mk (Custom.to_descr g)
+      | `Custom h -> base_type >: mk h.handler.typ.Type.descr
       | `Encoder f ->
           (* Ensure that we only use well-formed terms. *)
           let rec check_enc (_, p) =

--- a/src/lang/types/type_base.ml
+++ b/src/lang/types/type_base.ml
@@ -78,7 +78,7 @@ module R = struct
   and 'a var = string * 'a Type_constraints.t
 end
 
-type custom = ..
+type custom
 
 type t = { pos : Pos.Option.t; descr : descr }
 
@@ -118,6 +118,7 @@ and repr_t = { t : t; json_repr : [ `Tuple | `Object ] }
 
 and custom_handler = {
   typ : custom;
+  custom_name : string;
   copy_with : (t -> t) -> custom -> custom;
   occur_check : (t -> unit) -> custom -> unit;
   filter_vars : (var list -> t -> var list) -> var list -> custom -> var list;
@@ -126,6 +127,8 @@ and custom_handler = {
   sup : (t -> t -> t) -> custom -> custom -> custom;
   to_string : custom -> string;
 }
+
+and var_t = { id : int; mutable contents : invar }
 
 and descr =
   | String
@@ -141,7 +144,7 @@ and descr =
   | Nullable of t  (** something that is either t or null *)
   | Meth of meth * t  (** t with a method added *)
   | Arrow of t argument list * t  (** a function *)
-  | Var of invar ref  (** a type variable *)
+  | Var of var_t  (** a type variable *)
 
 module Constraints = struct
   include Type_constraints
@@ -284,25 +287,25 @@ let split_meths t =
 
 (** Create a fresh variable. *)
 let var_name =
-  let c = ref (-1) in
-  fun () ->
-    incr c;
-    !c
+  let c = Atomic.make (-1) in
+  fun () -> Atomic.fetch_and_add c 1
 
-let var =
-  let f ?(constraints = []) ?(level = max_int) ?pos () =
-    let constraints = Constraints.of_list constraints in
-    let name = var_name () in
-    make ?pos (Var (ref (Free { name; level; constraints })))
-  in
-  f
+let var_id =
+  let c = Atomic.make (-1) in
+  fun () -> Atomic.fetch_and_add c 1
+
+let var ?(constraints = []) ?(level = max_int) ?pos () =
+  let constraints = Constraints.of_list constraints in
+  let name = var_name () in
+  make ?pos
+    (Var { id = var_id (); contents = Free { name; level; constraints } })
 
 module Fresh = struct
   type mapper = {
     level : int option;
     selector : var -> bool;
     var_maps : (var, var) Hashtbl.t;
-    link_maps : (invar ref, invar ref) Hashtbl.t;
+    link_maps : (int, var_t) Hashtbl.t;
   }
 
   let init ?(selector = fun _ -> true) ?level () =
@@ -356,21 +359,23 @@ module Fresh = struct
          so we are better off keeping them. Also, we need to create fresh
          links to make sure that a suppremum computation in the refreshed
          type does not impact the original type. *)
-      | Var ({ contents = Link (v, t) } as link) ->
+      | Var { id; contents = Link (v, t) } ->
           Var
-            (try Hashtbl.find link_maps link
+            (try Hashtbl.find link_maps id
              with Not_found ->
-               let new_link = { contents = Link (v, map t) } in
-               Hashtbl.replace link_maps link new_link;
+               let new_link = { id = var_id (); contents = Link (v, map t) } in
+               Hashtbl.replace link_maps id new_link;
                new_link)
-      | Var ({ contents = Free var } as link) as descr ->
+      | Var { id; contents = Free var } as descr ->
           if not (selector var) then descr
           else
             Var
-              (try Hashtbl.find link_maps link
+              (try Hashtbl.find link_maps id
                with Not_found ->
-                 let new_link = { contents = Free (map_var var) } in
-                 Hashtbl.replace link_maps link new_link;
+                 let new_link =
+                   { id = var_id (); contents = Free (map_var var) }
+                 in
+                 Hashtbl.replace link_maps id new_link;
                  new_link)
     in
     let rec map { descr } = { pos = None; descr = map_descr map descr } in
@@ -431,6 +436,6 @@ let find_type_opt = Hashtbl.find_opt custom_types
 let rec mk_invariant t =
   match t with
     | { descr = Var ({ contents = Link (_, t) } as c) } ->
-        c := Link (`Invariant, t);
+        c.contents <- Link (`Invariant, t);
         mk_invariant t
     | _ -> ()

--- a/src/lang/types/type_custom.mli
+++ b/src/lang/types/type_custom.mli
@@ -20,13 +20,31 @@
 
  *****************************************************************************)
 
-module type Spec = sig
+open Type_base
+
+type custom = Type_base.custom
+
+module type Specs = sig
+  type content
+
   val name : string
+  val copy_with : (t -> t) -> content -> content
+  val occur_check : (t -> unit) -> content -> unit
+
+  val filter_vars :
+    (var list -> t -> var list) -> var list -> content -> var list
+
+  val repr : (var list -> t -> Repr.t) -> var list -> content -> Repr.t
+  val subtype : (t -> t -> unit) -> content -> content -> unit
+  val sup : (t -> t -> t) -> content -> content -> content
+  val to_string : content -> string
 end
 
 module type Implementation = sig
-  val descr : Type_base.descr
-  val is_descr : Type_base.descr -> bool
+  type content
+
+  val handler : content -> Type_base.custom_handler
+  val to_content : custom -> content
 end
 
-module Make (_ : Spec) : Implementation
+module Make (S : Specs) : Implementation with type content = S.content

--- a/src/lang/typing.ml
+++ b/src/lang/typing.ml
@@ -297,7 +297,7 @@ and bind ?(variance = `Invariant) a b =
   (* update_level a.level b; *)
   satisfies_constraints b (Constraints.elements a.constraints);
   let b = if b.pos = None then Type.make ?pos:a0.pos b.Type.descr else b in
-  v := Link (variance, b)
+  v.contents <- Link (variance, b)
 
 (** Ensure that the type for the method [l] in [a] is a subtype of the one for the same method in [b]. *)
 and unify_meth a b l =
@@ -407,10 +407,10 @@ and ( <: ) a b =
              failwith
                (Printf.sprintf "invalid sup: %s !< %s (%s)" (Type.to_string b')
                   (Type.to_string b'') (Printexc.to_string e)));
-          if b'' != b' then var := Link (`Covariant, b'');
+          if b'' != b' then var.contents <- Link (`Covariant, b'');
           a <: b''
       | Var ({ contents = Link (`Covariant, a') } as var), _ ->
-          var := Link (`Invariant, a');
+          var.contents <- Link (`Invariant, a');
           a <: b
       | _, Var { contents = Link (_, b) } -> a <: b
       | Var { contents = Link (_, a) }, _ -> a <: b

--- a/src/lang/value.ml
+++ b/src/lang/value.ml
@@ -76,7 +76,7 @@ let rec to_string v =
       | Float f -> Utils.string_of_float f
       | Bool b -> string_of_bool b
       | String s -> Lang_string.quote_string s
-      | Custom g -> Custom.to_string g
+      | Custom c -> Custom.to_string c
       | List l -> "[" ^ String.concat ", " (List.map to_string l) ^ "]"
       | Tuple l -> "(" ^ String.concat ", " (List.map to_string l) ^ ")"
       | Null -> "null"
@@ -223,7 +223,6 @@ module type Custom = sig
 
   val to_value : ?pos:Pos.t -> content -> t
   val of_value : t -> content
-  val is_value : t -> bool
 end
 
 module type CustomDef = Term.CustomDef
@@ -241,11 +240,9 @@ module MkCustomFromTerm (Term : Term.Custom) = struct
     }
 
   let of_value t =
-    match t.value with
-      | Custom g when is_custom g -> of_custom g
-      | _ -> assert false
+    match t.value with Custom c -> of_custom c | _ -> assert false
 
-  let is_value t = match t.value with Custom g -> is_custom g | _ -> false
+  let is_value t = match t.value with Custom c -> is_custom c | _ -> false
 end
 
 module MkCustom (Def : CustomDef) = struct

--- a/tests/core/dune
+++ b/tests/core/dune
@@ -1,3 +1,11 @@
+(env
+ (release
+  (ocamlopt_flags
+   (:standard -w -9 -alert --deprecated -O2)))
+ (_
+  (flags
+   (:standard -w -9 -alert --deprecated))))
+
 ; Regenerate using dune build @gendune --auto-promote
 
 (include dune.inc)

--- a/tests/core/more_types.ml
+++ b/tests/core/more_types.ml
@@ -68,13 +68,7 @@ let () =
   (* term = (1 : int.{opt?: string}).foo *)
   let typ = Type.meth ~optional:true "opt" ([], Lang.string_t) Lang.int_t in
   let term =
-    {
-      Term.t = typ;
-      term = `Int 1;
-      methods = Term.Methods.empty;
-      flags = 0;
-      id = 123;
-    }
+    { Term.t = typ; term = `Int 1; methods = Term.Methods.empty; flags = 0 }
   in
   let invoke =
     {
@@ -83,7 +77,6 @@ let () =
         `Invoke { Term.invoked = term; invoke_default = None; meth = "opt" };
       methods = Term.Methods.empty;
       flags = 0;
-      id = 234;
     }
   in
   try

--- a/tests/harbor/http.liq
+++ b/tests/harbor/http.liq
@@ -308,7 +308,7 @@ def f() =
   end
 
   # Register output on the same port
-  output.harbor(port=3456, mount="bla.wav", on_start=test.pass, %wav, sine())
+  output.harbor(port=4455, mount="bla.wav", on_start=test.pass, %wav, sine())
 end
 
 test.check(f)

--- a/tests/language/dune.inc
+++ b/tests/language/dune.inc
@@ -489,7 +489,7 @@
   (:stdlib ../../src/libs/stdlib.liq)
   (:test_liq ../test.liq)
   (:run_test ../run_test.exe))
- (action (run %{run_test} type_errors.liq liquidsoap %{test_liq} type_errors.liq)))
+ (action (run %{run_test} type_errors.liq liquidsoap %{test_liq} type_errors.liq --top-level)))
 
 (rule
  (alias citest)

--- a/tests/language/gen_dune.ml
+++ b/tests/language/gen_dune.ml
@@ -22,9 +22,10 @@ let () =
   (:stdlib ../../src/libs/stdlib.liq)
   (:test_liq ../test.liq)
   (:run_test ../run_test.exe))
- (action (run %%{run_test} %s liquidsoap %%{test_liq} %s)))
+ (action (run %%{run_test} %s liquidsoap %%{test_liq} %s%s)))
   |}
-        test test test)
+        test test test
+        (if test = "type_errors.liq" then " --top-level" else ""))
     tests;
 
   let output_tests =


### PR DESCRIPTION
This PR introduces a cache for running scripts!

### Functionality

During the first execution, the script is parsed, type checked and evaluated. On second and any following execution, a cache of the script is used, reducing the typechecking phase by a 100x factor!

First execution (m3 macbook):
<img width="302" alt="Screenshot 2024-05-24 at 4 13 43 PM" src="https://github.com/savonet/liquidsoap/assets/871060/f07735d2-d943-4917-a177-40dcfbb4ca7c">

Second execution:
<img width="320" alt="Screenshot 2024-05-24 at 4 14 29 PM" src="https://github.com/savonet/liquidsoap/assets/871060/5d8f435d-cc4c-4513-8a19-b567980ba6cd">

This will greatly improve runtime performances for most users. We have had reports of startup time taking up to `5` minutes so this was long overdue!

Additionally, about `~15Mo` of memory is saved after those changes (see below).

Scripts can be cached ahead of time, for instance while compiling a docker image, using `--cache-only`. Cache can also be disabled using `--no-cache`.

On windows, the default cache directory is located in the same directory as the binary. On unix systems, it is located at: `$HOME/.cache/liquidsoap`

For obvious reasons, cache parameters have to be set before parsing and executing scripts so:
* cache directory can be changed using the `LIQ_CACHE_DIR` environments
* cache can be disabled by setting `LIQ_CACHE` to anything else than `"true"`

A cache maintenance routine is added which deletes unused cache files after 10 days and keeps the cache to a maximum of `200` files. This can be set through settings but won't be effective by default.

`liquidsoap.cache()` returns the cache directory and `liquidsoap.cache.maintenance()` runs the cache maintenance, if you need to do it after changing default parameters.

## Implementation

The cache is inserted right after type-checking and before evaluation. It is using the plain `Marshal` module from OCaml after removing extensible variant types which are unfortunately not supported by `Marshal`.

Cache is indexed by a hash of the parsed script with all `%include` fully expanded. Comments and position informations are ignored. This should provide a solid basis for cache invalidation.

Cache is also invalidated when the binary is recompiled.

The biggest change besides getting rid of extensible variants is that the optimization to drop most types at runtime is now applied to the runtime term before executing it.

Before that, it was applied through a weak hash of terms remaining after running the evaluation. This mechanism was relying on registering terms when instantiating them. Wen using marshal, this mechanism is hard to reproduce. Plus, it was hacky.

This also means that the evaluation of the term cannot be kept at top-level as its types are now incomplete for top-level description.  This results in additional memory saving of about `~15Mo` from the types that were previously kept at top-level.

In order to be able to still describe the standard library functions, for instance when querying the doc of an operator or listing all available functions, it is possible to disable type trimming and force evaluation to be registered at top-level.

This is done implicitly when using any of the documentation options such as `-h <operator>` and can also be forced using the `--top-level` option.