### PR TITLE
fix backticks in icy_metadata.md

### DIFF
--- a/doc/content/icy_metadata.md
+++ b/doc/content/icy_metadata.md
@@ -16,7 +16,7 @@ in liquidsoap. We list some of those here.
 ## Enable/disable ICY metadata updates
 
 You can enable or disable icy metadata update in `output.icecast`
-by setting the `send_icy_metadata` parameter to `null(), `true`or`false`. The default value is `null()` and does the following:
+by setting the `send_icy_metadata` parameter to `null()`, `true` or `false`. The default value is `null()` and does the following:
 
 - Set `true` for: mp3, aac, aac+, wav
 - Set `false` for any format using the ogg container


### PR DESCRIPTION
Backticks were wonky in ice_medatdata.md. Fixed them for documentation formatting purposes.