### PR TITLE
No extensible type for types.

### DIFF
--- a/src/core/builtins/builtins_settings.ml
+++ b/src/core/builtins/builtins_settings.ml
@@ -24,13 +24,10 @@ exception Found of (Lang.value * Lang.value option)
 
 let settings = ref Lang.null
 
-type Type.constr_t += Dtools
-
 let dtools_constr =
   let open Liquidsoap_lang in
   let open Type in
   {
-    t = Dtools;
     constr_descr = "unit, bool, int, float, string or [string]";
     univ_descr = None;
     satisfied =

--- a/src/core/builtins/builtins_sqlite.ml
+++ b/src/core/builtins/builtins_sqlite.ml
@@ -29,12 +29,9 @@ let escape =
   let rex = Pcre.regexp "'" in
   fun s -> "'" ^ Pcre.substitute ~rex ~subst:(fun _ -> "''") s ^ "'"
 
-type Type.constr_t += Insert_value | Insert_record
-
 let insert_value_constr =
   let open Type in
   {
-    t = Insert_value;
     constr_descr = "int, float, string or null.";
     univ_descr = None;
     satisfied =
@@ -55,7 +52,6 @@ let insert_value_constr =
 let insert_record_constr =
   let open Type in
   {
-    t = Insert_record;
     constr_descr = "a record with int, float, string or null methods.";
     univ_descr = None;
     satisfied =

--- a/src/core/types/format_type.ml
+++ b/src/core/types/format_type.ml
@@ -22,14 +22,6 @@
 
 type Type.custom += Kind of (Content_base.kind * Type.t)
 type Type.custom += Format of Content_base.format
-
-type Type.constr_t +=
-  | PcmAudio
-  | Track
-  | MuxedTracks
-  | InternalTrack
-  | InternalTracks
-
 type descr = [ `Format of Content_base.format | `Kind of Content_base.kind ]
 
 let get_format = function Format f -> f | _ -> assert false
@@ -197,10 +189,9 @@ let is_format f m =
   let module Content = (val m : Content) in
   Content.is_format f
 
-let check_track ?univ_descr ~t modules =
+let check_track ?univ_descr modules =
   {
-    Type.t;
-    constr_descr =
+    Type.constr_descr =
       Printf.sprintf "a track of type: %s"
         (Utils.concat_with_last ~last:"or" ", "
            (List.map string_of_kind modules));
@@ -220,13 +211,12 @@ let check_track ?univ_descr ~t modules =
           | _ -> raise Type.Unsatisfied_constraint);
   }
 
-let pcm_audio = check_track ~univ_descr:"pcm*" ~t:PcmAudio pcm_modules
-let internal_track = check_track ~t:InternalTrack internal_modules
+let pcm_audio = check_track ~univ_descr:"pcm*" pcm_modules
+let internal_track = check_track internal_modules
 
 let internal_tracks =
   {
-    Type.t = InternalTracks;
-    constr_descr = "a set of internal tracks";
+    Type.constr_descr = "a set of internal tracks";
     univ_descr = None;
     satisfied =
       (fun ~subtype:_ ~satisfies b ->
@@ -254,8 +244,7 @@ let internal_tracks =
 
 let track =
   {
-    Type.t = Track;
-    constr_descr = "a track";
+    Type.constr_descr = "a track";
     univ_descr = None;
     satisfied =
       (fun ~subtype:_ ~satisfies b ->
@@ -271,8 +260,7 @@ let track =
 
 let muxed_tracks =
   {
-    Type.t = MuxedTracks;
-    constr_descr = "a set of tracks to be muxed into a source";
+    Type.constr_descr = "a set of tracks to be muxed into a source";
     univ_descr = None;
     satisfied =
       (fun ~subtype:_ ~satisfies b ->

--- a/src/lang/dune
+++ b/src/lang/dune
@@ -138,6 +138,7 @@
   term_reducer
   type
   type_base
+  type_constraints
   typechecking
   typing
   unifier

--- a/src/lang/repr.ml
+++ b/src/lang/repr.ml
@@ -31,6 +31,8 @@ let global_evar_names = ref false
 open Type_base
 include R
 
+type t = Type_base.constr R.t
+
 (** Given a position, find the relevant excerpt. *)
 let excerpt (start, stop) =
   try
@@ -197,8 +199,7 @@ let make ?(filter_out = fun _ -> false) ?(generalized = []) t : t =
         | Var { contents = Link (`Covariant, t) } when !debug || !debug_variance
           ->
             `Debug ("[>", repr g t, "]")
-        | Var { contents = Link (_, t) } -> repr g t
-        | _ -> raise NotImplemented)
+        | Var { contents = Link (_, t) } -> repr g t)
   in
   repr generalized t
 

--- a/src/lang/type.ml
+++ b/src/lang/type.ml
@@ -26,7 +26,6 @@ module Ground = Ground_type
 
 let record_constr =
   {
-    t = Record;
     constr_descr = "a record type";
     univ_descr = None;
     satisfied =
@@ -41,7 +40,6 @@ let record_constr =
 
 let num_constr =
   {
-    t = Num;
     constr_descr = "a number type";
     univ_descr = None;
     satisfied =
@@ -58,7 +56,6 @@ let num_constr =
 
 let ord_constr =
   {
-    t = Ord;
     constr_descr = "an orderable type";
     univ_descr = None;
     satisfied =

--- a/src/lang/type.mli
+++ b/src/lang/type.mli
@@ -26,14 +26,23 @@ val debug_variance : bool ref
 
 (** {2 Types} *)
 
+open Type_base
+
 type variance = [ `Covariant | `Invariant ]
-type descr = Type_base.descr = ..
 type t = Type_base.t = private { pos : Pos.Option.t; descr : descr }
-type constr_t = Type_base.constr_t = ..
-type constr_t += Num | Ord
+
+type descr = Type_base.descr =
+  | Custom of custom_handler
+  | Constr of constructed
+  | Getter of t  (** a getter: something that is either a t or () -> t *)
+  | List of repr_t
+  | Tuple of t list
+  | Nullable of t  (** something that is either t or null *)
+  | Meth of meth * t  (** t with a method added *)
+  | Arrow of t argument list * t  (** a function *)
+  | Var of invar ref  (** a type variable *)
 
 type constr = Type_base.constr = {
-  t : constr_t;
   constr_descr : string;
   univ_descr : string option;
   satisfied : subtype:(t -> t -> unit) -> satisfies:(t -> unit) -> t -> unit;
@@ -52,7 +61,7 @@ type var = Type_base.var = {
   mutable constraints : Constraints.t;
 }
 
-type invar = Free of var | Link of variance * t
+type invar = Type_base.invar = Free of var | Link of variance * t
 type scheme = var list * t
 
 type meth = Type_base.meth = {
@@ -86,17 +95,6 @@ type custom_handler = Type_base.custom_handler = {
 }
 
 type 'a argument = bool * string * 'a
-
-type descr +=
-  | Custom of custom_handler
-  | Constr of constructed
-  | Getter of t
-  | List of repr_t
-  | Tuple of t list
-  | Nullable of t
-  | Meth of meth * t
-  | Arrow of t argument list * t
-  | Var of invar ref
 
 exception NotImplemented
 exception Exists of Pos.Option.t * string

--- a/src/lang/types/type_constraints.ml
+++ b/src/lang/types/type_constraints.ml
@@ -24,6 +24,7 @@ type 'a t = 'a list
 
 let create () = []
 let add el set = el :: List.filter (fun e -> e != el) set
+let mem = List.memq
 
 let of_list l =
   List.fold_left

--- a/src/lang/types/type_constraints.ml
+++ b/src/lang/types/type_constraints.ml
@@ -1,0 +1,37 @@
+(*****************************************************************************
+
+  Liquidsoap, a programmable stream generator.
+  Copyright 2003-2024 Savonet team
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details, fully stated in the COPYING
+  file at the root of the liquidsoap distribution.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA
+
+ *****************************************************************************)
+
+type 'a t = 'a list
+
+let create () = []
+let add el set = el :: List.filter (fun e -> e != el) set
+
+let of_list l =
+  List.fold_left
+    (fun ret el -> if List.memq el ret then ret else el :: ret)
+    [] l
+
+let compare = Stdlib.compare
+let elements l = l
+let cardinal = List.length
+let choose = function [] -> raise Not_found | x :: _ -> x
+let is_empty = function [] -> true | _ -> false

--- a/src/lang/types/type_constraints.mli
+++ b/src/lang/types/type_constraints.mli
@@ -24,6 +24,7 @@ type 'a t
 
 val create : unit -> 'a t
 val add : 'a -> 'a t -> 'a t
+val mem : 'a -> 'a t -> bool
 val compare : 'a t -> 'a t -> int
 val of_list : 'a list -> 'a t
 val elements : 'a t -> 'a list

--- a/src/lang/types/type_constraints.mli
+++ b/src/lang/types/type_constraints.mli
@@ -1,0 +1,32 @@
+(*****************************************************************************
+
+  Liquidsoap, a programmable stream generator.
+  Copyright 2003-2024 Savonet team
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details, fully stated in the COPYING
+  file at the root of the liquidsoap distribution.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA
+
+ *****************************************************************************)
+
+type 'a t
+
+val create : unit -> 'a t
+val add : 'a -> 'a t -> 'a t
+val compare : 'a t -> 'a t -> int
+val of_list : 'a list -> 'a t
+val elements : 'a t -> 'a list
+val cardinal : 'a t -> int
+val choose : 'a t -> 'a
+val is_empty : 'a t -> bool

--- a/src/lang/typing.ml
+++ b/src/lang/typing.ml
@@ -90,7 +90,6 @@ let filter_vars f t =
       | Var { contents = Free var } ->
           if f var && not (List.exists (Var.eq var) l) then var :: l else l
       | Var { contents = Link _ } -> assert false
-      | _ -> raise NotImplemented
   in
   aux [] t
 
@@ -142,7 +141,6 @@ let occur_check (a : var) =
         if Type.Var.eq a x then raise (Occur_check (a, b));
         x.level <- min a.level x.level
     | { descr = Var { contents = Link (_, b) } } -> occur_check b
-    | _ -> raise NotImplemented
   in
   occur_check
 


### PR DESCRIPTION
This is a sub-set of the larger changes required to enable term/type caching.

This PR removes extensible types for type description.

This has an impact on typing performances as extensible type variants are not as optimized as regular variants. On my laptop, typechecking the whole standard library goes from `3.33s` to `2.91s`, which is about `15%` faster.