### PR TITLE
Implement lufs processing in C

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,7 @@
 
 Fixed:
 
-- Optimized CPU usage (#4369)
+- Optimized CPU usage (#4369, #4370)
 
 ---
 

--- a/src/core/dune
+++ b/src/core/dune
@@ -41,7 +41,7 @@
    (-> file_watcher.mtime.ml)))
  (foreign_stubs
   (language c)
-  (names unix_c defer_c content_pcm_c))
+  (names unix_c defer_c content_pcm_c lufs_c))
  (wrapped false)
  (library_flags -linkall)
  (modules

--- a/src/core/operators/lufs.ml
+++ b/src/core/operators/lufs.ml
@@ -35,9 +35,9 @@ module IIR = struct
 
   type t = {
     channels : int;
-    mutable x : sample * sample;
+    x : sample * sample;
     (* (x', x'') *)
-    mutable y : sample * sample;
+    y : sample * sample;
     (* (y', y'') *)
     a1 : float;
     a2 : float;
@@ -80,23 +80,15 @@ module IIR = struct
   let stage2 =
     create ~a1:(-1.99004745483398) ~a2:0.99007225036621 ~b0:1. ~b1:(-2.) ~b2:1.
 
-  (** Process a sample. *)
+  external process : t -> float array -> float array -> unit
+    = "liquidsoap_lufs_process"
+  [@@noalloc]
+
   let process iir x =
     let channels = iir.channels in
     assert (Array.length x = channels);
-    let x', x'' = iir.x in
-    let y', y'' = iir.y in
     let y = Array.make channels 0. in
-    for i = 0 to channels - 1 do
-      y.(i) <-
-        (iir.b0 *. x.(i))
-        +. (iir.b1 *. x'.(i))
-        +. (iir.b2 *. x''.(i))
-        -. (iir.a1 *. y'.(i))
-        -. (iir.a2 *. y''.(i))
-    done;
-    iir.x <- (x, x');
-    iir.y <- (y, y');
+    process iir x y;
     y
 end
 

--- a/src/core/operators/lufs_c.c
+++ b/src/core/operators/lufs_c.c
@@ -1,0 +1,37 @@
+#include <caml/alloc.h>
+#include <caml/fail.h>
+#include <caml/memory.h>
+
+CAMLprim value liquidsoap_lufs_process(value _iir, value _x, value _y)
+{
+  CAMLparam3(_iir, _x, _y);
+  CAMLlocal4(_x1, _x2, _y1, _y2);
+  int i;
+  double tmp;
+  int channels = Int_val(Field(_iir, 0));
+
+  _x1 = Field(Field(_iir, 1), 0);
+  _x2 = Field(Field(_iir, 1), 1);
+  _y1 = Field(Field(_iir, 2), 0);
+  _y2 = Field(Field(_iir, 2), 1);
+
+  double a1 = Double_val(Field(_iir, 3));
+  double a2 = Double_val(Field(_iir, 4));
+  double b0 = Double_val(Field(_iir, 5));
+  double b1 = Double_val(Field(_iir, 6));
+  double b2 = Double_val(Field(_iir, 7));
+
+  for (i = 0; i < channels; i++) {
+    tmp = b0 * Double_array_field(_x, i) + b1 * Double_array_field(_x1, i) +
+          b2 * Double_array_field(_x2, i) - a1 * Double_array_field(_y1, i) -
+          a2 * Double_array_field(_y2, i);
+    Store_double_array_field(_y, i, tmp);
+  }
+
+  Store_field(Field(_iir, 1), 0, _x);
+  Store_field(Field(_iir, 1), 0, _x1);
+  Store_field(Field(_iir, 2), 0, _y);
+  Store_field(Field(_iir, 2), 0, _y1);
+
+  CAMLreturn(Val_unit);
+}

--- a/src/core/operators/lufs_c.c
+++ b/src/core/operators/lufs_c.c
@@ -1,37 +1,111 @@
 #include <caml/alloc.h>
+#include <caml/custom.h>
 #include <caml/fail.h>
 #include <caml/memory.h>
 
-CAMLprim value liquidsoap_lufs_process(value _iir, value _x, value _y)
-{
-  CAMLparam3(_iir, _x, _y);
-  CAMLlocal4(_x1, _x2, _y1, _y2);
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define MAX_CHANNELS 12
+
+typedef struct iir {
+  uint8_t channels;
+  double x1[MAX_CHANNELS];
+  double x2[MAX_CHANNELS];
+  double y1[MAX_CHANNELS];
+  double y2[MAX_CHANNELS];
+  double a1;
+  double a2;
+  double b0;
+  double b1;
+  double b2;
+} iir_t;
+
+#define IIR_val(v) (*(iir_t **)Data_custom_val(v))
+
+static void finalize_iir(value v) {
+  iir_t *iir = IIR_val(v);
+  free(iir);
+}
+
+static struct custom_operations iir_ops = {
+    "liquidsoap_iir",         finalize_iir,
+    custom_compare_default,   custom_hash_default,
+    custom_serialize_default, custom_deserialize_default};
+
+CAMLprim value liquidsoap_lufs_create_native(value _channels, value _a1,
+                                             value _a2, value _b0, value _b1,
+                                             value _b2) {
+  CAMLparam5(_a1, _a2, _b0, _b1, _b2);
+  CAMLlocal1(ans);
+  int channels = Int_val(_channels);
+
+  if (channels > MAX_CHANNELS)
+    caml_failwith("LUFS: too many channels! Maximum channels is 12.");
+
+  iir_t *iir = calloc(sizeof(iir_t), 1);
+  if (!iir)
+    caml_raise_out_of_memory();
+
+  iir->channels = channels;
+  iir->a1 = Double_val(_a1);
+  iir->a2 = Double_val(_a2);
+  iir->b0 = Double_val(_b0);
+  iir->b1 = Double_val(_b1);
+  iir->b2 = Double_val(_b2);
+
+  ans = caml_alloc_custom(&iir_ops, sizeof(iir_t *), 0, 1);
+  IIR_val(ans) = iir;
+  CAMLreturn(ans);
+}
+
+CAMLprim value liquidsoap_lufs_create_bytecode(value *argv, int argn) {
+  return liquidsoap_lufs_create_native(argv[0], argv[1], argv[2], argv[3],
+                                       argv[4], argv[5]);
+}
+
+static inline void liquidsoap_lufs_process_stage(iir_t *iir, double *x,
+                                                 double *y) {
   int i;
-  double tmp;
-  int channels = Int_val(Field(_iir, 0));
+  size_t buf_len = iir->channels * sizeof(double);
 
-  _x1 = Field(Field(_iir, 1), 0);
-  _x2 = Field(Field(_iir, 1), 1);
-  _y1 = Field(Field(_iir, 2), 0);
-  _y2 = Field(Field(_iir, 2), 1);
+  for (i = 0; i < iir->channels; i++)
+    y[i] = iir->b0 * x[i] + iir->b1 * iir->x1[i] + iir->b2 * iir->x2[i] -
+           iir->a1 * iir->y1[i] - iir->a2 * iir->y2[i];
 
-  double a1 = Double_val(Field(_iir, 3));
-  double a2 = Double_val(Field(_iir, 4));
-  double b0 = Double_val(Field(_iir, 5));
-  double b1 = Double_val(Field(_iir, 6));
-  double b2 = Double_val(Field(_iir, 7));
+  memcpy(iir->x2, iir->x1, buf_len);
+  memcpy(iir->x1, x, buf_len);
+  memcpy(iir->y2, iir->y1, buf_len);
+  memcpy(iir->y1, y, buf_len);
+}
 
-  for (i = 0; i < channels; i++) {
-    tmp = b0 * Double_array_field(_x, i) + b1 * Double_array_field(_x1, i) +
-          b2 * Double_array_field(_x2, i) - a1 * Double_array_field(_y1, i) -
-          a2 * Double_array_field(_y2, i);
-    Store_double_array_field(_y, i, tmp);
+CAMLprim value liquidsoap_lufs_process_native(value _stage1, value _stage2,
+                                              value _x, value _ret) {
+  CAMLparam4(_stage1, _stage2, _x, _ret);
+  double tmp1[MAX_CHANNELS], tmp2[MAX_CHANNELS];
+  double power = 0;
+  int samples = Wosize_val(Field(_x, 0)) / Double_wosize;
+  iir_t *stage1 = IIR_val(_stage1);
+  iir_t *stage2 = IIR_val(_stage2);
+  int i, c;
+
+  for (i = 0; i < samples; i++) {
+    for (c = 0; c < stage1->channels; c++)
+      tmp1[c] = Double_field(Field(_x, c), i);
+
+    liquidsoap_lufs_process_stage(stage1, tmp1, tmp2);
+    liquidsoap_lufs_process_stage(stage2, tmp2, tmp1);
+
+    for (c = 0; c < stage1->channels; c++)
+      power += tmp1[c] * tmp1[c];
   }
 
-  Store_field(Field(_iir, 1), 0, _x);
-  Store_field(Field(_iir, 1), 0, _x1);
-  Store_field(Field(_iir, 2), 0, _y);
-  Store_field(Field(_iir, 2), 0, _y1);
+  CAMLreturn(power / samples);
+}
 
-  CAMLreturn(Val_unit);
+CAMLprim value liquidsoap_lufs_process_bytecode(value _stage1, value _stage2,
+                                                value _x, value _ret) {
+  return caml_copy_double(
+      liquidsoap_lufs_process_native(_stage1, _stage2, _x, _ret));
 }


### PR DESCRIPTION
This saves a pretty good deal of CPU usage.

Before:
```
Computing integrated loudness for /tmp/bla/02 Hello Baby.wav
Integrated loudness: -10.0785549383 LUFS
./liquidsoap ./scripts/compute_integrated_lufs.liq --   2.71s user 0.21s system 53% cpu 5.425 total
```

After:
```
Computing integrated loudness for /tmp/bla/02 Hello Baby.wav
Integrated loudness: -10.0785549383 LUFS
./liquidsoap ./scripts/compute_integrated_lufs.liq --   1.99s user 0.25s system 41% cpu 5.366 total
```
