### PR TITLE
Introducing Liquidsoap Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Copyright 2003-2024 Savonet team
 [![GitHub release](https://img.shields.io/github/release/savonet/liquidsoap.svg)](https://GitHub.com/savonet/liquidsoap/releases/)
 [![Install with Opam!](https://img.shields.io/badge/Install%20with-Opam-1abc9c.svg)](http://opam.ocaml.org/packages/liquidsoap/)
 [![Chat on Discord!](https://img.shields.io/badge/Chat%20on-Discord-5865f2.svg)](http://chat.liquidsoap.info/)
+[![](https://img.shields.io/badge/Gurubase-Ask%20Liquidsoap%20Guru-006BFF)](https://gurubase.io/g/liquidsoap)
 
 |                           |                                                                         |
 | ------------------------- | ----------------------------------------------------------------------- |


### PR DESCRIPTION
Hello Liquidsoap team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [Liquidsoap Guru](https://gurubase.io/g/liquidsoap) to Gurubase. Liquidsoap Guru uses the data from this repo and data from the [docs](https://www.liquidsoap.info/doc-2.2.5/) to answer questions by leveraging the LLM.

In this PR, I showcased the "Liquidsoap Guru" badge, which highlights that Liquidsoap now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable Liquidsoap Guru in Gurubase, just let me know that's totally fine.