### PR TITLE
chore(github): Add GitHub security policy description

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,33 @@
+# Security Policy
+
+## Supported Versions
+
+Currently, we provide active support for the following versions of liquidsoap:
+
+| Version | Supported          |
+| ------- | ------------------ |
+| `2.2.x` | :white_check_mark: |
+| `2.1.x` | :x:                |
+| `2.0.x` | :x:                |
+| `1.4.x` | :x:                |
+| `< 1.4` | :x:                |
+
+If you find a vulnerability in an unsupported version, please tell us. We will assess the risk and guide you accordingly.
+
+## Reporting Security Issues
+
+At Liquidsoap, we take security seriously. We appreciate your efforts to responsibly disclose your findings, and we are committed to working
+with you to resolve any security issues.
+
+To report a security issue, please use the ["Report a Vulnerability"](https://github.com/savonet/liquidsoap/security/advisories/new) in the
+GitHub Security Advisory tab.
+
+## Responsible Disclosure
+
+We kindly ask you not to disclose any vulnerabilities publicly until we have addressed them. We aim to promptly respond to your report and
+provide an estimated timeline for a fix.
+
+## Thank You
+
+We appreciate your contributions to enhancing the security of our project. Your assistance in identifying and resolving vulnerabilities is
+priceless, and we are committed to maintaining a safe and secure environment for all our users.


### PR DESCRIPTION
## Summary

Add a SECURITY.md file following recommendation at https://docs.github.com/en/code-security/getting-started/adding-a-security-policy-to-your-repository. It will give users a conscious guide on how to report security vulnerabilities.

## Additionally

I've made a repository that will demonstrate the expected behavior.
https://github.com/vitoyucepi/liquidsoap-issue-3999

If you merge this pull request, I expect you to enable the *Security advisories* GitHub feature. A guide is available at https://docs.github.com/en/code-security/security-advisories/working-with-repository-security-advisories/configuring-private-vulnerability-reporting-for-a-repository.