### PR TITLE
Don't load external plugins when building extra doc.

### DIFF
--- a/doc/dune.inc
+++ b/doc/dune.inc
@@ -33,7 +33,7 @@
     (with-stdout-to reference-extras.md
       (progn (cat %{header}) (echo "\n")
       (setenv PAGER none
-        (run %{bin:liquidsoap} --list-extra-functions-md)))))
+        (run %{bin:liquidsoap} --no-external-plugins --list-extra-functions-md)))))
       )
 
 (rule

--- a/doc/gen_dune.ml
+++ b/doc/gen_dune.ml
@@ -5,7 +5,7 @@ let generated_md =
     ("protocols.md", "--list-protocols-md", None);
     ("reference.md", "--list-functions-md", Some "content/reference-header.md");
     ( "reference-extras.md",
-      "--list-extra-functions-md",
+      "--no-external-plugins --list-extra-functions-md",
       Some "content/reference-header.md" );
     ( "reference-deprecated.md",
       "--list-deprecated-functions-md",

--- a/src/core/operators/ladspa_op.ml
+++ b/src/core/operators/ladspa_op.ml
@@ -408,5 +408,5 @@ let register_plugins () =
 
 let () =
   Lifecycle.on_load ~name:"ladspa plugin registration" (fun () ->
-      if ladspa_enabled then
+      if !Startup.register_external_plugins && ladspa_enabled then
         Startup.time "LADSPA plugins registration" register_plugins)

--- a/src/core/operators/lilv_op.ml
+++ b/src/core/operators/lilv_op.ml
@@ -361,5 +361,5 @@ let register_plugins () =
 
 let () =
   Lifecycle.on_load ~name:"lilv plugin registration" (fun () ->
-      if lilv_enabled then
+      if !Startup.register_external_plugins && lilv_enabled then
         Startup.time "Lilv plugins registration" register_plugins)

--- a/src/lang/startup.ml
+++ b/src/lang/startup.ml
@@ -22,9 +22,11 @@
 
 let messages = Atomic.make []
 
+(* Add a startup message. *)
 let message fmt =
   Printf.ksprintf (fun s -> Atomic.set messages (s :: Atomic.get messages)) fmt
 
+(* Time a startup function. *)
 let time name f =
   let t = Sys.time () in
   let ans = f () in
@@ -32,3 +34,6 @@ let time name f =
   ans
 
 let messages () = Atomic.get messages |> List.rev
+
+(* Should we register external plugins? *)
+let register_external_plugins = ref true

--- a/src/runtime/main.ml
+++ b/src/runtime/main.ml
@@ -244,6 +244,9 @@ let options =
              cache := true),
          "Parse, type-check and save script's cache but do no run it." );
        (["--no-cache"], Arg.Clear cache, "Disable cache");
+       ( ["--no-external-plugins"],
+         Arg.Clear Startup.register_external_plugins,
+         "Disable external plugins." );
        ( ["-q"; "--quiet"],
          Arg.Unit (fun () -> Dtools.Log.conf_stdout#set false),
          "Do not print log messages on standard output." );


### PR DESCRIPTION
With many ladspa / dssi / lv2 plugins installed pandoc doc generation takes forever. Disable this by default.