### PR TITLE
Flip default behavior for `metadata.map` strip argument.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,9 +1,16 @@
 # 2.3.3 (unreleased)
 
+Fixed:
+
+- Do not send empty metadata to shoutcast servers (#4408)
+
 Changed:
 
 - `dtools`, `duppy` and `xmlplaylist` have been moved into the liquidsoap code
   base and will no longer be developed or required as stand-alone packages (#12582)
+- Changed default value of `metadata.map` `strip` argument to `true` and `insert_missing`
+  to `false` Added `settings.metadata.map.strip` and `settings.metadata.map.insert_missing`
+  configuration keys to revert to previous defaults. (#4447)
 
 ---
 

--- a/src/core/operators/map_metadata.ml
+++ b/src/core/operators/map_metadata.ml
@@ -22,6 +22,17 @@
 
 open Source
 
+let conf_metadata =
+  Dtools.Conf.void ~p:(Configure.conf#plug "Metadata") "Metadata settings"
+
+let conf_metadata_map =
+  Dtools.Conf.void ~p:(conf_metadata#plug "map") "Metadata map settings"
+
+let conf_metadata_map_strip =
+  Dtools.Conf.bool
+    ~p:(conf_metadata_map#plug "strip")
+    ~d:true "Default value for the `strip` parameter."
+
 class map_metadata source rewrite_f insert_missing update strip =
   object (self)
     inherit operator ~name:"metadata.map" [source]
@@ -89,8 +100,8 @@ let register =
           "Update metadata. If false, existing metadata are cleared and only \
            returned values are set as new metadata." );
       ( "strip",
-        Lang.bool_t,
-        Some (Lang.bool false),
+        Lang.nullable_t Lang.bool_t,
+        Some Lang.null,
         Some
           "Completely remove empty metadata. Operates on both empty values and \
            empty metadata chunk." );
@@ -100,7 +111,7 @@ let register =
         Some
           "Treat track beginnings without metadata as having empty ones. The \
            operational order is: create empty if needed, map and strip if \
-           enabled." );
+           enabled. Defaults to `settings.metadata.map.strip` when `null`." );
       ("", return_t, None, None);
     ]
     ~category:`Track ~descr:"Rewrite metadata on the fly using a function."
@@ -110,6 +121,7 @@ let register =
       assert (field = Frame.Fields.metadata);
       let f = Lang.assoc "" 1 p in
       let update = Lang.to_bool (List.assoc "update" p) in
-      let strip = Lang.to_bool (List.assoc "strip" p) in
+      let strip = Lang.to_valued_option Lang.to_bool (List.assoc "strip" p) in
+      let strip = Option.value ~default:conf_metadata_map_strip#get strip in
       let missing = Lang.to_bool (List.assoc "insert_missing" p) in
       (field, new map_metadata source f missing update strip))

--- a/src/core/operators/map_metadata.ml
+++ b/src/core/operators/map_metadata.ml
@@ -36,7 +36,7 @@ let conf_metadata_map_strip =
 let conf_metadata_map_insert_missing =
   Dtools.Conf.bool
     ~p:(conf_metadata_map#plug "insert_missing")
-    ~d:true "Default value for the `insert_missing` parameter."
+    ~d:false "Default value for the `insert_missing` parameter."
 
 class map_metadata source rewrite_f insert_missing update strip =
   object (self)

--- a/src/core/operators/map_metadata.ml
+++ b/src/core/operators/map_metadata.ml
@@ -33,6 +33,11 @@ let conf_metadata_map_strip =
     ~p:(conf_metadata_map#plug "strip")
     ~d:true "Default value for the `strip` parameter."
 
+let conf_metadata_map_insert_missing =
+  Dtools.Conf.bool
+    ~p:(conf_metadata_map#plug "insert_missing")
+    ~d:true "Default value for the `insert_missing` parameter."
+
 class map_metadata source rewrite_f insert_missing update strip =
   object (self)
     inherit operator ~name:"metadata.map" [source]
@@ -104,14 +109,16 @@ let register =
         Some Lang.null,
         Some
           "Completely remove empty metadata. Operates on both empty values and \
-           empty metadata chunk." );
+           empty metadata chunk. Defaults to `settings.metadata.map.strip` \
+           when `null`." );
       ( "insert_missing",
-        Lang.bool_t,
-        Some (Lang.bool true),
+        Lang.nullable_t Lang.bool_t,
+        Some Lang.null,
         Some
           "Treat track beginnings without metadata as having empty ones. The \
            operational order is: create empty if needed, map and strip if \
-           enabled. Defaults to `settings.metadata.map.strip` when `null`." );
+           enabled. Defaults to `settings.metadata.map.insert_missing` when \
+           `null`." );
       ("", return_t, None, None);
     ]
     ~category:`Track ~descr:"Rewrite metadata on the fly using a function."
@@ -123,5 +130,10 @@ let register =
       let update = Lang.to_bool (List.assoc "update" p) in
       let strip = Lang.to_valued_option Lang.to_bool (List.assoc "strip" p) in
       let strip = Option.value ~default:conf_metadata_map_strip#get strip in
-      let missing = Lang.to_bool (List.assoc "insert_missing" p) in
+      let missing =
+        Lang.to_valued_option Lang.to_bool (List.assoc "insert_missing" p)
+      in
+      let missing =
+        Option.value ~default:conf_metadata_map_insert_missing#get missing
+      in
       (field, new map_metadata source f missing update strip))

--- a/tests/media/ffmpeg_filter_changing_rate.liq
+++ b/tests/media/ffmpeg_filter_changing_rate.liq
@@ -27,7 +27,7 @@ end
 s = single(fname)
 s' = single(fname2)
 last = single(id="last", fname)
-last = metadata.map(fun (_) -> [("title", "done")], last)
+last = metadata.map(insert_missing=true, fun (_) -> [("title", "done")], last)
 s = sequence([s, s', s, s', s, last, s, s', s])
 s = f(s)
 done = ref(false)

--- a/tests/regression/AC5109.liq
+++ b/tests/regression/AC5109.liq
@@ -7,9 +7,9 @@ s = sequence([s1, s2])
 
 def transition(a, b) =
   s1 = sine(duration=0.5)
-  s1 = metadata.map(fun (_) -> [("type", "s1")], s1)
+  s1 = metadata.map(insert_missing=true,fun (_) -> [("type", "s1")], s1)
   s2 = sine(duration=0.5)
-  s2 = metadata.map(fun (_) -> [("type", "s2")], s2)
+  s2 = metadata.map(insert_missing=true,fun (_) -> [("type", "s2")], s2)
   sequence(
     [(a.source : source), (s1 : source), (s2 : source), (b.source : source)]
   )

--- a/tests/regression/AC5109.liq
+++ b/tests/regression/AC5109.liq
@@ -7,9 +7,9 @@ s = sequence([s1, s2])
 
 def transition(a, b) =
   s1 = sine(duration=0.5)
-  s1 = metadata.map(insert_missing=true,fun (_) -> [("type", "s1")], s1)
+  s1 = metadata.map(insert_missing=true, fun (_) -> [("type", "s1")], s1)
   s2 = sine(duration=0.5)
-  s2 = metadata.map(insert_missing=true,fun (_) -> [("type", "s2")], s2)
+  s2 = metadata.map(insert_missing=true, fun (_) -> [("type", "s2")], s2)
   sequence(
     [(a.source : source), (s1 : source), (s2 : source), (b.source : source)]
   )

--- a/tests/regression/GH1129.liq
+++ b/tests/regression/GH1129.liq
@@ -9,7 +9,7 @@ def m1(_) =
   [("id", "s1")]
 end
 
-s1 = metadata.map(insert_missing=true,id="s1", m1, s1)
+s1 = metadata.map(insert_missing=true, id="s1", m1, s1)
 s2_ready = ref(false)
 s2 = switch(id="s2", [({!s2_ready}, blank(duration=0.04))])
 
@@ -17,14 +17,14 @@ def m2(_) =
   [("id", "s2")]
 end
 
-s2 = metadata.map(insert_missing=true,id="s2", m2, s2)
+s2 = metadata.map(insert_missing=true, id="s2", m2, s2)
 s3 = blank(id="s3", duration=0.04)
 
 def m3(_) =
   [("id", "s3")]
 end
 
-s3 = metadata.map(insert_missing=true,id="s3", m3, s3)
+s3 = metadata.map(insert_missing=true, id="s3", m3, s3)
 
 def f(m) =
   s2_ready := !s2_ready or m["id"] == "s3"

--- a/tests/regression/GH1129.liq
+++ b/tests/regression/GH1129.liq
@@ -9,7 +9,7 @@ def m1(_) =
   [("id", "s1")]
 end
 
-s1 = metadata.map(id="s1", m1, s1)
+s1 = metadata.map(insert_missing=true,id="s1", m1, s1)
 s2_ready = ref(false)
 s2 = switch(id="s2", [({!s2_ready}, blank(duration=0.04))])
 
@@ -17,14 +17,14 @@ def m2(_) =
   [("id", "s2")]
 end
 
-s2 = metadata.map(id="s2", m2, s2)
+s2 = metadata.map(insert_missing=true,id="s2", m2, s2)
 s3 = blank(id="s3", duration=0.04)
 
 def m3(_) =
   [("id", "s3")]
 end
 
-s3 = metadata.map(id="s3", m3, s3)
+s3 = metadata.map(insert_missing=true,id="s3", m3, s3)
 
 def f(m) =
   s2_ready := !s2_ready or m["id"] == "s3"

--- a/tests/regression/GH1279.liq
+++ b/tests/regression/GH1279.liq
@@ -5,14 +5,14 @@ def m1(_) =
   [("id", "s1")]
 end
 
-s1 = metadata.map(insert_missing=true,id="s1", m1, s1)
+s1 = metadata.map(insert_missing=true, id="s1", m1, s1)
 s2 = blank(duration=0.04)
 
 def m2(_) =
   [("id", "s2")]
 end
 
-s2 = metadata.map(insert_missing=true,id="s2", m2, s2)
+s2 = metadata.map(insert_missing=true, id="s2", m2, s2)
 
 def f(m) =
   selected := list.add(m["id"], !selected)

--- a/tests/regression/GH1279.liq
+++ b/tests/regression/GH1279.liq
@@ -5,14 +5,14 @@ def m1(_) =
   [("id", "s1")]
 end
 
-s1 = metadata.map(id="s1", m1, s1)
+s1 = metadata.map(insert_missing=true,id="s1", m1, s1)
 s2 = blank(duration=0.04)
 
 def m2(_) =
   [("id", "s2")]
 end
 
-s2 = metadata.map(id="s2", m2, s2)
+s2 = metadata.map(insert_missing=true,id="s2", m2, s2)
 
 def f(m) =
   selected := list.add(m["id"], !selected)

--- a/tests/regression/GH1327.liq
+++ b/tests/regression/GH1327.liq
@@ -8,7 +8,7 @@ def m1(_) =
   [("id", "s1")]
 end
 
-s1 = metadata.map(id="s1", m1, s1)
+s1 = metadata.map(insert_missing=true, id="s1", m1, s1)
 
 s2 = blank(duration=0.1)
 
@@ -16,7 +16,7 @@ def m2(_) =
   [("id", "s2")]
 end
 
-s2 = metadata.map(id="s2", m2, s2)
+s2 = metadata.map(insert_missing=true, id="s2", m2, s2)
 
 def f(m) =
   selected := list.add(m["id"], !selected)
@@ -30,7 +30,7 @@ def m_noise(_) =
   [("id", "noise")]
 end
 
-noise = metadata.map(id="noise", m_noise, noise())
+noise = metadata.map(insert_missing=true, id="noise", m_noise, noise())
 
 ready = ref(false)
 

--- a/tests/regression/GH3132.liq
+++ b/tests/regression/GH3132.liq
@@ -1,11 +1,6 @@
 last_source = sine()
 last_source =
-  metadata.map(
-    insert_missing=true,
-    insert_missing=true,
-    fun (_) -> [("last", "true")],
-    last_source
-  )
+  metadata.map(insert_missing=true, fun (_) -> [("last", "true")], last_source)
 
 s = sequence([sine(duration=5.), blank(duration=5.), last_source])
 s = blank.eat(max_blank=1., s)

--- a/tests/regression/GH3132.liq
+++ b/tests/regression/GH3132.liq
@@ -1,6 +1,11 @@
 last_source = sine()
 last_source =
-  metadata.map(insert_missing=true,insert_missing=true, fun (_) -> [("last", "true")], last_source)
+  metadata.map(
+    insert_missing=true,
+    insert_missing=true,
+    fun (_) -> [("last", "true")],
+    last_source
+  )
 
 s = sequence([sine(duration=5.), blank(duration=5.), last_source])
 s = blank.eat(max_blank=1., s)

--- a/tests/regression/GH3132.liq
+++ b/tests/regression/GH3132.liq
@@ -1,6 +1,6 @@
 last_source = sine()
 last_source =
-  metadata.map(insert_missing=true, fun (_) -> [("last", "true")], last_source)
+  metadata.map(insert_missing=true,insert_missing=true, fun (_) -> [("last", "true")], last_source)
 
 s = sequence([sine(duration=5.), blank(duration=5.), last_source])
 s = blank.eat(max_blank=1., s)

--- a/tests/regression/GH4163.liq
+++ b/tests/regression/GH4163.liq
@@ -1,11 +1,17 @@
 first_blank =
-  metadata.map(insert_missing=true,
-    id="first_blank", fun (_) -> [("title", "first_blank")], blank(duration=3.)
+  metadata.map(
+    insert_missing=true,
+    id="first_blank",
+    fun (_) -> [("title", "first_blank")],
+    blank(duration=3.)
   )
 
 after_blank =
-  metadata.map(insert_missing=true,
-    id="after_blank", fun (_) -> [("title", "after_blank")], sine(duration=10.)
+  metadata.map(
+    insert_missing=true,
+    id="after_blank",
+    fun (_) -> [("title", "after_blank")],
+    sine(duration=10.)
   )
 
 blank_sequence = sequence(id="blank_sequence", [first_blank, after_blank])
@@ -14,7 +20,12 @@ blank_strip =
   blank.strip(id="blank_strip", max_blank=5., start_blank=true, blank_sequence)
 
 fallback_sine =
-  metadata.map(insert_missing=true,id="fallback_sine", fun (_) -> [("title", "fallback")], sine())
+  metadata.map(
+    insert_missing=true,
+    id="fallback_sine",
+    fun (_) -> [("title", "fallback")],
+    sine()
+  )
 
 s =
   fallback(

--- a/tests/regression/GH4163.liq
+++ b/tests/regression/GH4163.liq
@@ -1,10 +1,10 @@
 first_blank =
-  metadata.map(
+  metadata.map(insert_missing=true,
     id="first_blank", fun (_) -> [("title", "first_blank")], blank(duration=3.)
   )
 
 after_blank =
-  metadata.map(
+  metadata.map(insert_missing=true,
     id="after_blank", fun (_) -> [("title", "after_blank")], sine(duration=10.)
   )
 
@@ -14,7 +14,7 @@ blank_strip =
   blank.strip(id="blank_strip", max_blank=5., start_blank=true, blank_sequence)
 
 fallback_sine =
-  metadata.map(id="fallback_sine", fun (_) -> [("title", "fallback")], sine())
+  metadata.map(insert_missing=true,id="fallback_sine", fun (_) -> [("title", "fallback")], sine())
 
 s =
   fallback(

--- a/tests/regression/GH4281-2.liq
+++ b/tests/regression/GH4281-2.liq
@@ -1,8 +1,8 @@
 d = sequence([sine(duration=3.), sine(duration=3.)])
-d = metadata.map(update=false, (fun (_) -> [("title", "delay")]), d)
+d = metadata.map(insert_missing=true,update=false, (fun (_) -> [("title", "delay")]), d)
 
 f = sequence([sine(duration=3.), sine(duration=3.)])
-f = metadata.map(update=false, (fun (_) -> [("title", "fallback")]), f)
+f = metadata.map(insert_missing=true,update=false, (fun (_) -> [("title", "fallback")]), f)
 
 s = fallback([delay(initial=true, 1., d), f])
 

--- a/tests/regression/GH4281-2.liq
+++ b/tests/regression/GH4281-2.liq
@@ -1,8 +1,14 @@
 d = sequence([sine(duration=3.), sine(duration=3.)])
-d = metadata.map(insert_missing=true,update=false, (fun (_) -> [("title", "delay")]), d)
+d =
+  metadata.map(
+    insert_missing=true, update=false, (fun (_) -> [("title", "delay")]), d
+  )
 
 f = sequence([sine(duration=3.), sine(duration=3.)])
-f = metadata.map(insert_missing=true,update=false, (fun (_) -> [("title", "fallback")]), f)
+f =
+  metadata.map(
+    insert_missing=true, update=false, (fun (_) -> [("title", "fallback")]), f
+  )
 
 s = fallback([delay(initial=true, 1., d), f])
 

--- a/tests/regression/GH4281.liq
+++ b/tests/regression/GH4281.liq
@@ -1,8 +1,8 @@
 d = sequence([sine(duration=3.), sine(duration=3.)])
-d = metadata.map(update=false, (fun (_) -> [("title", "delay")]), d)
+d = metadata.map(insert_missing=true,update=false, (fun (_) -> [("title", "delay")]), d)
 
 f = sequence([sine(duration=3.), sine(duration=3.)])
-f = metadata.map(update=false, (fun (_) -> [("title", "fallback")]), f)
+f = metadata.map(insert_missing=true,update=false, (fun (_) -> [("title", "fallback")]), f)
 
 s = fallback([delay(1., d), f])
 

--- a/tests/regression/GH4281.liq
+++ b/tests/regression/GH4281.liq
@@ -1,8 +1,14 @@
 d = sequence([sine(duration=3.), sine(duration=3.)])
-d = metadata.map(insert_missing=true,update=false, (fun (_) -> [("title", "delay")]), d)
+d =
+  metadata.map(
+    insert_missing=true, update=false, (fun (_) -> [("title", "delay")]), d
+  )
 
 f = sequence([sine(duration=3.), sine(duration=3.)])
-f = metadata.map(insert_missing=true,update=false, (fun (_) -> [("title", "fallback")]), f)
+f =
+  metadata.map(
+    insert_missing=true, update=false, (fun (_) -> [("title", "fallback")]), f
+  )
 
 s = fallback([delay(1., d), f])
 

--- a/tests/regression/append-merge.liq
+++ b/tests/regression/append-merge.liq
@@ -2,7 +2,7 @@ music = chop(every=1., metadata=[("source", "s1")], sine(amplitude=0.1, 440.))
 
 def next(_) =
   s = sine(amplitude=0.1, duration=.5, 880.)
-  metadata.map(insert_missing=true, fun (_) -> [("source", "s2")], s)
+  metadata.map(insert_missing=true,insert_missing=true, fun (_) -> [("source", "s2")], s)
 end
 
 s = append(merge=true, music, next)

--- a/tests/regression/append-merge.liq
+++ b/tests/regression/append-merge.liq
@@ -2,7 +2,9 @@ music = chop(every=1., metadata=[("source", "s1")], sine(amplitude=0.1, 440.))
 
 def next(_) =
   s = sine(amplitude=0.1, duration=.5, 880.)
-  metadata.map(insert_missing=true,insert_missing=true, fun (_) -> [("source", "s2")], s)
+  metadata.map(
+    insert_missing=true, insert_missing=true, fun (_) -> [("source", "s2")], s
+  )
 end
 
 s = append(merge=true, music, next)

--- a/tests/regression/append-merge.liq
+++ b/tests/regression/append-merge.liq
@@ -3,7 +3,7 @@ music = chop(every=1., metadata=[("source", "s1")], sine(amplitude=0.1, 440.))
 def next(_) =
   s = sine(amplitude=0.1, duration=.5, 880.)
   metadata.map(
-    insert_missing=true, insert_missing=true, fun (_) -> [("source", "s2")], s
+    insert_missing=true, fun (_) -> [("source", "s2")], s
   )
 end
 

--- a/tests/regression/seek_track_map.liq
+++ b/tests/regression/seek_track_map.liq
@@ -8,7 +8,7 @@ def set_cues(s) =
     [("liq_cue_in", "#{in}"), ("liq_cue_out", "#{out}")]
   end
 
-  metadata.map(f, s)
+  metadata.map(insert_missing=true, f, s)
 end
 
 s = set_cues(s)

--- a/tests/streams/cross-override-end.liq
+++ b/tests/streams/cross-override-end.liq
@@ -1,11 +1,11 @@
 success = ref(false)
 
 a = sine(duration=5., 440.)
-a = metadata.map(id="a", update=false, (fun (_) -> [("source", "a")]), a)
+a = metadata.map(insert_missing=true,id="a", update=false, (fun (_) -> [("source", "a")]), a)
 
 b = sine(duration=5., 880.)
 b =
-  metadata.map(
+  metadata.map(insert_missing=true,
     id="b",
     update=false,
     (fun (_) -> [("source", "b"), ("liq_cross_end_duration", "1.1")]),
@@ -13,7 +13,7 @@ b =
   )
 
 c = sine(duration=5., 440.)
-c = metadata.map(id="c", update=false, (fun (_) -> [("source", "c")]), c)
+c = metadata.map(insert_missing=true,id="c", update=false, (fun (_) -> [("source", "c")]), c)
 
 s = sequence([a, b, c])
 s = crossfade(end_duration=5., start_duration=4., s)

--- a/tests/streams/cross-override-end.liq
+++ b/tests/streams/cross-override-end.liq
@@ -1,11 +1,15 @@
 success = ref(false)
 
 a = sine(duration=5., 440.)
-a = metadata.map(insert_missing=true,id="a", update=false, (fun (_) -> [("source", "a")]), a)
+a =
+  metadata.map(
+    insert_missing=true, id="a", update=false, (fun (_) -> [("source", "a")]), a
+  )
 
 b = sine(duration=5., 880.)
 b =
-  metadata.map(insert_missing=true,
+  metadata.map(
+    insert_missing=true,
     id="b",
     update=false,
     (fun (_) -> [("source", "b"), ("liq_cross_end_duration", "1.1")]),
@@ -13,7 +17,10 @@ b =
   )
 
 c = sine(duration=5., 440.)
-c = metadata.map(insert_missing=true,id="c", update=false, (fun (_) -> [("source", "c")]), c)
+c =
+  metadata.map(
+    insert_missing=true, id="c", update=false, (fun (_) -> [("source", "c")]), c
+  )
 
 s = sequence([a, b, c])
 s = crossfade(end_duration=5., start_duration=4., s)

--- a/tests/streams/cross-override-start.liq
+++ b/tests/streams/cross-override-start.liq
@@ -1,11 +1,15 @@
 success = ref(false)
 
 a = sine(duration=5., 440.)
-a = metadata.map(insert_missing=true,id="a", update=false, (fun (_) -> [("source", "a")]), a)
+a =
+  metadata.map(
+    insert_missing=true, id="a", update=false, (fun (_) -> [("source", "a")]), a
+  )
 
 b = sine(duration=5., 880.)
 b =
-  metadata.map(insert_missing=true,
+  metadata.map(
+    insert_missing=true,
     id="b",
     update=false,
     (fun (_) -> [("source", "b"), ("liq_cross_start_duration", "1.1")]),
@@ -13,7 +17,10 @@ b =
   )
 
 c = sine(duration=5., 440.)
-c = metadata.map(insert_missing=true,id="c", update=false, (fun (_) -> [("source", "c")]), c)
+c =
+  metadata.map(
+    insert_missing=true, id="c", update=false, (fun (_) -> [("source", "c")]), c
+  )
 
 s = sequence([a, b, c])
 s = crossfade(start_duration=5., end_duration=4., s)

--- a/tests/streams/cross-override-start.liq
+++ b/tests/streams/cross-override-start.liq
@@ -1,11 +1,11 @@
 success = ref(false)
 
 a = sine(duration=5., 440.)
-a = metadata.map(id="a", update=false, (fun (_) -> [("source", "a")]), a)
+a = metadata.map(insert_missing=true,id="a", update=false, (fun (_) -> [("source", "a")]), a)
 
 b = sine(duration=5., 880.)
 b =
-  metadata.map(
+  metadata.map(insert_missing=true,
     id="b",
     update=false,
     (fun (_) -> [("source", "b"), ("liq_cross_start_duration", "1.1")]),
@@ -13,7 +13,7 @@ b =
   )
 
 c = sine(duration=5., 440.)
-c = metadata.map(id="c", update=false, (fun (_) -> [("source", "c")]), c)
+c = metadata.map(insert_missing=true,id="c", update=false, (fun (_) -> [("source", "c")]), c)
 
 s = sequence([a, b, c])
 s = crossfade(start_duration=5., end_duration=4., s)

--- a/tests/streams/cross-override.liq
+++ b/tests/streams/cross-override.liq
@@ -1,11 +1,15 @@
 success = ref(false)
 
 a = sine(duration=5., 440.)
-a = metadata.map(insert_missing=true,id="a", update=false, (fun (_) -> [("source", "a")]), a)
+a =
+  metadata.map(
+    insert_missing=true, id="a", update=false, (fun (_) -> [("source", "a")]), a
+  )
 
 b = sine(duration=5., 880.)
 b =
-  metadata.map(insert_missing=true,
+  metadata.map(
+    insert_missing=true,
     id="b",
     update=false,
     (fun (_) -> [("source", "b"), ("liq_cross_duration", "1.1")]),
@@ -13,7 +17,10 @@ b =
   )
 
 c = sine(duration=5., 440.)
-c = metadata.map(insert_missing=true,id="c", update=false, (fun (_) -> [("source", "c")]), c)
+c =
+  metadata.map(
+    insert_missing=true, id="c", update=false, (fun (_) -> [("source", "c")]), c
+  )
 
 s = sequence([a, b, c])
 s = crossfade(duration=5., s)

--- a/tests/streams/cross-override.liq
+++ b/tests/streams/cross-override.liq
@@ -1,11 +1,11 @@
 success = ref(false)
 
 a = sine(duration=5., 440.)
-a = metadata.map(id="a", update=false, (fun (_) -> [("source", "a")]), a)
+a = metadata.map(insert_missing=true,id="a", update=false, (fun (_) -> [("source", "a")]), a)
 
 b = sine(duration=5., 880.)
 b =
-  metadata.map(
+  metadata.map(insert_missing=true,
     id="b",
     update=false,
     (fun (_) -> [("source", "b"), ("liq_cross_duration", "1.1")]),
@@ -13,7 +13,7 @@ b =
   )
 
 c = sine(duration=5., 440.)
-c = metadata.map(id="c", update=false, (fun (_) -> [("source", "c")]), c)
+c = metadata.map(insert_missing=true,id="c", update=false, (fun (_) -> [("source", "c")]), c)
 
 s = sequence([a, b, c])
 s = crossfade(duration=5., s)

--- a/tests/streams/cross-persist-end-override.liq
+++ b/tests/streams/cross-persist-end-override.liq
@@ -1,11 +1,11 @@
 success = ref(false)
 
 a = sine(duration=5., 440.)
-a = metadata.map(id="a", update=false, (fun (_) -> [("source", "a")]), a)
+a = metadata.map(insert_missing=true,id="a", update=false, (fun (_) -> [("source", "a")]), a)
 
 b = sine(duration=5., 880.)
 b =
-  metadata.map(
+  metadata.map(insert_missing=true,
     id="b",
     update=false,
     (fun (_) -> [("source", "b"), ("liq_cross_end_duration", "1.1")]),
@@ -13,7 +13,7 @@ b =
   )
 
 c = sine(duration=5., 440.)
-c = metadata.map(id="c", update=false, (fun (_) -> [("source", "c")]), c)
+c = metadata.map(insert_missing=true,id="c", update=false, (fun (_) -> [("source", "c")]), c)
 
 s = sequence([a, b, c])
 s = crossfade(persist_override=true, start_duration=5., end_duration=4., s)

--- a/tests/streams/cross-persist-end-override.liq
+++ b/tests/streams/cross-persist-end-override.liq
@@ -1,11 +1,15 @@
 success = ref(false)
 
 a = sine(duration=5., 440.)
-a = metadata.map(insert_missing=true,id="a", update=false, (fun (_) -> [("source", "a")]), a)
+a =
+  metadata.map(
+    insert_missing=true, id="a", update=false, (fun (_) -> [("source", "a")]), a
+  )
 
 b = sine(duration=5., 880.)
 b =
-  metadata.map(insert_missing=true,
+  metadata.map(
+    insert_missing=true,
     id="b",
     update=false,
     (fun (_) -> [("source", "b"), ("liq_cross_end_duration", "1.1")]),
@@ -13,7 +17,10 @@ b =
   )
 
 c = sine(duration=5., 440.)
-c = metadata.map(insert_missing=true,id="c", update=false, (fun (_) -> [("source", "c")]), c)
+c =
+  metadata.map(
+    insert_missing=true, id="c", update=false, (fun (_) -> [("source", "c")]), c
+  )
 
 s = sequence([a, b, c])
 s = crossfade(persist_override=true, start_duration=5., end_duration=4., s)

--- a/tests/streams/cross-persist-override.liq
+++ b/tests/streams/cross-persist-override.liq
@@ -1,11 +1,11 @@
 success = ref(false)
 
 a = sine(duration=5., 440.)
-a = metadata.map(id="a", update=false, (fun (_) -> [("source", "a")]), a)
+a = metadata.map(insert_missing=true,id="a", update=false, (fun (_) -> [("source", "a")]), a)
 
 b = sine(duration=5., 880.)
 b =
-  metadata.map(
+  metadata.map(insert_missing=true,
     id="b",
     update=false,
     (fun (_) -> [("source", "b"), ("liq_cross_duration", "1.1")]),
@@ -13,7 +13,7 @@ b =
   )
 
 c = sine(duration=5., 440.)
-c = metadata.map(id="c", update=false, (fun (_) -> [("source", "c")]), c)
+c = metadata.map(insert_missing=true,id="c", update=false, (fun (_) -> [("source", "c")]), c)
 
 s = sequence([a, b, c])
 s = crossfade(persist_override=true, duration=5., s)

--- a/tests/streams/cross-persist-override.liq
+++ b/tests/streams/cross-persist-override.liq
@@ -1,11 +1,15 @@
 success = ref(false)
 
 a = sine(duration=5., 440.)
-a = metadata.map(insert_missing=true,id="a", update=false, (fun (_) -> [("source", "a")]), a)
+a =
+  metadata.map(
+    insert_missing=true, id="a", update=false, (fun (_) -> [("source", "a")]), a
+  )
 
 b = sine(duration=5., 880.)
 b =
-  metadata.map(insert_missing=true,
+  metadata.map(
+    insert_missing=true,
     id="b",
     update=false,
     (fun (_) -> [("source", "b"), ("liq_cross_duration", "1.1")]),
@@ -13,7 +17,10 @@ b =
   )
 
 c = sine(duration=5., 440.)
-c = metadata.map(insert_missing=true,id="c", update=false, (fun (_) -> [("source", "c")]), c)
+c =
+  metadata.map(
+    insert_missing=true, id="c", update=false, (fun (_) -> [("source", "c")]), c
+  )
 
 s = sequence([a, b, c])
 s = crossfade(persist_override=true, duration=5., s)

--- a/tests/streams/cross-persist-start-override.liq
+++ b/tests/streams/cross-persist-start-override.liq
@@ -1,11 +1,15 @@
 success = ref(false)
 
 a = sine(duration=5., 440.)
-a = metadata.map(id="a", update=false, (fun (_) -> [("source", "a")]), a)
+a =
+  metadata.map(
+    insert_missing=true, id="a", update=false, (fun (_) -> [("source", "a")]), a
+  )
 
 b = sine(duration=5., 880.)
 b =
   metadata.map(
+    insert_missing=true,
     id="b",
     update=false,
     (fun (_) -> [("source", "b"), ("liq_cross_start_duration", "1.1")]),
@@ -13,7 +17,10 @@ b =
   )
 
 c = sine(duration=5., 440.)
-c = metadata.map(id="c", update=false, (fun (_) -> [("source", "c")]), c)
+c =
+  metadata.map(
+    insert_missing=true, id="c", update=false, (fun (_) -> [("source", "c")]), c
+  )
 
 s = sequence([a, b, c])
 s = crossfade(persist_override=true, start_duration=5., end_duration=4., s)

--- a/tests/streams/cross.liq
+++ b/tests/streams/cross.liq
@@ -1,8 +1,14 @@
 video.frame.rate.set(24)
 a = sine(duration=5., 440.)
-a = metadata.map(update=false, (fun (_) -> [("title", "a")]), a)
+a =
+  metadata.map(
+    insert_missing=true, update=false, (fun (_) -> [("title", "a")]), a
+  )
 b = sine(duration=5., 880.)
-b = metadata.map(update=false, (fun (_) -> [("title", "b")]), b)
+b =
+  metadata.map(
+    insert_missing=true, update=false, (fun (_) -> [("title", "b")]), b
+  )
 s = sequence([a, b])
 
 def t(a, b) =

--- a/tests/streams/crossfade-plot.liq
+++ b/tests/streams/crossfade-plot.liq
@@ -3,6 +3,7 @@ log.level := 5
 a = sine(duration=20., 440.)
 a =
   metadata.map(
+    insert_missing=true,
     update=false,
     fun (_) ->
       [
@@ -18,6 +19,7 @@ a =
 b = sine(duration=20., 880.)
 b =
   metadata.map(
+    insert_missing=true,
     update=false,
     fun (_) ->
       [

--- a/tests/streams/crossfade.liq
+++ b/tests/streams/crossfade.liq
@@ -1,10 +1,10 @@
 video.frame.rate.set(24)
 
 a = sine(duration=20., 440.)
-a = metadata.map(update=false, (fun (_) -> [("title", "a")]), a)
+a = metadata.map(insert_missing=true,update=false, (fun (_) -> [("title", "a")]), a)
 
 b = sine(duration=20., 880.)
-b = metadata.map(update=false, (fun (_) -> [("title", "b")]), b)
+b = metadata.map(insert_missing=true,update=false, (fun (_) -> [("title", "b")]), b)
 
 s = sequence([a, b])
 

--- a/tests/streams/crossfade.liq
+++ b/tests/streams/crossfade.liq
@@ -1,10 +1,16 @@
 video.frame.rate.set(24)
 
 a = sine(duration=20., 440.)
-a = metadata.map(insert_missing=true,update=false, (fun (_) -> [("title", "a")]), a)
+a =
+  metadata.map(
+    insert_missing=true, update=false, (fun (_) -> [("title", "a")]), a
+  )
 
 b = sine(duration=20., 880.)
-b = metadata.map(insert_missing=true,update=false, (fun (_) -> [("title", "b")]), b)
+b =
+  metadata.map(
+    insert_missing=true, update=false, (fun (_) -> [("title", "b")]), b
+  )
 
 s = sequence([a, b])
 

--- a/tests/streams/fades-overrides.liq
+++ b/tests/streams/fades-overrides.liq
@@ -1,11 +1,11 @@
 success = ref(false)
 
 a = sine(duration=5., 440.)
-a = metadata.map(update=false, (fun (_) -> [("source", "a")]), a)
+a = metadata.map(insert_missing=true,update=false, (fun (_) -> [("source", "a")]), a)
 
 b = sine(duration=5., 880.)
 b =
-  metadata.map(
+  metadata.map(insert_missing=true,
     update=false,
     (
       fun (_) ->
@@ -21,7 +21,7 @@ b =
   )
 
 c = sine(duration=5., 440.)
-c = metadata.map(update=false, (fun (_) -> [("source", "c")]), c)
+c = metadata.map(insert_missing=true,update=false, (fun (_) -> [("source", "c")]), c)
 
 s = sequence([a, b, c])
 

--- a/tests/streams/fades-overrides.liq
+++ b/tests/streams/fades-overrides.liq
@@ -1,11 +1,15 @@
 success = ref(false)
 
 a = sine(duration=5., 440.)
-a = metadata.map(insert_missing=true,update=false, (fun (_) -> [("source", "a")]), a)
+a =
+  metadata.map(
+    insert_missing=true, update=false, (fun (_) -> [("source", "a")]), a
+  )
 
 b = sine(duration=5., 880.)
 b =
-  metadata.map(insert_missing=true,
+  metadata.map(
+    insert_missing=true,
     update=false,
     (
       fun (_) ->
@@ -21,7 +25,10 @@ b =
   )
 
 c = sine(duration=5., 440.)
-c = metadata.map(insert_missing=true,update=false, (fun (_) -> [("source", "c")]), c)
+c =
+  metadata.map(
+    insert_missing=true, update=false, (fun (_) -> [("source", "c")]), c
+  )
 
 s = sequence([a, b, c])
 

--- a/tests/streams/fades-persistent-override.liq
+++ b/tests/streams/fades-persistent-override.liq
@@ -1,11 +1,11 @@
 success = ref(false)
 
 a = sine(duration=5., 440.)
-a = metadata.map(update=false, (fun (_) -> [("source", "a")]), a)
+a = metadata.map(insert_missing=true,update=false, (fun (_) -> [("source", "a")]), a)
 
 b = sine(duration=5., 880.)
 b =
-  metadata.map(
+  metadata.map(insert_missing=true,
     update=false,
     (
       fun (_) ->
@@ -21,7 +21,7 @@ b =
   )
 
 c = sine(duration=5., 440.)
-c = metadata.map(update=false, (fun (_) -> [("source", "c")]), c)
+c = metadata.map(insert_missing=true,update=false, (fun (_) -> [("source", "c")]), c)
 
 s = sequence([a, b, c])
 

--- a/tests/streams/fades-persistent-override.liq
+++ b/tests/streams/fades-persistent-override.liq
@@ -1,11 +1,15 @@
 success = ref(false)
 
 a = sine(duration=5., 440.)
-a = metadata.map(insert_missing=true,update=false, (fun (_) -> [("source", "a")]), a)
+a =
+  metadata.map(
+    insert_missing=true, update=false, (fun (_) -> [("source", "a")]), a
+  )
 
 b = sine(duration=5., 880.)
 b =
-  metadata.map(insert_missing=true,
+  metadata.map(
+    insert_missing=true,
     update=false,
     (
       fun (_) ->
@@ -21,7 +25,10 @@ b =
   )
 
 c = sine(duration=5., 440.)
-c = metadata.map(insert_missing=true,update=false, (fun (_) -> [("source", "c")]), c)
+c =
+  metadata.map(
+    insert_missing=true, update=false, (fun (_) -> [("source", "c")]), c
+  )
 
 s = sequence([a, b, c])
 

--- a/tests/streams/hls_id3v2.liq
+++ b/tests/streams/hls_id3v2.liq
@@ -167,6 +167,7 @@ end
 s = sine()
 s =
   metadata.map(
+    insert_missing=true,
     fun (_) ->
       [
         (

--- a/tests/streams/random.liq
+++ b/tests/streams/random.liq
@@ -9,7 +9,7 @@ def m1(_) =
   [("id", "s1")]
 end
 
-s1 = metadata.map(id="s1-map", m1, s1)
+s1 = metadata.map(insert_missing=true,id="s1-map", m1, s1)
 s1_ready = ref(true)
 s1 = switch(id="s1", track_sensitive=false, [(s1_ready, s1)])
 s1_weight = ref(1)
@@ -19,7 +19,7 @@ def m2(_) =
   [("id", "s2")]
 end
 
-s2 = metadata.map(id="s2-map", m2, s2)
+s2 = metadata.map(insert_missing=true,id="s2-map", m2, s2)
 s2_ready = ref(false)
 s2 = switch(id="s2", track_sensitive=false, [(s2_ready, s2)])
 s2_weight = ref(1)

--- a/tests/streams/random.liq
+++ b/tests/streams/random.liq
@@ -9,7 +9,7 @@ def m1(_) =
   [("id", "s1")]
 end
 
-s1 = metadata.map(insert_missing=true,id="s1-map", m1, s1)
+s1 = metadata.map(insert_missing=true, id="s1-map", m1, s1)
 s1_ready = ref(true)
 s1 = switch(id="s1", track_sensitive=false, [(s1_ready, s1)])
 s1_weight = ref(1)
@@ -19,7 +19,7 @@ def m2(_) =
   [("id", "s2")]
 end
 
-s2 = metadata.map(insert_missing=true,id="s2-map", m2, s2)
+s2 = metadata.map(insert_missing=true, id="s2-map", m2, s2)
 s2_ready = ref(false)
 s2 = switch(id="s2", track_sensitive=false, [(s2_ready, s2)])
 s2_weight = ref(1)

--- a/tests/streams/rotate.liq
+++ b/tests/streams/rotate.liq
@@ -1,5 +1,10 @@
 def mksource(id="", url) =
-  metadata.map(id=id, fun (_) -> [("source", id)], mksafe(playlist(url)))
+  metadata.map(
+    insert_missing=true,
+    id=id,
+    fun (_) -> [("source", id)],
+    mksafe(playlist(url))
+  )
 end
 
 jingles = mksource("jingles", "jingles")


### PR DESCRIPTION
With the new content API, track marks are more common than before. In most cases, user to not expect track marks to generate empty metadata, typically when switching to a default `blank` source. Likewise, if a metadata key has an empty value, most user would expect that empty value to be removed all together.

Thus, this PR flips default behavior for `metadata.map` strip argument, add global settings to revert to legacy value if needed.

Fixes: #4408