### PR TITLE
Generalize function applications

### DIFF
--- a/src/lang/typechecking.ml
+++ b/src/lang/typechecking.ml
@@ -29,8 +29,24 @@ let debug = ref false
 
 (** {1 Type checking / inference} *)
 
-(** Can a function body type be generalized after being applied?
-    This is called after typechecking the function. *)
+(** Can a function return type be generalized after being applied?
+    Current implementation considers it safe to generalize when all
+    universal types in the function return type are specified by a non-optional
+    argument.
+
+    For instance, this can be generalized:
+      [def f() = fun (x) -> x end; fn = f() : fun ('a) -> 'a ]
+    But this cannot:
+      [s = single() : source('A) ]
+    and this cannot either:
+      [def f() = fun (x=null()) -> ref(x) end; fn = f() : (?'A?) -> ref('A) ]
+
+    When all universal types in the return are specified by a non-optional
+    argument, we are assured that anything that would be generalized is later
+    specified when the required argument is passed. If this argument is still
+    of a universal type, then the argument's universal type takes over the
+    type that was generalized. *)
+
 let function_app_value_restriction fn =
   let rec filter_app_vars l t =
     let t = Type.deref t in

--- a/src/lang/typechecking.ml
+++ b/src/lang/typechecking.ml
@@ -76,7 +76,9 @@ let function_app_value_restriction fn =
           in
           List.filter (fun v -> not (List.memq v pl)) l
   in
-  filter_app_vars [] fn.Term.t = []
+  match Type.demeth fn.Term.t with
+    | { Type.descr = Arrow (_, t) } -> filter_app_vars [] t = []
+    | _ -> false
 
 (** Terms for which generalization is safe. *)
 let value_restriction t =

--- a/tests/language/functions.liq
+++ b/tests/language/functions.liq
@@ -41,8 +41,22 @@ def f() =
     fun (_) -> 1
   end
   fn = f()
-  fn(1)
-  fn("bla")
+  ignore(fn(1))
+  ignore(fn("bla"))
+
+  def f() =
+    fun (x) -> {foo=x}
+  end
+  fn = f()
+  test.equal(fn(1), {foo=1})
+  test.equal(fn("aabb"), {foo="aabb"})
+
+  def f() =
+    fun (x) -> {foo=x.gni}
+  end
+  fn = f()
+  test.equal(fn({gni=1}), {foo=1})
+  test.equal(fn({gni="aabb"}), {foo="aabb"})
 
   test.pass()
 end

--- a/tests/language/functions.liq
+++ b/tests/language/functions.liq
@@ -35,6 +35,15 @@ def f() =
   x = replacesg
   let evalf = ()
   x = evalf
+
+  # Function application generalization
+  def f() =
+    fun (_) -> 1
+  end
+  fn = f()
+  fn(1)
+  fn("bla")
+
   test.pass()
 end
 

--- a/tests/language/type_errors.liq
+++ b/tests/language/type_errors.liq
@@ -109,6 +109,12 @@ def f() =
   incorrect(
     'def f(x,y) = y end ignore(f(2))'
   )
+
+  # Invalid type generalization
+  incorrect(
+    'def f(x=null()) = ref(x) end r = f(); r.set(1); r.set("aabb")'
+  )
+
   incorrect('fallback(transitions=[fun(~l)->1],[blank()])')
   incorrect('fallback(transitions=[fun(~l=1)->1],[blank()])')
   incorrect('fallback(transitions=[fun(x,y=blank())->y],[blank()])')

--- a/tests/regression/GH3303.liq
+++ b/tests/regression/GH3303.liq
@@ -1,0 +1,14 @@
+def f() =
+  def a(_, res) =
+    res.json({a=null()})
+  end
+  def b(_, res) =
+    res.json({b=null()})
+  end
+  harbor.http.register(port=3303, "/a", a)
+  harbor.http.register(port=3303, "/b", b)
+
+  test.pass()
+end
+
+test.check(f)

--- a/tests/regression/dune.inc
+++ b/tests/regression/dune.inc
@@ -468,6 +468,21 @@
  (alias citest)
  (package liquidsoap)
  (deps
+  GH3303.liq
+  ../media/all_media_files
+  ../../src/bin/liquidsoap.exe
+  ../streams/file1.png
+  ../streams/file1.mp3
+  (package liquidsoap)
+  (source_tree ../../src/libs)
+  (:test_liq ../test.liq)
+  (:run_test ../run_test.exe))
+ (action (run %{run_test} GH3303.liq liquidsoap %{test_liq} GH3303.liq)))
+
+(rule
+ (alias citest)
+ (package liquidsoap)
+ (deps
   GH3316.liq
   ../media/all_media_files
   ../../src/bin/liquidsoap.exe


### PR DESCRIPTION
This PR improves function application type generalization. This fixes #3303.

In #3303, we discussed several cases where type generalization should and should not be done over a function application.

Here are a couple of examples:

### Source type

```liquidsoap
s = single()
s : source('A)
```

Here, we cannot generalize the universal type of the source because it can be used with operators requiring different type of content, for instance:

```liquidsoap
enc = %ffmpeg(
  format="aac",
  %audio(codec="aac"),
)

# Here, type is source(audio=pcm)
output.file(fallible=true, enc, "/tmp/bla.mkv", s)

# Here type is source(audio=ffmpeg.copy('a))
ignore(ffmpeg.decode.audio(s))
```

### Ref return

```liquidsoap
def f(x=null()) =
  ref(x)
end
f : (?'a?) -> (() -> 'a?).{set : ('a?) -> unit}
```
If we generalize the returned value of this function, we end up with a reference cell to which we can assign values of any type:
```liquidsoap
r = f()
r : (() -> 'a?).{set : ('a?) -> unit} = <fun>.{set=<fun>}
r.set(1)
r.set("aabb")
```

### Pure function return

```liquidsoap
def f() =
  fun (x) -> x
end
f : () -> ('a) -> 'a
``` 
This one is safe to generalize:

```liquidsoap
fn = f()
fn : ('a) -> 'a
```

## The idea

The idea here is that, if a universal type is present in the type of the returned value of the function, we should not generalize. 

However, if this type is actually itself inside a function for which there is a non-optional argument containing it, then it should be safe to generalize.

The reason being that, if we generalize this type, it will be unified with any future application of the function it belongs to therefore making the type generalization safe.

Other examples:

```liquidsoap
# Type generalization with a method:
def f() =
  fun (x) -> { foo = x }
end
fn = f()
fn : ('a) -> {foo : 'a}

def f() =
  fun (x) -> {foo = x.gni }
end
fn : ('b.{gni : 'a}) -> {foo : 'a}

# With a tuple:
def f() =
   def g(x) =
    let (y, _) = x
    y
  end
  g
end
fn : (('a * 'b)) -> 'a
```
Etc.