### PR TITLE
Add support for type annotations for optional types with methods.

### DIFF
--- a/src/lang/parser.mly
+++ b/src/lang/parser.mly
@@ -292,6 +292,8 @@ ty:
   | LPAR argsty RPAR YIELDS ty   { `Arrow ($2,$5) }
   | LCUR record_ty RCUR          { `Record $2 }
   | ty DOT VAR                   { `Invoke ($1, $3) }
+  | ty QUESTION_DOT LCUR record_ty RCUR
+                                 { `Method (`Nullable $1, $4) }
   | ty DOT LCUR record_ty RCUR   { `Method ($1, $4) }
   | ty_source                    { `Source $1 }
 

--- a/tests/language/typing.liq
+++ b/tests/language/typing.liq
@@ -209,6 +209,9 @@ def f() =
     int.{ "✨ name ✨" as foo: float, gni: string }
   )
 
+  # Nullable type with methods:
+  (123.{foo="aabb"} : int?.{ foo: string })
+
   (() : {})
   (() : unit.{  })
   ({foo=123} : {foo?: int})


### PR DESCRIPTION
This was missing in the parser.