### PR TITLE
Update `queue` in `request.queue`

### DIFF
--- a/src/libs/request.liq
+++ b/src/libs/request.liq
@@ -186,7 +186,7 @@ def request.queue(
     s.set_queue([])
   end
 
-  def queue() =
+  def get_queue() =
     [...s.queue(), ...(queue())]
   end
 
@@ -195,7 +195,7 @@ def request.queue(
     push=push.{uri=push_uri},
     length={list.length(queue()) + list.length(s.queue())},
     set_queue=set_queue,
-    queue=queue
+    queue=get_queue
   }
 end
 

--- a/src/libs/request.liq
+++ b/src/libs/request.liq
@@ -186,11 +186,16 @@ def request.queue(
     s.set_queue([])
   end
 
+  def queue() =
+    [...s.queue(), ...(queue())]
+  end
+
   s.{
     add=add,
     push=push.{uri=push_uri},
     length={list.length(queue()) + list.length(s.queue())},
-    set_queue=set_queue
+    set_queue=set_queue,
+    queue=queue
   }
 end
 


### PR DESCRIPTION
Whenever we use `set_queue` in `requests.queue` it updates the backing `queue` list, however when we try to get the queue using `requests.queue.queue()`, we only get the requests within `s.queue`, which is set to empty after calling `set_queue`. 

Therefore, even though the queue should have the items specified in `set_queue`, we get an empty list when calling `queue`. See the `show_queue` server function for reference.