### PR TITLE
Fix naming logic.

### DIFF
--- a/src/core/builtins/builtins_source.ml
+++ b/src/core/builtins/builtins_source.ml
@@ -23,8 +23,8 @@
 let source = Muxer.source
 
 let _ =
-  Lang.add_builtin ~base:source "set_name" ~category:(`Source `Liquidsoap)
-    ~descr:"Set the name of an operator."
+  Lang.add_builtin ~base:source "set_id" ~category:(`Source `Liquidsoap)
+    ~descr:"Set the id of an operator."
     [
       ("", Lang.source_t (Lang.univ_t ()), None, None);
       ("", Lang.string_t, None, None);
@@ -33,7 +33,7 @@ let _ =
     (fun p ->
       let s = Lang.assoc "" 1 p |> Lang.to_source in
       let n = Lang.assoc "" 2 p |> Lang.to_string in
-      s#set_name n;
+      s#set_id n;
       Lang.unit)
 
 let _ =

--- a/src/core/outputs/output.ml
+++ b/src/core/outputs/output.ml
@@ -141,7 +141,7 @@ class virtual output ~output_kind ?clock ?(name = "") ~infallible
       self#on_wake_up (fun () ->
           (* We prefer [name] as an ID over the default, but do not overwrite
              user-defined ID. Our ID will be used for the server interface. *)
-          if name <> "" then self#set_id ~definitive:false name;
+          if name <> "" then self#set_id ~force:false name;
 
           self#log#debug "Clock is %s." (Clock.id self#clock);
           self#log#important "Content type is %s."

--- a/src/core/source.mli
+++ b/src/core/source.mli
@@ -78,7 +78,7 @@ type watcher = {
 class virtual source :
   ?stack:Pos.t list ->
   ?clock:Clock.t ->
-  ?name:string ->
+  name:string ->
   unit ->
 object
   method private mutexify : 'a 'b. ('a -> 'b) -> 'a -> 'b
@@ -88,8 +88,7 @@ object
   (** Identifier of the source. *)
   method id : string
 
-  method set_name : string -> unit
-  method set_id : ?definitive:bool -> string -> unit
+  method set_id : ?force:bool -> string -> unit
 
   (** Position in script *)
   method pos : Pos.Option.t
@@ -332,7 +331,7 @@ end
 and virtual active_source :
   ?stack:Pos.t list ->
   ?clock:Clock.t ->
-  ?name:string ->
+  name:string ->
   unit ->
 object
   inherit source
@@ -347,7 +346,7 @@ end
 class virtual operator :
   ?stack:Pos.t list ->
   ?clock:Clock.t ->
-  ?name:string ->
+  name:string ->
   source list ->
 object
   inherit source
@@ -358,7 +357,7 @@ end
 class virtual active_operator :
   ?stack:Pos.t list ->
   ?clock:Clock.t ->
-  ?name:string ->
+  name:string ->
   source list ->
 object
   inherit active_source

--- a/src/core/sources/synthesized.ml
+++ b/src/core/sources/synthesized.ml
@@ -24,10 +24,10 @@
    support seek by doing nothing. However, for other, seek should be
    disabled. Thus, if [seek] is [true], the seek function is [fun x -> x]
    otherwise it is [fun _ -> 0] *)
-class virtual source ?name ~seek duration =
+class virtual source ~name ~seek duration =
   let track_size = Option.map Frame.main_of_seconds duration in
   object (self)
-    inherit Source.source ?name ()
+    inherit Source.source ~name ()
     method fallible = track_size <> None
     val mutable remaining = track_size
     method private can_generate_frame = remaining <> Some 0

--- a/src/libs/clock.liq
+++ b/src/libs/clock.liq
@@ -10,9 +10,5 @@
 #                  mostly for debugging purposes.
 def clock.assign_new(~sync="auto", ~id=null(), ~on_error=null(), sources) =
   c = clock.create(id=id, sync=sync, on_error=on_error)
-
   list.iter(fun (s) -> c.unify(s.clock), sources)
-
-  # Clock unification can override id so we reset it here.
-  if null.defined(id) then c.id := null.get(id) end
 end

--- a/src/libs/playlist.liq
+++ b/src/libs/playlist.liq
@@ -757,7 +757,7 @@ def playlist.list(
     default()
 %endif
 
-  source.set_name(s, "playlist.list.reloadable")
+  source.set_id(s, "playlist.list.reloadable")
 
   # The reload function
   def reload(~empty_queue=true, p) =
@@ -1096,7 +1096,7 @@ def replaces playlist(
     list.length(files())
   end
 
-  source.set_name(s, "playlist")
+  source.set_id(s, "playlist")
 
   # Set up reloading for seconds and watch
   if

--- a/src/libs/request.liq
+++ b/src/libs/request.liq
@@ -142,7 +142,7 @@ def request.queue(
       end
   )
 
-  source.set_name(s, "request.queue")
+  source.set_id(s, "request.queue")
   fetch := s.fetch
 
   if


### PR DESCRIPTION
* Source `name` is a class-level variable used to denote the class of operator. It should never be changed and should be required
* Clock `id` should remain unset until explicitly set. If unset before starting, pick the first pending source.