### PR TITLE
Fix inotify GC cleanup removing the watch function

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -28,6 +28,7 @@ Fixed:
   and `replaygain` metadata resolvers (#4245, fixed in #4246)
 - Fixed source `last_metadata` not being properly updated (#4262)
 - Convert all ICY (icecast) metadata from `input.http` to `utf8`.
+- Fixed `inotify` unwatching due to GC cleanup (#4275)
 
 ---
 

--- a/src/core/file_watcher.inotify.ml
+++ b/src/core/file_watcher.inotify.ml
@@ -82,7 +82,7 @@ let watch : watch =
            with exn ->
              let bt = Printexc.get_backtrace () in
              Utils.log_exception ~log ~bt
-               (Printf.sprintf "Error whole removing file watch handler: %s"
+               (Printf.sprintf "Error while removing file watch handler: %s"
                   (Printexc.to_string exn)));
           handlers := List.remove_assoc wd !handlers))
     ()


### PR DESCRIPTION
Some of the changes to optimize liquidsoap's memory footprint did remove unused methods. This might have triggered a situation where we acutally removes the watch call during a GC of the `unwatch` method.

Instead, we should require the user to explicitely call `unwatch`.

Fixes: #4275