### PR TITLE
Send last metadata when connecting to icecast.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,11 +18,15 @@ Changed:
   `input.harbord` disabled when either `"artist"` or `"title"`
   is also passed. Add a configuration key to disable this mechanism.
   (#4235, #2676)
+- `output.icecast` now re-sends the last metadata when connecting to the
+  remote server unless explicitly disabled using the `send_last_metadata_on_connect`
+  option (#3906)
 
 Fixed:
 
 - Fixed request resolution loop when enabling both `autocue`
   and `replaygain` metadata resolvers (#4245, fixed in #4246)
+- Fixed source `last_metadata` not being properly updated (#4262)
 - Convert all ICY (icecast) metadata from `input.http` to `utf8`.
 
 ---

--- a/src/core/source.ml
+++ b/src/core/source.ml
@@ -563,7 +563,8 @@ class virtual operator ?(stack = []) ?clock ?(name = "src") sources =
             "generate_frame: got metadata at position %d: calling handlers..." i;
           List.iter (fun fn -> fn m) on_metadata)
         metadata;
-      if has_track_mark then self#execute_on_track buf;
+      if has_track_mark then self#execute_on_track buf
+      else self#set_last_metadata buf;
       self#iter_watchers (fun w ->
           w.generate_frame ~start_time ~end_time ~length ~has_track_mark
             ~metadata);

--- a/tests/streams/dune.inc
+++ b/tests/streams/dune.inc
@@ -1026,6 +1026,37 @@
  (alias citest)
  (package liquidsoap)
  (deps
+  icecast_last_meta.liq
+  ./file1.mp3
+  ./file2.mp3
+  ./file3.mp3
+  ./jingle1.mp3
+  ./jingle2.mp3
+  ./jingle3.mp3
+  ./file1.png
+  ./file2.png
+  ./jingles
+  ./playlist
+  ./huge_playlist
+  ./replaygain_track_gain.mp3
+  ./r128_track_gain.mp3
+  ./replaygain_r128_track_gain.mp3
+  ./replaygain_track_gain.opus
+  ./r128_track_gain.opus
+  ./replaygain_r128_track_gain.opus
+  ./without_replaygain_track_gain.mp3
+  ./crossfade-plot.old.txt
+  ./crossfade-plot.new.txt
+  ../../src/bin/liquidsoap.exe
+  (package liquidsoap)
+  (:test_liq ../test.liq)
+  (:run_test ../run_test.exe))
+ (action (run %{run_test} icecast_last_meta.liq liquidsoap %{test_liq} icecast_last_meta.liq)))
+  
+(rule
+ (alias citest)
+ (package liquidsoap)
+ (deps
   image.liq
   ./file1.mp3
   ./file2.mp3

--- a/tests/streams/icecast_last_meta.liq
+++ b/tests/streams/icecast_last_meta.liq
@@ -1,0 +1,43 @@
+port = 6723
+
+s = sine()
+
+s = insert_metadata(s)
+
+insert_metadata = s.insert_metadata
+
+output.dummy(s)
+
+thread.run(
+  delay=0.1,
+  {
+    insert_metadata(
+      [
+        (
+          "title",
+          "some title"
+        )
+      ]
+    )
+  }
+)
+
+thread.run(
+  delay=0.3, {output.icecast(port=port, mount="metadata_test", %mp3, s)}
+)
+
+i = input.harbor(buffer=2., port=port, "metadata_test")
+
+i =
+  source.on_metadata(
+    i,
+    fun (m) ->
+      if
+        m["title"] ==
+          "some title"
+      then
+        test.pass()
+      end
+  )
+
+output.dummy(fallible=true, i)


### PR DESCRIPTION
This also fixes source's last metadata.

Fixes: #4262, #3906