### PR TITLE
Add generic thread queues, use them to implement autocue-specific queue

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -34,6 +34,8 @@ New:
 - Added `video.canvas` to make it possible to position video elements independently
   of the rendered video size ([#3656](https://github.com/savonet/liquidsoap/pull/3656), [blog post](https://www.liquidsoap.info/blog/2024-02-10-video-canvas-and-ai/))
 - Added cover manager from an original code by @vitoyucepi (#3651)
+- Reworked scheduler queues logic, allow user-defined queues, add options to pick
+  the queue to send asynchronous tasks to (#4151)
 - Added non-interleaved API to `%ffmpeg` encoder, enabled by default when only
   one stream is encoded.
 - Allow trailing commas in record definition (#3300).

--- a/doc/content/liq/radiopi.liq
+++ b/doc/content/liq/radiopi.liq
@@ -16,12 +16,6 @@ settings.harbor.bind_addrs.set(["0.0.0.0"])
 # Verbose logs
 log.level.set(4)
 
-# We use the scheduler intensively,
-# therefore we create many queues.
-settings.scheduler.generic_queues.set(5)
-settings.scheduler.fast_queues.set(3)
-settings.scheduler.non_blocking_queues.set(3)
-
 # === Settings ===
 
 # The host to request files

--- a/doc/content/liq/task-example.liq
+++ b/doc/content/liq/task-example.liq
@@ -1,0 +1,5 @@
+def connect_callback() =
+  ignore(http.post("http://host/on_connect"))
+end
+
+thread.run(connect_callback)

--- a/doc/content/liq/task-with-queue.liq
+++ b/doc/content/liq/task-with-queue.liq
@@ -1,0 +1,12 @@
+# Add 3 foo queue
+settings.scheduler.queues.set([
+   ...settings.scheduler.queues(),
+   ("foo", 3)
+])
+
+def connect_callback() =
+  ignore(http.post("http://host/on_connect"))
+end
+
+# Execute inside the foo queue
+thread.run(queue="foo", connect_callback)

--- a/doc/content/migrating.md
+++ b/doc/content/migrating.md
@@ -76,6 +76,34 @@ def transition(old, new) =
 end
 ```
 
+### Thread queues
+
+In order to improve issues with complex inter-dependent asynchronous tasks such as `autocue` data computation,
+scheduler queues have been improved.
+
+User-provided named queues can now be created and used to send asynchronous tasks, making it possible to control
+concurrency of certain classes of tasks and also to remedy any potential dependency between asynchronous tasks.
+
+Settings for queues have thus changed and now will look like this:
+
+```liquidsoap
+# Add a custom queue with 4 workers, increase generic queues to 4:
+settings.scheduler.queues.set([
+  ...list.assoc,remove("generic", settings.scheduler.queues()),
+  ("generic", 4),
+  ("custom", 4)
+]
+```
+
+The `fast` argument of the `thread.run.*` functions has been replaced by `queue`, telling the operator which queue should the
+asynchronous tasks sent to.
+
+Likewise, `request.dynamic`, `playlist`, `single` etc. have also been updated to accept a `thread_queue` argument controlling
+which asynchronous queue their request resolution tasks should be sent to.
+
+See [the original Pull Request)[https://github.com/savonet/liquidsoap/pull/4151) and [the threads page](threads.html)
+for more details.
+
 ### Replaygain
 
 - There is a new `metadata.replaygain` function that extracts the replay gain value in _dB_ from the metadata.

--- a/doc/content/threads.md
+++ b/doc/content/threads.md
@@ -23,7 +23,7 @@ By convention, tasks that are known to be executing very fast should be sent to 
 
 You can decide which queue to send tasks to by using the `queue` parameter of the
 `thread.run` functions. Some other operators who also use threads can have a similar
-parameter such as `queue_name` for `request.dynamic` and `playlist`.
+parameter such as `thread_queue` for `request.dynamic` and `playlist`.
 
 ```{.liquidsoap include="task-with-queue.liq"}
 

--- a/doc/content/threads.md
+++ b/doc/content/threads.md
@@ -1,0 +1,45 @@
+# Threads
+
+The main purpose of liquidsoap is to create real time media streams. When streams are created, everything that
+is needed to compute them needs to happen very quickly so that we make sure that the stream can in fact
+be created in real time.
+
+When a tasks is required that may take some time and whose result is not required for the stream generation,
+for instance when executing a `on_stop` or `on_connect` callback, it can be useful to execute this task in a _thread_.
+
+Threads in liquidsoap are callback functions that are executed by an asynchronous queue. Here's an example:
+
+```{.liquidsoap include="task-example.liq"}
+
+```
+
+By default, there are two type of queues available in liquidsoap:
+
+- `generic` queues
+- `non_blocking` queues
+
+By convention, tasks that are known to be executing very fast should be sent to the
+`non_blockin` queues and all the other tasks should be sent to the `generic` queue.
+
+You can decide which queue to send tasks to by using the `queue` parameter of the
+`thread.run` functions. Some other operators who also use threads can have a similar
+parameter such as `queue_name` for `request.dynamic` and `playlist`.
+
+```{.liquidsoap include="task-with-queue.liq"}
+
+```
+
+You can also define your own named queue using the `settings.scheduler.queues` setting.
+This is particularly useful for two applications:
+
+- To control concurrent execution of specific tasks.
+- To prevent deadlocks in cases some tasks depends on other tasks.
+
+Typically, `autocue` data resolution is executed inside a `request` resolution. To
+control the concurrency with which this CPU-intensive task is executed, we place them
+in specific queues. The number of queues controls how many of these tasks can be executed
+concurrently.
+
+Also, this prevents a deadlock where all the request resolution fill up the available
+`generic` queues, making it impossible for the autocue computation to finish, thus preventing
+the request resolution from returning.

--- a/doc/dune.inc
+++ b/doc/dune.inc
@@ -167,6 +167,8 @@
     content/liq/srt-receiver.liq
     content/liq/srt-sender.liq
     content/liq/switch-show.liq
+    content/liq/task-example.liq
+    content/liq/task-with-queue.liq
     content/liq/transcoding.liq
     content/liq/video-anonymizer.liq
     content/liq/video-bluescreen.liq
@@ -295,6 +297,8 @@
     content/liq/srt-receiver.liq
     content/liq/srt-sender.liq
     content/liq/switch-show.liq
+    content/liq/task-example.liq
+    content/liq/task-with-queue.liq
     content/liq/transcoding.liq
     content/liq/video-anonymizer.liq
     content/liq/video-bluescreen.liq
@@ -423,6 +427,8 @@
     content/liq/srt-receiver.liq
     content/liq/srt-sender.liq
     content/liq/switch-show.liq
+    content/liq/task-example.liq
+    content/liq/task-with-queue.liq
     content/liq/transcoding.liq
     content/liq/video-anonymizer.liq
     content/liq/video-bluescreen.liq
@@ -551,6 +557,8 @@
     content/liq/srt-receiver.liq
     content/liq/srt-sender.liq
     content/liq/switch-show.liq
+    content/liq/task-example.liq
+    content/liq/task-with-queue.liq
     content/liq/transcoding.liq
     content/liq/video-anonymizer.liq
     content/liq/video-bluescreen.liq
@@ -679,6 +687,8 @@
     content/liq/srt-receiver.liq
     content/liq/srt-sender.liq
     content/liq/switch-show.liq
+    content/liq/task-example.liq
+    content/liq/task-with-queue.liq
     content/liq/transcoding.liq
     content/liq/video-anonymizer.liq
     content/liq/video-bluescreen.liq
@@ -807,6 +817,8 @@
     content/liq/srt-receiver.liq
     content/liq/srt-sender.liq
     content/liq/switch-show.liq
+    content/liq/task-example.liq
+    content/liq/task-with-queue.liq
     content/liq/transcoding.liq
     content/liq/video-anonymizer.liq
     content/liq/video-bluescreen.liq
@@ -935,6 +947,8 @@
     content/liq/srt-receiver.liq
     content/liq/srt-sender.liq
     content/liq/switch-show.liq
+    content/liq/task-example.liq
+    content/liq/task-with-queue.liq
     content/liq/transcoding.liq
     content/liq/video-anonymizer.liq
     content/liq/video-bluescreen.liq
@@ -1063,6 +1077,8 @@
     content/liq/srt-receiver.liq
     content/liq/srt-sender.liq
     content/liq/switch-show.liq
+    content/liq/task-example.liq
+    content/liq/task-with-queue.liq
     content/liq/transcoding.liq
     content/liq/video-anonymizer.liq
     content/liq/video-bluescreen.liq
@@ -1191,6 +1207,8 @@
     content/liq/srt-receiver.liq
     content/liq/srt-sender.liq
     content/liq/switch-show.liq
+    content/liq/task-example.liq
+    content/liq/task-with-queue.liq
     content/liq/transcoding.liq
     content/liq/video-anonymizer.liq
     content/liq/video-bluescreen.liq
@@ -1319,6 +1337,8 @@
     content/liq/srt-receiver.liq
     content/liq/srt-sender.liq
     content/liq/switch-show.liq
+    content/liq/task-example.liq
+    content/liq/task-with-queue.liq
     content/liq/transcoding.liq
     content/liq/video-anonymizer.liq
     content/liq/video-bluescreen.liq
@@ -1447,6 +1467,8 @@
     content/liq/srt-receiver.liq
     content/liq/srt-sender.liq
     content/liq/switch-show.liq
+    content/liq/task-example.liq
+    content/liq/task-with-queue.liq
     content/liq/transcoding.liq
     content/liq/video-anonymizer.liq
     content/liq/video-bluescreen.liq
@@ -1575,6 +1597,8 @@
     content/liq/srt-receiver.liq
     content/liq/srt-sender.liq
     content/liq/switch-show.liq
+    content/liq/task-example.liq
+    content/liq/task-with-queue.liq
     content/liq/transcoding.liq
     content/liq/video-anonymizer.liq
     content/liq/video-bluescreen.liq
@@ -1703,6 +1727,8 @@
     content/liq/srt-receiver.liq
     content/liq/srt-sender.liq
     content/liq/switch-show.liq
+    content/liq/task-example.liq
+    content/liq/task-with-queue.liq
     content/liq/transcoding.liq
     content/liq/video-anonymizer.liq
     content/liq/video-bluescreen.liq
@@ -1831,6 +1857,8 @@
     content/liq/srt-receiver.liq
     content/liq/srt-sender.liq
     content/liq/switch-show.liq
+    content/liq/task-example.liq
+    content/liq/task-with-queue.liq
     content/liq/transcoding.liq
     content/liq/video-anonymizer.liq
     content/liq/video-bluescreen.liq
@@ -1959,6 +1987,8 @@
     content/liq/srt-receiver.liq
     content/liq/srt-sender.liq
     content/liq/switch-show.liq
+    content/liq/task-example.liq
+    content/liq/task-with-queue.liq
     content/liq/transcoding.liq
     content/liq/video-anonymizer.liq
     content/liq/video-bluescreen.liq
@@ -2087,6 +2117,8 @@
     content/liq/srt-receiver.liq
     content/liq/srt-sender.liq
     content/liq/switch-show.liq
+    content/liq/task-example.liq
+    content/liq/task-with-queue.liq
     content/liq/transcoding.liq
     content/liq/video-anonymizer.liq
     content/liq/video-bluescreen.liq
@@ -2215,6 +2247,8 @@
     content/liq/srt-receiver.liq
     content/liq/srt-sender.liq
     content/liq/switch-show.liq
+    content/liq/task-example.liq
+    content/liq/task-with-queue.liq
     content/liq/transcoding.liq
     content/liq/video-anonymizer.liq
     content/liq/video-bluescreen.liq
@@ -2343,6 +2377,8 @@
     content/liq/srt-receiver.liq
     content/liq/srt-sender.liq
     content/liq/switch-show.liq
+    content/liq/task-example.liq
+    content/liq/task-with-queue.liq
     content/liq/transcoding.liq
     content/liq/video-anonymizer.liq
     content/liq/video-bluescreen.liq
@@ -2471,6 +2507,8 @@
     content/liq/srt-receiver.liq
     content/liq/srt-sender.liq
     content/liq/switch-show.liq
+    content/liq/task-example.liq
+    content/liq/task-with-queue.liq
     content/liq/transcoding.liq
     content/liq/video-anonymizer.liq
     content/liq/video-bluescreen.liq
@@ -2599,6 +2637,8 @@
     content/liq/srt-receiver.liq
     content/liq/srt-sender.liq
     content/liq/switch-show.liq
+    content/liq/task-example.liq
+    content/liq/task-with-queue.liq
     content/liq/transcoding.liq
     content/liq/video-anonymizer.liq
     content/liq/video-bluescreen.liq
@@ -2727,6 +2767,8 @@
     content/liq/srt-receiver.liq
     content/liq/srt-sender.liq
     content/liq/switch-show.liq
+    content/liq/task-example.liq
+    content/liq/task-with-queue.liq
     content/liq/transcoding.liq
     content/liq/video-anonymizer.liq
     content/liq/video-bluescreen.liq
@@ -2855,6 +2897,8 @@
     content/liq/srt-receiver.liq
     content/liq/srt-sender.liq
     content/liq/switch-show.liq
+    content/liq/task-example.liq
+    content/liq/task-with-queue.liq
     content/liq/transcoding.liq
     content/liq/video-anonymizer.liq
     content/liq/video-bluescreen.liq
@@ -2983,6 +3027,8 @@
     content/liq/srt-receiver.liq
     content/liq/srt-sender.liq
     content/liq/switch-show.liq
+    content/liq/task-example.liq
+    content/liq/task-with-queue.liq
     content/liq/transcoding.liq
     content/liq/video-anonymizer.liq
     content/liq/video-bluescreen.liq
@@ -3111,6 +3157,8 @@
     content/liq/srt-receiver.liq
     content/liq/srt-sender.liq
     content/liq/switch-show.liq
+    content/liq/task-example.liq
+    content/liq/task-with-queue.liq
     content/liq/transcoding.liq
     content/liq/video-anonymizer.liq
     content/liq/video-bluescreen.liq
@@ -3239,6 +3287,8 @@
     content/liq/srt-receiver.liq
     content/liq/srt-sender.liq
     content/liq/switch-show.liq
+    content/liq/task-example.liq
+    content/liq/task-with-queue.liq
     content/liq/transcoding.liq
     content/liq/video-anonymizer.liq
     content/liq/video-bluescreen.liq
@@ -3367,6 +3417,8 @@
     content/liq/srt-receiver.liq
     content/liq/srt-sender.liq
     content/liq/switch-show.liq
+    content/liq/task-example.liq
+    content/liq/task-with-queue.liq
     content/liq/transcoding.liq
     content/liq/video-anonymizer.liq
     content/liq/video-bluescreen.liq
@@ -3495,6 +3547,8 @@
     content/liq/srt-receiver.liq
     content/liq/srt-sender.liq
     content/liq/switch-show.liq
+    content/liq/task-example.liq
+    content/liq/task-with-queue.liq
     content/liq/transcoding.liq
     content/liq/video-anonymizer.liq
     content/liq/video-bluescreen.liq
@@ -3623,6 +3677,8 @@
     content/liq/srt-receiver.liq
     content/liq/srt-sender.liq
     content/liq/switch-show.liq
+    content/liq/task-example.liq
+    content/liq/task-with-queue.liq
     content/liq/transcoding.liq
     content/liq/video-anonymizer.liq
     content/liq/video-bluescreen.liq
@@ -3751,6 +3807,8 @@
     content/liq/srt-receiver.liq
     content/liq/srt-sender.liq
     content/liq/switch-show.liq
+    content/liq/task-example.liq
+    content/liq/task-with-queue.liq
     content/liq/transcoding.liq
     content/liq/video-anonymizer.liq
     content/liq/video-bluescreen.liq
@@ -3879,6 +3937,8 @@
     content/liq/srt-receiver.liq
     content/liq/srt-sender.liq
     content/liq/switch-show.liq
+    content/liq/task-example.liq
+    content/liq/task-with-queue.liq
     content/liq/transcoding.liq
     content/liq/video-anonymizer.liq
     content/liq/video-bluescreen.liq
@@ -4007,6 +4067,8 @@
     content/liq/srt-receiver.liq
     content/liq/srt-sender.liq
     content/liq/switch-show.liq
+    content/liq/task-example.liq
+    content/liq/task-with-queue.liq
     content/liq/transcoding.liq
     content/liq/video-anonymizer.liq
     content/liq/video-bluescreen.liq
@@ -4135,6 +4197,8 @@
     content/liq/srt-receiver.liq
     content/liq/srt-sender.liq
     content/liq/switch-show.liq
+    content/liq/task-example.liq
+    content/liq/task-with-queue.liq
     content/liq/transcoding.liq
     content/liq/video-anonymizer.liq
     content/liq/video-bluescreen.liq
@@ -4263,6 +4327,8 @@
     content/liq/srt-receiver.liq
     content/liq/srt-sender.liq
     content/liq/switch-show.liq
+    content/liq/task-example.liq
+    content/liq/task-with-queue.liq
     content/liq/transcoding.liq
     content/liq/video-anonymizer.liq
     content/liq/video-bluescreen.liq
@@ -4391,6 +4457,8 @@
     content/liq/srt-receiver.liq
     content/liq/srt-sender.liq
     content/liq/switch-show.liq
+    content/liq/task-example.liq
+    content/liq/task-with-queue.liq
     content/liq/transcoding.liq
     content/liq/video-anonymizer.liq
     content/liq/video-bluescreen.liq
@@ -4519,6 +4587,8 @@
     content/liq/srt-receiver.liq
     content/liq/srt-sender.liq
     content/liq/switch-show.liq
+    content/liq/task-example.liq
+    content/liq/task-with-queue.liq
     content/liq/transcoding.liq
     content/liq/video-anonymizer.liq
     content/liq/video-bluescreen.liq
@@ -4647,6 +4717,8 @@
     content/liq/srt-receiver.liq
     content/liq/srt-sender.liq
     content/liq/switch-show.liq
+    content/liq/task-example.liq
+    content/liq/task-with-queue.liq
     content/liq/transcoding.liq
     content/liq/video-anonymizer.liq
     content/liq/video-bluescreen.liq
@@ -4775,6 +4847,8 @@
     content/liq/srt-receiver.liq
     content/liq/srt-sender.liq
     content/liq/switch-show.liq
+    content/liq/task-example.liq
+    content/liq/task-with-queue.liq
     content/liq/transcoding.liq
     content/liq/video-anonymizer.liq
     content/liq/video-bluescreen.liq
@@ -4903,6 +4977,8 @@
     content/liq/srt-receiver.liq
     content/liq/srt-sender.liq
     content/liq/switch-show.liq
+    content/liq/task-example.liq
+    content/liq/task-with-queue.liq
     content/liq/transcoding.liq
     content/liq/video-anonymizer.liq
     content/liq/video-bluescreen.liq
@@ -5031,6 +5107,8 @@
     content/liq/srt-receiver.liq
     content/liq/srt-sender.liq
     content/liq/switch-show.liq
+    content/liq/task-example.liq
+    content/liq/task-with-queue.liq
     content/liq/transcoding.liq
     content/liq/video-anonymizer.liq
     content/liq/video-bluescreen.liq
@@ -5159,6 +5237,8 @@
     content/liq/srt-receiver.liq
     content/liq/srt-sender.liq
     content/liq/switch-show.liq
+    content/liq/task-example.liq
+    content/liq/task-with-queue.liq
     content/liq/transcoding.liq
     content/liq/video-anonymizer.liq
     content/liq/video-bluescreen.liq
@@ -5287,6 +5367,8 @@
     content/liq/srt-receiver.liq
     content/liq/srt-sender.liq
     content/liq/switch-show.liq
+    content/liq/task-example.liq
+    content/liq/task-with-queue.liq
     content/liq/transcoding.liq
     content/liq/video-anonymizer.liq
     content/liq/video-bluescreen.liq
@@ -5415,6 +5497,8 @@
     content/liq/srt-receiver.liq
     content/liq/srt-sender.liq
     content/liq/switch-show.liq
+    content/liq/task-example.liq
+    content/liq/task-with-queue.liq
     content/liq/transcoding.liq
     content/liq/video-anonymizer.liq
     content/liq/video-bluescreen.liq
@@ -5543,6 +5627,8 @@
     content/liq/srt-receiver.liq
     content/liq/srt-sender.liq
     content/liq/switch-show.liq
+    content/liq/task-example.liq
+    content/liq/task-with-queue.liq
     content/liq/transcoding.liq
     content/liq/video-anonymizer.liq
     content/liq/video-bluescreen.liq
@@ -5671,6 +5757,8 @@
     content/liq/srt-receiver.liq
     content/liq/srt-sender.liq
     content/liq/switch-show.liq
+    content/liq/task-example.liq
+    content/liq/task-with-queue.liq
     content/liq/transcoding.liq
     content/liq/video-anonymizer.liq
     content/liq/video-bluescreen.liq
@@ -5799,6 +5887,8 @@
     content/liq/srt-receiver.liq
     content/liq/srt-sender.liq
     content/liq/switch-show.liq
+    content/liq/task-example.liq
+    content/liq/task-with-queue.liq
     content/liq/transcoding.liq
     content/liq/video-anonymizer.liq
     content/liq/video-bluescreen.liq
@@ -5927,6 +6017,8 @@
     content/liq/srt-receiver.liq
     content/liq/srt-sender.liq
     content/liq/switch-show.liq
+    content/liq/task-example.liq
+    content/liq/task-with-queue.liq
     content/liq/transcoding.liq
     content/liq/video-anonymizer.liq
     content/liq/video-bluescreen.liq
@@ -6055,6 +6147,8 @@
     content/liq/srt-receiver.liq
     content/liq/srt-sender.liq
     content/liq/switch-show.liq
+    content/liq/task-example.liq
+    content/liq/task-with-queue.liq
     content/liq/transcoding.liq
     content/liq/video-anonymizer.liq
     content/liq/video-bluescreen.liq
@@ -6183,6 +6277,8 @@
     content/liq/srt-receiver.liq
     content/liq/srt-sender.liq
     content/liq/switch-show.liq
+    content/liq/task-example.liq
+    content/liq/task-with-queue.liq
     content/liq/transcoding.liq
     content/liq/video-anonymizer.liq
     content/liq/video-bluescreen.liq
@@ -6311,6 +6407,8 @@
     content/liq/srt-receiver.liq
     content/liq/srt-sender.liq
     content/liq/switch-show.liq
+    content/liq/task-example.liq
+    content/liq/task-with-queue.liq
     content/liq/transcoding.liq
     content/liq/video-anonymizer.liq
     content/liq/video-bluescreen.liq
@@ -6439,6 +6537,8 @@
     content/liq/srt-receiver.liq
     content/liq/srt-sender.liq
     content/liq/switch-show.liq
+    content/liq/task-example.liq
+    content/liq/task-with-queue.liq
     content/liq/transcoding.liq
     content/liq/video-anonymizer.liq
     content/liq/video-bluescreen.liq
@@ -6567,6 +6667,8 @@
     content/liq/srt-receiver.liq
     content/liq/srt-sender.liq
     content/liq/switch-show.liq
+    content/liq/task-example.liq
+    content/liq/task-with-queue.liq
     content/liq/transcoding.liq
     content/liq/video-anonymizer.liq
     content/liq/video-bluescreen.liq
@@ -6695,6 +6797,8 @@
     content/liq/srt-receiver.liq
     content/liq/srt-sender.liq
     content/liq/switch-show.liq
+    content/liq/task-example.liq
+    content/liq/task-with-queue.liq
     content/liq/transcoding.liq
     content/liq/video-anonymizer.liq
     content/liq/video-bluescreen.liq
@@ -6823,6 +6927,8 @@
     content/liq/srt-receiver.liq
     content/liq/srt-sender.liq
     content/liq/switch-show.liq
+    content/liq/task-example.liq
+    content/liq/task-with-queue.liq
     content/liq/transcoding.liq
     content/liq/video-anonymizer.liq
     content/liq/video-bluescreen.liq
@@ -6951,6 +7057,8 @@
     content/liq/srt-receiver.liq
     content/liq/srt-sender.liq
     content/liq/switch-show.liq
+    content/liq/task-example.liq
+    content/liq/task-with-queue.liq
     content/liq/transcoding.liq
     content/liq/video-anonymizer.liq
     content/liq/video-bluescreen.liq
@@ -7079,6 +7187,8 @@
     content/liq/srt-receiver.liq
     content/liq/srt-sender.liq
     content/liq/switch-show.liq
+    content/liq/task-example.liq
+    content/liq/task-with-queue.liq
     content/liq/transcoding.liq
     content/liq/video-anonymizer.liq
     content/liq/video-bluescreen.liq
@@ -7207,6 +7317,8 @@
     content/liq/srt-receiver.liq
     content/liq/srt-sender.liq
     content/liq/switch-show.liq
+    content/liq/task-example.liq
+    content/liq/task-with-queue.liq
     content/liq/transcoding.liq
     content/liq/video-anonymizer.liq
     content/liq/video-bluescreen.liq
@@ -7335,6 +7447,8 @@
     content/liq/srt-receiver.liq
     content/liq/srt-sender.liq
     content/liq/switch-show.liq
+    content/liq/task-example.liq
+    content/liq/task-with-queue.liq
     content/liq/transcoding.liq
     content/liq/video-anonymizer.liq
     content/liq/video-bluescreen.liq
@@ -7463,6 +7577,8 @@
     content/liq/srt-receiver.liq
     content/liq/srt-sender.liq
     content/liq/switch-show.liq
+    content/liq/task-example.liq
+    content/liq/task-with-queue.liq
     content/liq/transcoding.liq
     content/liq/video-anonymizer.liq
     content/liq/video-bluescreen.liq
@@ -7591,6 +7707,8 @@
     content/liq/srt-receiver.liq
     content/liq/srt-sender.liq
     content/liq/switch-show.liq
+    content/liq/task-example.liq
+    content/liq/task-with-queue.liq
     content/liq/transcoding.liq
     content/liq/video-anonymizer.liq
     content/liq/video-bluescreen.liq
@@ -7719,6 +7837,8 @@
     content/liq/srt-receiver.liq
     content/liq/srt-sender.liq
     content/liq/switch-show.liq
+    content/liq/task-example.liq
+    content/liq/task-with-queue.liq
     content/liq/transcoding.liq
     content/liq/video-anonymizer.liq
     content/liq/video-bluescreen.liq
@@ -7847,6 +7967,8 @@
     content/liq/srt-receiver.liq
     content/liq/srt-sender.liq
     content/liq/switch-show.liq
+    content/liq/task-example.liq
+    content/liq/task-with-queue.liq
     content/liq/transcoding.liq
     content/liq/video-anonymizer.liq
     content/liq/video-bluescreen.liq
@@ -7975,6 +8097,8 @@
     content/liq/srt-receiver.liq
     content/liq/srt-sender.liq
     content/liq/switch-show.liq
+    content/liq/task-example.liq
+    content/liq/task-with-queue.liq
     content/liq/transcoding.liq
     content/liq/video-anonymizer.liq
     content/liq/video-bluescreen.liq
@@ -8103,6 +8227,8 @@
     content/liq/srt-receiver.liq
     content/liq/srt-sender.liq
     content/liq/switch-show.liq
+    content/liq/task-example.liq
+    content/liq/task-with-queue.liq
     content/liq/transcoding.liq
     content/liq/video-anonymizer.liq
     content/liq/video-bluescreen.liq
@@ -8231,6 +8357,8 @@
     content/liq/srt-receiver.liq
     content/liq/srt-sender.liq
     content/liq/switch-show.liq
+    content/liq/task-example.liq
+    content/liq/task-with-queue.liq
     content/liq/transcoding.liq
     content/liq/video-anonymizer.liq
     content/liq/video-bluescreen.liq
@@ -8359,6 +8487,8 @@
     content/liq/srt-receiver.liq
     content/liq/srt-sender.liq
     content/liq/switch-show.liq
+    content/liq/task-example.liq
+    content/liq/task-with-queue.liq
     content/liq/transcoding.liq
     content/liq/video-anonymizer.liq
     content/liq/video-bluescreen.liq
@@ -8487,6 +8617,8 @@
     content/liq/srt-receiver.liq
     content/liq/srt-sender.liq
     content/liq/switch-show.liq
+    content/liq/task-example.liq
+    content/liq/task-with-queue.liq
     content/liq/transcoding.liq
     content/liq/video-anonymizer.liq
     content/liq/video-bluescreen.liq
@@ -8615,6 +8747,8 @@
     content/liq/srt-receiver.liq
     content/liq/srt-sender.liq
     content/liq/switch-show.liq
+    content/liq/task-example.liq
+    content/liq/task-with-queue.liq
     content/liq/transcoding.liq
     content/liq/video-anonymizer.liq
     content/liq/video-bluescreen.liq
@@ -8743,6 +8877,8 @@
     content/liq/srt-receiver.liq
     content/liq/srt-sender.liq
     content/liq/switch-show.liq
+    content/liq/task-example.liq
+    content/liq/task-with-queue.liq
     content/liq/transcoding.liq
     content/liq/video-anonymizer.liq
     content/liq/video-bluescreen.liq
@@ -8871,6 +9007,8 @@
     content/liq/srt-receiver.liq
     content/liq/srt-sender.liq
     content/liq/switch-show.liq
+    content/liq/task-example.liq
+    content/liq/task-with-queue.liq
     content/liq/transcoding.liq
     content/liq/video-anonymizer.liq
     content/liq/video-bluescreen.liq
@@ -8999,6 +9137,8 @@
     content/liq/srt-receiver.liq
     content/liq/srt-sender.liq
     content/liq/switch-show.liq
+    content/liq/task-example.liq
+    content/liq/task-with-queue.liq
     content/liq/transcoding.liq
     content/liq/video-anonymizer.liq
     content/liq/video-bluescreen.liq
@@ -9021,6 +9161,136 @@
       (run pandoc %{md} -t json)
       (run pandoc-include --directory content/liq)
       (run pandoc -f json --syntax-definition=liquidsoap.xml --highlight=pygments --metadata pagetitle=strings_encoding --template=template.html -o %{target})
+    )
+  )
+)
+
+(rule
+  (alias doc)
+  (package liquidsoap)
+  (enabled_if (not %{bin-available:pandoc}))
+  (deps (:no_pandoc no-pandoc))
+  (target threads.html)
+  (action (run cp %{no_pandoc} %{target}))
+)
+
+(rule
+  (alias doc)
+  (package liquidsoap)
+  (enabled_if %{bin-available:pandoc})
+  (deps
+    liquidsoap.xml
+    language.dtd
+    template.html
+    content/liq/append-silence.liq
+    content/liq/archive-cleaner.liq
+    content/liq/basic-radio.liq
+    content/liq/beets-amplify.liq
+    content/liq/beets-protocol-short.liq
+    content/liq/beets-protocol.liq
+    content/liq/beets-source.liq
+    content/liq/blank-detect.liq
+    content/liq/blank-sorry.liq
+    content/liq/complete-case.liq
+    content/liq/cross.custom.liq
+    content/liq/crossfade.liq
+    content/liq/decoder-faad.liq
+    content/liq/decoder-flac.liq
+    content/liq/decoder-metaflac.liq
+    content/liq/dump-hourly.liq
+    content/liq/dump-hourly2.liq
+    content/liq/dynamic-source.liq
+    content/liq/external-output.file.liq
+    content/liq/fallback.liq
+    content/liq/ffmpeg-filter-dynamic-volume.liq
+    content/liq/ffmpeg-filter-flanger-highpass.liq
+    content/liq/ffmpeg-filter-hflip.liq
+    content/liq/ffmpeg-filter-hflip2.liq
+    content/liq/ffmpeg-filter-parallel-flanger-highpass.liq
+    content/liq/ffmpeg-live-switch.liq
+    content/liq/ffmpeg-relay-ondemand.liq
+    content/liq/ffmpeg-relay.liq
+    content/liq/ffmpeg-shared-encoding-rtmp.liq
+    content/liq/ffmpeg-shared-encoding.liq
+    content/liq/fixed-time1.liq
+    content/liq/fixed-time2.liq
+    content/liq/frame-size.liq
+    content/liq/harbor-auth.liq
+    content/liq/harbor-dynamic.liq
+    content/liq/harbor-insert-metadata.liq
+    content/liq/harbor-metadata.liq
+    content/liq/harbor-redirect.liq
+    content/liq/harbor-simple.liq
+    content/liq/harbor-usage.liq
+    content/liq/harbor.http.register.liq
+    content/liq/harbor.http.response.liq
+    content/liq/hls-metadata.liq
+    content/liq/hls-mp4.liq
+    content/liq/http-input.liq
+    content/liq/icy-update.liq
+    content/liq/input.mplayer.liq
+    content/liq/jingle-hour.liq
+    content/liq/json-ex.liq
+    content/liq/json-stringify.liq
+    content/liq/json1.liq
+    content/liq/live-switch.liq
+    content/liq/medialib-predicate.liq
+    content/liq/medialib.liq
+    content/liq/medialib.sqlite.liq
+    content/liq/multitrack-add-video-track.liq
+    content/liq/multitrack-add-video-track2.liq
+    content/liq/multitrack-default-video-track.liq
+    content/liq/multitrack.liq
+    content/liq/multitrack2.liq
+    content/liq/multitrack3.liq
+    content/liq/output.file.hls.liq
+    content/liq/playlists.liq
+    content/liq/prometheus-callback.liq
+    content/liq/prometheus-settings.liq
+    content/liq/radiopi.liq
+    content/liq/re-encode.liq
+    content/liq/regular.liq
+    content/liq/replaygain-metadata.liq
+    content/liq/replaygain-playlist.liq
+    content/liq/request.dynamic.liq
+    content/liq/rtmp.liq
+    content/liq/samplerate3.liq
+    content/liq/scheduling.liq
+    content/liq/seek-telnet.liq
+    content/liq/settings.liq
+    content/liq/shoutcast.liq
+    content/liq/single.liq
+    content/liq/source-cue.liq
+    content/liq/space_overhead.liq
+    content/liq/split-cue.liq
+    content/liq/sqlite.liq
+    content/liq/srt-receiver.liq
+    content/liq/srt-sender.liq
+    content/liq/switch-show.liq
+    content/liq/task-example.liq
+    content/liq/task-with-queue.liq
+    content/liq/transcoding.liq
+    content/liq/video-anonymizer.liq
+    content/liq/video-bluescreen.liq
+    content/liq/video-canvas-example.liq
+    content/liq/video-default-canvas.liq
+    content/liq/video-in-video.liq
+    content/liq/video-logo.liq
+    content/liq/video-osc.liq
+    content/liq/video-simple.liq
+    content/liq/video-static.liq
+    content/liq/video-text.liq
+    content/liq/video-transition.liq
+    content/liq/video-weather.liq
+    content/liq/video-webcam.liq
+    (:md content/threads.md)
+  )
+  (target threads.html)
+  (action
+    (pipe-stdout
+      (run pandoc %{md} -t json)
+      (run pandoc-include --directory content/liq)
+      (run pandoc -f json --syntax-definition=liquidsoap.xml --highlight=pygments --metadata pagetitle=threads --template=template.html -o %{target})
     )
   )
 )
@@ -9127,6 +9397,8 @@
     content/liq/srt-receiver.liq
     content/liq/srt-sender.liq
     content/liq/switch-show.liq
+    content/liq/task-example.liq
+    content/liq/task-with-queue.liq
     content/liq/transcoding.liq
     content/liq/video-anonymizer.liq
     content/liq/video-bluescreen.liq
@@ -9255,6 +9527,8 @@
     content/liq/srt-receiver.liq
     content/liq/srt-sender.liq
     content/liq/switch-show.liq
+    content/liq/task-example.liq
+    content/liq/task-with-queue.liq
     content/liq/transcoding.liq
     content/liq/video-anonymizer.liq
     content/liq/video-bluescreen.liq
@@ -9383,6 +9657,8 @@
     content/liq/srt-receiver.liq
     content/liq/srt-sender.liq
     content/liq/switch-show.liq
+    content/liq/task-example.liq
+    content/liq/task-with-queue.liq
     content/liq/transcoding.liq
     content/liq/video-anonymizer.liq
     content/liq/video-bluescreen.liq
@@ -10264,6 +10540,26 @@
   (package liquidsoap)
   (deps
     (source_tree ../src/libs)
+    (:test_liq content/liq/task-example.liq)
+  )
+  (action (run %{bin:liquidsoap} --check --no-fallible-check content/liq/task-example.liq))
+)
+
+(rule
+  (alias doctest)
+  (package liquidsoap)
+  (deps
+    (source_tree ../src/libs)
+    (:test_liq content/liq/task-with-queue.liq)
+  )
+  (action (run %{bin:liquidsoap} --check --no-fallible-check content/liq/task-with-queue.liq))
+)
+
+(rule
+  (alias doctest)
+  (package liquidsoap)
+  (deps
+    (source_tree ../src/libs)
     (:test_liq content/liq/transcoding.liq)
   )
   (action (run %{bin:liquidsoap} --check --no-fallible-check content/liq/transcoding.liq))
@@ -10494,6 +10790,7 @@
     (stereotool.html as html/stereotool.html)
     (stream_content.html as html/stream_content.html)
     (strings_encoding.html as html/strings_encoding.html)
+    (threads.html as html/threads.html)
     (video-static.html as html/video-static.html)
     (video.html as html/video.html)
     (yaml.html as html/yaml.html)

--- a/src/core/builtins/builtins_socket.ml
+++ b/src/core/builtins/builtins_socket.ml
@@ -230,11 +230,7 @@ module Socket_value = struct
                   []
                 in
                 Duppy.Task.add Tutils.scheduler
-                  {
-                    Duppy.Task.priority = `Maybe_blocking;
-                    events;
-                    handler = fn;
-                  };
+                  { Duppy.Task.priority = `Generic; events; handler = fn };
                 Lang.unit) );
         ]
     in

--- a/src/core/builtins/builtins_thread.ml
+++ b/src/core/builtins/builtins_thread.ml
@@ -40,16 +40,14 @@ let _ =
 let _ =
   Lang.add_builtin ~base:thread_run "recurrent" ~category:`Programming
     [
-      ( "fast",
-        Lang.bool_t,
-        Some (Lang.bool true),
+      ( "queue",
+        Lang.string_t,
+        Some (Lang.string "generic"),
         Some
-          "Whether the thread is supposed to return quickly or not. Typically, \
-           blocking tasks (e.g. fetching data over the internet) should not be \
-           considered to be fast. When set to `false` its priority will be \
-           lowered below that of request resolutions and fast timeouts. This \
-           is only effective if you set a dedicated queue for fast tasks, see \
-           the \"scheduler\" settings for more details." );
+          "Queue to use for the task. Should be one of: `\"generic\"` or \
+           `\"non_blocking\"`. Non blocking should be reserved for tasks that \
+           are known to complete quickly. You can also use declared via \
+           `settings.scheduler.queues`." );
       ( "delay",
         Lang.float_t,
         Some (Lang.float 0.),
@@ -74,8 +72,10 @@ let _ =
       let delay = Lang.to_float (List.assoc "delay" p) in
       let f = List.assoc "" p in
       let priority =
-        if Lang.to_bool (List.assoc "fast" p) then `Maybe_blocking
-        else `Blocking
+        match Lang.to_string (List.assoc "queue" p) with
+          | "generic" -> `Generic
+          | "non_blocking" -> `Non_blocking
+          | n -> `Named n
       in
       let on_error = Lang.to_option (List.assoc "on_error" p) in
       let on_error =

--- a/src/core/decoder/external_decoder.ml
+++ b/src/core/decoder/external_decoder.ml
@@ -49,7 +49,7 @@ let external_input process input =
   in
   let log s = log#important "%s" s in
   (* reading from input is blocking.. *)
-  let priority = `Blocking in
+  let priority = `Generic in
   let process =
     Process_handler.run ~priority ~on_stdin ~on_stderr ~log process
   in

--- a/src/core/file_watcher.inotify.ml
+++ b/src/core/file_watcher.inotify.ml
@@ -51,7 +51,7 @@ let rec watchdog () =
           events;
         [watchdog ()])
   in
-  { Duppy.Task.priority = `Maybe_blocking; events = [`Read fd]; handler }
+  { Duppy.Task.priority = `Generic; events = [`Read fd]; handler }
 
 let watch : watch =
  fun ~pos e file f ->

--- a/src/core/file_watcher.mtime.ml
+++ b/src/core/file_watcher.mtime.ml
@@ -61,7 +61,7 @@ let rec handler _ =
               (Printf.sprintf "Error while executing file watcher callback: %s"
                  (Printexc.to_string exn)))
         !watched;
-      [{ Duppy.Task.priority = `Maybe_blocking; events = [`Delay 1.]; handler }])
+      [{ Duppy.Task.priority = `Generic; events = [`Delay 1.]; handler }])
     ()
 
 let watch : watch =
@@ -73,11 +73,7 @@ let watch : watch =
         if not !launched then begin
           launched := true;
           Duppy.Task.add Tutils.scheduler
-            {
-              Duppy.Task.priority = `Maybe_blocking;
-              events = [`Delay 1.];
-              handler;
-            }
+            { Duppy.Task.priority = `Generic; events = [`Delay 1.]; handler }
         end;
         let mtime = try file_mtime file with _ -> 0. in
         watched := { file; mtime; callback } :: !watched;

--- a/src/core/harbor/harbor.ml
+++ b/src/core/harbor/harbor.ml
@@ -374,7 +374,7 @@ module Make (T : Transport_t) : T with type socket = T.socket = struct
         simple_reply "No / mountpoint\r\n\r\n"
     in
     (* Authentication can be blocking. *)
-    Duppy.Monad.Io.exec ~priority:`Maybe_blocking h
+    Duppy.Monad.Io.exec ~priority:`Generic h
       (let user, auth_f = s#login in
        let user = if requested_user = "" then user else requested_user in
        if auth_f ~socket:h.Duppy.Monad.Io.socket user password then
@@ -488,7 +488,7 @@ module Make (T : Transport_t) : T with type socket = T.socket = struct
           Hashtbl.fold (fun lbl k query -> (lbl, k) :: query) query [])
         args
     in
-    Duppy.Monad.Io.exec ~priority:`Maybe_blocking h
+    Duppy.Monad.Io.exec ~priority:`Generic h
       (http_auth_check ?query ~login h.Duppy.Monad.Io.socket headers)
 
   (* We do not implement anything with this handler for now. *)
@@ -631,7 +631,7 @@ module Make (T : Transport_t) : T with type socket = T.socket = struct
         (Bytes.of_string (Websocket.upgrade headers))
     in
     let* stype, huri, user, password =
-      Duppy.Monad.Io.exec ~priority:`Blocking h
+      Duppy.Monad.Io.exec ~priority:`Generic h
         (read_hello h.Duppy.Monad.Io.socket)
     in
     log#info "Mime type: %s" stype;
@@ -899,7 +899,7 @@ module Make (T : Transport_t) : T with type socket = T.socket = struct
                   fun timeout -> fst (Http.read_chunked ~timeout socket)
               | _ -> fun _ -> ""
           in
-          Duppy.Monad.Io.exec ~priority:`Maybe_blocking h
+          Duppy.Monad.Io.exec ~priority:`Generic h
             (handler ~protocol ~meth ~headers ~data
                ~socket:h.Duppy.Monad.Io.socket ~query base_uri)
       | e ->
@@ -969,7 +969,7 @@ module Make (T : Transport_t) : T with type socket = T.socket = struct
                 ~priority:
                   (* ICY = true means that authentication has already
                      happened *)
-                  `Maybe_blocking h
+                  `Generic h
                 (let valid_user, auth_f = s#login in
                  if
                    not

--- a/src/core/io/ffmpeg_io.ml
+++ b/src/core/io/ffmpeg_io.ml
@@ -200,7 +200,7 @@ class input ?(name = "input.ffmpeg") ~autostart ~self_sync ~poll_delay ~debug
               | Some t -> Duppy.Async.wake_up t
               | None ->
                   let t =
-                    Duppy.Async.add ~priority:`Blocking Tutils.scheduler
+                    Duppy.Async.add ~priority:`Generic Tutils.scheduler
                       self#connect_task
                   in
                   Atomic.set connect_task (Some t);

--- a/src/core/io/srt_io.ml
+++ b/src/core/io/srt_io.ml
@@ -355,7 +355,7 @@ module Poll = struct
                (Printexc.to_string exn));
           -1.
 
-  let task = Duppy.Async.add ~priority:`Blocking Tutils.scheduler process
+  let task = Duppy.Async.add ~priority:`Generic Tutils.scheduler process
 
   let add_socket ~mode socket fn =
     Srt.setsockflag socket Srt.sndsyn false;
@@ -529,7 +529,7 @@ class virtual caller ~enforced_encryption ~pbkeylen ~passphrase ~streamid
         | Some t -> Duppy.Async.wake_up t
         | None ->
             let t =
-              Duppy.Async.add ~priority:`Blocking Tutils.scheduler
+              Duppy.Async.add ~priority:`Generic Tutils.scheduler
                 self#connect_fn
             in
             connect_task <- Some t;

--- a/src/core/operators/pipe.ml
+++ b/src/core/operators/pipe.ml
@@ -254,7 +254,7 @@ class pipe ~replay_delay ~data_len ~process ~bufferize ~max ~restart
             Some
               (Process_handler.run ~on_stop:self#on_stop ~on_start:self#on_start
                  ~on_stdout:self#on_stdout ~on_stdin:self#on_stdin
-                 ~priority:`Blocking ~on_stderr:self#on_stderr ~log process))
+                 ~priority:`Generic ~on_stderr:self#on_stderr ~log process))
 
     method! abort_track = source#abort_track
 

--- a/src/core/outputs/harbor_output.ml
+++ b/src/core/outputs/harbor_output.ml
@@ -261,7 +261,7 @@ let add_meta c data =
 
 let rec client_task c =
   let* data =
-    Duppy.Monad.Io.exec ~priority:`Maybe_blocking c.handler
+    Duppy.Monad.Io.exec ~priority:`Generic c.handler
       (Mutex_utils.mutexify c.mutex
          (fun () ->
            let buflen = Strings.Mutable.length c.buffer in
@@ -283,7 +283,7 @@ let rec client_task c =
         c.handler (Strings.to_bytes data)
   in
   let* state =
-    Duppy.Monad.Io.exec ~priority:`Maybe_blocking c.handler
+    Duppy.Monad.Io.exec ~priority:`Generic c.handler
       (let ret = Mutex_utils.mutexify c.mutex (fun () -> c.state) () in
        Duppy.Monad.return ret)
   in
@@ -521,7 +521,7 @@ class output p =
              || auth_function <> None
            then (
              let default_user = Option.value default_user ~default:"" in
-             Duppy.Monad.Io.exec ~priority:`Maybe_blocking handler
+             Duppy.Monad.Io.exec ~priority:`Generic handler
                (Harbor.http_auth_check ~query ~login:(default_user, login) s
                   headers))
            else Duppy.Monad.return ())
@@ -532,7 +532,7 @@ class output p =
                 Harbor.reply s
             | _ -> assert false)
       in
-      Duppy.Monad.Io.exec ~priority:`Maybe_blocking handler
+      Duppy.Monad.Io.exec ~priority:`Generic handler
         (Harbor.relayed reply (fun () ->
              self#log#info "Client %s connected" ip;
              Mutex_utils.mutexify clients_m

--- a/src/core/tools/external_input.ml
+++ b/src/core/tools/external_input.ml
@@ -67,7 +67,7 @@ class virtual base ~name ~restart ~restart_on_error ~on_data ?read_header
           let log s = self#log#important "%s" s in
           process <-
             Some
-              (Process_handler.run ~priority:`Blocking ~on_stop ~on_stdout
+              (Process_handler.run ~priority:`Generic ~on_stop ~on_stdout
                  ~on_stderr ~log (command ())));
 
       self#on_sleep (fun () ->

--- a/src/core/tools/liqfm.ml
+++ b/src/core/tools/liqfm.ml
@@ -231,7 +231,7 @@ let init host =
       reason (Printexc.to_string e);
       -1.
   in
-  let task = Duppy.Async.add ~priority:`Blocking Tutils.scheduler do_submit in
+  let task = Duppy.Async.add ~priority:`Generic Tutils.scheduler do_submit in
   { task; submit_m; submissions }
 
 let submit (user, password) task length source stype songs =

--- a/src/core/tools/server.ml
+++ b/src/core/tools/server.ml
@@ -317,7 +317,7 @@ let handle_client socket ip =
         | e -> Duppy.Monad.raise e
     in
     let* ans =
-      Duppy.Monad.Io.exec ~priority:`Maybe_blocking h (run (fun () -> exec req))
+      Duppy.Monad.Io.exec ~priority:`Generic h (run (fun () -> exec req))
     in
     let* () =
       let* () =

--- a/src/core/tools/tutils.mli
+++ b/src/core/tools/tutils.mli
@@ -55,9 +55,12 @@ val join_all : unit -> unit
 
 (** Priorities for the different scheduler usages. *)
 type priority =
-  [ `Blocking  (** For example a last.fm submission. *)
-  | `Maybe_blocking  (** Request resolutions vary a lot. *)
+  [ `Generic  (** Generic queues accept all tasks. *)
+  | `Named of string  (** Named queues only accept tasks with their priority. *)
   | `Non_blocking  (** Non-blocking tasks like the server. *) ]
+
+(** Queues configuration. *)
+val queues_conf : Liquidsoap_lang.Lang.value
 
 (** task scheduler *)
 val scheduler : priority Duppy.scheduler

--- a/src/libs/autocue.liq
+++ b/src/libs/autocue.liq
@@ -58,6 +58,25 @@ let settings.autocue.internal.metadata_override =
     ]
   )
 
+let settings.autocue.internal.queues_count =
+  settings.make(
+    description=
+      "Number of dedicated queues for resolving autocue data using the internal \
+       implementation",
+    1
+  )
+
+def settings.autocue.internal.queues_count.set(c) =
+  settings.scheduler.queues :=
+    [
+      ...list.assoc.remove("autocue", settings.scheduler.queues()),
+      ("autocue", c)
+    ]
+  settings.autocue.internal.queues_count.set(c)
+end
+
+settings.autocue.internal.queues_count.set(1)
+
 let settings.autocue.internal.lufs_target =
   settings.make(
     description=
@@ -187,7 +206,10 @@ def autocue.internal.ebur128(~ratio=50., ~timeout=10., filename) =
     )
     []
   else
-    s = request.once(request.create(resolve_metadata=false, filename))
+    s =
+      request.once(
+        thread_queue="autocue", request.create(resolve_metadata=false, filename)
+      )
     frames = ref([])
 
     def ebur128(s) =

--- a/src/libs/extra/deprecations.liq
+++ b/src/libs/extra/deprecations.liq
@@ -76,9 +76,10 @@ end
 
 # Deprecated: this function has been replaced by `thread.run.recurrent`.
 # @flag deprecated
-def add_timeout(~fast=true, delay, f) =
+def add_timeout(~fast, delay, f) =
   deprecated("add_timeout", "thread.run.recurrent")
-  thread.run.recurrent(fast=fast, delay=delay, f)
+  ignore(fast or true)
+  thread.run.recurrent(queue="generic", delay=delay, f)
 end
 
 # Deprecated: this function has been replaced by `thread.when`.
@@ -314,7 +315,7 @@ def register_flow(
     ping_period
   end
 
-  thread.run.recurrent(fast=false, delay=ping_period, ping)
+  thread.run.recurrent(delay=ping_period, ping)
 
   # Register streams
   def register_stream(format_url) =
@@ -339,7 +340,7 @@ def register_flow(
     artist = m["artist"]
     title = m["title"]
     params = [("m_title", title), ("m_artist", artist)]
-    thread.run(fast=false, {request(cmd="metadata", params=params)})
+    thread.run({request(cmd="metadata", params=params)})
   end
 
   s.on_metadata(metadata)

--- a/src/libs/extra/native.liq
+++ b/src/libs/extra/native.liq
@@ -170,7 +170,7 @@ def native.request.dynamic(%argsof(request.dynamic), f) =
     if list.length(queue()) < prefetch then ignore(fetch()) end
   end
 
-  thread.run(every=retry_delay, fill)
+  thread.run(queue=thread_queue, every=retry_delay, fill)
 
   # Source
   def s() =

--- a/src/libs/extra/visualization.liq
+++ b/src/libs/extra/visualization.liq
@@ -28,7 +28,7 @@ def vumeter(~rms_min=-25., ~rms_max=-5., ~window=0.5, ~scroll=false, s) =
     print(newline=false, bar())
   end
 
-  thread.run(fast=true, every=window, display)
+  thread.run(queue="non_blocking", every=window, display)
   s
 end
 
@@ -62,7 +62,7 @@ def video.vumeter(
     width := int_of_float(x * float_of_int(video.frame.width()))
   end
 
-  thread.run(fast=true, every=window, update)
+  thread.run(queue="non_blocking", every=window, update)
   s = video.add_rectangle(width=width, height=height, color=color, s)
   video.persistence(duration=persistence, s)
 end

--- a/src/libs/playlist.liq
+++ b/src/libs/playlist.liq
@@ -185,6 +185,7 @@ let stdlib_native = native
 #  whole round ("randomize" mode), or pick a random file in the playlist each time \
 #  ("random" mode).
 # @param ~native Use native implementation, when available.
+# @param ~thread_queue Queue used to resolve requests.
 # @param ~on_loop Function executed when the playlist is about to loop.
 # @param ~on_done Function executed when the playlist is finished.
 # @param ~max_fail When this number of requests fail to resolve, the whole playlists is considered as failed and `on_fail` is called.
@@ -197,6 +198,7 @@ let stdlib_native = native
 # @method remaining_files Songs remaining to be played.
 def playlist.list(
   ~id=null(),
+  ~thread_queue="generic",
   ~check_next=null(),
   ~prefetch=null(),
   ~loop=true,
@@ -263,6 +265,7 @@ def playlist.list(
     fun () ->
       request.dynamic(
         id=id,
+        thread_queue=thread_queue,
         prefetch=prefetch,
         timeout=timeout,
         retry_delay=1.,
@@ -272,7 +275,13 @@ def playlist.list(
 
   s =
 %ifdef native
-    if native then stdlib_native.request.dynamic(id=id, next) else default() end
+    if
+      native
+    then
+      stdlib_native.request.dynamic(id=id, thread_queue=thread_queue, next)
+    else
+      default()
+    end
 %else
     default()
 %endif
@@ -455,6 +464,7 @@ end
 #  the playlist), "rounds", "seconds" or "watch" (reload the file whenever it is \
 #  changed).
 # @param ~timeout Timeout (in sec.) for a single download.
+# @param ~thread_queue Queue used to resolve requests.
 # @param ~cue_in_metadata Metadata for cue in points. Disabled if `null`.
 # @param ~cue_out_metadata Metadata for cue out points. Disabled if `null`.
 # @param uri Playlist URI.
@@ -463,6 +473,7 @@ end
 # @method remaining_files Songs remaining to be played.
 def replaces playlist(
   ~id=null(),
+  ~thread_queue="generic",
   ~check_next=null(),
   ~prefetch=null(),
   ~loop=true,
@@ -582,6 +593,7 @@ def replaces playlist(
   s =
     playlist.list(
       id=id,
+      thread_queue=thread_queue,
       check_next=check_next,
       prefetch=prefetch,
       loop=loop,

--- a/src/libs/request.liq
+++ b/src/libs/request.liq
@@ -27,6 +27,7 @@ end
 # @param ~prefetch How many requests should be queued in advance.
 # @param ~native Use native implementation, when available.
 # @param ~queue Initial queue of requests.
+# @param ~thread_queue Queue used to resolve requests.
 # @param ~timeout Timeout (in sec.) for a single download.
 # @method add This method is internal and should not be used. Consider using `push` instead.
 # @method push Push a request on the request queue.
@@ -37,6 +38,7 @@ def request.queue(
   ~prefetch=null(),
   ~native=false,
   ~queue=[],
+  ~thread_queue="generic",
   ~timeout=20.
 ) =
   ignore(native)
@@ -77,6 +79,7 @@ def request.queue(
       request.dynamic(
         id=id,
         prefetch=prefetch,
+        thread_queue=thread_queue,
         timeout=timeout,
         available={not list.is_empty(queue())},
         next
@@ -87,7 +90,9 @@ def request.queue(
     if
       native
     then
-      stdlib_native.request.dynamic(id=id, timeout=timeout, next)
+      stdlib_native.request.dynamic(
+        id=id, thread_queue=thread_queue, timeout=timeout, next
+      )
     else
       default()
     end
@@ -204,9 +209,15 @@ end
 
 # Play a request once and become unavailable.
 # @category Source / Input
+# @param ~thread_queue Queue used to resolve requests.
 # @param ~timeout Timeout in seconds for resolving the request.
 # @param r Request to play.
-def request.once(~id=null("request.once"), ~timeout=20., r) =
+def request.once(
+  ~id=null("request.once"),
+  ~thread_queue="generic",
+  ~timeout=20.,
+  r
+) =
   id = string.id.default(default="request.once", id)
 
   done = ref(false)
@@ -222,7 +233,7 @@ def request.once(~id=null("request.once"), ~timeout=20., r) =
       if
         request.resolve(r, timeout=timeout)
       then
-        request.queue(queue=[r])
+        request.queue(thread_queue=thread_queue, queue=[r])
       else
         log.critical(
           label=id,
@@ -246,6 +257,7 @@ end
 # static, and time is not.
 # @category Source / Input
 # @param ~prefetch How many requests should be queued in advance.
+# @param ~thread_queue Queue used to resolve requests.
 # @param ~timeout Timeout (in sec.) for a single download.
 # @param ~fallible Enforce fallibility of the request.
 # @param r Request
@@ -253,6 +265,7 @@ def request.single(
   ~id=null("request.single"),
   ~prefetch=null(),
   ~timeout=20.,
+  ~thread_queue="generic",
   ~fallible=null(),
   r
 ) =
@@ -329,7 +342,7 @@ def request.single(
         static_request() ?? getter.get(r)
       end
 
-      s = request.dynamic(prefetch=prefetch, next)
+      s = request.dynamic(prefetch=prefetch, thread_queue=thread_queue, next)
       if infallible then s.set_queue([next()]) end
       s
     end

--- a/src/libs/thread.liq
+++ b/src/libs/thread.liq
@@ -1,13 +1,15 @@
 # Run a function in a separate thread.
 # @category Programming
-# @param ~fast Whether the thread is supposed to return quickly or not. Typically, blocking tasks (e.g. fetching data over the internet) should not be considered to be fast. When set to `false` its priority will be lowered below that of request resolutions and fast timeouts. This is only effective if you set a dedicated queue for fast tasks, see the "scheduler" settings for more details.
+# @param ~queue Queue to use for the task. Should be one of: `"generic"` or `"non_blocking"`. \
+#               Non blocking should be reserved for tasks that are known to complete quickly. \
+#               You can also use a dedicated queue name declared via `settings.scheduler.queues`.
 # @param ~delay Delay (in seconds) after which the thread should be launched.
 # @param ~every How often (in seconds) the thread should be run. If negative or `null`, run once.
 # @param ~on_error Error callback executed when an error occurred while running the given function. When passed, \
 #                  all raised errors are silenced unless re-raised by the callback.
 # @param f Function to execute.
 def replaces thread.run(
-  ~fast=true,
+  ~queue="generic",
   ~delay=0.,
   ~on_error=null(),
   ~every=null(),
@@ -31,7 +33,7 @@ def replaces thread.run(
       on_error
     )
 
-  thread.run.recurrent(fast=fast, delay=delay, on_error=on_error, f)
+  thread.run.recurrent(queue=queue, delay=delay, on_error=on_error, f)
 end
 
 # Execute a callback when a predicate is `true`. The predicate
@@ -39,7 +41,9 @@ end
 # called when the predicate returns `true` after having been
 # `false`, following the same semantics as `predicate.activates`.
 # @category Programming
-# @param ~fast Whether the callback is supposed to return quickly or not.
+# @param ~queue Queue to use for the task. Should be one of: `"generic"` or `"non_blocking"`. \
+#               Non blocking should be reserved for tasks that are known to complete quickly. \
+#               You can also use a dedicated queue name declared via `settings.scheduler.queues`.
 # @param ~init Detect at beginning.
 # @param ~every How often (in sec.) to check for the predicate.
 # @param ~once Execute the function only once.
@@ -49,7 +53,7 @@ end
 # @param p Predicate indicating when to execute the function, typically a time interval such as `{10h-10h30}`.
 # @param f Function to execute when the predicate is true.
 def thread.when(
-  ~fast=true,
+  ~queue="generic",
   ~init=true,
   ~every=getter(0.5),
   ~once=false,
@@ -71,7 +75,7 @@ def thread.when(
     end
   end
 
-  thread.run.recurrent(fast=fast, delay=0., on_error=on_error, check)
+  thread.run.recurrent(queue=queue, delay=0., on_error=on_error, check)
 end
 
 # @flag hidden

--- a/tests/language/error.liq
+++ b/tests/language/error.liq
@@ -70,7 +70,7 @@ def f() =
     )
 
   test.equal(r/error.liq, line 58 char 4 - line 63 char 7/.test(pos), true)
-  test.equal(r/thread.liq, line 19, char 11-14/.test(pos), true)
+  test.equal(r/thread.liq, line 21, char 11-14/.test(pos), true)
   e' = error.register("bla")
   test.equal(false, (e == e'))
 


### PR DESCRIPTION
This PR changes the way we handle queues in the scheduler.

Previously, we had the following queues:
* `non_blocking`, for processing fast tasks, typically for the harbor server and telnet.
* `blocking`, for blocking tasks.
* `maybe_blocking` for... ? This was never clear.

These were maped to, resp, `non_blocking`, `generic` and `fast`queues, `fast` queues processing `maybe_blocking` tasks.. 🤔.

By default, there were `0` fast queues (again, not sure why) and `2` generic queues. Generic queues process any available task.

With the adoption of `autocue` internal resolution via `source.drop`, we started seeing some interesting queue deadlock:
1. `2` generic queues are created
2. `2` `request.dynamic` or `playlist` are created, each requesting a request resolution.
3. Each request resolution kicks in an `autocue` computation which, in turn, also requires a request resolution.
4. No more queues are available to resolve the `autocue` request resolution
5. The top-level request resolution never terminate.

This PR cleans up the scheduler notion of queues and allows for dedicated queues to fix this dependency issue.

### Default queues, named queues

By default, we only have 2 type of queues:
* `non_blocking` queues, defaults to `2`
* `generic`, defaults to `2`.

We also support named queues, which are queues with any arbitrary string name value. These are created when requested by the user.

New queues can be configured as follows:

```liquidsoap
settings.scheduler.queues.set([
   ...settings.scheduler.queues(),
  ("my-queue", 4)
])
```

Now, each type of queue only process tasks for their own queue, making it possible to control the concurrency of each tasks sent to them.

All the `thread.run.*` functions are updated to remove the `fast` parameter and add an explicit `queue` parameter instead, which controls to which queue a given task is sent.

### `autocue` queue

`autocue` resolutions are not sent to a dedicated `autocue` queue. Only one `autocue` queue is created by default.

This is made possible by adding a `thread_queue` parameter to `request.dynamic` and all the operators relying on it.

This way, the `autocue` computations happen one at a time by default, which help controlling CPU usage with them, and never prevent request resolution from completing.

