### PR TITLE
Make pulseaudio input and output resilient to errors.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -91,6 +91,7 @@ Changed:
 - Changed the port for the built-in Prometheus exporter to `9599` (#3801).
 - Set `segments_overheader` in HLS outputs to disable segments cleanup altogether.
 - Added support for caching LV2 and LADSPA plugins (#3959).
+- Pulseaudio input and output now restart on pulseaudio errors (#4174).
 
 Fixed:
 


### PR DESCRIPTION
This PR changes the behavior of pulseaudio input and output to be resilient to errors from the pulseaudio server.

This makes sens because the server is actually software and not hardware like alsa so it can be restarted etc.

By default, the operators now retry every `retry_delay`. 

`input.pulseaudio` can be forced back to the old behavior by setting `fallible=false`.

For `ouptut.pulseaudio`, the `on_error` callback can now be used to raise an exception and abort the script on errors.

Fixes: #4157