### PR TITLE
Fix mutual recursion between autocue and replaygain metadata resolvers.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,8 +16,10 @@ Changed:
   is also passed. Add a configuration key to disable this mechanism.
   (#4235, #2676)
 
-Changed:
+Fixed:
 
+- Fixed request resolution loop when enabling both `autcue`
+  and `replaygain` metadata resolvers (#4245, fixed in #4246)
 - Convert all ICY (icecast) metadata from `input.http` to `utf8`.
 
 ---

--- a/src/core/builtins/builtins_resolvers.ml
+++ b/src/core/builtins/builtins_resolvers.ml
@@ -20,8 +20,6 @@
 
  *****************************************************************************)
 
-module Queue = Liquidsoap_lang.Queues.Queue
-
 let decoder_metadata = Lang.add_module ~base:Modules.decoder "metadata"
 let reentrant_decoders = ref []
 

--- a/src/libs/autocue.liq
+++ b/src/libs/autocue.liq
@@ -775,7 +775,7 @@ def autocue.internal.implementation(
             fade_out_type?: string,
             fade_out_curve?: float,
             start_next?: float,
-            extra_metadata?: [(string * string)]
+            extra_metadata?: [(string*string)]
           }
         )
       end
@@ -823,7 +823,10 @@ def file.autocue.metadata(~request_metadata, uri) =
       )
     end
 
-  r = request.create(excluded_metadata_resolvers=["autocue"], uri)
+  r =
+    request.create(
+      excluded_metadata_resolvers=decoder.metadata.reentrant(), uri
+    )
 
   if
     not request.resolve(r)
@@ -1059,6 +1062,7 @@ def enable_autocue_metadata() =
     mime_types=mime_types,
     file_extensions=file_extensions,
     priority=settings.autocue.metadata.priority,
+    reentrant=true,
     "autocue",
     autocue_metadata
   )

--- a/src/libs/replaygain.liq
+++ b/src/libs/replaygain.liq
@@ -76,7 +76,7 @@ def replaces file.replaygain(~id=null(), ~compute=true, ~ratio=50., file_name) =
   id = string.id.default(default="file.replaygain", id)
   file_name_quoted = string.quote(file_name)
 
-  _metadata = file.metadata(exclude=["replaygain_track_gain"], file_name)
+  _metadata = file.metadata(exclude=decoder.metadata.reentrant(), file_name)
   gain = metadata.replaygain(_metadata)
 
   if
@@ -138,5 +138,7 @@ def enable_replaygain_metadata(~compute=true, ~ratio=50.) =
     end
   end
 
-  decoder.metadata.add("replaygain_track_gain", replaygain_metadata)
+  decoder.metadata.add(
+    reentrant=true, "replaygain_track_gain", replaygain_metadata
+  )
 end

--- a/tests/regression/GH4246.liq
+++ b/tests/regression/GH4246.liq
@@ -1,0 +1,6 @@
+enable_replaygain_metadata()
+enable_autocue_metadata()
+
+audio = once(single("../media/@shine[channels=2].mp3"))
+
+output.dummy(fallible=true, on_start=test.pass, audio)

--- a/tests/regression/dune.inc
+++ b/tests/regression/dune.inc
@@ -771,6 +771,22 @@
  (alias citest)
  (package liquidsoap)
  (deps
+  GH4246.liq
+  ../media/all_media_files
+  ../../src/bin/liquidsoap.exe
+  ../streams/file1.png
+  ../streams/file1.mp3
+  ./theora-test.mp4
+  (package liquidsoap)
+  (source_tree ../../src/libs)
+  (:test_liq ../test.liq)
+  (:run_test ../run_test.exe))
+ (action (run %{run_test} GH4246.liq liquidsoap %{test_liq} GH4246.liq)))
+  
+(rule
+ (alias citest)
+ (package liquidsoap)
+ (deps
   LS268.liq
   ../media/all_media_files
   ../../src/bin/liquidsoap.exe


### PR DESCRIPTION
This PR fixes a mutual recursion between the `autocue` and `replaygain` decoders which results in an infinite decoding loop.

The proposed solution is to mark both decoders as `reentrant` and make sure to exclude all `reentrant` decoders when implementing decoders that rely on request resolution.

Fixes: #4245