### PR TITLE
Add integrated loudness measurement

### DIFF
--- a/src/libs/extra/telnet.liq
+++ b/src/libs/extra/telnet.liq
@@ -241,6 +241,15 @@ def replaces lufs(%argsof(lufs), s) =
         server.register(
           namespace=source.id(s),
           description=
+            "Average LUFS value over the current track.",
+          "lufs_integrated",
+          fun (_) ->
+            "#{s.lufs_integrated()} LUFS"
+        )
+
+        server.register(
+          namespace=source.id(s),
+          description=
             "Momentary LUFS (over a 400ms window).",
           "lufs_momentary",
           fun (_) ->

--- a/tests/media/dune
+++ b/tests/media/dune
@@ -243,3 +243,22 @@
    --
    ./@ffmpeg[format='mp4',@audio[codec='aac',channels=2],@video[codec='libx264']].mp4
    ./@ffmpeg[format='mp4',@audio[codec='aac',channels=2],@video[codec='libx264',r=12]].mp4)))
+
+(rule
+ (alias mediatest)
+ (package liquidsoap)
+ (deps
+  all_media_files
+  lufs_integrated.liq
+  ../../src/bin/liquidsoap.exe
+  (package liquidsoap)
+  (source_tree ../../src/lib)
+  (:test_liq ../test.liq)
+  (:run_test ../run_test.exe))
+ (action
+  (run
+   %{run_test}
+   "Integrated LUFS computation"
+   liquidsoap
+   %{test_liq}
+   lufs_integrated.liq)))

--- a/tests/media/lufs_integrated.liq
+++ b/tests/media/lufs_integrated.liq
@@ -1,0 +1,17 @@
+def f() =
+  lufs_integrated = ref(0.)
+
+  def process(s) =
+    s = lufs(s)
+    source.on_frame(s, {lufs_integrated := s.lufs_integrated()})
+  end
+
+  r = request.create("@mp3[mono].mp3")
+
+  request.process(process=process, r)
+
+  test.almost_equal(lufs_integrated(), -4.14942548907)
+  test.pass()
+end
+
+test.check(f)

--- a/tests/media/lufs_integrated.liq
+++ b/tests/media/lufs_integrated.liq
@@ -10,7 +10,7 @@ def f() =
 
   request.process(process=process, r)
 
-  test.almost_equal(lufs_integrated(), -4.14942548907)
+  test.almost_equal(lufs_integrated(), -4.15123570523)
   test.pass()
 end
 


### PR DESCRIPTION
This PR adds support for integrated LUFS measurements which are LUFS measurements averaged over the duration of the current track.

It yields the same values as the FFmpeg `ebur128` filter:

```
Computing integrated loudness for /tmp/bla/01 Madeline.wav
Integrated loudness: -9.94996700195 LUFS
FFMPEG
  Integrated loudness:
    I:          -9.9 LUFS
    Threshold: -20.0 LUFS

Computing integrated loudness for /tmp/bla/02 Hello Baby.wav
Integrated loudness: -10.0785549383 LUFS
FFMPEG
  Integrated loudness:
    I:         -10.1 LUFS
    Threshold: -20.2 LUFS

Computing integrated loudness for /tmp/bla/03 Whatever.wav
Integrated loudness: -9.88789118814 LUFS
FFMPEG
  Integrated loudness:
    I:          -9.9 LUFS
    Threshold: -19.9 LUFS

Computing integrated loudness for /tmp/bla/04 It's Alright.wav
Integrated loudness: -9.90689520009 LUFS
FFMPEG
  Integrated loudness:
    I:          -9.9 LUFS
    Threshold: -19.9 LUFS

Computing integrated loudness for /tmp/bla/05 Roaches.wav
Integrated loudness: -9.44288325581 LUFS
FFMPEG
  Integrated loudness:
    I:          -9.4 LUFS
    Threshold: -19.5 LUFS

Computing integrated loudness for /tmp/bla/06 Aww Baby.wav
Integrated loudness: -9.61122652025 LUFS
FFMPEG
  Integrated loudness:
    I:          -9.6 LUFS
    Threshold: -19.7 LUFS

Computing integrated loudness for /tmp/bla/07 A Change Is Gonna Come.wav
Integrated loudness: -9.40400375696 LUFS
FFMPEG
  Integrated loudness:
    I:          -9.4 LUFS
    Threshold: -19.6 LUFS

Computing integrated loudness for /tmp/bla/08 Oh Ye Yaille.wav
Integrated loudness: -9.83478052896 LUFS
FFMPEG
  Integrated loudness:
    I:          -9.8 LUFS
    Threshold: -19.9 LUFS

Computing integrated loudness for /tmp/bla/09 Richest Man.wav
Integrated loudness: -9.95607141564 LUFS
FFMPEG
  Integrated loudness:
    I:          -9.9 LUFS
    Threshold: -20.2 LUFS

Computing integrated loudness for /tmp/bla/10 Swing.wav
Integrated loudness: -9.25842127505 LUFS
FFMPEG
  Integrated loudness:
    I:          -9.3 LUFS
    Threshold: -19.3 LUFS

Computing integrated loudness for /tmp/bla/11 No Good Woman.wav
Integrated loudness: -9.67044896066 LUFS
FFMPEG
  Integrated loudness:
    I:          -9.7 LUFS
    Threshold: -19.8 LUFS

Computing integrated loudness for /tmp/bla/12 Falling In Love With Jesus.wav
Integrated loudness: -9.88534712407 LUFS
FFMPEG
  Integrated loudness:
    I:          -9.9 LUFS
    Threshold: -20.0 LUFS
```