### PR TITLE
Fix metadata cover cleanup.

### DIFF
--- a/src/core/builtins/builtins_request.ml
+++ b/src/core/builtins/builtins_request.ml
@@ -245,7 +245,6 @@ let _ =
           | `Idle -> "idle"
           | `Resolving _ -> "resolving"
           | `Ready -> "ready"
-          | `Playing _ -> "playing"
           | `Destroyed -> "destroyed"
           | `Failed -> "failed"
       in

--- a/src/core/decoder/aac_decoder.ml
+++ b/src/core/decoder/aac_decoder.ml
@@ -147,7 +147,7 @@ let aac_priority =
 
 (* Get the number of channels of audio in an AAC file. *)
 let file_type ~metadata:_ ~ctype:_ filename =
-  let fd = Unix.openfile filename [Unix.O_RDONLY; Unix.O_CLOEXEC] 0o644 in
+  let fd = Decoder.openfile file in
   Fun.protect
     ~finally:(fun () -> Unix.close fd)
     (fun () ->
@@ -226,7 +226,7 @@ let create_decoder input =
 (* Get the number of channels of audio in an MP4 file. *)
 let file_type ~metadata:_ ~ctype:_ filename =
   let dec = Faad.create () in
-  let fd = Unix.openfile filename [Unix.O_RDONLY; Unix.O_CLOEXEC] 0o644 in
+  let fd = Decoder.openfile file in
   Fun.protect
     ~finally:(fun () -> Unix.close fd)
     (fun () ->
@@ -282,7 +282,7 @@ let get_tags ~metadata:_ ~extension ~mime file =
       (Decoder.test_file ~log ~extension ~mime ~mimes:(Some mp4_mime_types#get)
          ~extensions:(Some mp4_file_extensions#get) file)
   then raise Not_found;
-  let fd = Unix.openfile file [Unix.O_RDONLY; Unix.O_CLOEXEC] 0o644 in
+  let fd = Decoder.openfile file in
   Fun.protect
     ~finally:(fun () -> Unix.close fd)
     (fun () ->

--- a/src/core/decoder/aac_decoder.ml
+++ b/src/core/decoder/aac_decoder.ml
@@ -147,7 +147,7 @@ let aac_priority =
 
 (* Get the number of channels of audio in an AAC file. *)
 let file_type ~metadata:_ ~ctype:_ filename =
-  let fd = Decoder.openfile file in
+  let fd = Decoder.openfile filename in
   Fun.protect
     ~finally:(fun () -> Unix.close fd)
     (fun () ->
@@ -226,7 +226,7 @@ let create_decoder input =
 (* Get the number of channels of audio in an MP4 file. *)
 let file_type ~metadata:_ ~ctype:_ filename =
   let dec = Faad.create () in
-  let fd = Decoder.openfile file in
+  let fd = Decoder.openfile filename in
   Fun.protect
     ~finally:(fun () -> Unix.close fd)
     (fun () ->

--- a/src/core/decoder/decoder.ml
+++ b/src/core/decoder/decoder.ml
@@ -543,11 +543,12 @@ let file_decoder ~filename ~remaining ~ctype decoder =
   let buffer = mk_buffer ~ctype generator in
   mk_decoder ~filename ~remaining ~buffer decoder
 
-let opaque_file_decoder ~filename ~ctype create_decoder =
+let openfile filename =
   let extra_flags = if Sys.win32 then [Unix.O_SHARE_DELETE] else [] in
-  let fd =
-    Unix.openfile filename ([Unix.O_RDONLY; Unix.O_CLOEXEC] @ extra_flags) 0
-  in
+  Unix.openfile filename ([Unix.O_RDONLY; Unix.O_CLOEXEC] @ extra_flags) 0
+
+let opaque_file_decoder ~filename ~ctype create_decoder =
+  let fd = openfile filename in
 
   let file_size = (Unix.stat filename).Unix.st_size in
   let proc_bytes = ref 0 in

--- a/src/core/decoder/decoder.mli
+++ b/src/core/decoder/decoder.mli
@@ -106,6 +106,9 @@ val conf_mime_types : Dtools.Conf.ut
 val conf_file_extensions : Dtools.Conf.ut
 val conf_priorities : Dtools.Conf.ut
 
+(** Open file with readonly, cloxec and share delete on windows. *)
+val openfile : string -> Unix.file_descr
+
 (** Test file extension and mime if available *)
 val test_file :
   log:Log.t ->

--- a/src/core/decoder/decoder.mli
+++ b/src/core/decoder/decoder.mli
@@ -106,7 +106,7 @@ val conf_mime_types : Dtools.Conf.ut
 val conf_file_extensions : Dtools.Conf.ut
 val conf_priorities : Dtools.Conf.ut
 
-(** Open file with readonly, cloxec and share delete on windows. *)
+(** Open file with readonly, cloexec and share delete on windows. *)
 val openfile : string -> Unix.file_descr
 
 (** Test file extension and mime if available *)

--- a/src/core/decoder/liq_flac_decoder.ml
+++ b/src/core/decoder/liq_flac_decoder.ml
@@ -113,7 +113,7 @@ let priority =
  * This is done by decoding a first chunk of data, thus checking
  * that libmad can actually open the file -- which doesn't mean much. *)
 let file_type filename =
-  let fd = Unix.openfile filename [Unix.O_RDONLY; Unix.O_CLOEXEC] 0o640 in
+  let fd = Decoder.openfile filename in
   Fun.protect
     ~finally:(fun () -> Unix.close fd)
     (fun () ->
@@ -156,7 +156,7 @@ let get_tags ~metadata:_ ~extension ~mime file =
       (Decoder.test_file ~log ~extension ~mime ~mimes:(Some mime_types#get)
          ~extensions:(Some file_extensions#get) file)
   then raise Not_found;
-  let fd = Unix.openfile file [Unix.O_RDONLY; Unix.O_CLOEXEC] 0o640 in
+  let fd = Decoder.openfile file in
   Fun.protect
     ~finally:(fun () -> Unix.close fd)
     (fun () ->
@@ -186,7 +186,7 @@ let check filename =
 
 let duration ~metadata:_ file =
   if not (check file) then raise Not_found;
-  let fd = Unix.openfile file [Unix.O_RDONLY; Unix.O_CLOEXEC] 0o640 in
+  let fd = Decoder.openfile file in
   Fun.protect
     ~finally:(fun () -> Unix.close fd)
     (fun () ->

--- a/src/core/request.ml
+++ b/src/core/request.ml
@@ -620,10 +620,10 @@ let resolve t timeout =
 
 let resolve t timeout =
   match t.status with
+    | `Idle -> resolve t timeout
     | `Resolving _ -> raise Invalid_state
     | `Ready -> `Resolved
     | `Destroyed | `Failed -> `Failed
-    | _ -> resolve t timeout
 
 (* Make a few functions more user-friendly, internal stuff is over. *)
 

--- a/src/core/request.ml
+++ b/src/core/request.ml
@@ -467,9 +467,7 @@ let is_playing t =
   add_log t "Currently on air."
 
 let done_playing t =
-  match t.status with
-    | `Playing _ -> t.status <- `Ready
-    | _ -> raise Invalid_state
+  match t.status with `Playing _ -> t.status <- `Ready | _ -> ()
 
 let get_cue ~r = function
   | None -> None

--- a/src/core/request.ml
+++ b/src/core/request.ml
@@ -417,7 +417,8 @@ let destroy ?force t =
             with e -> log#severe "Unlink failed: %S" (Printexc.to_string e)))
         t.indicators;
 
-      t.indicators <- [];
+      (* Keep the first indicator as initial_uri .*)
+      t.indicators <- [List.hd (List.rev t.indicators)];
       t.status <- `Destroyed;
       add_log t "Request destroyed.")
 

--- a/src/core/request.mli
+++ b/src/core/request.mli
@@ -64,13 +64,7 @@ val initial_uri : t -> string
 val destroy : ?force:bool -> t -> unit
 
 (** Status of a request. *)
-type status =
-  [ `Idle
-  | `Resolving of float
-  | `Ready
-  | `Playing of float
-  | `Destroyed
-  | `Failed ]
+type status = [ `Idle | `Resolving of float | `Ready | `Destroyed | `Failed ]
 
 (** Current status of a request. *)
 val status : t -> status
@@ -89,12 +83,6 @@ val all : unit -> t list
 
 (** Retrieve a request from its id. *)
 val from_id : int -> t option
-
-(** Mark the request as playing. *)
-val is_playing : t -> unit
-
-(** Mark the request as done playing. *)
-val done_playing : t -> unit
 
 (** {1 Resolving}
 

--- a/src/core/sources/request_dynamic.ml
+++ b/src/core/sources/request_dynamic.ml
@@ -86,7 +86,6 @@ class dynamic ~retry_delay ~available (f : Lang.value) prefetch timeout =
               | None -> ()
               | Some f -> self#log#info "Finished with %S." f);
             cur.close ();
-            Request.done_playing cur.req;
             Request.destroy cur.req
           end
 
@@ -147,7 +146,6 @@ class dynamic ~retry_delay ~available (f : Lang.value) prefetch timeout =
         | Some cur ->
             let buf = cur.fread len in
             if first_fill then (
-              Request.is_playing cur.req;
               let m = Request.metadata cur.req in
               let buf = Frame.add_metadata buf 0 m in
               let buf = Frame.add_track_mark buf 0 in

--- a/src/core/sources/request_dynamic.ml
+++ b/src/core/sources/request_dynamic.ml
@@ -81,19 +81,14 @@ class dynamic ~retry_delay ~available (f : Lang.value) prefetch timeout =
       remaining <- 0;
       match Atomic.exchange current None with
         | None -> ()
-        | Some cur ->
-            begin
-              match Request.get_filename cur.req with
-                | None ->
-                    self#log#severe
-                      "Finished with a non-existent file?! Something may have \
-                       been moved or destroyed during decoding. It is VERY \
-                       dangerous, avoid it!"
-                | Some f -> self#log#info "Finished with %S." f
-            end;
+        | Some cur -> begin
+            (match Request.get_filename cur.req with
+              | None -> ()
+              | Some f -> self#log#info "Finished with %S." f);
             cur.close ();
             Request.done_playing cur.req;
             Request.destroy cur.req
+          end
 
     method private fetch_request =
       assert (self#current = None);

--- a/src/core/tools/server_builtins.ml
+++ b/src/core/tools/server_builtins.ml
@@ -29,13 +29,6 @@ let () =
       "Liquidsoap " ^ Configure.version);
   add "request.all" ~descr:"Get the identifiers of all existing requests."
     (fun _ -> ids (Request.all ()));
-  add "request.on_air" ~descr:"Get the identifiers of requests that are on air."
-    (fun _ ->
-      ids
-        (List.filter
-           (fun r ->
-             match Request.status r with `Playing _ -> true | _ -> false)
-           (Request.all ())));
   add "request.resolving"
     ~descr:"Get the identifiers of requests that are being prepared." (fun _ ->
       ids

--- a/src/lang/term/term_reducer.ml
+++ b/src/lang/term/term_reducer.ml
@@ -21,7 +21,6 @@
  *****************************************************************************)
 
 type processor = Term_preprocessor.processor
-type env = (string * Runtime_term.t) list
 
 open Parsed_term
 include Runtime_term
@@ -559,9 +558,7 @@ let args_of ~only ~except ~pos ~env name =
                        n))
           except;
         List.filter (fun { label } -> not (List.mem label except)) filtered_args
-    | Some tm ->
-        Printf.printf "Term: %s\n%!" (Term_base.to_string tm);
-        parse_error ~pos (Printf.sprintf "%s is not a function!" name)
+    | Some _ -> parse_error ~pos (Printf.sprintf "%s is not a function!" name)
     | None -> builtin_args_of ~only ~except ~pos name
 
 let expand_argsof ~pos ~env ~to_term args =
@@ -577,7 +574,7 @@ let expand_argsof ~pos ~env ~to_term args =
                  (match arg.typ with
                    | None -> mk_var ()
                    | Some typ -> Parser_helper.mk_ty typ);
-               default = Option.map to_term arg.default;
+               default = Option.map (to_term ~env) arg.default;
              }
              :: args)
        [] args)
@@ -592,7 +589,7 @@ let expand_appof ~pos ~env ~to_term args =
        (fun args -> function
          | `Argsof { only; except; source } ->
              List.rev (app_of ~pos ~only ~except ~env source) @ args
-         | `Term (l, v) -> (l, to_term v) :: args)
+         | `Term (l, v) -> (l, to_term ~env v) :: args)
        [] args)
 
 (** When doing chained calls, we want to update all nested defaults so that, e.g.
@@ -670,8 +667,8 @@ and update_invoke_default ~pos ~optional expr name value =
     | _ -> expr
 
 let mk_invoke ?(default : Parsed_term.t option) ~pos ~env ~to_term expr v =
-  let expr = to_term expr in
-  let default = Option.map to_term default in
+  let expr = to_term ~env expr in
+  let default = Option.map (to_term ~env) default in
   let optional, value =
     match default with Some v -> (true, v) | None -> (false, mk ~pos `Null)
   in
@@ -710,36 +707,38 @@ let mk_coalesce ~pos ~(default : Parsed_term.t) ~env ~to_term
             (`Invoke
               { invoked = null; invoke_default = None; meth = "default" })
         in
-        let handler = mk_fun ~pos [] (to_term default) in
-        `App (op, [("", to_term computed); ("", handler)])
+        let handler = mk_fun ~pos [] (to_term ~env default) in
+        `App (op, [("", to_term ~env computed); ("", handler)])
 
-let get_reducer ~pos ~to_term = function
+let get_reducer ~pos ~env ~to_term = function
   | `Get tm ->
       Printf.eprintf
         "Warning, %s: the notation !x for references is deprecated, please use \
          x() instead.\n\
          %!"
         Pos.(to_string (of_lexing_pos pos));
-      `App (to_term tm, [])
+      `App (to_term ~env tm, [])
 
-let set_reducer ~pos ~to_term = function
+let set_reducer ~pos ~env ~to_term = function
   | `Set (tm, v) ->
       let op =
         mk ~pos
           (`Invoke
-            { invoked = to_term tm; invoke_default = None; meth = "set" })
+            { invoked = to_term ~env tm; invoke_default = None; meth = "set" })
       in
       `Cast
         {
-          cast = mk ~pos (`App (op, [("", to_term v)]));
+          cast = mk ~pos (`App (op, [("", to_term ~env v)]));
           typ = mk_ty ~pos Type.unit;
         }
 
-let if_reducer ~pos ~to_term = function
+let if_reducer ~pos ~env ~to_term = function
   | `Inline_if { if_condition; if_then; if_elsif; if_else }
   | `If { if_condition; if_then; if_elsif; if_else } ->
       let if_else =
-        match if_else with None -> mk ~pos (`Tuple []) | Some t -> to_term t
+        match if_else with
+          | None -> mk ~pos (`Tuple [])
+          | Some t -> to_term ~env t
       in
       let term =
         List.fold_left
@@ -749,8 +748,8 @@ let if_reducer ~pos ~to_term = function
               (`App
                 ( op,
                   [
-                    ("", to_term condition);
-                    ("then", mk_fun ~pos [] (to_term _then));
+                    ("", to_term ~env condition);
+                    ("then", mk_fun ~pos [] (to_term ~env _then));
                     ("else", mk_fun ~pos [] if_else);
                   ] )))
           if_else
@@ -758,11 +757,11 @@ let if_reducer ~pos ~to_term = function
       in
       term.term
 
-let while_reducer ~pos ~to_term = function
+let while_reducer ~pos ~env ~to_term = function
   | `While { while_condition; while_loop } ->
       let op = mk ~pos (`Var "while") in
-      let while_condition = mk_fun ~pos [] (to_term while_condition) in
-      let while_loop = mk_fun ~pos [] (to_term while_loop) in
+      let while_condition = mk_fun ~pos [] (to_term ~env while_condition) in
+      let while_loop = mk_fun ~pos [] (to_term ~env while_loop) in
       `App (op, [("", while_condition); ("", while_loop)])
 
 let base_for_reducer ~pos for_variable for_iterator for_loop =
@@ -781,14 +780,14 @@ let base_for_reducer ~pos for_variable for_iterator for_loop =
   in
   `App (for_op, [("", for_iterator); ("", for_loop)])
 
-let iterable_for_reducer ~pos ~to_term = function
+let iterable_for_reducer ~pos ~env ~to_term = function
   | `Iterable_for
       { iterable_for_variable; iterable_for_iterator; iterable_for_loop } ->
       base_for_reducer ~pos iterable_for_variable
-        (to_term iterable_for_iterator)
-        (to_term iterable_for_loop)
+        (to_term ~env iterable_for_iterator)
+        (to_term ~env iterable_for_loop)
 
-let for_reducer ~pos ~to_term = function
+let for_reducer ~pos ~env ~to_term = function
   | `For { for_variable; for_from; for_to; for_loop } ->
       let to_op = mk ~pos (`Var "iterator") in
       let to_op =
@@ -796,70 +795,78 @@ let for_reducer ~pos ~to_term = function
           (`Invoke { invoked = to_op; invoke_default = None; meth = "int" })
       in
       let for_condition =
-        mk ~pos (`App (to_op, [("", to_term for_from); ("", to_term for_to)]))
+        mk ~pos
+          (`App
+            (to_op, [("", to_term ~env for_from); ("", to_term ~env for_to)]))
       in
-      base_for_reducer ~pos for_variable for_condition (to_term for_loop)
+      base_for_reducer ~pos for_variable for_condition (to_term ~env for_loop)
 
-let infix_reducer ~pos ~to_term = function
+let infix_reducer ~pos ~env ~to_term = function
   | `Infix (tm, op, tm') ->
       let op = mk ~pos (`Var op) in
-      `App (op, [("", to_term tm); ("", to_term tm')])
+      `App (op, [("", to_term ~env tm); ("", to_term ~env tm')])
 
-let bool_op_reducer ~pos ~to_term = function
+let bool_op_reducer ~pos ~env ~to_term = function
   | `BoolOp (op, tm :: terms) ->
       List.fold_left
         (fun tm tm' ->
           let op = mk ~pos (`Var op) in
           let tm = mk_fun ~pos [] (mk ~pos tm) in
-          let tm' = mk_fun ~pos [] (to_term tm') in
+          let tm' = mk_fun ~pos [] (to_term ~env tm') in
           `App (op, [("", tm); ("", tm')]))
-        (to_term tm).term terms
+        (to_term ~env tm).term terms
   | `BoolOp (_, []) -> assert false
 
-let simple_fun_reducer ~pos:_ ~to_term = function
+let simple_fun_reducer ~pos:_ ~env ~to_term = function
   | `Simple_fun tm ->
-      `Fun { name = None; arguments = []; body = to_term tm; free_vars = None }
+      `Fun
+        {
+          name = None;
+          arguments = [];
+          body = to_term ~env tm;
+          free_vars = None;
+        }
 
-let negative_reducer ~pos ~to_term = function
+let negative_reducer ~pos ~env ~to_term = function
   | `Negative tm ->
       let op = mk ~pos (`Var "~-") in
-      `App (op, [("", to_term tm)])
+      `App (op, [("", to_term ~env tm)])
 
-let not_reducer ~pos ~to_term = function
+let not_reducer ~pos ~env ~to_term = function
   | `Not tm ->
       let op = mk ~pos (`Var "not") in
-      `App (op, [("", to_term tm)])
+      `App (op, [("", to_term ~env tm)])
 
 let append_term ~pos a b =
   let op = mk ~pos (`Var "_::_") in
   `App (op, [("", a); ("", b)])
 
-let append_reducer ~pos ~to_term = function
-  | `Append (tm, tm') -> append_term ~pos (to_term tm) (to_term tm')
+let append_reducer ~pos ~env ~to_term = function
+  | `Append (tm, tm') -> append_term ~pos (to_term ~env tm) (to_term ~env tm')
 
-let rec list_reducer ~pos ?(cur = `List []) ~to_term l =
+let rec list_reducer ~pos ?(cur = `List []) ~env ~to_term l =
   match (l, cur) with
     | [], cur -> cur
     | `Term v :: rem, `List cur ->
-        list_reducer ~cur:(`List (to_term v :: cur)) ~pos ~to_term rem
+        list_reducer ~cur:(`List (to_term ~env v :: cur)) ~pos ~env ~to_term rem
     | `Term v :: rem, cur ->
-        let cur = append_term ~pos (to_term v) (mk ~pos cur) in
-        list_reducer ~pos ~cur ~to_term rem
+        let cur = append_term ~pos (to_term ~env v) (mk ~pos cur) in
+        list_reducer ~pos ~cur ~env ~to_term rem
     | `Ellipsis v :: rem, cur ->
         let list = mk ~pos (`Var "list") in
         let op =
           mk ~pos
             (`Invoke { invoked = list; invoke_default = None; meth = "append" })
         in
-        let cur = `App (op, [("", to_term v); ("", mk ~pos cur)]) in
-        list_reducer ~pos ~cur ~to_term rem
+        let cur = `App (op, [("", to_term ~env v); ("", mk ~pos cur)]) in
+        list_reducer ~pos ~cur ~env ~to_term rem
 
-let assoc_reducer ~pos ~to_term = function
+let assoc_reducer ~pos ~env ~to_term = function
   | `Assoc (tm, tm') ->
       let op = mk ~pos (`Var "_[_]") in
-      `App (op, [("", to_term tm); ("", to_term tm')])
+      `App (op, [("", to_term ~env tm); ("", to_term ~env tm')])
 
-let regexp_reducer ~pos ~to_term:_ = function
+let regexp_reducer ~pos ~env:_ ~to_term:_ = function
   | `Regexp (regexp, flags) ->
       let regexp = render_string ~pos ~sep:'/' regexp in
       let regexp = mk ~pos (`String regexp) in
@@ -869,10 +876,10 @@ let regexp_reducer ~pos ~to_term:_ = function
       let op = mk ~pos (`Var "regexp") in
       `App (op, [("", regexp); ("flags", flags)])
 
-let try_reducer ~pos ~to_term = function
+let try_reducer ~pos ~env ~to_term = function
   | `Try { try_body; try_variable; try_errors_list; try_handler; try_finally }
     ->
-      let try_body = mk_fun ~pos [] (to_term try_body) in
+      let try_body = mk_fun ~pos [] (to_term ~env try_body) in
       let err_arg =
         [
           {
@@ -886,20 +893,20 @@ let try_reducer ~pos ~to_term = function
       let finally_pos, finally =
         match try_finally with
           | None -> (pos, mk ~pos (`Tuple []))
-          | Some tm -> (tm.pos, to_term tm)
+          | Some tm -> (tm.pos, to_term ~env tm)
       in
       let finally = mk_fun ~pos:finally_pos [] finally in
       let handler_pos, handler =
         match try_handler with
           | None -> (pos, mk ~pos (`Tuple []))
-          | Some tm -> (tm.pos, to_term tm)
+          | Some tm -> (tm.pos, to_term ~env tm)
       in
       let handler = mk_fun ~pos:handler_pos err_arg handler in
       let error_module = mk ~pos (`Var "error") in
       let try_errors_list =
         match try_errors_list with
           | None -> mk ~pos `Null
-          | Some tm -> to_term tm
+          | Some tm -> to_term ~env tm
       in
       let op =
         mk ~pos
@@ -1014,8 +1021,7 @@ let string_of_let_decoration = function
   | `Yaml_parse -> "yaml.parse"
   | `Json_parse _ -> "json.parse"
 
-let mk_let ~env ~pos ~(to_term : env:env -> Parsed_term.t -> Runtime_term.t)
-    ({ decoration; pat; arglist; def; cast }, body) =
+let mk_let ~env ~pos ~to_term ({ decoration; pat; arglist; def; cast }, body) =
   let def = to_term ~env def in
   let mk_body def =
     let env =
@@ -1025,7 +1031,8 @@ let mk_let ~env ~pos ~(to_term : env:env -> Parsed_term.t -> Runtime_term.t)
             let env =
               if decoration <> `Replaces then
                 List.filter
-                  (fun (p, _) -> not (String.starts_with ~prefix:path p))
+                  (fun (p, _) ->
+                    not (String.starts_with ~prefix:(path ^ ".") p))
                   env
               else env
             in
@@ -1034,7 +1041,6 @@ let mk_let ~env ~pos ~(to_term : env:env -> Parsed_term.t -> Runtime_term.t)
     in
     to_term ~env body
   in
-  let to_term = to_term ~env in
   let cast = Option.map (Parser_helper.mk_ty ~pos) cast in
   let arglist = Option.map (expand_argsof ~pos ~env ~to_term) arglist in
   match (arglist, decoration) with
@@ -1070,7 +1076,7 @@ let mk_let ~env ~pos ~(to_term : env:env -> Parsed_term.t -> Runtime_term.t)
         let body = mk_body def in
         mk_eval ~pos (pat, def, body, cast)
     | None, `Json_parse args ->
-        let args = List.map (fun (l, v) -> (l, to_term v)) args in
+        let args = List.map (fun (l, v) -> (l, to_term ~env v)) args in
         let body = mk_body def in
         mk_let_json_parse ~pos (args, pat, def, cast) body
     | None, `Yaml_parse ->
@@ -1106,29 +1112,27 @@ and to_encoder ~env ~to_term (lbl, params) =
   (lbl, to_encoder_params ~env ~to_term params)
 
 let rec to_ast ~env ~pos ast =
-  let to_term_with_env = to_term in
-  let to_term = to_term ~env in
   match ast with
     | `Methods _ | `Block _ | `Parenthesis _ | `Eof | `Include _ -> assert false
     | (`If_def _ as ast) | (`If_encoder _ as ast) | (`If_version _ as ast) ->
-        (to_term (pp_if_reducer ~pos ~env ast)).term
-    | `Get _ as ast -> get_reducer ~pos ~to_term ast
-    | `Set _ as ast -> set_reducer ~pos ~to_term ast
-    | `Inline_if _ as ast -> if_reducer ~pos ~to_term ast
-    | `If _ as ast -> if_reducer ~pos ~to_term ast
-    | `While _ as ast -> while_reducer ~pos ~to_term ast
-    | `For _ as ast -> for_reducer ~pos ~to_term ast
-    | `Iterable_for _ as ast -> iterable_for_reducer ~pos ~to_term ast
-    | `Not _ as ast -> not_reducer ~pos ~to_term ast
-    | `Negative _ as ast -> negative_reducer ~pos ~to_term ast
-    | `Append _ as ast -> append_reducer ~pos ~to_term ast
-    | `Assoc _ as ast -> assoc_reducer ~pos ~to_term ast
-    | `Infix _ as ast -> infix_reducer ~pos ~to_term ast
+        (to_term ~env (pp_if_reducer ~pos ~env ast)).term
+    | `Get _ as ast -> get_reducer ~pos ~env ~to_term ast
+    | `Set _ as ast -> set_reducer ~pos ~env ~to_term ast
+    | `Inline_if _ as ast -> if_reducer ~pos ~env ~to_term ast
+    | `If _ as ast -> if_reducer ~pos ~env ~to_term ast
+    | `While _ as ast -> while_reducer ~pos ~env ~to_term ast
+    | `For _ as ast -> for_reducer ~pos ~env ~to_term ast
+    | `Iterable_for _ as ast -> iterable_for_reducer ~pos ~env ~to_term ast
+    | `Not _ as ast -> not_reducer ~pos ~env ~to_term ast
+    | `Negative _ as ast -> negative_reducer ~pos ~env ~to_term ast
+    | `Append _ as ast -> append_reducer ~pos ~env ~to_term ast
+    | `Assoc _ as ast -> assoc_reducer ~pos ~env ~to_term ast
+    | `Infix _ as ast -> infix_reducer ~pos ~env ~to_term ast
     | `Bool _ as ast -> ast
-    | `BoolOp _ as ast -> bool_op_reducer ~pos ~to_term ast
-    | `Simple_fun _ as ast -> simple_fun_reducer ~pos ~to_term ast
-    | `Regexp _ as ast -> regexp_reducer ~pos ~to_term ast
-    | `Try _ as ast -> try_reducer ~pos ~to_term ast
+    | `BoolOp _ as ast -> bool_op_reducer ~pos ~env ~to_term ast
+    | `Simple_fun _ as ast -> simple_fun_reducer ~pos ~env ~to_term ast
+    | `Regexp _ as ast -> regexp_reducer ~pos ~env ~to_term ast
+    | `Try _ as ast -> try_reducer ~pos ~env ~to_term ast
     | `String_interpolation (sep, l) ->
         let l =
           List.map
@@ -1150,16 +1154,15 @@ let rec to_ast ~env ~pos ast =
               })
         in
         to_ast ~env ~pos (`App (op, [`Term ("", mk_parsed ~pos (`List l))]))
-    | `Def p | `Let p | `Binding p ->
-        mk_let ~pos ~env ~to_term:to_term_with_env p
+    | `Def p | `Let p | `Binding p -> mk_let ~pos ~env ~to_term p
     | `Coalesce (t, default) -> mk_coalesce ~pos ~env ~to_term ~default t
-    | `At (t, t') -> `App (to_term t', [("", to_term t)])
+    | `At (t, t') -> `App (to_term ~env t', [("", to_term ~env t)])
     | `Time t -> mk_time_pred ~pos (during ~pos t)
     | `Time_interval (t, t') -> mk_time_pred ~pos (between ~pos t t')
     | `Custom _ as ast -> ast
-    | `Encoder e -> `Encoder (to_encoder ~to_term:to_term_with_env ~env e)
-    | `List l -> list_reducer ~pos ~to_term (List.rev l)
-    | `Tuple l -> `Tuple (List.map to_term l)
+    | `Encoder e -> `Encoder (to_encoder ~to_term ~env e)
+    | `List l -> list_reducer ~pos ~env ~to_term (List.rev l)
+    | `Tuple l -> `Tuple (List.map (to_term ~env) l)
     | `String (sep, s) -> `String (render_string ~pos ~sep s)
     | `Int i -> `Int (int_of_string i)
     | `Float f -> (
@@ -1168,16 +1171,16 @@ let rec to_ast ~env ~pos ast =
           parse_error ~pos (Printf.sprintf "Invalid float value: %s" f))
     | `Null -> `Null
     | `Cast { cast = t; typ } ->
-        `Cast { cast = to_term t; typ = Parser_helper.mk_ty ~pos typ }
+        `Cast { cast = to_term ~env t; typ = Parser_helper.mk_ty ~pos typ }
     | `Invoke { invoked; optional; meth } ->
         let default = if optional then Some (mk_parsed ~pos `Null) else None in
         mk_invoke ~pos ~env ?default ~to_term invoked meth
-    | `Open (t, t') -> `Open (to_term t, to_term t')
+    | `Open (t, t') -> `Open (to_term ~env t, to_term ~env t')
     | `Var s -> `Var s
-    | `Seq (t, t') -> `Seq (to_term t, to_term t')
+    | `Seq (t, t') -> `Seq (to_term ~env t, to_term ~env t')
     | `App (t, args) ->
         let args = expand_appof ~pos ~env ~to_term args in
-        `App (to_term t, args)
+        `App (to_term ~env t, args)
     | `Fun (args, body) -> `Fun (to_func ~pos ~env ~to_term args body)
     | `RFun (name, args, body) ->
         `Fun (to_func ~pos ~env ~to_term ~name args body)
@@ -1186,7 +1189,7 @@ and to_func ~pos ~env ~to_term ?name arguments body =
   {
     name;
     arguments = expand_argsof ~pos ~env ~to_term arguments;
-    body = to_term body;
+    body = to_term ~env body;
     free_vars = None;
   }
 

--- a/src/libs/extra/metadata.liq
+++ b/src/libs/extra/metadata.liq
@@ -23,23 +23,6 @@ def file.cover.manager(
 
   current_cover_request = ref(default)
 
-  def save_cover_to_file(cover) =
-    mime = cover.mime
-    extension = mime_types[mime]
-
-    cover_file =
-      if
-        extension != ""
-      then
-        cover_file = file.temp("#{id}_", ".#{extension}")
-        file.write(cover_file, data=cover)
-        cover_file
-      else
-        null()
-      end
-    (cover_file, mime)
-  end
-
   def extract_cover_from_metadata(_metadata) =
     filename = _metadata["filename"]
     log.info(
@@ -47,39 +30,41 @@ def file.cover.manager(
       "Extracting cover from #{string.quote(filename)}."
     )
     cover = metadata.cover(_metadata)
-    let (cover_file, mime) =
-      null.case(cover, {(null(), "")}, save_cover_to_file)
 
-    next_cover =
+    new_cover =
       if
-        cover == null()
+        not null.defined(cover)
       then
-        log.important(
-          label=id,
-          "File #{string.quote(filename)} has no cover."
-        )
-        default
-      elsif
-        cover_file == null()
-      then
-        log.important(
-          label=id,
-          "File #{string.quote(filename)} has unknown mime type #{
-            string.quote(mime)
-          }."
-        )
-        default
+        null()
       else
-        cover_file = null.get(cover_file)
-        log.important(
-          label=id,
-          "Cover for #{string.quote(filename)} saved to #{
-            string.quote(cover_file)
-          }."
-        )
-        request.create(temporary=true, cover_file)
+        cover = null.get(cover)
+        extension = mime_types[cover.mime]
+        if
+          extension == ""
+        then
+          log.important(
+            label=id,
+            "File #{string.quote(filename)} has unknown mime type #{
+              string.quote(cover.mime)
+            }."
+          )
+          null()
+        else
+          cover_file = file.temp("#{id}_", ".#{extension}")
+          file.write(cover_file, data=cover)
+
+          log.important(
+            label=id,
+            "Cover for #{string.quote(filename)} saved to #{
+              string.quote(cover_file)
+            }."
+          )
+
+          request.create(temporary=true, cover_file)
+        end
       end
-    current_cover_request := next_cover
+
+    current_cover_request := (new_cover ?? default)
   end
 
   current_cover_request.{set=extract_cover_from_metadata}

--- a/src/libs/extra/metadata.liq
+++ b/src/libs/extra/metadata.liq
@@ -35,6 +35,10 @@ def file.cover.manager(
       if
         not null.defined(cover)
       then
+        log.important(
+          label=id,
+          "File #{string.quote(filename)} has no cover."
+        )
         null()
       else
         cover = null.get(cover)

--- a/src/libs/extra/metadata.liq
+++ b/src/libs/extra/metadata.liq
@@ -21,23 +21,9 @@ def file.cover.manager(
   id = string.id.default(id, default="cover")
   temp_dir = file.temp_dir("cover-manager")
   on_cleanup({file.rmdir(temp_dir)})
+  default = request.create(persistent=true, default)
 
-  current_cover_file = ref(default)
-
-  def set_current_cover(filename) =
-    last_cover = current_cover_file()
-    current_cover_file := filename
-
-    if
-      last_cover != default
-    then
-      log.info(
-        label=id,
-        "Removing #{string.quote(last_cover)}"
-      )
-      file.remove(last_cover)
-    end
-  end
+  current_cover_request = ref(default)
 
   def save_cover_to_file(cover) =
     mime = cover.mime
@@ -93,10 +79,10 @@ def file.cover.manager(
             string.quote(cover_file)
           }."
         )
-        cover_file
+        request.create(temporary=true, cover_file)
       end
-    set_current_cover(next_cover)
+    current_cover_request := next_cover
   end
 
-  current_cover_file.{set=extract_cover_from_metadata}
+  current_cover_request.{set=extract_cover_from_metadata}
 end

--- a/src/libs/extra/metadata.liq
+++ b/src/libs/extra/metadata.liq
@@ -19,8 +19,6 @@ def file.cover.manager(
   ~default
 ) =
   id = string.id.default(id, default="cover")
-  temp_dir = file.temp_dir("cover-manager")
-  on_cleanup({file.rmdir(temp_dir)})
   default = request.create(persistent=true, default)
 
   current_cover_request = ref(default)
@@ -33,7 +31,7 @@ def file.cover.manager(
       if
         extension != ""
       then
-        cover_file = file.temp(directory=temp_dir, "#{id}_", ".#{extension}")
+        cover_file = file.temp("#{id}_", ".#{extension}")
         file.write(cover_file, data=cover)
         cover_file
       else

--- a/src/libs/extra/video.liq
+++ b/src/libs/extra/video.liq
@@ -27,7 +27,13 @@ def video.add_cover(
 ) =
   cover_file = file.cover.manager(mime_types=mime_types, default=default)
   s = source.on_metadata(s, cover_file.set)
-  video.add_image(
-    fallible=fallible, x=x, y=y, width=width, height=height, file=cover_file, s
+  video.add_request(
+    fallible=fallible,
+    x=x,
+    y=y,
+    width=width,
+    height=height,
+    request=cover_file,
+    s
   )
 end

--- a/src/libs/request.liq
+++ b/src/libs/request.liq
@@ -253,11 +253,24 @@ def request.single(
   ~id=null("request.single"),
   ~prefetch=null(),
   ~timeout=20.,
-  ~fallible=false,
+  ~fallible=null(),
   r
 ) =
   id = string.id.default(default="single", id)
-  uri = request.uri(r)
+
+  fallible = fallible ?? getter.is_constant(r)
+
+  if
+    not fallible and not getter.is_constant(r)
+  then
+    error.raise(
+      error.invalid,
+      "Infallible sources cannot change their underlying file."
+    )
+  end
+
+  initial_request = getter.get(r)
+  uri = request.uri(initial_request)
   infallible = request.is_static(uri) and not fallible
 
   static_request = ref(null())
@@ -272,15 +285,15 @@ def request.single(
         "#{uri} is static, resolving once for all..."
       )
       if
-        not request.resolve(r, timeout=timeout)
+        not request.resolve(initial_request, timeout=timeout)
       then
-        request.destroy(force=true, r)
+        request.destroy(force=true, initial_request)
         error.raise(
           error.invalid,
           "Could not resolve uri: #{uri}"
         )
       else
-        static_request := r
+        static_request := initial_request
       end
     end
   end
@@ -303,7 +316,7 @@ def request.single(
       done := true
 
       def next() =
-        r
+        static_request() ?? getter.get(r)
       end
 
       s = request.dynamic(prefetch=prefetch, next)
@@ -329,19 +342,34 @@ end
 # @param ~cue_out_metadata Metadata for cue out points. Disabled if `null`.
 # @param uri URI where to find the file
 def single(
-  %argsof(request.single[!id]),
+  %argsof(request.single[!id,!fallible]),
   ~id=null("single"),
+  ~fallible=false,
   ~cue_in_metadata=null("liq_cue_in"),
   ~cue_out_metadata=null("liq_cue_out"),
   uri
 ) =
   r =
-    request.create(
-      persistent=true,
-      cue_in_metadata=cue_in_metadata,
-      cue_out_metadata=cue_out_metadata,
-      uri
-    )
+    if
+      fallible
+    then
+      getter(
+        {
+          request.create(
+            cue_in_metadata=cue_in_metadata,
+            cue_out_metadata=cue_out_metadata,
+            uri
+          )
+        }
+      )
+    else
+      request.create(
+        persistent=true,
+        cue_in_metadata=cue_in_metadata,
+        cue_out_metadata=cue_out_metadata,
+        uri
+      )
+    end
 
   request.single(%argsof(request.single), r)
 end

--- a/src/libs/request.liq
+++ b/src/libs/request.liq
@@ -248,19 +248,16 @@ end
 # @param ~prefetch How many requests should be queued in advance.
 # @param ~timeout Timeout (in sec.) for a single download.
 # @param ~fallible Enforce fallibility of the request.
-# @param ~cue_in_metadata Metadata for cue in points. Disabled if `null`.
-# @param ~cue_out_metadata Metadata for cue out points. Disabled if `null`.
-# @param uri URI where to find the file
-def single(
-  ~id=null("single"),
+# @param r Request
+def request.single(
+  ~id=null("request.single"),
   ~prefetch=null(),
   ~timeout=20.,
   ~fallible=false,
-  ~cue_in_metadata=null("liq_cue_in"),
-  ~cue_out_metadata=null("liq_cue_out"),
-  uri
+  r
 ) =
   id = string.id.default(default="single", id)
+  uri = request.uri(r)
   infallible = request.is_static(uri) and not fallible
 
   static_request = ref(null())
@@ -274,13 +271,6 @@ def single(
         label=id,
         "#{uri} is static, resolving once for all..."
       )
-      r =
-        request.create(
-          persistent=true,
-          cue_in_metadata=cue_in_metadata,
-          cue_out_metadata=cue_out_metadata,
-          uri
-        )
       if
         not request.resolve(r, timeout=timeout)
       then
@@ -313,13 +303,7 @@ def single(
       done := true
 
       def next() =
-        static_request()
-          ??
-            request.create(
-              cue_in_metadata=cue_in_metadata,
-              cue_out_metadata=cue_out_metadata,
-              uri
-            )
+        r
       end
 
       s = request.dynamic(prefetch=prefetch, next)
@@ -335,6 +319,31 @@ def single(
   s.on_wake_up(on_wake_up)
   s.on_shutdown(on_shutdown)
   (s : source_methods)
+end
+
+# Loop on a URI. It never fails if the request is static, meaning
+# that it can be fetched once. Typically, http, ftp, say requests are
+# static, and time is not.
+# @argsof request.single
+# @param ~cue_in_metadata Metadata for cue in points. Disabled if `null`.
+# @param ~cue_out_metadata Metadata for cue out points. Disabled if `null`.
+# @param uri URI where to find the file
+def single(
+  %argsof(request.single[!id]),
+  ~id=null("single"),
+  ~cue_in_metadata=null("liq_cue_in"),
+  ~cue_out_metadata=null("liq_cue_out"),
+  uri
+) =
+  r =
+    request.create(
+      persistent=true,
+      cue_in_metadata=cue_in_metadata,
+      cue_out_metadata=cue_out_metadata,
+      uri
+    )
+
+  request.single(%argsof(request.single), r)
 end
 
 # Create a source on which plays immediately requests given with the `play`

--- a/src/libs/request.liq
+++ b/src/libs/request.liq
@@ -297,7 +297,7 @@ def request.single(
       if
         not request.resolve(initial_request, timeout=timeout)
       then
-        request.destroy(force=true, initial_request)
+        request.destroy(initial_request)
         error.raise(
           error.invalid,
           "Could not resolve uri: #{uri}"
@@ -312,7 +312,7 @@ def request.single(
     if
       null.defined(static_request())
     then
-      request.destroy(force=true, null.get(static_request()))
+      request.destroy(null.get(static_request()))
     end
     static_request := null()
   end

--- a/src/libs/request.liq
+++ b/src/libs/request.liq
@@ -260,18 +260,25 @@ def request.single(
 
   fallible = fallible ?? getter.is_constant(r)
 
-  if
-    not fallible and not getter.is_constant(r)
-  then
-    error.raise(
-      error.invalid,
-      "Infallible sources cannot change their underlying file."
-    )
-  end
+  infallible =
+    if
+      not fallible
+    then
+      if
+        not getter.is_constant(r)
+      then
+        error.raise(
+          error.invalid,
+          "Infallible sources cannot change their underlying file."
+        )
+      end
 
-  initial_request = getter.get(r)
-  uri = request.uri(initial_request)
-  infallible = request.is_static(uri) and not fallible
+      initial_request = getter.get(r)
+      uri = request.uri(initial_request)
+      request.is_static(uri)
+    else
+      false
+    end
 
   static_request = ref(null())
   done = ref(false)
@@ -280,6 +287,9 @@ def request.single(
     if
       infallible
     then
+      initial_request = getter.get(r)
+      uri = request.uri(initial_request)
+
       log.important(
         label=id,
         "#{uri} is static, resolving once for all..."
@@ -337,7 +347,10 @@ end
 # Loop on a URI. It never fails if the request is static, meaning
 # that it can be fetched once. Typically, http, ftp, say requests are
 # static, and time is not.
-# @argsof request.single
+# @category Source / Input
+# @param ~prefetch How many requests should be queued in advance.
+# @param ~timeout Timeout (in sec.) for a single download.
+# @param ~fallible Enforce fallibility of the request.
 # @param ~cue_in_metadata Metadata for cue in points. Disabled if `null`.
 # @param ~cue_out_metadata Metadata for cue out points. Disabled if `null`.
 # @param uri URI where to find the file

--- a/src/libs/video.liq
+++ b/src/libs/video.liq
@@ -16,7 +16,7 @@ def video.frame.rate =
   settings.frame.video.framerate
 end
 
-# Generate a source from a static image.
+# Generate a source from an image request.
 # @category Source / Video processing
 # @param ~id Force the value of the source ID.
 # @param ~fallible Whether we are allowed to fail (in case the file is non-existent or invalid).
@@ -24,45 +24,86 @@ end
 # @param ~height Scale to height
 # @param ~x x position.
 # @param ~y y position.
-# @param file Path to the image.
-# @method set Change the image.
-def image(
+# @param req Image request
+# @method set Change the request.
+def request.image(
   ~id=null(),
   ~fallible=false,
   ~width=null(),
   ~height=null(),
   ~x=getter(0),
   ~y=getter(0),
-  file
+  req
 ) =
   s = source.dynamic()
 
-  def set(file) =
-    image = single(id=id, fallible=fallible, file)
+  def set(req) =
+    image = request.single(id=id, fallible=fallible, req)
     image = video.crop(image)
     image = video.resize(id=id, x=x, y=y, width=width, height=height, image)
     s.set(image)
   end
 
-  current_file = ref(getter.get(file))
-  s.on_wake_up({set(current_file())})
+  current_req = ref(getter.get(req))
+  s.on_wake_up({set(current_req())})
 
   s =
     source.on_frame(
       s,
       fun () ->
         begin
-          new_file = getter.get(file)
+          new_req = getter.get(req)
           if
-            new_file != current_file()
+            new_req != current_req()
           then
-            set(new_file)
-            current_file.set(new_file)
+            set(new_req)
+            current_req.set(new_req)
           end
         end
     )
 
   s.{set=set}
+end
+
+# Generate a source from an image file.
+# @argsof request.image
+# @param file Path to the image.
+# @method set Change the request.
+def image(%argsof(request.image), file) =
+  r = getter.map(fun (file) -> request.create(file), file)
+
+  s = request.image(%argsof(request.image), r)
+
+  s.{set=fun (uri) -> s.set(request.create(uri))}
+end
+
+# @flag hidden
+let orig_request = request
+
+# Add a static request on the given video track.
+# @category Track / Video processing
+# @param ~id Force the value of the source ID.
+# @param ~fallible Whether we are allowed to fail (in case the file is non-existent or invalid).
+# @param ~width Scale to width
+# @param ~height Scale to height
+# @param ~x x position.
+# @param ~y y position.
+# @param ~request Request to add to the video track
+def track.video.add_request(
+  ~id=null("track.video.add_request"),
+  ~fallible=false,
+  ~width=null(),
+  ~height=null(),
+  ~x=getter(0),
+  ~y=getter(0),
+  ~request,
+  v
+) =
+  image =
+    orig_request.image(id=id, fallible=fallible, x=x, y=y, width=width, height=height, request)
+
+  let {video = image} = source.tracks(image)
+  track.video.add([v, image])
 end
 
 # Add a static image on the given video track.
@@ -89,6 +130,34 @@ def track.video.add_image(
 
   let {video = image} = source.tracks(image)
   track.video.add([v, image])
+end
+
+# Add a static request on the source video channel.
+# @category Source / Video processing
+# @param ~id Force the value of the source ID.
+# @param ~fallible Whether we are allowed to fail (in case the file is non-existent or invalid).
+# @param ~width Scale to width
+# @param ~height Scale to height
+# @param ~x x position.
+# @param ~y y position.
+# @param ~request Request to add to the video channel
+def video.add_request(
+  ~id=null("video.add_request"),
+  ~fallible=false,
+  ~width=null(),
+  ~height=null(),
+  ~x=getter(0),
+  ~y=getter(0),
+  ~request,
+  (s:source)
+) =
+  let {video, ...tracks} = source.tracks(s)
+  video =
+    track.video.add_request(
+      fallible=fallible, width=width, height=height, x=x, y=y, request=request, video
+    )
+
+  source(id=id, tracks.{video=video})
 end
 
 # Add a static image on the source video channel.

--- a/src/libs/video.liq
+++ b/src/libs/video.liq
@@ -25,7 +25,6 @@ end
 # @param ~x x position.
 # @param ~y y position.
 # @param req Image request
-# @method set Change the request.
 def request.image(
   ~id=null(),
   ~fallible=false,
@@ -37,32 +36,19 @@ def request.image(
 ) =
   s = source.dynamic()
 
-  def set(req) =
+  def set((req:request)) =
     image = request.single(id=id, fallible=fallible, req)
     image = video.crop(image)
     image = video.resize(id=id, x=x, y=y, width=width, height=height, image)
     s.set(image)
   end
 
-  current_req = ref(getter.get(req))
-  s.on_wake_up({set(current_req())})
+  s.on_wake_up({set(getter.get(req))})
 
-  s =
-    source.on_frame(
-      s,
-      fun () ->
-        begin
-          new_req = getter.get(req)
-          if
-            new_req != current_req()
-          then
-            set(new_req)
-            current_req.set(new_req)
-          end
-        end
-    )
+  on_change = getter.on_change(set, req)
+  on_change = {ignore(on_change())}
 
-  s.{set=set}
+  source.on_frame(s, on_change)
 end
 
 # Generate a source from an image file.
@@ -72,9 +58,7 @@ end
 def image(%argsof(request.image), file) =
   r = getter.map(fun (file) -> request.create(file), file)
 
-  s = request.image(%argsof(request.image), r)
-
-  s.{set=fun (uri) -> s.set(request.create(uri))}
+  request.image(%argsof(request.image), r)
 end
 
 # @flag hidden
@@ -100,7 +84,9 @@ def track.video.add_request(
   v
 ) =
   image =
-    orig_request.image(id=id, fallible=fallible, x=x, y=y, width=width, height=height, request)
+    orig_request.image(
+      id=id, fallible=fallible, x=x, y=y, width=width, height=height, request
+    )
 
   let {video = image} = source.tracks(image)
   track.video.add([v, image])
@@ -154,7 +140,13 @@ def video.add_request(
   let {video, ...tracks} = source.tracks(s)
   video =
     track.video.add_request(
-      fallible=fallible, width=width, height=height, x=x, y=y, request=request, video
+      fallible=fallible,
+      width=width,
+      height=height,
+      x=x,
+      y=y,
+      request=request,
+      video
     )
 
   source(id=id, tracks.{video=video})

--- a/src/libs/video.liq
+++ b/src/libs/video.liq
@@ -52,7 +52,13 @@ def request.image(
 end
 
 # Generate a source from an image file.
-# @argsof request.image
+# @category Source / Video processing
+# @param ~id Force the value of the source ID.
+# @param ~fallible Whether we are allowed to fail (in case the file is non-existent or invalid).
+# @param ~width Scale to width
+# @param ~height Scale to height
+# @param ~x x position.
+# @param ~y y position.
 # @param file Path to the image.
 # @method set Change the request.
 def image(%argsof(request.image), file) =


### PR DESCRIPTION
I finally figured out the issue with #4005 and the double cover save hack: once cover file are pushed down to the request pipeline, the underlying file should not be removed!

Instead, we have to lift the various APIs to directly consume requests so we can pass cover as plain requests and let the normal request cleanup mechanism take care of removing the temporary files.

Fixes: #4005