### PR TITLE
Show error message once for native fonts.

### DIFF
--- a/src/core/decoder/text/video_text_native.ml
+++ b/src/core/decoder/text/video_text_native.ml
@@ -21,12 +21,14 @@
  *****************************************************************************)
 
 open Mm
+open Extralib
 
 let log = Log.make ["video"; "text"; "native"]
 
 let render_text ~font ~size text =
   if font <> Configure.conf_default_font#get then
-    log#important "video.text.native does not support custom fonts yet!";
+    Fun.once (fun () ->
+        log#important "video.text.native does not support custom fonts yet!");
   let () = ignore font in
   let font = Image.Bitmap.Font.native in
   let bmp = Image.Bitmap.Font.render text in

--- a/src/lang/extralib.ml
+++ b/src/lang/extralib.ml
@@ -88,3 +88,15 @@ module Int = struct
       assert false
     with Exit -> !ans
 end
+
+module Fun = struct
+  include Fun
+
+  (** Execute a function at most once. *)
+  let once =
+    let already = ref false in
+    fun f ->
+      if not !already then (
+        already := true;
+        f ())
+end


### PR DESCRIPTION
This avoids flooding messages as in #4180.