### PR TITLE
Update protocols.liq. Fix typo in `process.uri` function. Add `g`.

### DIFF
--- a/src/libs/protocols.liq
+++ b/src/libs/protocols.liq
@@ -184,7 +184,7 @@ protocol.add(
 # @param ~uri Input uri
 def process.uri(~timeout=null(), ~extname, ~uri="", cmd) =
   timeout = null.case(timeout, {""}, fun (t) -> "timeout=" ^ string(t) ^ ",")
-  cmd = r/:/.replace(fun (_) -> "$(colon)", cmd)
+  cmd = r/:/g.replace(fun (_) -> "$(colon)", cmd)
   uri = if uri != "" then ":#{uri}" else "" end
   "process:#{timeout}#{extname},#{cmd}#{uri}"
 end


### PR DESCRIPTION
Fix typo in `process.uri` function. Add `g`.

https://github.com/savonet/liquidsoap/issues/3948