### PR TITLE
Fix call to `string.length`

### DIFF
--- a/src/libs/extra/audio.liq
+++ b/src/libs/extra/audio.liq
@@ -303,7 +303,7 @@ end
 def replaces dtmf(~duration=0.1, ~delay=0.05, dtmf) =
   l = ref([])
   for i = 0 to
-    string.length(encoding="ascii", dtmf) - 1
+    string.bytes.length(dtmf) - 1
   do
     c = string.sub(encoding="ascii", dtmf, start=i, length=1)
     let (row, col) =

--- a/src/libs/file.liq
+++ b/src/libs/file.liq
@@ -321,10 +321,10 @@ def file.metadata.flac.cover.encode(
   data
 ) =
   def encode_string(s) =
-    len = 1 + (string.length(encoding="ascii", s) / 8)
+    len = 1 + (string.bytes.length(s) / 8)
     str_len = string.binary.of_int(little_endian=false, pad=4, len)
     if
-      string.length(encoding="ascii", str_len) > 4
+      string.bytes.length(str_len) > 4
     then
       error.raise(
         error.invalid,
@@ -332,7 +332,7 @@ def file.metadata.flac.cover.encode(
       )
     end
 
-    pad = string.make(char_code=0, len * 8 - string.length(encoding="ascii", s))
+    pad = string.make(char_code=0, len * 8 - string.bytes.length(s))
     (str_len, "#{s}#{pad}")
   end
 

--- a/src/libs/http.liq
+++ b/src/libs/http.liq
@@ -139,10 +139,11 @@ def http.response(
         getter.is_constant(data)
       then
         data = getter.get(data)
+        len = string.length(encoding="ascii", data)
         if
           data != ""
         then
-          ("Content-Length", "#{string.length(data)}")::headers
+          ("Content-Length", "#{len}")::headers
         else
           headers
         end
@@ -308,7 +309,13 @@ end
 # @flag hidden
 def harbor.http.regexp_of_path(path) =
   def named_capture(s) =
-    name = string.sub(encoding="ascii", s, start=1, length=string.length(encoding="ascii", s) - 1)
+    name =
+      string.sub(
+        encoding="ascii",
+        s,
+        start=1,
+        length=string.length(encoding="ascii", s) - 1
+      )
     "(?<#{name}>[^/]+)"
   end
 
@@ -510,7 +517,13 @@ def harbor.http.static.base(
 
   basepath =
     if
-      string.sub(encoding="ascii", basepath, start=string.length(encoding="ascii", basepath) - 1, length=1) != "/"
+      string.sub(
+        encoding="ascii",
+        basepath,
+        start=string.length(encoding="ascii", basepath) - 1,
+        length=1
+      ) !=
+        "/"
     then
       basepath ^ "/"
     else
@@ -586,7 +599,13 @@ end
 def http.string_of_float(x) =
   s = string(x)
   n = string.length(encoding="ascii", s)
-  if string.sub(encoding="ascii", s, start=n - 1, length=1) == "." then s ^ "0" else s end
+  if
+    string.sub(encoding="ascii", s, start=n - 1, length=1) == "."
+  then
+    s ^ "0"
+  else
+    s
+  end
 end
 
 # @flag hidden

--- a/src/libs/http.liq
+++ b/src/libs/http.liq
@@ -139,7 +139,7 @@ def http.response(
         getter.is_constant(data)
       then
         data = getter.get(data)
-        len = string.length(encoding="ascii", data)
+        len = string.bytes.length(data)
         if
           data != ""
         then
@@ -181,7 +181,7 @@ def http.response(
       getter.get(data)
     else
       data = getter.get(data)
-      len = string.length(encoding="ascii", data)
+      len = string.bytes.length(data)
       response_ended := data == ""
       "#{string.hex_of_int(len)}\r\n#{data}\r\n"
     end
@@ -311,10 +311,7 @@ def harbor.http.regexp_of_path(path) =
   def named_capture(s) =
     name =
       string.sub(
-        encoding="ascii",
-        s,
-        start=1,
-        length=string.length(encoding="ascii", s) - 1
+        encoding="ascii", s, start=1, length=string.bytes.length(s) - 1
       )
     "(?<#{name}>[^/]+)"
   end
@@ -520,7 +517,7 @@ def harbor.http.static.base(
       string.sub(
         encoding="ascii",
         basepath,
-        start=string.length(encoding="ascii", basepath) - 1,
+        start=string.bytes.length(basepath) - 1,
         length=1
       ) !=
         "/"
@@ -598,7 +595,7 @@ end
 # @flag hidden
 def http.string_of_float(x) =
   s = string(x)
-  n = string.length(encoding="ascii", s)
+  n = string.bytes.length(s)
   if
     string.sub(encoding="ascii", s, start=n - 1, length=1) == "."
   then
@@ -967,7 +964,7 @@ def http.headers.content_disposition(headers) =
             type: string,
             filename?: string,
             name?: string,
-            args: [(string*string?)]
+            args: [(string * string?)]
           }
         )
       end,

--- a/src/libs/protocols.liq
+++ b/src/libs/protocols.liq
@@ -429,7 +429,7 @@ def protocol.ffmpeg(~rlog, ~maxtime, arg) =
     end
 
     m = string.concat(separator=",", list.map(f, m))
-    if string.length(encoding="ascii", m) > 0 then "annotate:#{m}:" else "" end
+    if string.bytes.length(m) > 0 then "annotate:#{m}:" else "" end
   end
 
   def parse_metadata(file) =

--- a/src/libs/string.liq
+++ b/src/libs/string.liq
@@ -35,6 +35,18 @@ def string.split(~separator, s) =
   regexp(separator).split(s)
 end
 
+# Return an array of the string's bytes.
+# @category String
+def string.bytes(s) =
+  string.split(separator="", s)
+end
+
+# Return the length of the string in bytes.
+# @category String
+def string.bytes.length(s) =
+  string.length(encoding="ascii", s)
+end
+
 # Split a string in two at first "separator".
 # @category String
 def string.split.first(~encoding=null(), ~separator, s) =
@@ -170,7 +182,7 @@ def string.of_int(~digits=0, n) =
   then
     s
   else
-    string.make(char_code=48, digits - string.length(s)) ^ s
+    string.make(char_code=48, digits - string.bytes.length(s)) ^ s
   end
 end
 
@@ -189,7 +201,7 @@ let string.binary = ()
 # @param s String containing the binary representation.
 def string.binary.to_int(~little_endian=true, s) =
   ans = ref(0)
-  n = string.length(encoding="ascii", s)
+  n = string.bytes.length(s)
   for i = 0 to
     n - 1
   do
@@ -225,7 +237,7 @@ def string.binary.of_int(~pad=0, ~little_endian=true, d) =
 
   ret = d == 0 ? "\\x00" : f(d, "")
   ret = string.unescape(ret)
-  len = string.length(encoding="ascii", ret)
+  len = string.bytes.length(ret)
   if
     len < pad
   then

--- a/tests/regression/GH4144.liq
+++ b/tests/regression/GH4144.liq
@@ -1,0 +1,38 @@
+def metadata_test(_) =
+  data = {test={test="好吗"}}
+  try
+    http.response(
+      status_code=200,
+      headers=
+        [
+          ("Content-Type", "application/json"),
+          ("Access-Control-Allow-Origin", "*")
+        ],
+      content_type=
+        "application/json; charset=UTF-8",
+      data=json.stringify(data, compact=true)
+    )
+  catch error do
+    log.severe(error.message, label="http")
+    http.response(
+      status_code=500,
+      content_type=
+        "application/json; charset=UTF-8",
+      data=
+        '{"status"="error","message"="Failed to serialize response data"}' ^
+          "\n"
+    )
+  end
+end
+
+port = 4144
+
+harbor.http.register.simple("/test", metadata_test, port=port, method="GET")
+
+def check() =
+  resp = http.get("http://localhost:#{port}/test")
+  test.equal(resp, '{"test":{"test":"好吗"}}')
+  test.pass()
+end
+
+test.check(check)

--- a/tests/regression/dune.inc
+++ b/tests/regression/dune.inc
@@ -723,6 +723,22 @@
  (alias citest)
  (package liquidsoap)
  (deps
+  GH4144.liq
+  ../media/all_media_files
+  ../../src/bin/liquidsoap.exe
+  ../streams/file1.png
+  ../streams/file1.mp3
+  ./theora-test.mp4
+  (package liquidsoap)
+  (source_tree ../../src/libs)
+  (:test_liq ../test.liq)
+  (:run_test ../run_test.exe))
+ (action (run %{run_test} GH4144.liq liquidsoap %{test_liq} GH4144.liq)))
+  
+(rule
+ (alias citest)
+ (package liquidsoap)
+ (deps
   LS268.liq
   ../media/all_media_files
   ../../src/bin/liquidsoap.exe


### PR DESCRIPTION
This fixes #4144.

An `string.bytes.length` specific API is also added for clarity.