### PR TITLE
Update audioscrobbler.liq

### DIFF
--- a/src/libs/extra/audioscrobbler.liq
+++ b/src/libs/extra/audioscrobbler.liq
@@ -283,6 +283,7 @@ def audioscrobbler.api.track.scrobble(
   ~api_secret=null(),
   ~artist,
   ~track,
+  ~timestamp=null(),
   ~album=null(),
   ~context=null(),
   ~streamId=null(),
@@ -306,7 +307,7 @@ def audioscrobbler.api.track.scrobble(
     [
       ("track", track),
       ("artist", artist),
-      ("timestamp", string(time())),
+      ("timestamp", string(timestamp ?? time())),
       ...(null.defined(album) ? [("album", null.get(album))] : [] ),
       ...(null.defined(context) ? [("context", null.get(context))] : [] ),
       ...(null.defined(streamId) ? [("streamId", null.get(streamId))] : [] ),

--- a/src/libs/extra/audioscrobbler.liq
+++ b/src/libs/extra/audioscrobbler.liq
@@ -283,7 +283,6 @@ def audioscrobbler.api.track.scrobble(
   ~api_secret=null(),
   ~artist,
   ~track,
-  ~timestamp=time(),
   ~album=null(),
   ~context=null(),
   ~streamId=null(),
@@ -307,7 +306,7 @@ def audioscrobbler.api.track.scrobble(
     [
       ("track", track),
       ("artist", artist),
-      ("timestamp", string(timestamp)),
+      ("timestamp", string(time())),
       ...(null.defined(album) ? [("album", null.get(album))] : [] ),
       ...(null.defined(context) ? [("context", null.get(context))] : [] ),
       ...(null.defined(streamId) ? [("streamId", null.get(streamId))] : [] ),


### PR DESCRIPTION
Defining timestamp as `time()` in `audioscrobbler.api.track.scrobble` function makes time freeze and show the same time for all scrobbled tracks. 

<img width="500" alt="Снимок экрана 2024-12-14 в 20 20 26" src="https://github.com/user-attachments/assets/c4766fa6-0d9a-4010-8e4b-c1ddbc475e5c" />

All of the above tracks have been played through from start to finish. But all of them are scrobbled at the exact same time/time ago. It is the time when first track has been scrobbled since the start of LS session.

Using `time()` right inside `params` fixes it.

```
 params =
    [
      ("track", track),
      ("artist", artist),
      ("timestamp", string(time())),
...
```
https://github.com/savonet/liquidsoap/pull/4250#top 

