### PR TITLE
Fix telnet functions for request.queue

### DIFF
--- a/src/libs/request.liq
+++ b/src/libs/request.liq
@@ -95,6 +95,32 @@ def request.queue(
     default()
 %endif
 
+  def add(r) =
+    log.severe(
+      label=s.id(),
+      "Please use #{s.id()}.push instead of #{s.id()}.add()"
+    )
+
+    s.add(r)
+  end
+
+  def set_queue(q) =
+    queue := q
+    s.set_queue([])
+  end
+
+  def get_queue() =
+    [...s.queue(), ...(queue())]
+  end
+
+  s.{
+    add=add,
+    push=push.{uri=push_uri},
+    length={list.length(queue()) + list.length(s.queue())},
+    set_queue=set_queue,
+    queue=get_queue
+  }
+
   s.on_wake_up({s.set_queue(initial_queue)})
 
   source.set_name(s, "request.queue")
@@ -137,7 +163,7 @@ def request.queue(
           )
 
           def show_queue(_) =
-            queue = [...s.queue(), ...(queue())]
+            queue = s.queue()
             string.concat(
               separator=
                 " ",
@@ -172,31 +198,7 @@ def request.queue(
     )
   end
 
-  def add(r) =
-    log.severe(
-      label=s.id(),
-      "Please use #{s.id()}.push instead of #{s.id()}.add()"
-    )
-
-    s.add(r)
-  end
-
-  def set_queue(q) =
-    queue := q
-    s.set_queue([])
-  end
-
-  def get_queue() =
-    [...s.queue(), ...(queue())]
-  end
-
-  s.{
-    add=add,
-    push=push.{uri=push_uri},
-    length={list.length(queue()) + list.length(s.queue())},
-    set_queue=set_queue,
-    queue=get_queue
-  }
+  s
 end
 
 # Play a request once and become unavailable.

--- a/src/libs/request.liq
+++ b/src/libs/request.liq
@@ -113,7 +113,7 @@ def request.queue(
     [...s.queue(), ...(queue())]
   end
 
-  s.{
+  s = s.{
     add=add,
     push=push.{uri=push_uri},
     length={list.length(queue()) + list.length(s.queue())},


### PR DESCRIPTION
This is a continuation of #3982 

There are issues with the telnet functions because they do not use the overridden methods of the request.queue implementation. 

For example, `flush_and_skip` does not actually clear the entire queue since it does not use the overwritten `set_queue` which clears the internal `s.queue()` and modifies the backing `queue`. Since it uses the default implementation of `set_queue` (and not the overwritten one), it does not set the backing `queue` to `[]`, so any requests that were in the backing `queue` are left over.

Fixed this by overwriting the methods beforehand, and using the result of that when specifying the telnet functions.