### PR TITLE
Don't insert missing metadata into shoutcast streams

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # 2.3.3 (unreleased)
 
+Fixed:
+
+- Don't insert empty metadata into shoutcast streams (#4408)
+
 Changed:
 
 - `dtools`, `duppy` and `xmlplaylist` have been moved into the liquidsoap code

--- a/src/libs/icecast.liq
+++ b/src/libs/icecast.liq
@@ -31,7 +31,7 @@ def output.shoutcast(
     if dj != "" then ("dj", dj)::m else m end
   end
 
-  s = metadata.map(map, s)
+  s = metadata.map(insert_missing=false, map, s)
   output.icecast(
     %argsof(output.icecast[!method,!mount,!headers,!description,!protocol]),
     mount="",


### PR DESCRIPTION
Don't insert missing metadata into shoutcast streams.

Fixes: #4408