### PR TITLE
Initialize ffmpeg filter input clocks as passive clocks.

### DIFF
--- a/src/core/io/ffmpeg_filter_io.ml
+++ b/src/core/io/ffmpeg_filter_io.ml
@@ -82,8 +82,9 @@ class virtual ['a] base_output ~pass_metadata ~name ~frame_t ~field source =
   object (self)
     inherit
       Output.output
+        ~clock:(Clock.create ~sync:`Passive ~id:name ())
         ~infallible:false ~register_telnet:false ~on_stop:noop ~on_start:noop
-          ~name ~output_kind:"ffmpeg.filter.input" (Lang.source source) true as super
+        ~name ~output_kind:"ffmpeg.filter.input" (Lang.source source) true as super
 
     inherit ['a] duration_converter
 


### PR DESCRIPTION
We've seen reports of the ffmpeg filter input clock starting before being unified with the filter's clock.

Fffmpeg filter inputs should always be passive clocks, driven by the filter's output so this PR initializes them as such.