### PR TITLE
Slice content before passing it to the encoders.

### DIFF
--- a/src/core/encoder/encoder.mli
+++ b/src/core/encoder/encoder.mli
@@ -92,8 +92,8 @@ type hls = {
   (* Returns true if id3 is enabled. *)
   init : ?id3_enabled:bool -> ?id3_version:int -> unit -> bool;
   (* Returns (init_segment, first_bytes) *)
-  init_encode : Frame.t -> int -> int -> Strings.t option * Strings.t;
-  split_encode : Frame.t -> int -> int -> split_result;
+  init_encode : Frame.t -> Strings.t option * Strings.t;
+  split_encode : Frame.t -> split_result;
   codec_attrs : unit -> string option;
   insert_id3 :
     frame_position:int ->
@@ -105,13 +105,13 @@ type hls = {
   video_size : unit -> (int * int) option;
 }
 
-val dummy_hls : (Frame.t -> int -> int -> Strings.t) -> hls
+val dummy_hls : (Frame.t -> Strings.t) -> hls
 
 type encoder = {
   insert_metadata : Frame.Metadata.Export.t -> unit;
   header : unit -> Strings.t;
   hls : hls;
-  encode : Frame.t -> int -> int -> Strings.t;
+  encode : Frame.t -> Strings.t;
   stop : unit -> Strings.t;
 }
 

--- a/src/core/encoder/encoders/external_encoder.ml
+++ b/src/core/encoder/encoders/external_encoder.ml
@@ -115,7 +115,7 @@ let encoder id ext =
   let ratio =
     float (Lazy.force ext.samplerate) /. float (Frame.audio_of_seconds 1.)
   in
-  let encode frame start len =
+  let encode frame =
     let channels = ext.channels in
     let samplerate = Lazy.force ext.samplerate in
     let sbuf =
@@ -124,14 +124,13 @@ let encoder id ext =
         let width = Lazy.force width in
         let height = Lazy.force height in
         Avi_encoder.encode_frame ~channels ~samplerate ~converter ~width ~height
-          frame start len)
+          frame)
       else (
         let b = AFrame.pcm frame in
-        let start = Frame.audio_of_main start in
-        let len = Frame.audio_of_main len in
+        let len = AFrame.position frame in
         (* Resample if needed. *)
         let b, start, len =
-          Audio_converter.Samplerate.resample converter ratio b start len
+          Audio_converter.Samplerate.resample converter ratio b 0 len
         in
         let slen = 2 * len * Array.length b in
         let sbuf = Bytes.create slen in

--- a/src/core/encoder/encoders/fdkaac_encoder.ml
+++ b/src/core/encoder/encoders/fdkaac_encoder.ml
@@ -78,13 +78,12 @@ let encoder ~pos aac =
   let dst_freq = float samplerate in
   let n = Utils.pagesize in
   let buf = Strings.Mutable.empty () in
-  let encode frame start len =
+  let encode frame =
     let b = AFrame.pcm frame in
-    let start = Frame.audio_of_main start in
-    let len = Frame.audio_of_main len in
+    let len = AFrame.position frame in
     let b, start, len =
       Audio_converter.Samplerate.resample samplerate_converter
-        (dst_freq /. src_freq) b start len
+        (dst_freq /. src_freq) b 0 len
     in
     let encoded = Strings.Mutable.empty () in
     Strings.Mutable.add buf (Audio.S16LE.make b start len);

--- a/src/core/encoder/encoders/ffmpeg_copy_encoder.ml
+++ b/src/core/encoder/encoders/ffmpeg_copy_encoder.ml
@@ -177,8 +177,8 @@ let mk_stream_copy ~get_stream ~on_keyframe ~remove_stream ~keyframe_opt ~field
       push ~time_base ~stream ~idx:stream_idx packet
   in
 
-  let encode frame start len =
-    let content = Content.sub (Frame.get frame field) start len in
+  let encode frame =
+    let content = Frame.get frame field in
     let data = (Ffmpeg_copy_content.get_data content).Content.Video.data in
 
     List.iter

--- a/src/core/encoder/encoders/flac_encoder.ml
+++ b/src/core/encoder/encoders/flac_encoder.ml
@@ -47,13 +47,12 @@ let encoder flac meta =
   let cb = Flac.Encoder.get_callbacks write in
   let enc = Flac.Encoder.create ~comments p cb in
   let enc = ref enc in
-  let encode frame start len =
+  let encode frame =
     let b = AFrame.pcm frame in
-    let start = Frame.audio_of_main start in
-    let len = Frame.audio_of_main len in
+    let len = AFrame.position frame in
     let b, start, len =
       Audio_converter.Samplerate.resample samplerate_converter
-        (dst_freq /. src_freq) b start len
+        (dst_freq /. src_freq) b 0 len
     in
     let b = Audio.sub b start len in
     Flac.Encoder.process !enc cb b;

--- a/src/core/encoder/encoders/lame_encoder.ml
+++ b/src/core/encoder/encoders/lame_encoder.ml
@@ -95,10 +95,9 @@ let () =
                 (Frame.Metadata.to_list
                    (Frame.Metadata.Export.to_metadata metadata))))
          mp3.id3v2);
-    let encode frame start len =
-      let b = AFrame.pcm frame in
+    let encode frame =
       Generator.put pending_data Frame.Fields.audio
-        (Content.sub (Content.Audio.lift_data b) start len);
+        (Frame.get frame Frame.Fields.audio);
       while Generator.length pending_data > frame_size do
         let pcm =
           Content.Audio.get_data

--- a/src/core/encoder/encoders/shine_encoder.ml
+++ b/src/core/encoder/encoders/shine_encoder.ml
@@ -41,13 +41,12 @@ let encoder ~pos shine =
       (Frame.Fields.make ~audio:(Content.Audio.format_of_channels channels) ())
   in
   let encoded = Strings.Mutable.empty () in
-  let encode frame start len =
+  let encode frame =
     let b = AFrame.pcm frame in
-    let start = Frame.audio_of_main start in
-    let len = Frame.audio_of_main len in
+    let len = AFrame.position frame in
     let b, start, len =
       Audio_converter.Samplerate.resample samplerate_converter
-        (dst_freq /. src_freq) b start len
+        (dst_freq /. src_freq) b 0 len
     in
     let start = Frame.main_of_audio start in
     let len = Frame.main_of_audio len in

--- a/src/core/encoder/encoders/wav_encoder.ml
+++ b/src/core/encoder/encoders/wav_encoder.ml
@@ -45,13 +45,12 @@ let encoder ~pos wav =
     Wav_aiff.wav_header ?len ~channels ~sample_rate ~sample_size ()
   in
   let need_header = ref wav.header in
-  let encode frame start len =
+  let encode frame =
     let b = AFrame.pcm frame in
-    let start = Frame.audio_of_main start in
-    let len = Frame.audio_of_main len in
+    let len = AFrame.position frame in
     (* Resample if needed. *)
     let b, start, len =
-      Audio_converter.Samplerate.resample converter ratio b start len
+      Audio_converter.Samplerate.resample converter ratio b 0 len
     in
     let s = Bytes.create (sample_size / 8 * len * channels) in
     let of_audio =

--- a/src/core/io/srt_io.ml
+++ b/src/core/io/srt_io.ml
@@ -992,8 +992,8 @@ class virtual output_base ~payload_size ~messageapi ~on_start ~on_stop
       self#mutexify (fun () -> Atomic.set should_stop true) ();
       self#disconnect
 
-    method private encode frame ofs len =
-      if self#is_connected then self#get_encoder.Encoder.encode frame ofs len
+    method private encode frame =
+      if self#is_connected then self#get_encoder.Encoder.encode frame
       else Strings.empty
 
     method private insert_metadata m =

--- a/src/core/io/udp_io.ml
+++ b/src/core/io/udp_io.ml
@@ -94,8 +94,7 @@ class output ~on_start ~on_stop ~register_telnet ~infallible ~autostart
       socket_send <- None;
       encoder <- None
 
-    method private encode frame ofs len =
-      (Option.get encoder).Encoder.encode frame ofs len
+    method private encode frame = (Option.get encoder).Encoder.encode frame
 
     method private insert_metadata m =
       (Option.get encoder).Encoder.insert_metadata m

--- a/src/core/outputs/harbor_output.ml
+++ b/src/core/outputs/harbor_output.ml
@@ -428,9 +428,7 @@ class output p =
     val mutable chunk_len = 0
     val burst_data = Strings.Mutable.empty ()
     val metadata = { metadata = None; metadata_m = Mutex.create () }
-
-    method encode frame ofs len =
-      (Option.get encoder).Encoder.encode frame ofs len
+    method encode frame = (Option.get encoder).Encoder.encode frame
 
     method insert_metadata m =
       let m = Frame.Metadata.Export.to_metadata m in

--- a/src/core/outputs/hls_output.ml
+++ b/src/core/outputs/hls_output.ml
@@ -1065,7 +1065,8 @@ class hls_output p =
           false )
       else (false, "", false)
 
-    method encode frame ofs len =
+    method encode frame =
+      let len = Frame.position frame in
       let frame_pos, samples_pos = current_position in
       let frame_size = Lazy.force Frame.size in
       let samples_pos = samples_pos + len in
@@ -1077,14 +1078,12 @@ class hls_output p =
           let b =
             if s.init_state = `Todo then (
               try
-                let init, encoded =
-                  Encoder.(s.encoder.hls.init_encode frame ofs len)
-                in
+                let init, encoded = Encoder.(s.encoder.hls.init_encode frame) in
                 self#process_init ~init ~segment s;
                 (len, None, encoded)
               with Encoder.Not_enough_data -> (len, None, Strings.empty))
             else (
-              match Encoder.(s.encoder.hls.split_encode frame ofs len) with
+              match Encoder.(s.encoder.hls.split_encode frame) with
                 | `Ok (flushed, encoded) -> (len, Some flushed, encoded)
                 | `Nope encoded -> (len, None, encoded))
           in

--- a/src/core/outputs/icecast2.ml
+++ b/src/core/outputs/icecast2.ml
@@ -496,12 +496,12 @@ class output p =
 
     val mutable encoder = None
 
-    method encode frame ofs len =
+    method encode frame =
       (* We assume here that there always is
        * an encoder available when the source
        * is connected. *)
       match (Cry.get_status connection, encoder) with
-        | Cry.Connected _, Some enc -> enc.Encoder.encode frame ofs len
+        | Cry.Connected _, Some enc -> enc.Encoder.encode frame
         | _ -> Strings.empty
 
     method insert_metadata m =

--- a/src/core/outputs/output.ml
+++ b/src/core/outputs/output.ml
@@ -233,13 +233,13 @@ class virtual ['a] encoded ~output_kind ?clock ~name ~infallible ~on_start
           ~register_telnet source autostart
 
     method virtual private insert_metadata : Frame.Metadata.Export.t -> unit
-    method virtual private encode : Frame.t -> int -> int -> 'a
+    method virtual private encode : Frame.t -> 'a
     method virtual private send : 'a -> unit
 
     method private send_frame frame =
       let rec output_chunks frame =
         let f start stop =
-          let data = self#encode frame start (stop - start) in
+          let data = self#encode (Frame.sub frame start (stop - start)) in
           self#send data;
           match Frame.get_metadata frame start with
             | None -> ()

--- a/src/core/outputs/output.mli
+++ b/src/core/outputs/output.mli
@@ -73,7 +73,7 @@ class virtual ['a] encoded :
   -> object
        inherit output
        method private send_frame : Frame.t -> unit
-       method virtual private encode : Frame.t -> int -> int -> 'a
+       method virtual private encode : Frame.t -> 'a
        method virtual private insert_metadata : Frame.Metadata.Export.t -> unit
        method virtual private send : 'a -> unit
        method private reset : unit

--- a/src/core/stream/frame.ml
+++ b/src/core/stream/frame.ml
@@ -79,15 +79,9 @@ let create ~length content_type =
     (Frame_base.Fields.map (Content.make ~length) content_type)
 
 let content_type = Fields.map Content.format
-
-let after frame offset =
-  let len = position frame - offset in
-  Fields.map (fun c -> Content.sub c offset len) frame
-
-let slice frame len =
-  Fields.map
-    (fun c -> if Content.length c <= len then c else Content.sub c 0 len)
-    frame
+let sub frame ofs len = Fields.map (fun c -> Content.sub c ofs len) frame
+let slice frame len = sub frame 0 len
+let after frame offset = sub frame offset (position frame - offset)
 
 let append f f' =
   Fields.mapi (fun field c -> Content.append c (Fields.find field f')) f

--- a/src/core/stream/frame.mli
+++ b/src/core/stream/frame.mli
@@ -106,6 +106,10 @@ val slice : t -> int -> t
 (** Get the content after a given offset. *)
 val after : t -> int -> t
 
+(** [sub frame ofs len]: get the a subset of length [len]
+    of the frame content, starting at [ofs]. *)
+val sub : t -> int -> int -> t
+
 (** Get a frame's content type. *)
 val content_type : t -> content_type
 

--- a/tests/core/output_encoded_test.ml
+++ b/tests/core/output_encoded_test.ml
@@ -19,7 +19,7 @@ class encoded_test =
       assert !send_called;
       insert_metadata_called := true
 
-    method encode _ _ _ =
+    method encode _ =
       encode_called := true;
       ()
 

--- a/tests/core/stream_decoder_test.ml
+++ b/tests/core/stream_decoder_test.ml
@@ -42,7 +42,7 @@ let () =
           decoder.Decoder.decode buffer
         done;
         let frame = Generator.slice generator size in
-        write (encoder.Encoder.encode frame 0 (Frame.position frame))
+        write (encoder.Encoder.encode frame)
       with Avutil.Error `Invalid_data -> ()
     done
   with Ffmpeg_decoder.End_of_file ->


### PR DESCRIPTION
This should reduce data copy when encoding.