### PR TITLE
Dynamic source tracks.

### DIFF
--- a/src/core/dune
+++ b/src/core/dune
@@ -233,6 +233,7 @@
   theora_format
   time_warp
   track
+  source_tracks
   track_map
   tutils
   type

--- a/src/core/hooks_implementations.ml
+++ b/src/core/hooks_implementations.ml
@@ -19,7 +19,7 @@ let eval_check ~env:_ ~tm v =
       Typing.(Lang_source.source_t ~methods:false s#frame_type <: ty);
       s#content_type_computation_allowed))
   else if Source_tracks.is_value v then (
-    let s = Source_tracks.of_value v in
+    let s = Source_tracks.source v in
     Typing.(s#frame_type <: tm.Term.t))
   else if Track.is_value v then (
     let field, source = Lang_source.to_track v in

--- a/src/core/hooks_implementations.ml
+++ b/src/core/hooks_implementations.ml
@@ -18,6 +18,10 @@ let eval_check ~env:_ ~tm v =
       let ty = Type.fresh (deep_demeth tm.Term.t) in
       Typing.(Lang_source.source_t ~methods:false s#frame_type <: ty);
       s#content_type_computation_allowed))
+  else if Source_tracks.is_value v then (
+    let s = Source_tracks.of_value v in
+    let ty = Type.fresh (deep_demeth tm.Term.t) in
+    Typing.(s#frame_type <: ty))
   else if Track.is_value v then (
     let field, source = Lang_source.to_track v in
     if not source#has_content_type then (

--- a/src/core/hooks_implementations.ml
+++ b/src/core/hooks_implementations.ml
@@ -20,8 +20,7 @@ let eval_check ~env:_ ~tm v =
       s#content_type_computation_allowed))
   else if Source_tracks.is_value v then (
     let s = Source_tracks.of_value v in
-    let ty = Type.fresh (deep_demeth tm.Term.t) in
-    Typing.(s#frame_type <: ty))
+    Typing.(s#frame_type <: tm.Term.t))
   else if Track.is_value v then (
     let field, source = Lang_source.to_track v in
     if not source#has_content_type then (

--- a/src/core/lang_source.ml
+++ b/src/core/lang_source.ml
@@ -361,17 +361,6 @@ let source_tracks_t frame_t =
     ([], Format_type.track_marks)
     (Type.meth "metadata" ([], Format_type.metadata) frame_t)
 
-let source_tracks s =
-  meth unit
-    (( Frame.Fields.string_of_field Frame.Fields.metadata,
-       Track.to_value (Frame.Fields.metadata, s) )
-    :: ( Frame.Fields.string_of_field Frame.Fields.track_marks,
-         Track.to_value (Frame.Fields.track_marks, s) )
-    :: List.map
-         (fun (field, _) ->
-           (Frame.Fields.string_of_field field, Track.to_value (field, s)))
-         (Frame.Fields.bindings s#content_type))
-
 let source_methods ~base s =
   meth base (List.map (fun (name, _, _, fn) -> (name, fn s)) source_methods)
 

--- a/src/core/operators/muxer.ml
+++ b/src/core/operators/muxer.ml
@@ -168,7 +168,7 @@ let muxer_operator p =
       []
       (Liquidsoap_lang.Methods.bindings tracks)
   in
-  let s = new muxer ~pos:(Lang.pos p) ~base tracks in
+  let s = new muxer ~pos:(try Lang.pos p with _ -> []) ~base tracks in
   let target_fields =
     List.fold_left
       (fun target_fields { source; fields } ->

--- a/src/core/operators/muxer.ml
+++ b/src/core/operators/muxer.ml
@@ -20,30 +20,22 @@
 
  *****************************************************************************)
 
-type field = {
-  target_field : Frame.field;
-  source_field : Frame.field;
-  processor : Content.data -> Content.data;
-}
-
+type field = { target_field : Frame.field; source_field : Frame.field }
 type track = { mutable fields : field list; source : Source.source }
 
-class muxer tracks =
+class muxer ~pos ~base tracks =
   let sources =
     List.fold_left
       (fun sources { source } ->
         if List.memq source sources then sources else source :: sources)
-      [] tracks
+      (match base with Some s -> [s] | None -> [])
+      tracks
   in
   let fallible = List.exists (fun s -> s#fallible) sources in
   let self_sync = Clock_base.self_sync sources in
   object (self)
     (* Pass duplicated list to operator to make sure caching is properly enabled. *)
-    inherit
-      Source.operator
-        ~name:"source"
-        (List.map (fun { source } -> source) tracks)
-
+    inherit Source.operator ~name:"source" sources
     method self_sync = self_sync ~source:self ()
     method fallible = fallible
     method abort_track = List.iter (fun s -> s#abort_track) sources
@@ -76,6 +68,66 @@ class muxer tracks =
         (-1)
         (List.filter (fun (s : Source.source) -> s#is_ready) sources)
 
+    val mutable muxed_tracks = None
+
+    method private tracks =
+      match muxed_tracks with
+        | Some s -> s
+        | None ->
+            let base =
+              match base with
+                | Some source ->
+                    let fields =
+                      Frame.Fields.metadata :: Frame.Fields.track_marks
+                      :: List.map fst
+                           (Frame.Fields.bindings source#content_type)
+                    in
+                    let fields =
+                      List.map
+                        (fun source_field ->
+                          { source_field; target_field = source_field })
+                        fields
+                    in
+                    [{ source; fields }]
+                | None -> []
+            in
+            let tracks =
+              List.fold_left
+                (fun tracks ({ source = s; fields } as t) ->
+                  match List.find_opt (fun { source = s' } -> s == s') base with
+                    | Some track ->
+                        let track_fields =
+                          List.filter
+                            (fun { target_field = t } ->
+                              not
+                                (List.exists
+                                   (fun { target_field = t' } -> t = t')
+                                   fields))
+                            track.fields
+                        in
+                        track.fields <- track_fields @ fields;
+                        tracks
+                    | None -> t :: tracks)
+                base tracks
+            in
+            if
+              List.for_all
+                (fun { fields } ->
+                  List.for_all
+                    (fun { target_field } ->
+                      target_field = Frame.Fields.metadata
+                      || target_field = Frame.Fields.track_marks)
+                    fields)
+                tracks
+            then
+              Runtime_error.raise ~pos
+                ~message:
+                  "source muxer needs at least one track with content that is \
+                   not metadata or track_marks!"
+                "invalid";
+            muxed_tracks <- Some tracks;
+            tracks
+
     method generate_frame =
       let length = Lazy.force Frame.size in
       let pos, frame =
@@ -84,49 +136,39 @@ class muxer tracks =
             let buf = source#get_frame in
             ( min pos (Frame.position buf),
               List.fold_left
-                (fun frame { source_field; target_field; processor } ->
-                  let c = processor (Frame.get buf source_field) in
+                (fun frame { source_field; target_field } ->
+                  let c = Frame.get buf source_field in
                   Frame.set frame target_field c)
                 frame fields ))
           (length, Frame.create ~length Frame.Fields.empty)
-          tracks
+          self#tracks
       in
       Frame.slice frame pos
   end
 
 let muxer_operator p =
-  let tracks = List.assoc "" p in
-  let processor c = c in
+  let base, tracks =
+    match List.assoc "" p with
+      | Liquidsoap_lang.Value.Custom { methods } as v
+        when Source_tracks.is_value v ->
+          (Some (Source_tracks.of_value v), methods)
+      | v -> (None, Liquidsoap_lang.Value.methods v)
+  in
   let tracks =
     List.fold_left
       (fun tracks (label, t) ->
         let source_field, s = Lang.to_track t in
         let target_field = Frame.Fields.register label in
-        let field = { source_field; target_field; processor } in
+        let field = { source_field; target_field } in
         match List.find_opt (fun { source } -> source == s) tracks with
           | Some track ->
               track.fields <- field :: track.fields;
               tracks
           | None -> { source = s; fields = [field] } :: tracks)
       []
-      (fst (Lang.split_meths tracks))
+      (Liquidsoap_lang.Methods.bindings tracks)
   in
-  if
-    List.for_all
-      (fun { fields } ->
-        List.for_all
-          (fun { target_field } ->
-            target_field = Frame.Fields.metadata
-            || target_field = Frame.Fields.track_marks)
-          fields)
-      tracks
-  then
-    Runtime_error.raise ~pos:(Lang.pos p)
-      ~message:
-        "source muxer needs at least one track with content that is not \
-         metadata or track_marks!"
-      "invalid";
-  let s = new muxer tracks in
+  let s = new muxer ~pos:(Lang.pos p) ~base tracks in
   let target_fields =
     List.fold_left
       (fun target_fields { source; fields } ->
@@ -151,7 +193,11 @@ let muxer_operator p =
         target_fields)
       Frame.Fields.empty tracks
   in
-  Typing.(s#frame_type <: Lang.frame_t (Lang.univ_t ()) target_fields);
+  Typing.(
+    s#frame_type
+    <: Lang.frame_t
+         (match base with Some s -> s#frame_type | None -> Lang.univ_t ())
+         target_fields);
   s
 
 let source =
@@ -199,6 +245,7 @@ let _ =
         Type.filter_meths return_t (fun { Type.meth } ->
             meth <> "metadata" && meth <> "track_marks")
       in
-      let s = Lang.to_source (List.assoc "" env) in
+      let source_val = List.assoc "" env in
+      let s = Lang.to_source source_val in
       Typing.(s#frame_type <: return_t);
-      Lang_source.source_tracks s)
+      Source_tracks.to_value s)

--- a/src/core/source_tracks.ml
+++ b/src/core/source_tracks.ml
@@ -43,3 +43,18 @@ let to_value ?pos s =
               Some (fun v -> Some (Track.to_value (Frame.Fields.register v, s)));
           }
     | _ -> assert false
+
+let source = of_value
+
+let fields = function
+  | Liquidsoap_lang.Value.Custom { hidden_methods } as v when is_value v ->
+      let source = of_value v in
+      let fields =
+        Frame.Fields.metadata :: Frame.Fields.track_marks
+        :: List.map fst (Frame.Fields.bindings source#content_type)
+      in
+      List.filter
+        (fun field ->
+          not (List.mem (Frame.Fields.string_of_field field) hidden_methods))
+        fields
+  | _ -> assert false

--- a/src/core/source_tracks.ml
+++ b/src/core/source_tracks.ml
@@ -1,0 +1,45 @@
+(*****************************************************************************
+
+  Liquidsoap, a programmable stream generator.
+  Copyright 2003-2024 Savonet team
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details, fully stated in the COPYING
+  file at the root of the liquidsoap distribution.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA
+
+ *****************************************************************************)
+
+include Liquidsoap_lang.Lang_core.MkCustom (struct
+  type content = Source.source
+
+  let name = "source.tracks"
+  let to_string s = Printf.sprintf "source.tracks(source=%s)" s#id
+
+  let to_json ~pos _ =
+    Runtime_error.raise ~pos
+      ~message:"Source tracks cannot be represented as json" "json"
+
+  let compare s1 s2 = Stdlib.compare s1#id s2#id
+end)
+
+let to_value ?pos s =
+  match to_value ?pos s with
+    | Liquidsoap_lang.Value.Custom p ->
+        Liquidsoap_lang.Value.Custom
+          {
+            p with
+            dynamic_methods =
+              Some (fun v -> Some (Track.to_value (Frame.Fields.register v, s)));
+          }
+    | _ -> assert false

--- a/src/core/source_tracks.ml
+++ b/src/core/source_tracks.ml
@@ -40,14 +40,22 @@ let to_value ?pos s =
           {
             p with
             dynamic_methods =
-              Some (fun v -> Some (Track.to_value (Frame.Fields.register v, s)));
+              Some
+                {
+                  hidden_methods = [];
+                  methods =
+                    (fun v ->
+                      Some (Track.to_value (Frame.Fields.register v, s)));
+                };
           }
     | _ -> assert false
 
 let source = of_value
 
 let fields = function
-  | Liquidsoap_lang.Value.Custom { hidden_methods } as v when is_value v ->
+  | Liquidsoap_lang.Value.Custom { dynamic_methods = Some { hidden_methods } }
+    as v
+    when is_value v ->
       let source = of_value v in
       let fields =
         Frame.Fields.metadata :: Frame.Fields.track_marks

--- a/src/core/source_tracks.mli
+++ b/src/core/source_tracks.mli
@@ -23,5 +23,6 @@
 type content = Source.source
 
 val to_value : ?pos:Pos.t -> content -> Value.t
-val of_value : Value.t -> content
+val source : Value.t -> content
 val is_value : Value.t -> bool
+val fields : Value.t -> Frame.Fields.field list

--- a/src/core/source_tracks.mli
+++ b/src/core/source_tracks.mli
@@ -1,0 +1,27 @@
+(*****************************************************************************
+
+  Liquidsoap, a programmable stream generator.
+  Copyright 2003-2024 Savonet team
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details, fully stated in the COPYING
+  file at the root of the liquidsoap distribution.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA
+
+ *****************************************************************************)
+
+type content = Source.source
+
+val to_value : ?pos:Pos.t -> content -> Value.t
+val of_value : Value.t -> content
+val is_value : Value.t -> bool

--- a/src/lang/evaluation.ml
+++ b/src/lang/evaluation.ml
@@ -180,17 +180,30 @@ and eval_base_term ~eval_check (env : Env.t) tm =
     | `List l -> mk (`List (List.map (eval ~eval_check env) l))
     | `Tuple l -> mk (`Tuple (List.map (fun a -> eval ~eval_check env a) l))
     | `Null -> mk `Null
-    | `Hide (tm, methods) ->
+    | `Hide (tm, methods) -> (
         let v = eval ~eval_check env tm in
-        Value.map_methods v
-          (Methods.filter (fun n _ -> not (List.mem n methods)))
+        let v =
+          Value.map_methods v
+            (Methods.filter (fun n _ -> not (List.mem n methods)))
+        in
+        match v with
+          | Value.Custom p ->
+              Value.Custom
+                {
+                  p with
+                  hidden_methods =
+                    List.sort_uniq Stdlib.compare (methods @ p.hidden_methods);
+                }
+          | v -> v)
     | `Cast { cast = e } -> Value.set_pos (eval ~eval_check env e) tm.t.Type.pos
     | `Invoke { invoked = t; invoke_default; meth } -> (
         let v = eval ~eval_check env t in
         let invoked_value =
           match (Value.Methods.find_opt meth (Value.methods v), v) with
             | Some v, _ -> Some v
-            | None, Value.Custom { dynamic_methods = Some fn } -> fn meth
+            | None, Value.Custom { hidden_methods; dynamic_methods = Some fn }
+              when not (List.mem meth hidden_methods) ->
+                fn meth
             | _ -> None
         in
         match (invoked_value, invoke_default) with

--- a/src/lang/value.ml
+++ b/src/lang/value.ml
@@ -62,7 +62,7 @@ and t =
       pos : Pos.Option.t; [@hash.ignore]
       value : Custom.t; [@hash.ignore]
       methods : t Methods.t;
-      dynamic_methods : dynamic_methods option; [@hash.ignore]
+      dynamic_methods : dynamic_methods option;
       mutable flags : Flags.flags; [@hash.ignore]
     }
   | List of {

--- a/src/lang/value.ml
+++ b/src/lang/value.ml
@@ -30,6 +30,11 @@ module Methods = Runtime_term.Methods
     when the builtin env change. We mostly keep name and methods. *)
 type env = (string * t) list
 
+and dynamic_methods = {
+  hidden_methods : string list;
+  methods : string -> t option; [@hash.ignore]
+}
+
 and t =
   | Int of {
       pos : Pos.Option.t; [@hash.ignore]
@@ -57,8 +62,7 @@ and t =
       pos : Pos.Option.t; [@hash.ignore]
       value : Custom.t; [@hash.ignore]
       methods : t Methods.t;
-      hidden_methods : string list;
-      dynamic_methods : (string -> t option) option; [@hash.ignore]
+      dynamic_methods : dynamic_methods option; [@hash.ignore]
       mutable flags : Flags.flags; [@hash.ignore]
     }
   | List of {
@@ -203,15 +207,7 @@ let make ?pos ?(methods = Methods.empty) ?(flags = Flags.empty) : in_value -> t
   | `String s -> String { pos; methods; value = s }
   | `Bool b -> Bool { pos; methods; value = b }
   | `Custom c ->
-      Custom
-        {
-          pos;
-          methods;
-          flags;
-          hidden_methods = [];
-          dynamic_methods = None;
-          value = c;
-        }
+      Custom { pos; methods; flags; dynamic_methods = None; value = c }
   | `Null -> Null { pos; methods }
   | `Tuple l -> Tuple { pos; methods; flags; value = l }
   | `List l -> List { pos; methods; flags; value = l }
@@ -266,9 +262,9 @@ let invoke x l =
   try
     match (Methods.find_opt l (methods x), x) with
       | Some v, _ -> v
-      | None, Custom { hidden_methods; dynamic_methods = Some fn }
+      | None, Custom { dynamic_methods = Some { hidden_methods; methods } }
         when not (List.mem l hidden_methods) ->
-          Option.get (fn l)
+          Option.get (methods l)
       | _ -> raise Not_found
   with _ -> failwith ("Could not find method " ^ l ^ " of " ^ to_string x)
 

--- a/src/lang/value.ml
+++ b/src/lang/value.ml
@@ -57,6 +57,7 @@ and t =
       pos : Pos.Option.t; [@hash.ignore]
       value : Custom.t; [@hash.ignore]
       methods : t Methods.t;
+      dynamic_methods : (string -> t option) option; [@hash.ignore]
       mutable flags : Flags.flags; [@hash.ignore]
     }
   | List of {
@@ -200,7 +201,8 @@ let make ?pos ?(methods = Methods.empty) ?(flags = Flags.empty) : in_value -> t
   | `Float f -> Float { pos; methods; value = f }
   | `String s -> String { pos; methods; value = s }
   | `Bool b -> Bool { pos; methods; value = b }
-  | `Custom c -> Custom { pos; methods; flags; value = c }
+  | `Custom c ->
+      Custom { pos; methods; flags; dynamic_methods = None; value = c }
   | `Null -> Null { pos; methods }
   | `Tuple l -> Tuple { pos; methods; flags; value = l }
   | `List l -> List { pos; methods; flags; value = l }
@@ -252,14 +254,23 @@ let rec to_string v =
 
 (** Find a method in a value. *)
 let invoke x l =
-  try Methods.find l (methods x)
-  with Not_found ->
-    failwith ("Could not find method " ^ l ^ " of " ^ to_string x)
+  try
+    match (Methods.find_opt l (methods x), x) with
+      | Some v, _ -> v
+      | None, Custom { dynamic_methods = Some fn } -> Option.get (fn l)
+      | _ -> raise Not_found
+  with _ -> failwith ("Could not find method " ^ l ^ " of " ^ to_string x)
 
 (** Perform a sequence of invokes: invokes x [l1;l2;l3;...] is x.l1.l2.l3... *)
 let rec invokes x = function l :: ll -> invokes (invoke x l) ll | [] -> x
 
-let demeth e = map_methods e (fun _ -> Methods.empty)
+let demeth e =
+  map_methods
+    (match e with
+      | Custom p ->
+          Custom { p with methods = Methods.empty; dynamic_methods = None }
+      | _ -> e)
+    (fun _ -> Methods.empty)
 
 let remeth t u =
   let t_methods = methods t in


### PR DESCRIPTION
There still are reports of issues with `source.tracks` forcing sources to compute their ` content_type` before we had a chance to assign their `frame_type`.

For reference:
* `frame_type` is a _type_ representing the source's content as computed during type unification, e.g. `{audio=pcm(stereo)}`, `{video=canvas, audio=pcm(5.1)}` etc. This value can be incomplete if no full restrictions are put on the source content. 

For instance, in:
```
s = blank()
output.dummy(s)
```
`s` can be any content because `output.dummy` does not care about the source's content. So, its `frame_type` is `'a`

* `content_type` is a  fully realized content value. It is calculated from the `frame_type`, adding default values.

For instance, a source with PCM audio without a specified number of channels, `{audio=pcm('a)}` is assigned a content type of `{audio=pcm(stereo)}`.

The problem is that there can be a competition between requesting the source's `content_type` and assigning the `frame_type`. If content type is requested before all the `frame_type` have been assigned then the result can be incompatible, e.g. assigning a `stereo` channel when the source should have had `5.1` channels.

The most typical case is when computing `source.tracks`. In the current implementation, the tracks are all extracted immediately at evaluation time which forces the computation of the source's content type right away.

In this PR, we introduce a _delayed_ `Source_tracks` runtime value. This value can be passed in-lieu of the actual record of source tracks and evaluated only when needed, e.g. in the muxer operator.

In order to make things work, we need to also introduce a notion of `dynamic_methods` so that we can do the following:

```liquidsoap
# s = blank();;
s :
  source('A)
  .{
...
  } where 'A is a set of internal tracks =
  <source(id=blank, frame_type=something that is a set of internal tracks>.{...}
# t = source.tracks(s);;
t :
  'A.{metadata : metadata, track_marks : track_marks}
  where 'A is a set of internal tracks = source.tracks(source=blank)
# s' = source({audio=t.audio});;
s' :
  source(audio='A)
  .{
...
  }
  where
    'A is a track and a track of type: pcm, pcm_s16, pcm_f32, canvas, metadata or track_marks =
  <source(id=source, frame_type={audio : 'A}
where
  'A is a track of type: pcm, pcm_s16, pcm_f32, canvas, metadata or track_marks and a track>.{...}
# t;;
- : 'A.{audio : 'B, metadata : metadata, track_marks : track_marks}
    where 'A is a set of internal tracks,
      'B is a track and a track of type: pcm, pcm_s16, pcm_f32, canvas, metadata or track_marks = source.tracks(source=blank)
```
It's a bit hacky but it seems to work fine.