### PR TITLE
chore: Update GitHub Actions to the latest versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
       is_snapshot: ${{ steps.build_details.outputs.is_snapshot }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Get build details
         env:
           IS_FORK: ${{ github.event.pull_request.head.repo.fork == true }}
@@ -129,9 +129,9 @@ jobs:
     needs: build_details
     steps:
       - name: Checkout latest code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: latest
       - name: Parse using tree-sitter
@@ -146,9 +146,9 @@ jobs:
     needs: build_details
     steps:
       - name: Checkout latest code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: latest
       - name: Parse using liquidsoap-lezer-print-tree
@@ -297,7 +297,7 @@ jobs:
           path: ${{ github.workspace }}/${{ github.run_number }}/metrics
       - name: Upload metrics
         if: needs.build_details.outputs.is_fork != 'true' && matrix.target == '@citest'
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_branch: metrics
@@ -336,12 +336,12 @@ jobs:
           - 5.2.x
     steps:
       - name: Checkout latest code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Update packages
         run: |
           sudo apt-get update
       - name: Setup OCaml
-        uses: ocaml/setup-ocaml@v2
+        uses: ocaml/setup-ocaml@v3
         with:
           ocaml-compiler: ${{ matrix.ocaml-compiler }}
           opam-pin: false
@@ -360,13 +360,13 @@ jobs:
         if: matrix.ocaml-compiler == '4.14.x'
         run: echo "PY=$(python -VV | sha256sum | cut -d' ' -f1)" >> $GITHUB_ENV
       - name: Restore pre-commit cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.cache/pre-commit
           key: pre-commit|${{ env.PY }}|${{ hashFiles('.pre-commit-config.yaml') }}
       - name: Run pre-commit
         if: matrix.ocaml-compiler == '4.14.x'
-        uses: pre-commit/action@v3.0.0
+        uses: pre-commit/action@v3.0.1
 
   build_posix:
     runs-on: ${{ matrix.runs-on }}
@@ -555,7 +555,7 @@ jobs:
     if: needs.build_details.outputs.is_release
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Tag commit
         uses: savonet/latest-tag@any-context
         with:
@@ -593,7 +593,7 @@ jobs:
           fail-if-no-release: false
           fail-if-no-assets: false
       - name: Upload assets to main repo release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           tag_name: ${{ needs.build_details.outputs.branch }}
@@ -602,7 +602,7 @@ jobs:
           body: "${{ env.RELEASE_NOTES}}\n\n${{ env.CHANGELOG }}"
           draft: true
       - name: Upload assets to release repo
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           token: ${{ secrets.LIQUIDSOAP_RELEASE_ASSETS_TOKEN }}
           tag_name: ${{ needs.build_details.outputs.branch }}
@@ -623,9 +623,9 @@ jobs:
         include: ${{ fromJson(needs.build_details.outputs.build_include) }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v3
       - name: Download all artifact
         uses: actions/download-artifact@v4
         with:
@@ -654,9 +654,9 @@ jobs:
         include: ${{ fromJson(needs.build_details.outputs.build_include) }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v3
       - name: Download all artifact
         uses: actions/download-artifact@v4
         with:
@@ -681,9 +681,9 @@ jobs:
         include: ${{ fromJson(needs.build_details.outputs.build_include) }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v3
       - name: Download all artifact
         uses: actions/download-artifact@v4
         with:
@@ -712,9 +712,9 @@ jobs:
         include: ${{ fromJson(needs.build_details.outputs.build_include) }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v3
       - name: Download all artifact
         uses: actions/download-artifact@v4
         with:
@@ -738,7 +738,7 @@ jobs:
     if: needs.build_details.outputs.docker_release
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Push consolidated manifest
         run: .github/scripts/push-docker.sh ${{ needs.build_details.outputs.branch }} ${{ secrets.DOCKERHUB_USER }} ${{ secrets.DOCKERHUB_PASSWORD }} ${{ github.actor }} ${{ secrets.GITHUB_TOKEN }} ${{ github.sha }}
 
@@ -748,6 +748,6 @@ jobs:
     if: needs.build_details.outputs.docker_release
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Push consolidated manifest
         run: .github/scripts/push-docker.sh ${{ needs.build_details.outputs.branch }}-minimal ${{ secrets.DOCKERHUB_USER }} ${{ secrets.DOCKERHUB_PASSWORD }} ${{ github.actor }} ${{ secrets.GITHUB_TOKEN }} ${{ github.sha }}-minimal


### PR DESCRIPTION
## Description

This pull request updates all GitHub Actions to the latest versions to make sure they work well with the new Ubuntu.

## Changes
- [`actions/checkout`](https://github.com/actions/checkout): [v3](https://github.com/actions/checkout/releases/tag/v3) to [v4](https://github.com/actions/checkout/releases/tag/v4)
- [`actions/setup-node`](https://github.com/actions/setup-node): [v3](https://github.com/actions/setup-node/releases/tag/v3) to [v4](https://github.com/actions/setup-node/releases/tag/v4)
- [`peaceiris/actions-gh-pages`](https://github.com/peaceiris/actions-gh-pages): [v3](https://github.com/peaceiris/actions-gh-pages/releases/tag/v3) to [v4](https://github.com/peaceiris/actions-gh-pages/releases/tag/v4)
- [`ocaml/setup-ocaml`](https://github.com/ocaml/setup-ocaml): [v2](https://github.com/ocaml/setup-ocaml/releases/tag/v2) to [v3](https://github.com/ocaml/setup-ocaml/releases/tag/v3)
- [`actions/cache`](https://github.com/actions/cache): [v3](https://github.com/actions/cache/releases/tag/v3) to [v4](https://github.com/actions/cache/releases/tag/v4)
- [`pre-commit/action`](https://github.com/pre-commit/action): [v3.0.0](https://github.com/pre-commit/action/releases/tag/v3.0.0) to [v3.0.1](https://github.com/pre-commit/action/releases/tag/v3.0.1)
- [`softprops/action-gh-release`](https://github.com/softprops/action-gh-release): [v1](https://github.com/softprops/action-gh-release/releases/tag/v1) to [v2](https://github.com/softprops/action-gh-release/releases/tag/v2)
- [`docker/setup-buildx-action`](https://github.com/docker/setup-buildx-action): [v1](https://github.com/docker/setup-buildx-action/releases/tag/v1) to [v3](https://github.com/docker/setup-buildx-action/releases/tag/v3)