### PR TITLE
Add support for ipv6 address resolution preferences to `srt`.

### DIFF
--- a/.github/opam/liquidsoap-core-windows.opam
+++ b/.github/opam/liquidsoap-core-windows.opam
@@ -112,7 +112,7 @@ conflicts: [
   "ogg-windows" {< "0.7.4"}
   "opus-windows" {< "0.2.0"}
   "portaudio-windows" {< "0.2.0"}
-  "posix-socket" {< "2.1.0"}
+  "posix-socket-windows" {< "2.1.0"}
   "pulseaudio-windows" {< "0.1.4"}
   "samplerate-windows" {< "0.1.5"}
   "shine-windows" {< "0.2.0"}

--- a/.github/opam/liquidsoap-core-windows.opam
+++ b/.github/opam/liquidsoap-core-windows.opam
@@ -73,6 +73,7 @@ depopts: [
   "osx-secure-transport-windows"
   "portaudio-windows"
   "posix-time2-windows"
+  "posix-socket-windows"
   "pulseaudio-windows"
   "prometheus-liquidsoap-windows"
   "samplerate-windows"
@@ -111,6 +112,7 @@ conflicts: [
   "ogg-windows" {< "0.7.4"}
   "opus-windows" {< "0.2.0"}
   "portaudio-windows" {< "0.2.0"}
+  "posix-socket" {< "2.1.0"}
   "pulseaudio-windows" {< "0.1.4"}
   "samplerate-windows" {< "0.1.5"}
   "shine-windows" {< "0.2.0"}

--- a/.github/opam/liquidsoap-core-windows.opam
+++ b/.github/opam/liquidsoap-core-windows.opam
@@ -116,7 +116,7 @@ conflicts: [
   "shine-windows" {< "0.2.0"}
   "soundtouch-windows" {< "0.1.9"}
   "speex-windows" {< "0.4.0"}
-  "srt-windows" {< "0.3.0"}
+  "srt-windows" {< "0.3.2"}
   "ssl-windows" {< "0.5.2"}
   "sdl-liquidsoap-windows" {< "2"}
   "tsdl-image-windows" {< "0.3.2"}

--- a/.github/scripts/build-posix.sh
+++ b/.github/scripts/build-posix.sh
@@ -55,6 +55,7 @@ cd ..
 
 opam update
 opam remove -y jemalloc
+opam unpin -n posix-socket posix-base posix-time2 posix-types
 opam install -y tls.1.0.2 ca-certs mirage-crypto-rng cstruct saturn_lockfree.0.5.0 ppx_hash memtrace xml-light posix-socket.2.1.0 posix-base.2.1.0 posix-time2.2.1.0 posix-types.2.1.0
 
 cd /tmp/liquidsoap-full

--- a/.github/scripts/build-posix.sh
+++ b/.github/scripts/build-posix.sh
@@ -53,6 +53,10 @@ cd ocaml-posix
 opam pin -ny .
 opam install -y posix-socket.2.1.0 posix-base.2.1.0 posix-time2.2.1.0 posix-types.2.1.0
 
+git clone https://github.com/savonet/ocaml-srt.git
+cd ocaml-srt
+opam install -y .
+
 cd /tmp/liquidsoap-full/liquidsoap
 
 ./.github/scripts/checkout-deps.sh

--- a/.github/scripts/build-posix.sh
+++ b/.github/scripts/build-posix.sh
@@ -53,6 +53,10 @@ cd ocaml-posix
 opam pin -ny .
 opam install -y posix-socket.2.1.0 posix-base.2.1.0 posix-time2.2.1.0 posix-types.2.1.0
 
+git clone https://github.com/savonet/ocaml-posix.git
+cd ocaml-srt
+opam install -y .
+
 git clone https://github.com/savonet/ocaml-srt.git
 cd ocaml-srt
 opam install -y .

--- a/.github/scripts/build-posix.sh
+++ b/.github/scripts/build-posix.sh
@@ -53,14 +53,6 @@ cd ocaml-posix
 opam pin -ny .
 opam install -y posix-socket.2.1.0 posix-base.2.1.0 posix-time2.2.1.0 posix-types.2.1.0
 
-git clone https://github.com/savonet/ocaml-posix.git
-cd ocaml-srt
-opam install -y .
-
-git clone https://github.com/savonet/ocaml-srt.git
-cd ocaml-srt
-opam install -y .
-
 cd /tmp/liquidsoap-full/liquidsoap
 
 ./.github/scripts/checkout-deps.sh

--- a/.github/scripts/build-posix.sh
+++ b/.github/scripts/build-posix.sh
@@ -39,19 +39,10 @@ echo "::endgroup::"
 
 echo "::group::Setting up specific dependencies"
 
-opam install -y xml-light
-
 git clone https://github.com/savonet/ocaml-xiph.git
 cd ocaml-xiph
 opam install -y .
 cd ..
-
-cd /tmp
-rm -rf ocaml-posix
-git clone https://github.com/savonet/ocaml-posix.git
-cd ocaml-posix
-opam pin -ny .
-opam install -y posix-socket.2.1.0 posix-base.2.1.0 posix-time2.2.1.0 posix-types.2.1.0
 
 cd /tmp/liquidsoap-full/liquidsoap
 
@@ -64,7 +55,7 @@ cd ..
 
 opam update
 opam remove -y jemalloc
-opam install -y tls.1.0.2 ca-certs mirage-crypto-rng cstruct saturn_lockfree.0.5.0 ppx_hash memtrace
+opam install -y tls.1.0.2 ca-certs mirage-crypto-rng cstruct saturn_lockfree.0.5.0 ppx_hash memtrace xml-light posix-socket.2.1.0 posix-base.2.1.0 posix-time2.2.1.0 posix-types.2.1.0
 
 cd /tmp/liquidsoap-full
 

--- a/.github/scripts/build-win32.sh
+++ b/.github/scripts/build-win32.sh
@@ -45,7 +45,7 @@ echo "::group::Installing deps"
 
 eval "$(opam config env)"
 opam repository set-url windows https://github.com/ocaml-cross/opam-cross-windows.git
-opam update windows
+opam update
 opam install srt-windows.0.3.2
 
 echo "::endgroup::"

--- a/.github/scripts/build-win32.sh
+++ b/.github/scripts/build-win32.sh
@@ -46,7 +46,7 @@ echo "::group::Installing deps"
 eval "$(opam config env)"
 opam repository set-url windows https://github.com/ocaml-cross/opam-cross-windows.git
 opam update
-opam install srt-windows.0.3.2
+opam install -y srt-windows.0.3.2
 
 echo "::endgroup::"
 

--- a/.github/scripts/build-win32.sh
+++ b/.github/scripts/build-win32.sh
@@ -46,6 +46,7 @@ echo "::group::Installing deps"
 eval "$(opam config env)"
 opam repository set-url windows https://github.com/ocaml-cross/opam-cross-windows.git
 opam update windows
+opam install srt-windows.0.3.2
 
 echo "::endgroup::"
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,6 +23,8 @@ Changed:
 - `output.icecast` now re-sends the last metadata when connecting to the
   remote server unless explicitly disabled using the `send_last_metadata_on_connect`
   option (#3906)
+- Add full explicit support for `ipv4` vs. `ipv6` resolution in SRT inputs and outputs,
+  add global `settings.srt.prefer_address` and `settings.icecast.prefer_address` (#4317)
 
 Fixed:
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 New:
 
+- Added support for addressed resolution preference in SRT (#4317)
+- Added global address resolution settings for SRT and Icecast (#4317)
 - Added support for parsing and rendering XML natively (#4252)
 - Added support for `WAVE_FORMAT_EXTENSIBLE` to the internal
   wav dexcoder.

--- a/dune-project
+++ b/dune-project
@@ -92,6 +92,7 @@
     osc-unix
     portaudio
     posix-time2
+    posix-socket
     pulseaudio
     prometheus-liquidsoap
     samplerate
@@ -129,6 +130,7 @@
     (opus (< 0.2.0))
     (portaudio (< 0.2.0))
     (posix-time2 (< 2.0.2))
+    (posix-socket (>= 2.1.0))
     (pulseaudio (< 0.1.4))
     (samplerate (< 0.1.5))
     (shine (< 0.2.0))

--- a/dune-project
+++ b/dune-project
@@ -130,7 +130,7 @@
     (opus (< 0.2.0))
     (portaudio (< 0.2.0))
     (posix-time2 (< 2.0.2))
-    (posix-socket (>= 2.1.0))
+    (posix-socket (< 2.1.0))
     (pulseaudio (< 0.1.4))
     (samplerate (< 0.1.5))
     (shine (< 0.2.0))

--- a/dune-project
+++ b/dune-project
@@ -134,7 +134,7 @@
     (shine (< 0.2.0))
     (soundtouch (< 0.1.9))
     (speex (< 1.0.0))
-    (srt (< 0.3.0))
+    (srt (< 0.3.2))
     (ssl (< 0.7.0))
     (tls (< 1.0.2))
     (sdl-liquidsoap (< 2))

--- a/liquidsoap-core.opam
+++ b/liquidsoap-core.opam
@@ -57,6 +57,7 @@ depopts: [
   "osc-unix"
   "portaudio"
   "posix-time2"
+  "posix-socket"
   "pulseaudio"
   "prometheus-liquidsoap"
   "samplerate"
@@ -95,6 +96,7 @@ conflicts: [
   "opus" {< "0.2.0"}
   "portaudio" {< "0.2.0"}
   "posix-time2" {< "2.0.2"}
+  "posix-socket" {>= "2.1.0"}
   "pulseaudio" {< "0.1.4"}
   "samplerate" {< "0.1.5"}
   "shine" {< "0.2.0"}

--- a/liquidsoap-core.opam
+++ b/liquidsoap-core.opam
@@ -100,7 +100,7 @@ conflicts: [
   "shine" {< "0.2.0"}
   "soundtouch" {< "0.1.9"}
   "speex" {< "1.0.0"}
-  "srt" {< "0.3.0"}
+  "srt" {< "0.3.2"}
   "ssl" {< "0.7.0"}
   "tls" {< "1.0.2"}
   "sdl-liquidsoap" {< "2"}

--- a/liquidsoap-core.opam
+++ b/liquidsoap-core.opam
@@ -96,7 +96,7 @@ conflicts: [
   "opus" {< "0.2.0"}
   "portaudio" {< "0.2.0"}
   "posix-time2" {< "2.0.2"}
-  "posix-socket" {>= "2.1.0"}
+  "posix-socket" {< "2.1.0"}
   "pulseaudio" {< "0.1.4"}
   "samplerate" {< "0.1.5"}
   "shine" {< "0.2.0"}

--- a/src/core/io/srt_io.ml
+++ b/src/core/io/srt_io.ml
@@ -89,25 +89,25 @@ let getaddrinfo ~(log : Log.t) ~prefer_address address port =
           match prefer_address with
             | `System_default -> first_address
             | `Ipv4 ->
-                let rec f ptr cur =
+                let rec f ptr =
                   let sockaddr = !@ptr in
-                  if is_null sockaddr then cur
+                  if is_null sockaddr then first_address
                   else (
                     match !@(sockaddr |-> Sockaddr.sa_family) with
                       | id when id = af_inet -> sockaddr
-                      | _ -> f (ptr +@ 1) cur)
+                      | _ -> f (ptr +@ 1))
                 in
-                f ptr first_address
+                f ptr
             | `Ipv6 ->
-                let rec f ptr cur =
+                let rec f ptr =
                   let sockaddr = !@ptr in
-                  if is_null sockaddr then cur
+                  if is_null sockaddr then first_address
                   else (
                     match !@(sockaddr |-> Sockaddr.sa_family) with
                       | id when id = af_inet6 -> sockaddr
-                      | _ -> f (ptr +@ 1) cur)
+                      | _ -> f (ptr +@ 1))
                 in
-                f ptr first_address
+                f ptr
         in
         if log#active 5 then
           log#f 5 "Address %s:%n resolved to: %s" address port

--- a/src/core/io/srt_io.ml
+++ b/src/core/io/srt_io.ml
@@ -74,12 +74,7 @@ let getaddrinfo ~(log : Log.t) ~prefer_address address port =
   let open Posix_socket in
   let hints = allocate_n Addrinfo.t ~count:1 in
   hints |-> Addrinfo.ai_flags <-@ ni_numerichost;
-  (hints |-> Addrinfo.ai_family
-  <-@
-  match prefer_address with
-    | `System_default -> af_unspec
-    | `Ipv4 -> af_inet
-    | `Ipv6 -> af_inet6);
+  hints |-> Addrinfo.ai_family <-@ af_unspec;
   hints |-> Addrinfo.ai_socktype <-@ sock_stream;
   match getaddrinfo ~hints ~port:(`Int port) address with
     | ptr when is_null !@ptr ->
@@ -89,7 +84,31 @@ let getaddrinfo ~(log : Log.t) ~prefer_address address port =
                address port)
           "srt"
     | ptr ->
-        let sockaddr = !@ptr in
+        let first_address = !@ptr in
+        let sockaddr =
+          match prefer_address with
+            | `System_default -> first_address
+            | `Ipv4 ->
+                let rec f ptr cur =
+                  let sockaddr = !@ptr in
+                  if is_null sockaddr then cur
+                  else (
+                    match !@(sockaddr |-> Sockaddr.sa_family) with
+                      | id when id = af_inet -> sockaddr
+                      | _ -> f (ptr +@ 1) cur)
+                in
+                f ptr first_address
+            | `Ipv6 ->
+                let rec f ptr cur =
+                  let sockaddr = !@ptr in
+                  if is_null sockaddr then cur
+                  else (
+                    match !@(sockaddr |-> Sockaddr.sa_family) with
+                      | id when id = af_inet6 -> sockaddr
+                      | _ -> f (ptr +@ 1) cur)
+                in
+                f ptr first_address
+        in
         if log#active 5 then
           log#f 5 "Address %s:%n resolved to: %s" address port
             (string_of_address (to_unix_sockaddr sockaddr));

--- a/src/core/io/srt_io.ml
+++ b/src/core/io/srt_io.ml
@@ -108,7 +108,7 @@ let common_options ~mode =
       Some "Address to bind on the local machine. Used only in listener mode" );
     ( "ipv6only",
       Lang.nullable_t Lang.bool_t,
-      Some (Lang.bool true),
+      Some (Lang.bool false),
       Some
         "If `true`, binding to the ipv6 wildcard address `::` will bind to \
          both IPv6 and IPv4 wildcard address. Defaults to system default when \

--- a/tests/streams/icecast_last_meta.liq
+++ b/tests/streams/icecast_last_meta.liq
@@ -1,4 +1,5 @@
 port = 6723
+settings.icecast.prefer_address := "ipv4"
 
 s = sine()
 

--- a/tests/streams/icecast_ssl.liq
+++ b/tests/streams/icecast_ssl.liq
@@ -1,4 +1,5 @@
 transport = http.transport.ssl(certificate="./ssl.cert", key="./ssl.key")
+settings.icecast.prefer_address := "ipv4"
 
 port = 1443
 

--- a/tests/streams/icecast_ssl_tls.liq
+++ b/tests/streams/icecast_ssl_tls.liq
@@ -1,7 +1,5 @@
 log.level := 4
-
-# This test is too flakey
-test.skip()
+settings.icecast.prefer_address := "ipv4"
 
 tls = http.transport.tls(certificate="./ssl.cert", key="./ssl.key")
 

--- a/tests/streams/icecast_tls.liq
+++ b/tests/streams/icecast_tls.liq
@@ -1,4 +1,5 @@
 log.level := 4
+settings.icecast.prefer_address := "ipv4"
 
 transport = http.transport.tls(certificate="./ssl.cert", key="./ssl.key")
 

--- a/tests/streams/icecast_tls_ssl.liq
+++ b/tests/streams/icecast_tls_ssl.liq
@@ -1,4 +1,5 @@
 log.level := 4
+settings.icecast.prefer_address := "ipv4"
 
 tls = http.transport.tls(certificate="./ssl.cert", key="./ssl.key")
 

--- a/tests/streams/srt_listen_callback.liq
+++ b/tests/streams/srt_listen_callback.liq
@@ -1,5 +1,6 @@
 log.level.set(4)
 port = 8001
+settings.srt.prefer_address := "ipv4"
 
 def fn() =
   def listen_callback(~hs_version=_, ~peeraddr=_, ~streamid, _) =

--- a/tests/streams/srt_multiple_outputs.liq
+++ b/tests/streams/srt_multiple_outputs.liq
@@ -1,4 +1,5 @@
 port = 8002
+settings.srt.prefer_address := "ipv4"
 
 def fn() =
   connected = ref(0)

--- a/tests/streams/srt_passphrase.liq
+++ b/tests/streams/srt_passphrase.liq
@@ -1,4 +1,5 @@
 port = 8003
+settings.srt.prefer_address := "ipv4"
 
 def fn() =
   output.srt(

--- a/tests/streams/srt_raw_pcm.liq
+++ b/tests/streams/srt_raw_pcm.liq
@@ -1,4 +1,5 @@
 log.level := 4
+settings.srt.prefer_address := "ipv4"
 
 port = 8004
 


### PR DESCRIPTION
This PR introduces explicit resolution settings to SRT addresses. The user can decide if addresses should be resolved as `ipv4` or `ipv6` by default.

It also removes an indirection that was causing uncertainty when resolving addresses. With the chances in this PR, addresses are resolved only once and directly using the `getaddrinfo` API.

Global settings are also introduced for both SRT and icecast to allow the user to change the preference for all instances of their operators at once.