### PR TITLE
Revert "FFmpeg filters: keep value in TS unit, move time-based values…

### DIFF
--- a/src/core/io/ffmpeg_filter_io.ml
+++ b/src/core/io/ffmpeg_filter_io.ml
@@ -195,10 +195,7 @@ class virtual ['a] input_base ~name ~pass_metadata ~self_sync ~is_ready ~pull
         (fun result (label, fn) ->
           match fn frame with
             | None -> result
-            | Some v ->
-                ("lavfi.liq." ^ label, Int64.to_string v)
-                :: ("lavfi.liq." ^ label ^ "_time", get_time v)
-                :: result)
+            | Some v -> ("lavfi.liq." ^ label, get_time v) :: result)
         []
         [
           ("pts", Avutil.Frame.pts);

--- a/src/libs/autocue.liq
+++ b/src/libs/autocue.liq
@@ -227,17 +227,7 @@ def autocue.internal.ebur128(~duration, ~ratio=50., ~timeout=10., filename) =
     s = source.on_metadata(s, fun (m) -> frames := [...frames(), m])
     source.drop(ratio=ratio, s)
 
-    list.sort(
-      fun (m, m') ->
-        begin
-          pos =
-            float_of_string(list.assoc(default="0.", "lavfi.liq.pts_time", m))
-          pos' =
-            float_of_string(list.assoc(default="0.", "lavfi.liq.pts_time", m'))
-          if pos < pos' then -1 elsif pos < pos' then 1 else 0 end
-        end,
-      frames()
-    )
+    frames()
   end
 %else
   ignore(ratio)
@@ -417,9 +407,7 @@ def autocue.internal.implementation(
           # Get current frame loudness level and timestamp
           db_level = list.assoc(default="nan", string("lavfi.r128.M"), frame)
           current_ts :=
-            float_of_string(
-              list.assoc(default="0.", "lavfi.liq.pts_time", frame)
-            )
+            float_of_string(list.assoc(default="0.", "lavfi.liq.pts", frame))
 
           # Process only valid level values
           if


### PR DESCRIPTION
… to `_time`"

This reverts commit 65678e52effcc47f8fcd1b2f34cf952d2812110f.