### PR TITLE
Enhance srt output recovery

### DIFF
--- a/tests/regression/GH4395.liq
+++ b/tests/regression/GH4395.liq
@@ -1,0 +1,21 @@
+port = 9502
+settings.srt.prefer_address := "ipv4"
+
+track_count = ref(0)
+
+def on_track(_) =
+  ref.incr(track_count)
+  if track_count() > 1 then test.pass() end
+end
+
+s = input.srt(mode="caller", content_type="application/ogg", port=port)
+
+s.on_track(on_track)
+
+output.dummy(fallible=true, s)
+
+output.srt(id="output.srt", mode="listener", port=port, %opus, sine())
+
+thread.run(delay=3., s.disconnect)
+
+thread.run(delay=4., s.connect)

--- a/tests/regression/dune.inc
+++ b/tests/regression/dune.inc
@@ -819,6 +819,22 @@
  (alias citest)
  (package liquidsoap)
  (deps
+  GH4395.liq
+  ../media/all_media_files
+  ../../src/bin/liquidsoap.exe
+  ../streams/file1.png
+  ../streams/file1.mp3
+  ./theora-test.mp4
+  (package liquidsoap)
+  (source_tree ../../src/libs)
+  (:test_liq ../test.liq)
+  (:run_test ../run_test.exe))
+ (action (run %{run_test} GH4395.liq liquidsoap %{test_liq} GH4395.liq)))
+  
+(rule
+ (alias citest)
+ (package liquidsoap)
+ (deps
   LS268.liq
   ../media/all_media_files
   ../../src/bin/liquidsoap.exe


### PR DESCRIPTION
This PR enhances SRT behavior w.r.t. disconnections:

* Properly stop encoder on disconnection. This makes sure that the next client gets a clean stream with potential initial headers.
* Add connect/disconnect methods. Useful for programmatically manipulating SRT operators.
* Add regression test using the previous methods.

It's worth noting that, for ogg encapsulation, some limitations will always happen. In particular, it is very difficult to have multiple receivers getting data from the same encoder.

It is technically possible and icecast does it, by keeping the last ogg packets headers in memory and sending them to the newly connected client but this is tricky, blurs the line between transport, encapsulation and codec.

Unless there is a serious need for it, this will probably not be implemented so SRT connections using ogg encapsulation should be using at most one connection.

Fixes: #4395