### PR TITLE
Fix parsing of rolling-release version.

### DIFF
--- a/src/lang/lang_string.ml
+++ b/src/lang/lang_string.ml
@@ -357,7 +357,7 @@ module Version = struct
     let num = Re.Pcre.get_substring sub 1 in
     let str = try Re.Pcre.get_substring sub 2 with _ -> "" in
     let num =
-      let int_of_string s = if s = "x" then -1 else int_of_string s in
+      let int_of_string s = if s = "x" then max_int else int_of_string s in
       String.split_on_char '.' num |> List.map int_of_string
     in
     (num, str)

--- a/src/lang/lang_string.ml
+++ b/src/lang/lang_string.ml
@@ -357,7 +357,7 @@ module Version = struct
     let num = Re.Pcre.get_substring sub 1 in
     let str = try Re.Pcre.get_substring sub 2 with _ -> "" in
     let num =
-      let int_of_string s = if s = "x" then (-1) else int_of_string s in
+      let int_of_string s = if s = "x" then -1 else int_of_string s in
       String.split_on_char '.' num |> List.map int_of_string
     in
     (num, str)

--- a/src/lang/lang_string.ml
+++ b/src/lang/lang_string.ml
@@ -352,11 +352,14 @@ module Version = struct
 
   (* We assume something like, 2.0.0+git@7e211ffd *)
   let of_string s : t =
-    let rex = Re.Pcre.regexp "([\\.\\d]+)([^\\.]+)?" in
+    let rex = Re.Pcre.regexp "(?:rolling-release-v)?([\\.\\dx]+)([^\\.]+)?" in
     let sub = Re.Pcre.exec ~rex s in
     let num = Re.Pcre.get_substring sub 1 in
     let str = try Re.Pcre.get_substring sub 2 with _ -> "" in
-    let num = String.split_on_char '.' num |> List.map int_of_string in
+    let num =
+      let int_of_string s = if s = "x" then (-1) else int_of_string s in
+      String.split_on_char '.' num |> List.map int_of_string
+    in
     (num, str)
 
   (** Number part. *)

--- a/tests/core/string_test.ml
+++ b/tests/core/string_test.ml
@@ -1,4 +1,5 @@
 let () = assert ("aa\\\"bb" = Lang_string.escape_utf8_string "aa\"bb")
 
 (* Bug #4287 *)
-let () = ignore (Lang_string.Version.of_string "rolling-release-v2.3.x+git@2addd93da")
+let () =
+  ignore (Lang_string.Version.of_string "rolling-release-v2.3.x+git@2addd93da")

--- a/tests/core/string_test.ml
+++ b/tests/core/string_test.ml
@@ -1,1 +1,4 @@
 let () = assert ("aa\\\"bb" = Lang_string.escape_utf8_string "aa\"bb")
+
+(* Bug #4287 *)
+let () = ignore (Lang_string.Version.of_string "rolling-release-v2.3.x+git@2addd93da")


### PR DESCRIPTION
- allow "rolling-release-v" as prefix to the version
- consider "x" in the version number as -1

Fixes #4287.