### PR TITLE
`pan` fixes.

### DIFF
--- a/src/core/operators/pan.ml
+++ b/src/core/operators/pan.ml
@@ -39,8 +39,8 @@ class pan ~field (source : source) phi phi_0 =
       let phi_0 = phi_0 () *. Float.pi /. 360. in
       (* Map -1 / 1 to radians. *)
       let phi = phi () *. phi_0 in
-      let gain_left = (tan phi_0 +. tan phi) /. 2. in
-      let gain_right = (tan phi_0 -. tan phi) /. 2. in
+      let gain_left = (tan phi_0 -. tan phi) /. 2. in
+      let gain_right = (tan phi_0 +. tan phi) /. 2. in
       let len = source#frame_audio_position in
       Audio.Mono.amplify gain_left buffer.(0) 0 len;
       Audio.Mono.amplify gain_right buffer.(1) 0 len;
@@ -51,19 +51,21 @@ let _ =
   let track_t = Format_type.audio_stereo () in
   Lang.add_track_operator ~base:Stereo.stereo "pan"
     [
-      ( "pan",
-        Lang.getter_t Lang.float_t,
-        Some (Lang.float 0.),
-        Some "Pan ranges between -1 and 1." );
       ( "field",
         Lang.getter_t Lang.float_t,
         Some (Lang.float 90.),
         Some "Field width in degrees (between 0 and 90)." );
+      ( "",
+        Lang.getter_t Lang.float_t,
+        None,
+        Some
+          "Pan value. Should be between `-1` (left side) and `1` (right side)."
+      );
       ("", track_t, None, None);
     ]
     ~return_t:track_t ~category:`Audio ~descr:"Pan a stereo sound."
     (fun p ->
-      let field, s = Lang.to_track (Lang.assoc "" 1 p) in
-      let phi_0 = Lang.to_float_getter (Lang.assoc "field" 1 p) in
-      let phi = Lang.to_float_getter (Lang.assoc "pan" 1 p) in
+      let phi_0 = Lang.to_float_getter (List.assoc "field" p) in
+      let phi = Lang.to_float_getter (Lang.assoc "" 1 p) in
+      let field, s = Lang.to_track (Lang.assoc "" 2 p) in
       (field, new pan ~field s phi phi_0))

--- a/src/libs/audio.liq
+++ b/src/libs/audio.liq
@@ -215,7 +215,9 @@ end
 # @category Source / Conversion
 # @param t Track to extract from
 def track.audio.stereo.left(~id=null("track.audio.stereo.left"), t) =
-  track.audio.mean(id=id, track.audio.stereo.pan(pan=-1., t))
+  track.audio.amplify(
+    id=id, override=null(), 2., track.audio.mean(track.audio.stereo.pan(-1., t))
+  )
 end
 
 # Extract the left channel of a stereo source
@@ -230,7 +232,9 @@ end
 # @category Source / Conversion
 # @param s Track to extract from
 def track.audio.stereo.right(~id=null("track.audio.stereo.right"), t) =
-  track.audio.mean(id=id, track.audio.stereo.pan(pan=1., t))
+  track.audio.amplify(
+    id=id, override=null(), 2., track.audio.mean(track.audio.stereo.pan(1., t))
+  )
 end
 
 # Extract the right channel of a stereo source
@@ -252,9 +256,11 @@ end
 # Pan a stereo sound.
 # @category Source / Audio processing
 # @argsof track.audio.stereo.pan
+# @param pan Pan value. Should be between `-1` (left side) and `1` (right side).
 def stereo.pan(
   ~id=null("stereo.pan"),
   %argsof(track.audio.stereo.pan[!id]),
+  pan,
   (s:source)
 ) =
   tracks = source.tracks(s)
@@ -262,7 +268,9 @@ def stereo.pan(
     id=id,
     tracks.{
       audio=
-        track.audio.stereo.pan(%argsof(track.audio.stereo.pan), tracks.audio)
+        track.audio.stereo.pan(
+          %argsof(track.audio.stereo.pan), pan, tracks.audio
+        )
     }
   )
 end

--- a/tests/regression/GH4090.liq
+++ b/tests/regression/GH4090.liq
@@ -1,0 +1,29 @@
+let {audio = a} = source.tracks(sine())
+
+track_l = track.audio.amplify(2., track.audio.stereo.pan(-1., a))
+track_r = track.audio.amplify(0.5, track.audio.stereo.pan(1., a))
+
+s = source({audio=track.audio.add(normalize=false, [track_l, track_r])})
+
+r = rms.stereo(s, duration=1.)
+
+rl = rms(stereo.left(s), duration=1.)
+rr = rms(stereo.right(s), duration=1.)
+
+output.dummy(r)
+
+output.dummy(rl)
+output.dummy(rr)
+
+def check_peak() =
+  let (r_l, r_r) = r.rms()
+  rl = rl.rms()
+  rr = rr.rms()
+  test.almost_equal(r_l, rl)
+  test.almost_equal(r_r, rr)
+  test.pass()
+end
+
+thread.run(check_peak, delay=1.)
+
+output.dummy(s)

--- a/tests/regression/dune.inc
+++ b/tests/regression/dune.inc
@@ -618,6 +618,21 @@
  (alias citest)
  (package liquidsoap)
  (deps
+  GH4090.liq
+  ../media/all_media_files
+  ../../src/bin/liquidsoap.exe
+  ../streams/file1.png
+  ../streams/file1.mp3
+  (package liquidsoap)
+  (source_tree ../../src/libs)
+  (:test_liq ../test.liq)
+  (:run_test ../run_test.exe))
+ (action (run %{run_test} GH4090.liq liquidsoap %{test_liq} GH4090.liq)))
+  
+(rule
+ (alias citest)
+ (package liquidsoap)
+ (deps
   LS268.liq
   ../media/all_media_files
   ../../src/bin/liquidsoap.exe


### PR DESCRIPTION
* Restore original amplitude after mean in `stereo.left` operators.
* Fix inverted left/right mapping.
* Simplify `pan` API, remove default `0.` value.

Fixes: #4090 