### PR TITLE
Make sure that metadata decoder is only called once

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@ Changed:
 Fixed:
 
 - Replace `:` everywhere when processing `$(colon)` in protocols (#3952, @gAlleb)
+- Fixed metadata decoder being called twice (#3960)
 
 # 2.2.5 (2024-05-01) (Mayday!)
 

--- a/tests/regression/GH3960.liq
+++ b/tests/regression/GH3960.liq
@@ -1,0 +1,28 @@
+call_counts = ref([])
+
+def test_decoder(~metadata=_, filename) =
+  call_count = list.assoc(default=ref(0), filename, call_counts())
+
+  ref.incr(call_count)
+
+  if
+    1 < call_count()
+  then
+    print(
+      "Call count for #{filename}: #{call_count()}"
+    )
+    test.fail()
+  end
+
+  call_counts :=
+    [...list.assoc.remove.all(filename, call_counts()), (filename, call_count)]
+
+  []
+end
+decoder.metadata.add("test_decoder", test_decoder)
+
+radio = playlist("../media")
+
+output.dummy(radio, fallible=true)
+
+thread.run(delay=4., fun () -> test.pass())

--- a/tests/regression/dune.inc
+++ b/tests/regression/dune.inc
@@ -458,6 +458,19 @@
  (alias citest)
  (package liquidsoap)
  (deps
+  GH3960.liq
+  ../media/all_media_files
+  ../../src/bin/liquidsoap.exe
+  (package liquidsoap)
+  (:stdlib ../../src/libs/stdlib.liq)
+  (:test_liq ../test.liq)
+  (:run_test ../run_test.exe))
+ (action (run %{run_test} GH3960.liq liquidsoap %{test_liq} GH3960.liq)))
+
+(rule
+ (alias citest)
+ (package liquidsoap)
+ (deps
   LS268.liq
   ../media/all_media_files
   ../../src/bin/liquidsoap.exe


### PR DESCRIPTION
While cleaning up the request code in #4021, the cause for #3960 became pretty apparent.

This PR should fix the problem by tracking file metadata decoding and preventing a second run when it has already been executed.