### PR TITLE
let go YAML's `not_found` exception

### DIFF
--- a/src/lang/builtins_yaml.ml
+++ b/src/lang/builtins_yaml.ml
@@ -41,7 +41,8 @@ let _ =
       with exn -> (
         let bt = Printexc.get_raw_backtrace () in
         match exn with
-          | Runtime_error.Runtime_error e when e.Runtime_error.kind = "not_found" ->
+          | Runtime_error.Runtime_error e
+            when e.Runtime_error.kind = "not_found" ->
               Printexc.raise_with_backtrace exn bt
           | _ ->
               Runtime_error.raise ~bt ~pos:(Lang.pos p)

--- a/src/lang/builtins_yaml.ml
+++ b/src/lang/builtins_yaml.ml
@@ -41,6 +41,8 @@ let _ =
       with exn -> (
         let bt = Printexc.get_raw_backtrace () in
         match exn with
+          | Runtime_error.Runtime_error e when e.Runtime_error.kind = "not_found" ->
+              Printexc.raise_with_backtrace exn bt
           | _ ->
               Runtime_error.raise ~bt ~pos:(Lang.pos p)
                 ~message:


### PR DESCRIPTION
this would avoid #4248, where I didn't notice that `yaml` was an optional dependency