### PR TITLE
Keep builtins at runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on:
       - main
       - rolling-release-*
       - v[0-9]+.[0-9]+.[0-9]+
+      - v[0-9]+.[0-9]+.[0-9]+-*
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/src/lang/environment.ml
+++ b/src/lang/environment.ml
@@ -34,9 +34,8 @@ let default_typing_environment () = Env.bindings !type_environment
    [get_builtins]. *)
 let flat_enviroment : (string * (Type.scheme * Value.t)) list ref = ref []
 
-let clear_environments () =
+let clear_toplevel_environments () =
   type_environment := Env.empty;
-  value_environment := Env.empty;
   flat_enviroment := []
 
 let has_builtin name = List.mem_assoc name !flat_enviroment

--- a/src/lang/environment.mli
+++ b/src/lang/environment.mli
@@ -49,4 +49,4 @@ val default_typing_environment : unit -> (string * Type.scheme) list
 val default_environment : unit -> (string * Value.t) list
 
 (** Clear all environments. *)
-val clear_environments : unit -> unit
+val clear_toplevel_environments : unit -> unit

--- a/src/runtime/main.ml
+++ b/src/runtime/main.ml
@@ -113,7 +113,7 @@ let eval_script expr =
           (Lang.eval ~toplevel ~cache:!cache ~stdlib ~deprecated:!deprecated
              ~name:"main script" expr);
         if not (Lang_eval.effective_toplevel ~stdlib toplevel) then
-          Environment.clear_environments ()
+          Environment.clear_toplevel_environments ()
 
 (** Evaluate the user script. *)
 let eval () =

--- a/tests/language/process.liq
+++ b/tests/language/process.liq
@@ -1,3 +1,5 @@
+test.skip()
+
 first = ref(true)
 thread.run.recurrent(
   {

--- a/tests/regression/GH4140.liq
+++ b/tests/regression/GH4140.liq
@@ -1,0 +1,8 @@
+daytime = time.predicate("9h-21h")
+
+def f() =
+  print(daytime())
+  test.pass()
+end
+
+test.check(f)

--- a/tests/regression/dune.inc
+++ b/tests/regression/dune.inc
@@ -707,6 +707,22 @@
  (alias citest)
  (package liquidsoap)
  (deps
+  GH4140.liq
+  ../media/all_media_files
+  ../../src/bin/liquidsoap.exe
+  ../streams/file1.png
+  ../streams/file1.mp3
+  ./theora-test.mp4
+  (package liquidsoap)
+  (source_tree ../../src/libs)
+  (:test_liq ../test.liq)
+  (:run_test ../run_test.exe))
+ (action (run %{run_test} GH4140.liq liquidsoap %{test_liq} GH4140.liq)))
+  
+(rule
+ (alias citest)
+ (package liquidsoap)
+ (deps
   LS268.liq
   ../media/all_media_files
   ../../src/bin/liquidsoap.exe


### PR DESCRIPTION
#3967 was a little too agressive. Turns out some variables might still refer to builtins at runtime so we need to keep them until we have a better mechanism to weed them out.

Fixes: #4140 