### PR TITLE
switch: don't select the same source twice.

### DIFF
--- a/src/core/operators/switch.ml
+++ b/src/core/operators/switch.ml
@@ -89,6 +89,12 @@ class switch ~all_predicates ~override_meta ~transition_length ~replay_meta
     val mutable transition_length = transition_length
     val mutable selected : selection option = None
 
+    (* We cannot reselect the same source twice during a streaming cycle. *)
+    val mutable excluded_sources = []
+
+    initializer
+      self#on_before_streaming_cycle (fun () -> excluded_sources <- [])
+
     method private is_selected_generated =
       match selected with
         | None -> false
@@ -96,19 +102,18 @@ class switch ~all_predicates ~override_meta ~transition_length ~replay_meta
             source != effective_source
 
     method private select ~reselect () =
-      let may_reselect ~single s =
+      let may_select ~single s =
         match selected with
-          | Some { child; effective_source } ->
-              self#can_reselect ~reselect effective_source
-              && (child.source != s.source || not single)
-          | None -> true
+          | Some { child; effective_source } when child.source == s.source ->
+              (not single) && self#can_reselect ~reselect effective_source
+          | _ -> not (List.memq s excluded_sources)
       in
       try
         Some
           (pick_selection
              (find ~strict:all_predicates
                 (fun (d, single, s) ->
-                  satisfied d && may_reselect ~single s && s.source#is_ready)
+                  satisfied d && may_select ~single s && s.source#is_ready)
                 children))
       with Not_found -> None
 
@@ -219,6 +224,7 @@ class switch ~all_predicates ~override_meta ~transition_length ~replay_meta
             end;
             match selected with
               | Some s when s.effective_source#is_ready ->
+                  excluded_sources <- s.child :: excluded_sources;
                   Some s.effective_source
               | _ -> None)
 

--- a/src/core/operators/switch.ml
+++ b/src/core/operators/switch.ml
@@ -98,9 +98,10 @@ class switch ~all_predicates ~override_meta ~transition_length ~replay_meta
     method private select ~reselect () =
       let may_reselect ~single s =
         match selected with
-          | Some { child; effective_source } when child.source == s.source ->
-              (not single) && self#can_reselect ~reselect effective_source
-          | _ -> true
+          | Some { child; effective_source } ->
+              self#can_reselect ~reselect effective_source
+              && (child.source != s.source || not single)
+          | None -> true
       in
       try
         Some

--- a/src/core/source.ml
+++ b/src/core/source.ml
@@ -631,6 +631,7 @@ class virtual generate_from_multiple_sources ~merge ~track_sensitive () =
             | Some s' when last_source == s' ->
                 let remainder =
                   s#get_partial_frame (fun frame ->
+                      assert (last_chunk_pos < Frame.position frame);
                       Frame.slice frame (last_chunk_pos + rem))
                 in
                 let new_track = Frame.after remainder last_chunk_pos in

--- a/src/core/source.ml
+++ b/src/core/source.ml
@@ -619,7 +619,7 @@ class virtual generate_from_multiple_sources ~merge ~track_sensitive () =
       assert s#is_ready;
       let buf = self#continue_frame s in
       let size = Lazy.force Frame.size in
-      let rec f ~excluded_sources ~last_source ~last_chunk buf =
+      let rec f ~last_source ~last_chunk buf =
         let pos = Frame.position buf in
         let last_chunk_pos = Frame.position last_chunk in
         self#set_last_metadata last_chunk;
@@ -628,18 +628,13 @@ class virtual generate_from_multiple_sources ~merge ~track_sensitive () =
           match
             self#get_source ~reselect:(`After_position last_chunk_pos) ()
           with
-            | Some s when List.memq s excluded_sources -> (s, buf)
             | Some s' when last_source == s' ->
                 let remainder =
                   s#get_partial_frame (fun frame ->
                       Frame.slice frame (last_chunk_pos + rem))
                 in
                 let new_track = Frame.after remainder last_chunk_pos in
-                let excluded_sources =
-                  if Frame.position new_track = 0 then s :: excluded_sources
-                  else excluded_sources
-                in
-                f ~excluded_sources ~last_source ~last_chunk:remainder
+                f ~last_source ~last_chunk:remainder
                   (Frame.append buf new_track)
             | Some s ->
                 assert s#is_ready;
@@ -650,18 +645,12 @@ class virtual generate_from_multiple_sources ~merge ~track_sensitive () =
                             Frame.slice frame rem
                         | buf, _ -> Frame.slice buf rem)
                 in
-                let excluded_sources =
-                  if Frame.position new_track = 0 then s :: excluded_sources
-                  else excluded_sources
-                in
-                f ~excluded_sources ~last_source:s ~last_chunk:new_track
+                f ~last_source:s ~last_chunk:new_track
                   (Frame.append buf (self#begin_track new_track))
-            | None -> (last_source, buf))
+            | _ -> (last_source, buf))
         else (last_source, buf)
       in
-      let last_source, buf =
-        f ~excluded_sources:[] ~last_source:s ~last_chunk:buf buf
-      in
+      let last_source, buf = f ~last_source:s ~last_chunk:buf buf in
       current_source <- Some last_source;
       buf
   end


### PR DESCRIPTION
The new algorithm to fill up frames does not work if sources are interleaved, i.e. s1 is selected then s2 then s1 again so we need to make sure that this does not happen in the switch.

The only other source using this mechanism is `sequence` and there, sources are removed when switched to until we reach the last one so this should not happen.

Fixes: #4102 