### PR TITLE
Add mutex-protected stdlib override for atomic for pre-ocaml 5.

### DIFF
--- a/src/lang/dune
+++ b/src/lang/dune
@@ -88,6 +88,7 @@
   (pps sedlex.ppx ppx_string ppx_hash))
  (libraries
   liquidsoap-lang.console
+  liquidsoap-lang.custom-stdlib
   dune-site
   re
   str

--- a/src/stdlib/atomic.mli
+++ b/src/stdlib/atomic.mli
@@ -1,0 +1,10 @@
+type !'a t
+
+val make : 'a -> 'a t
+val get : 'a t -> 'a
+val set : 'a t -> 'a -> unit
+val exchange : 'a t -> 'a -> 'a
+val compare_and_set : 'a t -> 'a -> 'a -> bool
+val fetch_and_add : int t -> int -> int
+val incr : int t -> unit
+val decr : int t -> unit

--- a/src/stdlib/atomic.mutexify.ml
+++ b/src/stdlib/atomic.mutexify.ml
@@ -42,5 +42,5 @@ let fetch_and_add r n =
       cur)
     n
 
-let incr r = ignore ((fetch_and_add [@inlined]) r 1)
-let decr r = ignore ((fetch_and_add [@inlined]) r (-1))
+let incr r = ignore (fetch_and_add r 1)
+let decr r = ignore (fetch_and_add r (-1))

--- a/src/stdlib/atomic.mutexify.ml
+++ b/src/stdlib/atomic.mutexify.ml
@@ -1,0 +1,40 @@
+type 'a t = { m : Mutex.t; mutable v : 'a }
+
+let mutexify m f x =
+  Mutex.lock m;
+  match f x with
+    | exception exn ->
+        let bt = Printexc.get_raw_backtrace () in
+        Mutex.unlock m;
+        Printexc.raise_with_backtrace exn bt
+    | v ->
+        Mutex.unlock m;
+        v
+[@@inline always]
+
+let make v = { m = Mutex.create (); v }
+let get r = mutexify r.m (fun () -> r.v) ()
+let set r = mutexify r.m (fun v -> r.v <- v)
+
+let[@inline never] exchange r =
+  mutexify r.m (fun v ->
+      let cur = r.v in
+      r.v <- v;
+      cur)
+
+let[@inline never] compare_and_set r seen =
+  mutexify r.m (fun v ->
+      let cur = r.v in
+      if cur == seen then (
+        r.v <- v;
+        true)
+      else false)
+
+let[@inline never] fetch_and_add r =
+  mutexify r.m (fun n ->
+      let cur = r.v in
+      r.v <- cur + n;
+      cur)
+
+let incr r = ignore (fetch_and_add r 1)
+let decr r = ignore (fetch_and_add r (-1))

--- a/src/stdlib/atomic.stdlib.ml
+++ b/src/stdlib/atomic.stdlib.ml
@@ -1,0 +1,1 @@
+include Stdlib.Atomic

--- a/src/stdlib/dune
+++ b/src/stdlib/dune
@@ -1,0 +1,22 @@
+(library
+ (name custom_stdlib)
+ (public_name liquidsoap-lang.custom-stdlib)
+ (wrapped false)
+ (modules atomic)
+ (libraries threads))
+
+(rule
+ (target atomic.ml)
+ (deps atomic.mutexify.ml)
+ (enabled_if
+  (< %{ocaml_version} 5.0))
+ (action
+  (copy atomic.mutexify.ml atomic.ml)))
+
+(rule
+ (target atomic.ml)
+ (deps atomic.stdlib.ml)
+ (enabled_if
+  (>= %{ocaml_version} 5.0))
+ (action
+  (copy atomic.stdlib.ml atomic.ml)))


### PR DESCRIPTION
It turns out that the `Atomic` implementation in pre-OCaml 5 is a simple, unprotected access to a mutable reference.

We're investigating a possible segfault linked to this. This PR would provide a default implementation for pre-OCaml 5 that actually protects the atomic access with a mutex.