### PR TITLE
Improve song metadata handling in `input.harbor`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,10 @@ Changed:
 
 - Make alsa I/O work with buffer size different than
   liquidsoap internal frame (#4236)
+- Make `"song"` metadata mapping to `"title"` metadata in
+  `input.harbord` disabled when either `"artist"` or `"title"`
+  is also passed. Add a configuration key to disable this mechanism.
+  (#4235, #2676)
 
 Changed:
 

--- a/src/core/harbor/harbor_base.ml
+++ b/src/core/harbor/harbor_base.ml
@@ -63,6 +63,16 @@ let conf_icy_metadata =
       ]
     "Content-type (mime) of formats which allow shout metadata update."
 
+let conf_map_song_metadata =
+  Dtools.Conf.bool
+    ~p:(conf_harbor#plug "map_song_metadata")
+    ~d:true
+    "If `true`, `\"song\"` metadata in icecast metadata update is mapped to \
+     `\"title\"` unless on of: `\"artist\"` or `\"title\"` metadata is also \
+     passed in which case `\"song\"` metadata is removed as it usually \
+     contains redundant info that confuses the system. Metadata are passed \
+     as-is when `false`."
+
 let conf_timeout =
   Dtools.Conf.float
     ~p:(conf_harbor#plug "timeout")

--- a/tests/streams/dune.inc
+++ b/tests/streams/dune.inc
@@ -747,6 +747,68 @@
  (alias citest)
  (package liquidsoap)
  (deps
+  harbor_metadata_2.liq
+  ./file1.mp3
+  ./file2.mp3
+  ./file3.mp3
+  ./jingle1.mp3
+  ./jingle2.mp3
+  ./jingle3.mp3
+  ./file1.png
+  ./file2.png
+  ./jingles
+  ./playlist
+  ./huge_playlist
+  ./replaygain_track_gain.mp3
+  ./r128_track_gain.mp3
+  ./replaygain_r128_track_gain.mp3
+  ./replaygain_track_gain.opus
+  ./r128_track_gain.opus
+  ./replaygain_r128_track_gain.opus
+  ./without_replaygain_track_gain.mp3
+  ./crossfade-plot.old.txt
+  ./crossfade-plot.new.txt
+  ../../src/bin/liquidsoap.exe
+  (package liquidsoap)
+  (:test_liq ../test.liq)
+  (:run_test ../run_test.exe))
+ (action (run %{run_test} harbor_metadata_2.liq liquidsoap %{test_liq} harbor_metadata_2.liq)))
+  
+(rule
+ (alias citest)
+ (package liquidsoap)
+ (deps
+  harbor_metadata_3.liq
+  ./file1.mp3
+  ./file2.mp3
+  ./file3.mp3
+  ./jingle1.mp3
+  ./jingle2.mp3
+  ./jingle3.mp3
+  ./file1.png
+  ./file2.png
+  ./jingles
+  ./playlist
+  ./huge_playlist
+  ./replaygain_track_gain.mp3
+  ./r128_track_gain.mp3
+  ./replaygain_r128_track_gain.mp3
+  ./replaygain_track_gain.opus
+  ./r128_track_gain.opus
+  ./replaygain_r128_track_gain.opus
+  ./without_replaygain_track_gain.mp3
+  ./crossfade-plot.old.txt
+  ./crossfade-plot.new.txt
+  ../../src/bin/liquidsoap.exe
+  (package liquidsoap)
+  (:test_liq ../test.liq)
+  (:run_test ../run_test.exe))
+ (action (run %{run_test} harbor_metadata_3.liq liquidsoap %{test_liq} harbor_metadata_3.liq)))
+  
+(rule
+ (alias citest)
+ (package liquidsoap)
+ (deps
   hls_custom_tags.liq
   ./file1.mp3
   ./file2.mp3

--- a/tests/streams/harbor_metadata.liq
+++ b/tests/streams/harbor_metadata.liq
@@ -1,3 +1,5 @@
+port = 3461
+
 def fn() =
   def on_metadata(m) =
     if
@@ -23,7 +25,7 @@ def fn() =
           password="testtest",
           user="testtest",
           host="localhost",
-          port=9834,
+          port=port,
           mount="test",
           [
             (
@@ -46,14 +48,14 @@ def fn() =
       password="testtest",
       user="testtest",
       "test",
-      port=9834,
+      port=port,
       on_connect=on_connect
     )
 
   s.on_metadata(on_metadata)
   output.dummy(fallible=true, s)
   output.icecast(
-    %mp3, password="testtest", user="testtest", mount="test", port=9834, noise()
+    %mp3, password="testtest", user="testtest", mount="test", port=port, noise()
   )
 end
 

--- a/tests/streams/harbor_metadata_2.liq
+++ b/tests/streams/harbor_metadata_2.liq
@@ -1,3 +1,5 @@
+port = 3464
+
 def fn() =
   def on_metadata(m) =
     if
@@ -23,7 +25,7 @@ def fn() =
           password="testtest",
           user="testtest",
           host="localhost",
-          port=9834,
+          port=port,
           mount="test",
           [
             (
@@ -50,14 +52,14 @@ def fn() =
       password="testtest",
       user="testtest",
       "test",
-      port=9834,
+      port=port,
       on_connect=on_connect
     )
 
   s.on_metadata(on_metadata)
   output.dummy(fallible=true, s)
   output.icecast(
-    %mp3, password="testtest", user="testtest", mount="test", port=9834, noise()
+    %mp3, password="testtest", user="testtest", mount="test", port=port, noise()
   )
 end
 

--- a/tests/streams/harbor_metadata_2.liq
+++ b/tests/streams/harbor_metadata_2.liq
@@ -1,0 +1,64 @@
+def fn() =
+  def on_metadata(m) =
+    if
+
+        m["title"] ==
+          "the real title"
+
+    and
+
+        m["metadata_url"] ==
+          "metadata url"
+
+    then
+      test.pass()
+    end
+  end
+
+  def on_connect(_) =
+    thread.run(
+      delay=1.,
+      {
+        icy.update_metadata(
+          password="testtest",
+          user="testtest",
+          host="localhost",
+          port=9834,
+          mount="test",
+          [
+            (
+              "song",
+              "song title"
+            ),
+            (
+              "title",
+              "the real title"
+            ),
+            (
+              "url",
+              "metadata url"
+            )
+          ]
+        )
+      }
+    )
+  end
+
+  s =
+    input.harbor(
+      buffer=0.1,
+      password="testtest",
+      user="testtest",
+      "test",
+      port=9834,
+      on_connect=on_connect
+    )
+
+  s.on_metadata(on_metadata)
+  output.dummy(fallible=true, s)
+  output.icecast(
+    %mp3, password="testtest", user="testtest", mount="test", port=9834, noise()
+  )
+end
+
+test.check(fn)

--- a/tests/streams/harbor_metadata_3.liq
+++ b/tests/streams/harbor_metadata_3.liq
@@ -1,0 +1,67 @@
+def fn() =
+  def on_metadata(m) =
+  print(m)
+    if
+      m["title"] == ""
+    and
+
+        m["artist"] ==
+          "the artist"
+
+    and
+
+        m["metadata_url"] ==
+          "metadata url"
+
+    then
+      test.pass()
+    end
+  end
+
+  def on_connect(_) =
+    thread.run(
+      delay=1.,
+      {
+        icy.update_metadata(
+          password="testtest",
+          user="testtest",
+          host="localhost",
+          port=9834,
+          mount="test",
+          [
+            (
+              "song",
+              "song title"
+            ),
+            (
+              "artist",
+              "the artist"
+            ),
+            (
+              "url",
+              "metadata url"
+            )
+          ]
+        )
+      }
+    )
+  end
+
+  s =
+    input.harbor(
+      buffer=0.1,
+      password="testtest",
+      user="testtest",
+      "test",
+      port=9834,
+      on_connect=on_connect
+    )
+
+  s.on_metadata(on_metadata)
+  output.dummy(fallible=true, s)
+  output.icecast(
+    %mp3, password="testtest", user="testtest", mount="test", port=9834, noise()
+  )
+end
+
+test.check(fn)

--- a/tests/streams/harbor_metadata_3.liq
+++ b/tests/streams/harbor_metadata_3.liq
@@ -1,3 +1,5 @@
+port = 3463
+
 def fn() =
   def on_metadata(m) =
   print(m)
@@ -26,7 +28,7 @@ def fn() =
           password="testtest",
           user="testtest",
           host="localhost",
-          port=9834,
+          port=port,
           mount="test",
           [
             (
@@ -53,14 +55,14 @@ def fn() =
       password="testtest",
       user="testtest",
       "test",
-      port=9834,
+      port=port,
       on_connect=on_connect
     )
 
   s.on_metadata(on_metadata)
   output.dummy(fallible=true, s)
   output.icecast(
-    %mp3, password="testtest", user="testtest", mount="test", port=9834, noise()
+    %mp3, password="testtest", user="testtest", mount="test", port=port, noise()
   )
 end
 


### PR DESCRIPTION
Disable song metadata when either artist or title are passed.
Add configuration to allow to pass all metadata verbatim.

See #2676 and #4235 for details

Fixes: #4235