### PR TITLE
Deprecate `null()`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -485,7 +485,7 @@ Changed:
   into, respectively, `decoder.add`, `decoder.oblivious.add`, `decoder.metadata.add`
 - Deprecated `get_mime`, added `file.mime.libmagic` and `file.mime.cli`, made
   `file.mime` try `file.mime.libmagic` if present and `file.mime.cli` otherwise,
-  changed eturned value when no mime was found to `null()`.
+  changed returned value when no mime was found to `null()`.
 - Return a nullable float in `request.duration`.
 - Removed `--list-plugins-json` and `--list-plugins-xml` options.
 - Added `--list-functions-json` option.

--- a/doc/content/icy_metadata.md
+++ b/doc/content/icy_metadata.md
@@ -16,7 +16,7 @@ in liquidsoap. We list some of those here.
 ## Enable/disable ICY metadata updates
 
 You can enable or disable icy metadata update in `output.icecast`
-by setting the `send_icy_metadata` parameter to `null()`, `true` or `false`. The default value is `null()` and does the following:
+by setting the `send_icy_metadata` parameter to `null`, `true` or `false`. The default value is `null` and does the following:
 
 - Set `true` for: mp3, aac, aac+, wav
 - Set `false` for any format using the ogg container
@@ -34,7 +34,7 @@ We provide a default implementation that returns `artist` or `title` metadata
 when only one of these two is available and `$(artist) - $(title)` otherwise.
 
 You can use the `icy_song` parameter to use your own implementation. Returning
-`null()` from that function disables the metadata altogether.
+`null` from that function disables the metadata altogether.
 
 ## Update metadata manually
 

--- a/doc/content/json.md
+++ b/doc/content/json.md
@@ -184,11 +184,11 @@ test =
   if null.defined(scripts) then
     null.get(scripts.test)
   else
-    null ()
+    null.make()
   end
 
 # Use the ?? syntax:
-test = (scripts ?? { test = null() }).test
+test = (scripts ?? { test = null.make() }).test
 ```
 
 #### Tuple types

--- a/doc/content/language.md
+++ b/doc/content/language.md
@@ -1116,7 +1116,7 @@ let {foo = [x, y, z], gni} = {foo = [1, 2, 3], gni = "baz"}
 
 # Record capture with optional methods:
 let { foo? } = ()
-# foo = null()
+# foo = null.make()
 
 let { foo? } = { foo = 123 }
 # foo = 123
@@ -1301,7 +1301,7 @@ empty:
 
 ```liquidsoap
 def list.hd(l)
-  if l == [] then null() else list.hd(l) end
+  if l == [] then null.make() else list.hd(l) end
 end
 ```
 
@@ -1313,7 +1313,7 @@ whose type would be
 
 since it takes as argument a list whose elements are of type `'a` and returns a
 list whose elements are `'a` or `null`. As it can be observed above, the null
-value is created with `null()`.
+value is created with `null`.
 
 In order to use a nullable value, one typically uses the construction `x ?? d`
 which is the value `x` excepting when it is null, in which case it is the

--- a/doc/content/liq/beets-protocol.liq
+++ b/doc/content/liq/beets-protocol.liq
@@ -14,7 +14,7 @@ def beets_protocol(~rlog, ~maxtime, arg) =
     rlog(
       "Failed to execute #{command}: #{p.status} (#{p.status.code}) #{p.stderr}"
     )
-    null()
+    null.make()
   end
 end
 protocol.add(

--- a/doc/content/liq/crossfade.liq
+++ b/doc/content/liq/crossfade.liq
@@ -9,7 +9,7 @@
 # @param a Ending track
 # @param b Starting track
 def cross.smart(
-  ~id=null(),
+  ~id=null.make(),
   ~fade_in=3.,
   ~fade_out=3.,
   ~default=(fun (a, b) -> (sequence([a, b]) : source)),

--- a/doc/content/liq/harbor-simple.liq
+++ b/doc/content/liq/harbor-simple.liq
@@ -6,7 +6,7 @@ def handler(req) =
   req.socket.close()
 
   # Null indicates that we're using the socket directly.
-  null()
+  null.make()
 end
 
 harbor.http.register.simple("/custom", port=3456, handler)

--- a/doc/content/liq/request.dynamic.liq
+++ b/doc/content/liq/request.dynamic.liq
@@ -9,7 +9,7 @@ def get_next() =
   if
     files == []
   then
-    null()
+    null.make()
   else
     file = list.nth(files, pos())
     pos := pos() + 1 mod list.length(files)

--- a/doc/content/migrating.md
+++ b/doc/content/migrating.md
@@ -82,12 +82,12 @@ end
   It handles both `r128_track_gain` and `replaygain_track_gain` internally and returns a single unified gain value.
 
 - The `file.replaygain` function now takes a new compute parameter:
-  `file.replaygain(~id=null(), ~compute=true, ~ratio=50., file_name)`.
+  `file.replaygain(~id=null.make(), ~compute=true, ~ratio=50., file_name)`.
   The compute parameter determines if gain should be calculated when the metadata does not already contain replaygain tags.
 
 - The `enable_replaygain_metadata` function now accepts a compute parameter to control replaygain calculation.
 
-- The `replaygain` function no longer takes an `ebu_r128` parameter. The signature is now simply: `replaygain(~id=null(), s)`.
+- The `replaygain` function no longer takes an `ebu_r128` parameter. The signature is now simply: `replaygain(~id=null.make(), s)`.
   Previously, `ebu_r128` allowed controlling whether EBU R128 or standard replaygain was used.
   However, EBU R128 data is now extracted directly from metadata when available.
   So `replaygain` cannot control the gain type via this parameter anymore.

--- a/src/core/builtins/builtins_time.ml
+++ b/src/core/builtins/builtins_time.ml
@@ -158,7 +158,9 @@ let _ =
       try
         let tokenizer = Liquidsoap_lang.Preprocessor.mk_tokenizer lexbuf in
         let predicate =
-          Liquidsoap_lang.Term_reducer.to_term (processor tokenizer)
+          Liquidsoap_lang.Term_reducer.to_term
+            ~throw:(fun exn -> raise exn)
+            (processor tokenizer)
         in
         Lang.val_fun [] (fun _ -> Liquidsoap_lang.Evaluation.eval predicate)
       with _ ->

--- a/src/core/decoder/ffmpeg_decoder.ml
+++ b/src/core/decoder/ffmpeg_decoder.ml
@@ -517,7 +517,9 @@ let parse_encoder_params =
   fun s ->
     let lexbuf = Sedlexing.Utf8.from_string ("(" ^ s ^ ")") in
     let tokenizer = Liquidsoap_lang.Preprocessor.mk_tokenizer lexbuf in
-    Liquidsoap_lang.Term_reducer.to_encoder_params (processor tokenizer)
+    Liquidsoap_lang.Term_reducer.to_encoder_params
+      ~throw:(fun exn -> raise exn)
+      (processor tokenizer)
 
 let parse_input_args args =
   try

--- a/src/core/io/pulseaudio_io.ml
+++ b/src/core/io/pulseaudio_io.ml
@@ -61,7 +61,7 @@ class output ~infallible ~register_telnet ~start ~on_start ~on_stop p =
   let device =
     if device = Some "" then (
       log#important
-        "Empty device name \"\" is deprecated! Please use `null()` instead..";
+        "Empty device name \"\" is deprecated! Please use `null` instead..";
       None)
     else device
   in
@@ -150,7 +150,7 @@ class input p =
   let device =
     if device = Some "" then (
       log#important
-        "Empty device name \"\" is deprecated! Please use `null()` instead..";
+        "Empty device name \"\" is deprecated! Please use `null` instead..";
       None)
     else device
   in

--- a/src/core/outputs/icecast2.ml
+++ b/src/core/outputs/icecast2.ml
@@ -212,7 +212,7 @@ let default_icy_song =
   elsif title != "" then
     title
   else
-    null()
+    null.make()
   end
 end|}
 

--- a/src/core/outputs/pipe_output.ml
+++ b/src/core/outputs/pipe_output.ml
@@ -226,7 +226,8 @@ let _ =
     takes care of the various reload mechanisms. *)
 
 let default_reopen_on_error =
-  Lang.eval ~cache:false ~stdlib:`Disabled ~typecheck:false "fun (_) -> null()"
+  Lang.eval ~cache:false ~stdlib:`Disabled ~typecheck:false
+    "fun (_) -> null.make()"
 
 let default_reopen_on_metadata =
   Lang.eval ~cache:false ~stdlib:`Disabled ~typecheck:false "fun (_) -> false"

--- a/src/js/interactive_js.ml
+++ b/src/js/interactive_js.ml
@@ -65,7 +65,7 @@ let on_execute =
       let parsed_term = Runtime.program tokenizer in
       let json = Liquidsoap_tooling.Parsed_json.to_json parsed_term in
       let json = Liquidsoap_lang.Json.to_string json in
-      let term = Term_reducer.to_term parsed_term in
+      let term = Term_reducer.to_term ~throw parsed_term in
       let result = execute ~throw term in
       formatLiqCode (Js.string json) (fun formatted ->
           setOutput

--- a/src/lang/builtins_null.ml
+++ b/src/lang/builtins_null.ml
@@ -22,7 +22,12 @@
 
 let null =
   let a = Lang.univ_t () in
-  Lang.add_builtin "null" ~category:`Programming
+  Lang.add_builtin_base "null" ~category:`Programming ~descr:"The null value."
+    `Null (Lang.nullable_t a)
+
+let _ =
+  let a = Lang.univ_t () in
+  Lang.add_builtin ~base:null "make" ~category:`Programming
     ~descr:"Create a nullable value."
     [("", Lang.nullable_t a, Some Lang.null, Some "Value to make nullable.")]
     (Lang.nullable_t a)

--- a/src/lang/lexer.ml
+++ b/src/lang/lexer.ml
@@ -276,7 +276,6 @@ let rec token lexbuf =
     | '_' -> UNDERSCORE
     | "true" -> BOOL true
     | "false" -> BOOL false
-    | "null" -> NULL
     | int_literal -> INT (Sedlexing.Utf8.lexeme lexbuf)
     | decimal_literal, ".{" ->
         let matched = Sedlexing.Utf8.lexeme lexbuf in

--- a/src/lang/lexer.ml
+++ b/src/lang/lexer.ml
@@ -276,6 +276,7 @@ let rec token lexbuf =
     | '_' -> UNDERSCORE
     | "true" -> BOOL true
     | "false" -> BOOL false
+    | "null" -> NULL
     | int_literal -> INT (Sedlexing.Utf8.lexeme lexbuf)
     | decimal_literal, ".{" ->
         let matched = Sedlexing.Utf8.lexeme lexbuf in

--- a/src/lang/parser.mly
+++ b/src/lang/parser.mly
@@ -68,7 +68,6 @@ open Parser_helper
 %token UNDERSCORE
 %token NOT
 %token GET SET
-%token NULL
 %token <bool> PP_IFDEF
 %token PP_IFVERSION
 %token ARGS_OF
@@ -90,7 +89,6 @@ open Parser_helper
 %left BIN1 AT
 %left BIN2 MINUS
 %left BIN3 TIMES
-%nonassoc NULL
 %nonassoc COALESCE     (* (x ?? y) == z *)
 %nonassoc QUESTION_DOT (* (x ?. y) == z *)
 %right COLONCOLON
@@ -227,10 +225,7 @@ expr:
   | LCUR record optional_comma RCUR  { mk ~pos:$loc (`Methods (None, $2)) }
   | LCUR RCUR                        { mk ~pos:$loc (`Methods (None, [])) }
   | expr QUESTION_DOT invoke         { mk ~pos:$loc (`Invoke { invoked = $1; meth = $3; optional = true }) }
-  | NULL QUESTION_DOT invoke         { mk ~pos:$loc (`Invoke { invoked = mk ~pos:$loc($1) (`Var "null"); meth = $3; optional = true }) }
   | expr DOT invoke                  { mk ~pos:$loc (`Invoke { invoked = $1; meth = $3; optional = false }) }
-  | NULL DOT invoke                  { mk ~pos:$loc (`Invoke { invoked = mk ~pos:$loc($1) (`Var "null"); meth = $3; optional = false }) }
-  | NULL                             { mk ~pos:$loc `Null }
   | VARLPAR app_list RPAR            { mk_app ~pos:$loc ~var_pos:$loc($1) $1 $2 }
   | expr COLONCOLON expr             { mk ~pos:$loc (`Append ($1, $3)) }
   | VARLBRA expr RBRA                { mk ~pos:$loc (`Assoc (mk ~pos:$loc($1) (`Var $1), $2)) }

--- a/src/lang/parser.mly
+++ b/src/lang/parser.mly
@@ -68,6 +68,7 @@ open Parser_helper
 %token UNDERSCORE
 %token NOT
 %token GET SET
+%token NULL
 %token <bool> PP_IFDEF
 %token PP_IFVERSION
 %token ARGS_OF
@@ -89,6 +90,7 @@ open Parser_helper
 %left BIN1 AT
 %left BIN2 MINUS
 %left BIN3 TIMES
+%nonassoc NULL
 %nonassoc COALESCE     (* (x ?? y) == z *)
 %nonassoc QUESTION_DOT (* (x ?. y) == z *)
 %right COLONCOLON
@@ -225,7 +227,10 @@ expr:
   | LCUR record optional_comma RCUR  { mk ~pos:$loc (`Methods (None, $2)) }
   | LCUR RCUR                        { mk ~pos:$loc (`Methods (None, [])) }
   | expr QUESTION_DOT invoke         { mk ~pos:$loc (`Invoke { invoked = $1; meth = $3; optional = true }) }
+  | NULL QUESTION_DOT invoke         { mk ~pos:$loc (`Invoke { invoked = mk ~pos:$loc($1) (`Var "null"); meth = $3; optional = true }) }
   | expr DOT invoke                  { mk ~pos:$loc (`Invoke { invoked = $1; meth = $3; optional = false }) }
+  | NULL DOT invoke                  { mk ~pos:$loc (`Invoke { invoked = mk ~pos:$loc($1) (`Var "null"); meth = $3; optional = false }) }
+  | NULL                             { mk ~pos:$loc `Null }
   | VARLPAR app_list RPAR            { mk_app ~pos:$loc ~var_pos:$loc($1) $1 $2 }
   | expr COLONCOLON expr             { mk ~pos:$loc (`Append ($1, $3)) }
   | VARLBRA expr RBRA                { mk ~pos:$loc (`Assoc (mk ~pos:$loc($1) (`Var $1), $2)) }

--- a/src/lang/parser.mly
+++ b/src/lang/parser.mly
@@ -226,7 +226,7 @@ expr:
   | LCUR RCUR                        { mk ~pos:$loc (`Methods (None, [])) }
   | expr QUESTION_DOT invoke         { mk ~pos:$loc (`Invoke { invoked = $1; meth = $3; optional = true }) }
   | expr DOT invoke                  { mk ~pos:$loc (`Invoke { invoked = $1; meth = $3; optional = false }) }
-  | VARLPAR app_list RPAR            { mk ~pos:$loc (`App (mk ~pos:$loc($1) (`Var $1), $2)) }
+  | VARLPAR app_list RPAR            { mk_app ~pos:$loc ~var_pos:$loc($1) $1 $2 }
   | expr COLONCOLON expr             { mk ~pos:$loc (`Append ($1, $3)) }
   | VARLBRA expr RBRA                { mk ~pos:$loc (`Assoc (mk ~pos:$loc($1) (`Var $1), $2)) }
   | expr DOT VARLBRA expr RBRA       { let src = mk ~pos:($startpos($1),$endpos($3)) (`Invoke ({invoked = $1; optional = false; meth = `String $3})) in

--- a/src/lang/parser_helper.ml
+++ b/src/lang/parser_helper.ml
@@ -158,7 +158,19 @@ let mk_let ~pos _let body =
 let mk_encoder ~pos e p = mk ~pos (`Encoder (e, p))
 
 let mk_app ~pos ~var_pos v arglist =
-  let annotations =
-    match (v, arglist) with "null", [] -> [`Deprecated "use `null`"] | _ -> []
+  let v, annotations =
+    match v with
+      | "null" ->
+          let v =
+            mk ~pos:var_pos
+              (`Invoke
+                 {
+                   invoked = mk ~pos:var_pos (`Var "null");
+                   meth = `String "make";
+                   optional = false;
+                 })
+          in
+          (v, [`Deprecated "use `null.make`"])
+      | v -> (mk ~pos:var_pos (`Var v), [])
   in
-  mk ~annotations ~pos (`App (mk ~pos:var_pos (`Var v), arglist))
+  mk ~annotations ~pos (`App (v, arglist))

--- a/src/lang/parser_helper.ml
+++ b/src/lang/parser_helper.ml
@@ -156,3 +156,9 @@ let mk_let ~pos _let body =
   mk ~pos ast
 
 let mk_encoder ~pos e p = mk ~pos (`Encoder (e, p))
+
+let mk_app ~pos ~var_pos v arglist =
+  let annotations =
+    match (v, arglist) with "null", [] -> [`Deprecated "use `null`"] | _ -> []
+  in
+  mk ~annotations ~pos (`App (mk ~pos:var_pos (`Var v), arglist))

--- a/src/lang/parser_helper.mli
+++ b/src/lang/parser_helper.mli
@@ -72,6 +72,7 @@ val mk_json_assoc_object_ty :
 
 val mk :
   ?comments:(pos * Parsed_term.comment) list ->
+  ?annotations:Parsed_term.term_annotation list ->
   pos:pos ->
   Term.parsed_ast ->
   Term.t
@@ -91,3 +92,4 @@ val mk_encoder : pos:pos -> string -> Term.encoder_params -> Term.t
 val args_of_json_parse : pos:pos -> (string * 'a) list -> (string * 'a) list
 val render_string_ref : (pos:pos -> char * string -> string) ref
 val render_string : pos:pos -> char * string -> string
+val mk_app : pos:pos -> var_pos:pos -> string -> Term.app_arg list -> Term.t

--- a/src/lang/preprocessor.ml
+++ b/src/lang/preprocessor.ml
@@ -189,10 +189,13 @@ let strip_newlines tokenizer =
       | None -> (
           match tokenizer () with
             | Parser.PP_ENDL, _ -> token ()
-            | (Parser.VAR _, _) as v ->
+            | ((Parser.UNDERSCORE, _) as v)
+            | ((Parser.NULL, _) as v)
+            | ((Parser.VAR _, _) as v) ->
                 state := Some v;
                 token ()
             | x -> x)
+      | Some ((Parser.NULL, _) as v) -> inject_varlpar "null" v
       | Some ((Parser.VAR var, _) as v) -> inject_varlpar var v
       | Some ((Parser.UNDERSCORE, _) as v) -> inject_varlpar "_" v
       | Some x ->

--- a/src/lang/preprocessor.ml
+++ b/src/lang/preprocessor.ml
@@ -189,13 +189,10 @@ let strip_newlines tokenizer =
       | None -> (
           match tokenizer () with
             | Parser.PP_ENDL, _ -> token ()
-            | ((Parser.UNDERSCORE, _) as v)
-            | ((Parser.NULL, _) as v)
-            | ((Parser.VAR _, _) as v) ->
+            | ((Parser.UNDERSCORE, _) as v) | ((Parser.VAR _, _) as v) ->
                 state := Some v;
                 token ()
             | x -> x)
-      | Some ((Parser.NULL, _) as v) -> inject_varlpar "null" v
       | Some ((Parser.VAR var, _) as v) -> inject_varlpar var v
       | Some ((Parser.UNDERSCORE, _) as v) -> inject_varlpar "_" v
       | Some x ->

--- a/src/lang/runtime.ml
+++ b/src/lang/runtime.ml
@@ -89,6 +89,10 @@ let throw ?(formatter = Format.std_formatter) ~lexbuf () =
       warning_header ~formatter 4 (Some pos);
       Format.fprintf formatter "Unused variable %s@]@." s;
       if !strict then raise Error
+  | Term.Deprecated (s, pos) ->
+      flush_all ();
+      warning_header ~formatter 5 (Some pos);
+      Format.fprintf formatter "Deprecated: %s@]@." s
   (* Errors *)
   | Failure s when s = "lexing: empty token" ->
       print_error ~formatter 1 "Empty token";
@@ -253,7 +257,8 @@ let type_term ?name ?stdlib ?term ?ty ?cache_dirtype ~cache ~trim ~lib
                     | None ->
                         report ~lexbuf:None
                           ~default:(fun () -> raise Error)
-                          (fun ~throw:_ () -> Term_reducer.to_term parsed_term)
+                          (fun ~throw () ->
+                            Term_reducer.to_term ~throw parsed_term)
                     | Some tm -> tm
                 in
                 (term, term, None)
@@ -310,9 +315,9 @@ let interactive =
 let mk_expr ?fname processor lexbuf =
   report ~lexbuf:(Some lexbuf)
     ~default:(fun () -> raise Error)
-    (fun ~throw:_ () ->
+    (fun ~throw () ->
       let parsed_term = Term_reducer.mk_expr ?fname processor lexbuf in
-      (parsed_term, Term_reducer.to_term parsed_term))
+      (parsed_term, Term_reducer.to_term ~throw parsed_term))
 
 let parse s =
   let lexbuf = Sedlexing.Utf8.from_string s in

--- a/src/lang/term.mli
+++ b/src/lang/term.mli
@@ -62,6 +62,7 @@ exception No_label of t * string * bool * t
 exception Duplicate_label of Pos.Option.t * string
 exception Missing_arguments of Pos.Option.t * (string * Type.t) list
 exception Unused_variable of (string * Pos.t)
+exception Deprecated of (string * Pos.t)
 
 val check_unused : throw:(exn -> unit) -> lib:bool -> t -> unit
 

--- a/src/lang/term/parsed_term.ml
+++ b/src/lang/term/parsed_term.ml
@@ -24,6 +24,7 @@ open Term_hash
 include Runtime_term
 module Custom = Term_base.Custom
 
+type term_annotation = [ `Deprecated of string ]
 type comment = [ `Before of string list | `After of string list ]
 type pos = Term_base.parsed_pos
 
@@ -220,6 +221,7 @@ and t = {
   term : parsed_ast;
   pos : pos; [@hash.ignore]
   mutable comments : (pos * comment) list; [@hash.ignore]
+  annotations : term_annotation list; [@hash.ignore]
 }
 [@@deriving hash]
 
@@ -235,7 +237,9 @@ and encoder_params =
 and encoder = string * encoder_params
 
 let unit = `Tuple []
-let make ?(comments = []) ~pos term = { pos; term; comments }
+
+let make ?(comments = []) ?(annotations = []) ~pos term =
+  { pos; term; comments; annotations }
 
 let rec iter_term fn ({ term } as tm) =
   if term <> `Eof then fn tm;

--- a/src/lang/term/term_base.ml
+++ b/src/lang/term/term_base.ml
@@ -308,6 +308,8 @@ exception Missing_arguments of Pos.Option.t * (string * Type.t) list
     well as the ability to distinguish toplevel and inner let-in terms. *)
 exception Unused_variable of (string * Pos.t)
 
+exception Deprecated of (string * Pos.t)
+
 let check_unused ~throw ~lib tm =
   let rec check ?(toplevel = false) v tm =
     let v =

--- a/src/lang/term/term_reducer.ml
+++ b/src/lang/term/term_reducer.ml
@@ -757,11 +757,7 @@ and update_invoke_default ~pos ~optional expr name value =
     | _ -> expr
 
 let mk_invoke ?(default : Parsed_term.t option) ~pos ~env ~to_term expr v =
-  let expr =
-    match expr.Parsed_term.term with
-      | `Var "null" -> mk ~pos (`Var "null")
-      | _ -> to_term ~env expr
-  in
+  let expr = to_term ~env expr in
   let default = Option.map (to_term ~env) default in
   let optional, value =
     match default with Some v -> (true, v) | None -> (false, mk ~pos `Null)
@@ -1294,17 +1290,11 @@ let rec to_ast ~env ~pos ~comments ast =
         let default = if optional then Some (mk_parsed ~pos `Null) else None in
         mk_invoke ~pos ~env ?default ~to_term invoked meth
     | `Open (t, t') -> `Open (to_term ~env t, to_term ~env t')
-    | `Var "null" -> `Null
     | `Var s -> `Var s
     | `Seq (t, t') -> `Seq (to_term ~env t, to_term ~env t')
     | `App (t, args) ->
         let args = expand_appof ~pos ~env ~to_term args in
-        let t =
-          match t.Parsed_term.term with
-            | `Var "null" -> mk ~pos (`Var "null")
-            | _ -> to_term ~env t
-        in
-        `App (t, args)
+        `App (to_term ~env t, args)
     | `Fun (args, body) -> `Fun (to_func ~pos ~env ~to_term args body)
     | `RFun (name, args, body) ->
         `Fun (to_func ~pos ~env ~to_term ~name args body)

--- a/src/lang/term/term_reducer.mli
+++ b/src/lang/term/term_reducer.mli
@@ -30,6 +30,6 @@ type processor =
 val program : processor
 val typecheck : (?env:Typing.env -> Term.t -> unit) ref
 val mk_expr : ?fname:string -> processor -> Sedlexing.lexbuf -> Parsed_term.t
-val to_term : Parsed_term.t -> Term.t
+val to_term : throw:(exn -> unit) -> Parsed_term.t -> Term.t
 val to_encoder_params : Parsed_term.encoder_params -> Term.encoder_params
 val needs_toplevel : unit -> bool

--- a/src/lang/term/term_reducer.mli
+++ b/src/lang/term/term_reducer.mli
@@ -31,5 +31,8 @@ val program : processor
 val typecheck : (?env:Typing.env -> Term.t -> unit) ref
 val mk_expr : ?fname:string -> processor -> Sedlexing.lexbuf -> Parsed_term.t
 val to_term : throw:(exn -> unit) -> Parsed_term.t -> Term.t
-val to_encoder_params : Parsed_term.encoder_params -> Term.encoder_params
+
+val to_encoder_params :
+  throw:(exn -> unit) -> Parsed_term.encoder_params -> Term.encoder_params
+
 val needs_toplevel : unit -> bool

--- a/src/lang/term/term_stdlib.ml
+++ b/src/lang/term/term_stdlib.ml
@@ -63,9 +63,9 @@ let prepare ?libs ~cache ~error_on_no_stdlib ~deprecated parsed_term =
   let parsed_stdlib, stdlib =
     Runtime.report ~lexbuf:(Some lexbuf)
       ~default:(fun () -> raise Runtime.Error)
-      (fun ~throw:_ () ->
+      (fun ~throw () ->
         let parsed_stdlib = Term_reducer.mk_expr Term_reducer.program lexbuf in
-        (parsed_stdlib, Term_reducer.to_term parsed_stdlib))
+        (parsed_stdlib, Term_reducer.to_term ~throw parsed_stdlib))
   in
   let append () =
     let stdlib = append_ref stdlib in
@@ -79,7 +79,7 @@ let prepare ?libs ~cache ~error_on_no_stdlib ~deprecated parsed_term =
     let checked_term =
       Runtime.report ~lexbuf:None
         ~default:(fun () -> raise Runtime.Error)
-        (fun ~throw:_ () -> Term_reducer.to_term parsed_term)
+        (fun ~throw () -> Term_reducer.to_term ~throw parsed_term)
     in
     let full_term = prepend_stdlib ~term:checked_term stdlib in
     { Runtime.checked_term; full_term; env }

--- a/src/lang/typechecking.ml
+++ b/src/lang/typechecking.ml
@@ -38,7 +38,8 @@ let debug = ref false
       [def f() = fun (x) -> x end; fn = f() : fun ('a) -> 'a ]
     - but this cannot: [s = single() : source('A) ]
     - and this cannot either:
-      [def f() = fun (x=null()) -> ref(x) end; fn = f() : (?'A?) -> ref('A) ]
+      [def f() = fun (x=null.make()) -> ref(x) end; fn = f() : (?'A?) -> ref('A)
+       ]
 
     When all universal types in the return are specified by a non-optional
     argument, we are assured that anything that would be generalized is later

--- a/src/libs/audio.liq
+++ b/src/libs/audio.liq
@@ -104,7 +104,7 @@ lufs_builtin = lufs
 # @method target_gain Current target amplification coefficient (in linear scale).
 # @method rms Current rms (in linear scale).
 def replaces normalize(
-  ~id=null(),
+  ~id=null,
   ~target=getter(-13.),
   ~up=getter(10.),
   ~down=getter(.1),
@@ -116,7 +116,7 @@ def replaces normalize(
   ~threshold=getter(-40.),
   ~track_sensitive=true,
   ~enabled=getter(true),
-  ~debug=null(),
+  ~debug=null,
   s
 ) =
   let (s, rms) =
@@ -224,7 +224,7 @@ end
 # @param t Track to extract from
 def track.audio.stereo.left(~id=null("track.audio.stereo.left"), t) =
   track.audio.amplify(
-    id=id, override=null(), 2., track.audio.mean(track.audio.stereo.pan(-1., t))
+    id=id, override=null, 2., track.audio.mean(track.audio.stereo.pan(-1., t))
   )
 end
 
@@ -241,7 +241,7 @@ end
 # @param s Track to extract from
 def track.audio.stereo.right(~id=null("track.audio.stereo.right"), t) =
   track.audio.amplify(
-    id=id, override=null(), 2., track.audio.mean(track.audio.stereo.pan(1., t))
+    id=id, override=null, 2., track.audio.mean(track.audio.stereo.pan(1., t))
   )
 end
 

--- a/src/libs/audio.liq
+++ b/src/libs/audio.liq
@@ -3,14 +3,14 @@ let audio.encode = ()
 
 # Encode audio track to pcm_s16
 # @category Source / Audio processing
-def audio.encode.pcm_s16(~id=null("audio.encode.pcm_s16"), s) =
+def audio.encode.pcm_s16(~id=null.make("audio.encode.pcm_s16"), s) =
   let {audio, ...tracks} = source.tracks(s)
   source(id=id, tracks.{audio=track.encode.audio.pcm_s16(audio)})
 end
 
 # Encode audio track to pcm_f32
 # @category Source / Audio processing
-def audio.encode.pcm_f32(~id=null("audio.encode.pcm_f32"), s) =
+def audio.encode.pcm_f32(~id=null.make("audio.encode.pcm_f32"), s) =
   let {audio, ...tracks} = source.tracks(s)
   source(id=id, tracks.{audio=track.encode.audio.pcm_f32(audio)})
 end
@@ -19,14 +19,14 @@ let audio.decode = ()
 
 # Decode audio track to pcm_s16
 # @category Source / Audio processing
-def audio.decode.pcm_s16(~id=null("audio.decode.pcm_s16"), s) =
+def audio.decode.pcm_s16(~id=null.make("audio.decode.pcm_s16"), s) =
   let {audio, ...tracks} = source.tracks(s)
   source(id=id, tracks.{audio=track.decode.audio.pcm_s16(audio)})
 end
 
 # Decode audio track to pcm_f32
 # @category Source / Audio processing
-def audio.decode.pcm_f32(~id=null("audio.decode.pcm_f32"), s) =
+def audio.decode.pcm_f32(~id=null.make("audio.decode.pcm_f32"), s) =
   let {audio, ...tracks} = source.tracks(s)
   source(id=id, tracks.{audio=track.decode.audio.pcm_f32(audio)})
 end
@@ -47,14 +47,14 @@ end
 # @category Source / Audio processing
 # @param f Multiplicative factor.
 # @argsof track.audio.amplify
-def amplify(~id=null("amplify"), %argsof(track.audio.amplify[!id]), f, s) =
+def amplify(~id=null.make("amplify"), %argsof(track.audio.amplify[!id]), f, s) =
   tracks = source.tracks(s)
   source(
     id=id,
     tracks.{
       audio=
         track.audio.amplify(
-          id=null("track.amplify"),
+          id=null.make("track.amplify"),
           %argsof(track.audio.amplify[!id]),
           f,
           tracks.audio
@@ -68,7 +68,7 @@ end
 # values higher than `1` become `1`. `nan` values become `0`.
 # @category Source / Audio processing
 # @argsof track.audio.clip
-def clip(~id=null("clip"), %argsof(track.audio.clip[!id]), s) =
+def clip(~id=null.make("clip"), %argsof(track.audio.clip[!id]), s) =
   tracks = source.tracks(s)
   source(
     id=id,
@@ -104,7 +104,7 @@ lufs_builtin = lufs
 # @method target_gain Current target amplification coefficient (in linear scale).
 # @method rms Current rms (in linear scale).
 def replaces normalize(
-  ~id=null,
+  ~id=null.make(),
   ~target=getter(-13.),
   ~up=getter(10.),
   ~down=getter(.1),
@@ -116,7 +116,7 @@ def replaces normalize(
   ~threshold=getter(-40.),
   ~track_sensitive=true,
   ~enabled=getter(true),
-  ~debug=null,
+  ~debug=null.make(),
   s
 ) =
   let (s, rms) =
@@ -196,7 +196,7 @@ end
 
 # Swap two channels of a stereo source.
 # @category Source / Conversion
-def swap(id=null("swap"), s) =
+def swap(id=null.make("swap"), s) =
   tracks = source.tracks(s)
   source(id=id, tracks.{audio=track.audio.swap(tracks.audio)})
 end
@@ -204,7 +204,7 @@ end
 # Produce mono audio by taking the mean of all audio channels.
 # @category Source / Conversion
 # @argsof track.audio.mean
-def mean(~id=null("mean"), %argsof(track.audio.mean[!id]), s) =
+def mean(~id=null.make("mean"), %argsof(track.audio.mean[!id]), s) =
   tracks = source.tracks(s)
   source(
     id=id,
@@ -214,7 +214,7 @@ end
 
 # Convert any pcm audio source into a stereo source.
 # @category Source / Conversion
-def stereo(~id=null("stereo"), s) =
+def stereo(~id=null.make("stereo"), s) =
   tracks = source.tracks(s)
   source(id=id, tracks.{audio=track.audio.stereo(tracks.audio)})
 end
@@ -222,16 +222,19 @@ end
 # Extract the left channel of a stereo track
 # @category Source / Conversion
 # @param t Track to extract from
-def track.audio.stereo.left(~id=null("track.audio.stereo.left"), t) =
+def track.audio.stereo.left(~id=null.make("track.audio.stereo.left"), t) =
   track.audio.amplify(
-    id=id, override=null, 2., track.audio.mean(track.audio.stereo.pan(-1., t))
+    id=id,
+    override=null.make(),
+    2.,
+    track.audio.mean(track.audio.stereo.pan(-1., t))
   )
 end
 
 # Extract the left channel of a stereo source
 # @category Source / Conversion
 # @param s Source to extract from
-def stereo.left(~id=null("stereo.left"), s) =
+def stereo.left(~id=null.make("stereo.left"), s) =
   tracks = source.tracks(s)
   source(id=id, tracks.{audio=track.audio.stereo.left(tracks.audio)})
 end
@@ -239,16 +242,19 @@ end
 # Extract the right channel of a stereo track
 # @category Source / Conversion
 # @param s Track to extract from
-def track.audio.stereo.right(~id=null("track.audio.stereo.right"), t) =
+def track.audio.stereo.right(~id=null.make("track.audio.stereo.right"), t) =
   track.audio.amplify(
-    id=id, override=null, 2., track.audio.mean(track.audio.stereo.pan(1., t))
+    id=id,
+    override=null.make(),
+    2.,
+    track.audio.mean(track.audio.stereo.pan(1., t))
   )
 end
 
 # Extract the right channel of a stereo source
 # @category Source / Conversion
 # @param s Source to extract from
-def stereo.right(~id=null("stereo.right"), s) =
+def stereo.right(~id=null.make("stereo.right"), s) =
   tracks = source.tracks(s)
   source(id=id, tracks.{audio=track.audio.stereo.right(tracks.audio)})
 end
@@ -256,7 +262,7 @@ end
 # Spacializer which allows controlling the width of the signal.
 # @category Source / Audio processing
 # @param w Width of the signal (-1: mono, 0.: original, 1.: wide stereo).
-def stereo.width(~id=null("stereo.width"), w=getter(0.), (s:source)) =
+def stereo.width(~id=null.make("stereo.width"), w=getter(0.), (s:source)) =
   tracks = source.tracks(s)
   source(id=id, tracks.{audio=track.audio.stereo.width(w, tracks.audio)})
 end
@@ -266,7 +272,7 @@ end
 # @argsof track.audio.stereo.pan
 # @param pan Pan value. Should be between `-1` (left side) and `1` (right side).
 def stereo.pan(
-  ~id=null("stereo.pan"),
+  ~id=null.make("stereo.pan"),
   %argsof(track.audio.stereo.pan[!id]),
   pan,
   (s:source)
@@ -287,7 +293,7 @@ end
 # @category Source / Audio processing
 # @argsof track.audio.stretch
 def stretch(
-  ~id=null("stretch"),
+  ~id=null.make("stretch"),
   %argsof(track.audio.stretch[!id]),
   (s:source)
 ) =
@@ -303,7 +309,7 @@ let stereo.ms = ()
 # @category Source / Audio processing
 # @argsof track.audio.stereo.ms.decode
 def stereo.ms.decode(
-  ~id=null("stereo.ms.decode"),
+  ~id=null.make("stereo.ms.decode"),
   %argsof(track.audio.stereo.ms.decode[!id]),
   (s:source)
 ) =
@@ -323,7 +329,7 @@ end
 # @category Source / Audio processing
 # @argsof track.audio.stereo.ms.encode
 def stereo.ms.encode(
-  ~id=null("stereo.ms.encode"),
+  ~id=null.make("stereo.ms.encode"),
   %argsof(track.audio.stereo.ms.encode[!id]),
   (s:source)
 ) =
@@ -344,7 +350,7 @@ end
 # @argsof track.audio.stereotool
 # @category Source / Audio processing
 def stereotool(
-  ~id=null("stereotool"),
+  ~id=null.make("stereotool"),
   %argsof(track.audio.stereotool[!id]),
   s
 ) =
@@ -365,7 +371,7 @@ end
 # a low-level operator using directly the `pcm_s16` format.
 # @argsof track.audio.defer[!id]
 # @param ~id Force the source's ID
-def defer(~id=null("defer"), %argsof(track.audio.defer[!id]), s) =
+def defer(~id=null.make("defer"), %argsof(track.audio.defer[!id]), s) =
   let {audio = a} = source.tracks(s)
   a = track.encode.audio.pcm_s16(a)
   a = track.audio.defer(%argsof(track.audio.defer[!id]), a)
@@ -390,7 +396,7 @@ end
 # @argsof track.audio.defer[!id]
 # @param ~id Force the source's ID
 def defer.pcm_s16(
-  ~id=null("defer.pcm_s16"),
+  ~id=null.make("defer.pcm_s16"),
   %argsof(track.audio.defer[!id]),
   (s:source(audio=pcm_s16))
 ) =

--- a/src/libs/autocue.liq
+++ b/src/libs/autocue.liq
@@ -263,7 +263,7 @@ def autocue.internal.implementation(
       label="autocue.internal.metadata",
       "Override metadata detected for #{filename}, disabling autocue!"
     )
-    null
+    null.make()
   else
     log(
       level=4,
@@ -274,18 +274,18 @@ def autocue.internal.implementation(
 %ifdef request.duration.ffmpeg
     duration = request.duration.ffmpeg(resolve_metadata=false, filename)
 %else
-    duration = null
+    duration = null.make()
 %endif
 
     if
-      duration == null
+      duration == null.make()
     then
       log(
         level=2,
         label="autocue.internal",
         "Could not get request duration, internal autocue disabled!"
       )
-      null
+      null.make()
     else
       duration = null.get(duration)
 
@@ -302,7 +302,7 @@ def autocue.internal.implementation(
           label="autocue.internal",
           "Autocue computation failed!"
         )
-        null
+        null.make()
       else
         # Get the 2nd last frame which is the last with loudness data
         frame = list.nth(frames, list.length(frames) - 2)
@@ -981,7 +981,7 @@ def enable_autocue_metadata() =
       user_supplied_amplify =
         list.filter_map(
           fun (el) ->
-            if list.mem(fst(el), all_amplify) then fst(el) else null end,
+            if list.mem(fst(el), all_amplify) then fst(el) else null.make() end,
           metadata
         )
 
@@ -1054,8 +1054,8 @@ def enable_autocue_metadata() =
   mime_types = settings.decoder.mime_types.ffmpeg()
   file_extensions = settings.decoder.file_extensions.ffmpeg()
 %else
-  mime_types = null
-  file_extensions = null
+  mime_types = null.make()
+  file_extensions = null.make()
 %endif
 
   decoder.metadata.add(

--- a/src/libs/autocue.liq
+++ b/src/libs/autocue.liq
@@ -263,7 +263,7 @@ def autocue.internal.implementation(
       label="autocue.internal.metadata",
       "Override metadata detected for #{filename}, disabling autocue!"
     )
-    null()
+    null
   else
     log(
       level=4,
@@ -274,18 +274,18 @@ def autocue.internal.implementation(
 %ifdef request.duration.ffmpeg
     duration = request.duration.ffmpeg(resolve_metadata=false, filename)
 %else
-    duration = null()
+    duration = null
 %endif
 
     if
-      duration == null()
+      duration == null
     then
       log(
         level=2,
         label="autocue.internal",
         "Could not get request duration, internal autocue disabled!"
       )
-      null()
+      null
     else
       duration = null.get(duration)
 
@@ -302,7 +302,7 @@ def autocue.internal.implementation(
           label="autocue.internal",
           "Autocue computation failed!"
         )
-        null()
+        null
       else
         # Get the 2nd last frame which is the last with loudness data
         frame = list.nth(frames, list.length(frames) - 2)
@@ -775,7 +775,7 @@ def autocue.internal.implementation(
             fade_out_type?: string,
             fade_out_curve?: float,
             start_next?: float,
-            extra_metadata?: [(string*string)]
+            extra_metadata?: [(string * string)]
           }
         )
       end
@@ -981,7 +981,7 @@ def enable_autocue_metadata() =
       user_supplied_amplify =
         list.filter_map(
           fun (el) ->
-            if list.mem(fst(el), all_amplify) then fst(el) else null() end,
+            if list.mem(fst(el), all_amplify) then fst(el) else null end,
           metadata
         )
 
@@ -1054,8 +1054,8 @@ def enable_autocue_metadata() =
   mime_types = settings.decoder.mime_types.ffmpeg()
   file_extensions = settings.decoder.file_extensions.ffmpeg()
 %else
-  mime_types = null()
-  file_extensions = null()
+  mime_types = null
+  file_extensions = null
 %endif
 
   decoder.metadata.add(

--- a/src/libs/clock.liq
+++ b/src/libs/clock.liq
@@ -8,7 +8,7 @@
 # @param ~on_error Error callback executed when a streaming error occurs. \
 #                  When passed, all streaming errors are silenced. Intended \
 #                  mostly for debugging purposes.
-def clock.assign_new(~sync="auto", ~id=null, ~on_error=null, sources) =
+def clock.assign_new(~sync="auto", ~id=null.make(), ~on_error=null.make(), sources) =
   c = clock.create(id=id, sync=sync, on_error=on_error)
   list.iter(fun (s) -> c.unify(s.clock), sources)
 end

--- a/src/libs/clock.liq
+++ b/src/libs/clock.liq
@@ -8,7 +8,7 @@
 # @param ~on_error Error callback executed when a streaming error occurs. \
 #                  When passed, all streaming errors are silenced. Intended \
 #                  mostly for debugging purposes.
-def clock.assign_new(~sync="auto", ~id=null(), ~on_error=null(), sources) =
+def clock.assign_new(~sync="auto", ~id=null, ~on_error=null, sources) =
   c = clock.create(id=id, sync=sync, on_error=on_error)
   list.iter(fun (s) -> c.unify(s.clock), sources)
 end

--- a/src/libs/extra/audio.liq
+++ b/src/libs/extra/audio.liq
@@ -57,7 +57,7 @@ end
 # @category Source / Audio processing
 # @flag extra
 def limit(
-  ~id=null(),
+  ~id=null,
   ~attack=getter(50.),
   ~release=getter(200.),
   ~ratio=getter(20.),
@@ -87,7 +87,7 @@ let limiter = limit
 # @param ~low Lower frequency of the bandpass filter.
 # @param ~high Higher frequency of the bandpass filter.
 # @param ~q Q factor.
-def filter.iir.eq.low_high(~id=null(), ~low, ~high, ~q=1., s) =
+def filter.iir.eq.low_high(~id=null, ~low, ~high, ~q=1., s) =
   s =
     if
       not (getter.is_constant(high) and getter.get(high) == infinity)
@@ -345,7 +345,7 @@ end
 # @category Source / Audio processing
 # @param ~id Force the value of the source ID.
 # @param ~register_server_commands Register corresponding server commands
-def mix(~id=null(), ~register_server_commands=true, sources) =
+def mix(~id=null, ~register_server_commands=true, sources) =
   id = string.id.default(default="mixer", id)
   inputs =
     list.map(
@@ -585,7 +585,7 @@ end
 # @param ~playlist Playlist name
 # @param ~directory Directory to write to
 def output.file.dash(
-  ~id=null(),
+  ~id=null,
   ~fallible=false,
   ~on_start={()},
   ~on_stop={()},

--- a/src/libs/extra/audio.liq
+++ b/src/libs/extra/audio.liq
@@ -2,7 +2,7 @@
 # @category Source / Audio processing
 # @flag extra
 # @argsof track.audio.compand
-def compand(~id=null("compand"), %argsof(track.audio.compand[!id]), s) =
+def compand(~id=null.make("compand"), %argsof(track.audio.compand[!id]), s) =
   tracks = source.tracks(s)
   source(
     id=id,
@@ -16,7 +16,7 @@ end
 # @category Source / Audio processing
 # @argsof track.audio.comb
 # @flag extra
-def comb(~id=null("comb"), %argsof(track.audio.comb[!id]), s) =
+def comb(~id=null.make("comb"), %argsof(track.audio.comb[!id]), s) =
   tracks = source.tracks(s)
   source(
     id=id,
@@ -57,7 +57,7 @@ end
 # @category Source / Audio processing
 # @flag extra
 def limit(
-  ~id=null,
+  ~id=null.make(),
   ~attack=getter(50.),
   ~release=getter(200.),
   ~ratio=getter(20.),
@@ -87,7 +87,7 @@ let limiter = limit
 # @param ~low Lower frequency of the bandpass filter.
 # @param ~high Higher frequency of the bandpass filter.
 # @param ~q Q factor.
-def filter.iir.eq.low_high(~id=null, ~low, ~high, ~q=1., s) =
+def filter.iir.eq.low_high(~id=null.make(), ~low, ~high, ~q=1., s) =
   s =
     if
       not (getter.is_constant(high) and getter.get(high) == infinity)
@@ -345,7 +345,7 @@ end
 # @category Source / Audio processing
 # @param ~id Force the value of the source ID.
 # @param ~register_server_commands Register corresponding server commands
-def mix(~id=null, ~register_server_commands=true, sources) =
+def mix(~id=null.make(), ~register_server_commands=true, sources) =
   id = string.id.default(default="mixer", id)
   inputs =
     list.map(
@@ -585,7 +585,7 @@ end
 # @param ~playlist Playlist name
 # @param ~directory Directory to write to
 def output.file.dash(
-  ~id=null,
+  ~id=null.make(),
   ~fallible=false,
   ~on_start={()},
   ~on_stop={()},

--- a/src/libs/extra/audioscrobbler.liq
+++ b/src/libs/extra/audioscrobbler.liq
@@ -23,8 +23,8 @@ audioscrobbler = ()
 
 def audioscrobbler.request(
   ~base_url="http://ws.audioscrobbler.com/2.0",
-  ~api_key=null(),
-  ~api_secret=null(),
+  ~api_key=null,
+  ~api_secret=null,
   params
 ) =
   api_key = api_key ?? settings.audioscrobbler.api_key()
@@ -75,8 +75,8 @@ end
 def audioscrobbler.auth(
   ~username,
   ~password,
-  ~api_key=null(),
-  ~api_secret=null()
+  ~api_key=null,
+  ~api_secret=null
 ) =
   resp =
     audioscrobbler.request(
@@ -112,17 +112,17 @@ let audioscrobbler.api = {track=()}
 def audioscrobbler.api.track.updateNowPlaying(
   ~username,
   ~password,
-  ~session_key=null(),
-  ~api_key=null(),
-  ~api_secret=null(),
+  ~session_key=null,
+  ~api_key=null,
+  ~api_secret=null,
   ~artist,
   ~track,
-  ~album=null(),
-  ~context=null(),
-  ~trackNumber=null(),
-  ~mbid=null(),
-  ~albumArtist=null(),
-  ~duration=null()
+  ~album=null,
+  ~context=null,
+  ~trackNumber=null,
+  ~mbid=null,
+  ~albumArtist=null,
+  ~duration=null
 ) =
   session_key =
     session_key
@@ -211,7 +211,7 @@ def audioscrobbler.api.apply_meta(
   m
 ) =
   def c(v) =
-    v == "" ? null() : v
+    v == "" ? null : v
   end
   track = m["title"]
   artist = m["artist"]
@@ -229,7 +229,7 @@ def audioscrobbler.api.apply_meta(
       try
         null.map(int_of_string, c(m["tracknumber"]))
       catch _ do
-        null()
+        null
       end
     albumArtist = c(m["albumartist"])
     ignore(
@@ -255,9 +255,9 @@ end
 def audioscrobbler.api.track.updateNowPlaying.metadata(
   ~username,
   ~password,
-  ~session_key=null(),
-  ~api_key=null(),
-  ~api_secret=null(),
+  ~session_key=null,
+  ~api_key=null,
+  ~api_secret=null,
   m
 ) =
   audioscrobbler.api.apply_meta(
@@ -278,20 +278,20 @@ end
 def audioscrobbler.api.track.scrobble(
   ~username,
   ~password,
-  ~session_key=null(),
-  ~api_key=null(),
-  ~api_secret=null(),
+  ~session_key=null,
+  ~api_key=null,
+  ~api_secret=null,
   ~artist,
   ~track,
-  ~timestamp=null(),
-  ~album=null(),
-  ~context=null(),
-  ~streamId=null(),
+  ~timestamp=null,
+  ~album=null,
+  ~context=null,
+  ~streamId=null,
   ~chosenByUser=true,
-  ~trackNumber=null(),
-  ~mbid=null(),
-  ~albumArtist=null(),
-  ~duration=null()
+  ~trackNumber=null,
+  ~mbid=null,
+  ~albumArtist=null,
+  ~duration=null
 ) =
   session_key =
     session_key
@@ -382,9 +382,9 @@ end
 def audioscrobbler.api.track.scrobble.metadata(
   ~username,
   ~password,
-  ~session_key=null(),
-  ~api_key=null(),
-  ~api_secret=null(),
+  ~session_key=null,
+  ~api_key=null,
+  ~api_secret=null,
   m
 ) =
   audioscrobbler.api.apply_meta(
@@ -411,8 +411,8 @@ end
 def audioscrobbler.submit(
   ~username,
   ~password,
-  ~api_key=null(),
-  ~api_secret=null(),
+  ~api_key=null,
+  ~api_secret=null,
   ~delay=10.,
   ~force=false,
   ~metadata_preprocessor=fun (m) -> m,

--- a/src/libs/extra/audioscrobbler.liq
+++ b/src/libs/extra/audioscrobbler.liq
@@ -23,8 +23,8 @@ audioscrobbler = ()
 
 def audioscrobbler.request(
   ~base_url="http://ws.audioscrobbler.com/2.0",
-  ~api_key=null,
-  ~api_secret=null,
+  ~api_key=null.make(),
+  ~api_secret=null.make(),
   params
 ) =
   api_key = api_key ?? settings.audioscrobbler.api_key()
@@ -75,8 +75,8 @@ end
 def audioscrobbler.auth(
   ~username,
   ~password,
-  ~api_key=null,
-  ~api_secret=null
+  ~api_key=null.make(),
+  ~api_secret=null.make()
 ) =
   resp =
     audioscrobbler.request(
@@ -112,17 +112,17 @@ let audioscrobbler.api = {track=()}
 def audioscrobbler.api.track.updateNowPlaying(
   ~username,
   ~password,
-  ~session_key=null,
-  ~api_key=null,
-  ~api_secret=null,
+  ~session_key=null.make(),
+  ~api_key=null.make(),
+  ~api_secret=null.make(),
   ~artist,
   ~track,
-  ~album=null,
-  ~context=null,
-  ~trackNumber=null,
-  ~mbid=null,
-  ~albumArtist=null,
-  ~duration=null
+  ~album=null.make(),
+  ~context=null.make(),
+  ~trackNumber=null.make(),
+  ~mbid=null.make(),
+  ~albumArtist=null.make(),
+  ~duration=null.make()
 ) =
   session_key =
     session_key
@@ -211,7 +211,7 @@ def audioscrobbler.api.apply_meta(
   m
 ) =
   def c(v) =
-    v == "" ? null : v
+    v == "" ? null.make() : v
   end
   track = m["title"]
   artist = m["artist"]
@@ -229,7 +229,7 @@ def audioscrobbler.api.apply_meta(
       try
         null.map(int_of_string, c(m["tracknumber"]))
       catch _ do
-        null
+        null.make()
       end
     albumArtist = c(m["albumartist"])
     ignore(
@@ -255,9 +255,9 @@ end
 def audioscrobbler.api.track.updateNowPlaying.metadata(
   ~username,
   ~password,
-  ~session_key=null,
-  ~api_key=null,
-  ~api_secret=null,
+  ~session_key=null.make(),
+  ~api_key=null.make(),
+  ~api_secret=null.make(),
   m
 ) =
   audioscrobbler.api.apply_meta(
@@ -278,20 +278,20 @@ end
 def audioscrobbler.api.track.scrobble(
   ~username,
   ~password,
-  ~session_key=null,
-  ~api_key=null,
-  ~api_secret=null,
+  ~session_key=null.make(),
+  ~api_key=null.make(),
+  ~api_secret=null.make(),
   ~artist,
   ~track,
-  ~timestamp=null,
-  ~album=null,
-  ~context=null,
-  ~streamId=null,
+  ~timestamp=null.make(),
+  ~album=null.make(),
+  ~context=null.make(),
+  ~streamId=null.make(),
   ~chosenByUser=true,
-  ~trackNumber=null,
-  ~mbid=null,
-  ~albumArtist=null,
-  ~duration=null
+  ~trackNumber=null.make(),
+  ~mbid=null.make(),
+  ~albumArtist=null.make(),
+  ~duration=null.make()
 ) =
   session_key =
     session_key
@@ -382,9 +382,9 @@ end
 def audioscrobbler.api.track.scrobble.metadata(
   ~username,
   ~password,
-  ~session_key=null,
-  ~api_key=null,
-  ~api_secret=null,
+  ~session_key=null.make(),
+  ~api_key=null.make(),
+  ~api_secret=null.make(),
   m
 ) =
   audioscrobbler.api.apply_meta(
@@ -411,8 +411,8 @@ end
 def audioscrobbler.submit(
   ~username,
   ~password,
-  ~api_key=null,
-  ~api_secret=null,
+  ~api_key=null.make(),
+  ~api_secret=null.make(),
   ~delay=10.,
   ~force=false,
   ~metadata_preprocessor=fun (m) -> m,

--- a/src/libs/extra/deprecations.liq
+++ b/src/libs/extra/deprecations.liq
@@ -50,7 +50,7 @@ end
 # Deprecated: use mksafe and playlist instead.
 # @flag deprecated
 def playlist.safe(
-  ~id=null(),
+  ~id=null,
   ~mime_type="",
   ~mode="randomize",
   ~on_track={()},
@@ -115,7 +115,7 @@ end
 # `reload_mode` argument to `"never"` and `loop` to `false`.
 # @flag deprecated
 def playlist.once(
-  ~id=null(),
+  ~id=null,
   ~random=false,
   ~reload_mode="",
   ~prefetch=1,
@@ -165,7 +165,7 @@ end
 
 # Deprecated: this function will be removed in a future release
 # @flag deprecated
-def id(~id=null(), s) =
+def id(~id=null, s) =
   deprecated("id", "")
   ignore(id)
   s
@@ -347,7 +347,7 @@ end
 
 # Deprecated: this function has been replaced by `source.fail`.
 # @flag deprecated
-def empty(~id=null()) =
+def empty(~id=null) =
   deprecated("empty", "source.fail")
   source.fail(id=id)
 end
@@ -472,7 +472,7 @@ end
 
 # @flag deprecated
 def output.preferred(
-  ~id=null(),
+  ~id=null,
   ~fallible=false,
   ~on_start={()},
   ~on_stop={()},
@@ -495,7 +495,7 @@ end
 # Deprecated: use `input` instead.
 # @flag deprecated
 def in(
-  ~id=null(),
+  ~id=null,
   ~start=true,
   ~on_start={()},
   ~on_stop={()},
@@ -637,7 +637,7 @@ end
 # Deprecated: use `playlist` instead
 # @flag deprecated
 def playlist.reloadable(
-  ~id=null(),
+  ~id=null,
   ~mime_type="",
   ~mode="randomize",
   ~on_track={()},
@@ -675,7 +675,7 @@ def request.dynamic.list(%argsof(request.dynamic), f) =
       list.iter(add(), list.rev(q))
       r
     else
-      null()
+      null
     end
   end
 
@@ -841,14 +841,14 @@ end
 
 # Deprecated: use `source.stereo`
 # @flag deprecated
-def audio_to_stereo(~id=null(), s) =
+def audio_to_stereo(~id=null, s) =
   deprecated("audio_to_stereo", "stereo")
   stereo(id=id, s)
 end
 
 # Deprecated: use `source.tracks` and `source`
 # @flag deprecated
-def merge_tracks(~id=null(), s) =
+def merge_tracks(~id=null, s) =
   deprecated("merge_tracks", "source")
   let {track_marks = _, ...tracks} = source.tracks(s)
   source(id=id, tracks)
@@ -857,7 +857,7 @@ end
 %ifdef compress
 # Deprecated: use `compress`
 # @flag deprecated
-def compress.old(~id=null(), s) =
+def compress.old(~id=null, s) =
   deprecated("compress.old", "compress")
   compress(id=id, s)
 end

--- a/src/libs/extra/deprecations.liq
+++ b/src/libs/extra/deprecations.liq
@@ -50,7 +50,7 @@ end
 # Deprecated: use mksafe and playlist instead.
 # @flag deprecated
 def playlist.safe(
-  ~id=null,
+  ~id=null.make(),
   ~mime_type="",
   ~mode="randomize",
   ~on_track={()},
@@ -115,7 +115,7 @@ end
 # `reload_mode` argument to `"never"` and `loop` to `false`.
 # @flag deprecated
 def playlist.once(
-  ~id=null,
+  ~id=null.make(),
   ~random=false,
   ~reload_mode="",
   ~prefetch=1,
@@ -165,7 +165,7 @@ end
 
 # Deprecated: this function will be removed in a future release
 # @flag deprecated
-def id(~id=null, s) =
+def id(~id=null.make(), s) =
   deprecated("id", "")
   ignore(id)
   s
@@ -347,7 +347,7 @@ end
 
 # Deprecated: this function has been replaced by `source.fail`.
 # @flag deprecated
-def empty(~id=null) =
+def empty(~id=null.make()) =
   deprecated("empty", "source.fail")
   source.fail(id=id)
 end
@@ -472,7 +472,7 @@ end
 
 # @flag deprecated
 def output.preferred(
-  ~id=null,
+  ~id=null.make(),
   ~fallible=false,
   ~on_start={()},
   ~on_stop={()},
@@ -495,7 +495,7 @@ end
 # Deprecated: use `input` instead.
 # @flag deprecated
 def in(
-  ~id=null,
+  ~id=null.make(),
   ~start=true,
   ~on_start={()},
   ~on_stop={()},
@@ -637,7 +637,7 @@ end
 # Deprecated: use `playlist` instead
 # @flag deprecated
 def playlist.reloadable(
-  ~id=null,
+  ~id=null.make(),
   ~mime_type="",
   ~mode="randomize",
   ~on_track={()},
@@ -675,7 +675,7 @@ def request.dynamic.list(%argsof(request.dynamic), f) =
       list.iter(add(), list.rev(q))
       r
     else
-      null
+      null.make()
     end
   end
 
@@ -841,14 +841,14 @@ end
 
 # Deprecated: use `source.stereo`
 # @flag deprecated
-def audio_to_stereo(~id=null, s) =
+def audio_to_stereo(~id=null.make(), s) =
   deprecated("audio_to_stereo", "stereo")
   stereo(id=id, s)
 end
 
 # Deprecated: use `source.tracks` and `source`
 # @flag deprecated
-def merge_tracks(~id=null, s) =
+def merge_tracks(~id=null.make(), s) =
   deprecated("merge_tracks", "source")
   let {track_marks = _, ...tracks} = source.tracks(s)
   source(id=id, tracks)
@@ -857,7 +857,7 @@ end
 %ifdef compress
 # Deprecated: use `compress`
 # @flag deprecated
-def compress.old(~id=null, s) =
+def compress.old(~id=null.make(), s) =
   deprecated("compress.old", "compress")
   compress(id=id, s)
 end
@@ -885,7 +885,7 @@ end
 # Deprecated: integrated into requests resolution.
 # @flag deprecated
 def cue_cut(
-  ~id=null(""),
+  ~id=null.make(""),
   ~cue_in_metadata="",
   ~cue_out_metadata="",
   ~on_cue_in=(fun () -> ()),

--- a/src/libs/extra/externals.liq
+++ b/src/libs/extra/externals.liq
@@ -63,7 +63,7 @@ def enable_external_ffmpeg_decoder() =
   end
 
   if
-    file.which(ffmpeg) != null() and file.which(ffprobe) != null()
+    file.which(ffmpeg) != null and file.which(ffprobe) != null
   then
     log(
       label="external.decoder",
@@ -139,7 +139,7 @@ def enable_external_mpc_decoder() =
   end
 
   if
-    file.which(mpcdec) != null()
+    file.which(mpcdec) != null
   then
     log(
       label="external.decoder",
@@ -188,7 +188,7 @@ def enable_external_flac_decoder() =
   flac = settings.decoder.external.flac.path()
   metaflac = settings.decoder.external.metaflac.path()
   if
-    file.which(flac) != null()
+    file.which(flac) != null
   then
     log(
       label="external.decoder",
@@ -199,7 +199,7 @@ def enable_external_flac_decoder() =
 
     def test_flac(fname) =
       if
-        file.which(metaflac) != null()
+        file.which(metaflac) != null
       then
         channels =
           list.hd(
@@ -242,7 +242,7 @@ def enable_external_flac_decoder() =
   end
 
   if
-    file.which(metaflac) != null()
+    file.which(metaflac) != null
   then
     log(
       label="decoder.external",
@@ -348,7 +348,7 @@ def enable_external_faad_decoder() =
   end
 
   if
-    file.which(faad) != null()
+    file.which(faad) != null
   then
     log(
       label="decoder.external",
@@ -629,7 +629,7 @@ end
 # @param ~start Automatically start outputting whenever possible. If true, an infallible (normal) output will start outputting as soon as it is created, and a fallible output will (re)start as soon as its source becomes available for streaming.
 # @argsof output.external[reopen_on_metadata,reopen_on_error,reopen_when,reopen_delay,on_reopen]
 def output.external.ffmpeg(
-  ~id=null(),
+  ~id=null,
   ~show_command=false,
   ~flush=false,
   ~fallible=false,
@@ -693,7 +693,7 @@ end
 # @param ~directory Directory to write to
 # @argsof output.external[reopen_on_metadata,reopen_on_error,reopen_when,reopen_delay,on_reopen]
 def output.file.hls.ffmpeg(
-  ~id=null(),
+  ~id=null,
   ~flush=false,
   ~fallible=false,
   ~on_start={()},
@@ -753,7 +753,7 @@ let output.file.dash = ()
 # @param ~directory Directory to write to
 # @argsof output.external[reopen_on_metadata,reopen_on_error,reopen_when,reopen_delay,on_reopen]
 def output.file.dash.ffmpeg(
-  ~id=null(),
+  ~id=null,
   ~flush=false,
   ~fallible=false,
   ~on_start={()},

--- a/src/libs/extra/externals.liq
+++ b/src/libs/extra/externals.liq
@@ -63,7 +63,7 @@ def enable_external_ffmpeg_decoder() =
   end
 
   if
-    file.which(ffmpeg) != null and file.which(ffprobe) != null
+    file.which(ffmpeg) != null.make() and file.which(ffprobe) != null.make()
   then
     log(
       label="external.decoder",
@@ -139,7 +139,7 @@ def enable_external_mpc_decoder() =
   end
 
   if
-    file.which(mpcdec) != null
+    file.which(mpcdec) != null.make()
   then
     log(
       label="external.decoder",
@@ -188,7 +188,7 @@ def enable_external_flac_decoder() =
   flac = settings.decoder.external.flac.path()
   metaflac = settings.decoder.external.metaflac.path()
   if
-    file.which(flac) != null
+    file.which(flac) != null.make()
   then
     log(
       label="external.decoder",
@@ -199,7 +199,7 @@ def enable_external_flac_decoder() =
 
     def test_flac(fname) =
       if
-        file.which(metaflac) != null
+        file.which(metaflac) != null.make()
       then
         channels =
           list.hd(
@@ -242,7 +242,7 @@ def enable_external_flac_decoder() =
   end
 
   if
-    file.which(metaflac) != null
+    file.which(metaflac) != null.make()
   then
     log(
       label="decoder.external",
@@ -348,7 +348,7 @@ def enable_external_faad_decoder() =
   end
 
   if
-    file.which(faad) != null
+    file.which(faad) != null.make()
   then
     log(
       label="decoder.external",
@@ -629,7 +629,7 @@ end
 # @param ~start Automatically start outputting whenever possible. If true, an infallible (normal) output will start outputting as soon as it is created, and a fallible output will (re)start as soon as its source becomes available for streaming.
 # @argsof output.external[reopen_on_metadata,reopen_on_error,reopen_when,reopen_delay,on_reopen]
 def output.external.ffmpeg(
-  ~id=null,
+  ~id=null.make(),
   ~show_command=false,
   ~flush=false,
   ~fallible=false,
@@ -693,7 +693,7 @@ end
 # @param ~directory Directory to write to
 # @argsof output.external[reopen_on_metadata,reopen_on_error,reopen_when,reopen_delay,on_reopen]
 def output.file.hls.ffmpeg(
-  ~id=null,
+  ~id=null.make(),
   ~flush=false,
   ~fallible=false,
   ~on_start={()},
@@ -753,7 +753,7 @@ let output.file.dash = ()
 # @param ~directory Directory to write to
 # @argsof output.external[reopen_on_metadata,reopen_on_error,reopen_when,reopen_delay,on_reopen]
 def output.file.dash.ffmpeg(
-  ~id=null,
+  ~id=null.make(),
   ~flush=false,
   ~fallible=false,
   ~on_start={()},

--- a/src/libs/extra/fades.liq
+++ b/src/libs/extra/fades.liq
@@ -1,7 +1,7 @@
 # Plot the first crossfade transition. Used for visualizing and testing
 # crossfade transitions.
 # @flag extra
-def cross.plot(~png=null, ~dir=null, s) =
+def cross.plot(~png=null.make(), ~dir=null.make(), s) =
   dir =
     if
       null.defined(dir)
@@ -24,7 +24,7 @@ def cross.plot(~png=null, ~dir=null, s) =
 
   def store_rms(~id, s) =
     s = rms(duration=settings.frame.duration(), s)
-    t0 = ref(null)
+    t0 = ref(null.make())
 
     source.on_frame(
       before=false,

--- a/src/libs/extra/fades.liq
+++ b/src/libs/extra/fades.liq
@@ -1,7 +1,7 @@
 # Plot the first crossfade transition. Used for visualizing and testing
 # crossfade transitions.
 # @flag extra
-def cross.plot(~png=null(), ~dir=null(), s) =
+def cross.plot(~png=null, ~dir=null, s) =
   dir =
     if
       null.defined(dir)
@@ -24,7 +24,7 @@ def cross.plot(~png=null(), ~dir=null(), s) =
 
   def store_rms(~id, s) =
     s = rms(duration=settings.frame.duration(), s)
-    t0 = ref(null())
+    t0 = ref(null)
 
     source.on_frame(
       before=false,

--- a/src/libs/extra/file.liq
+++ b/src/libs/extra/file.liq
@@ -9,7 +9,7 @@
 # @method last How long ago a file was played (in seconds), `infinity` is returned if the song has never been played.
 def playlog(
   ~duration=infinity,
-  ~persistency=null,
+  ~persistency=null.make(),
   ~hash=fun (m) -> m["filename"]
 ) =
   l = ref([])
@@ -21,7 +21,7 @@ def playlog(
     if
       file.exists(null.get(persistency))
     then
-      let json.parse (parsed : [(string * float)]?) =
+      let json.parse (parsed : [(string*float)]?) =
         file.contents(null.get(persistency))
 
       if null.defined(parsed) then l := null.get(parsed) end

--- a/src/libs/extra/file.liq
+++ b/src/libs/extra/file.liq
@@ -9,7 +9,7 @@
 # @method last How long ago a file was played (in seconds), `infinity` is returned if the song has never been played.
 def playlog(
   ~duration=infinity,
-  ~persistency=null(),
+  ~persistency=null,
   ~hash=fun (m) -> m["filename"]
 ) =
   l = ref([])
@@ -21,7 +21,7 @@ def playlog(
     if
       file.exists(null.get(persistency))
     then
-      let json.parse (parsed : [(string*float)]?) =
+      let json.parse (parsed : [(string * float)]?) =
         file.contents(null.get(persistency))
 
       if null.defined(parsed) then l := null.get(parsed) end

--- a/src/libs/extra/http.liq
+++ b/src/libs/extra/http.liq
@@ -12,12 +12,12 @@
 # @param ~options_status_code Provides a status code to use for successful OPTIONS requests, since some legacy browsers (IE11, various SmartTVs) choke on 204.
 def harbor.http.middleware.cors(
   ~origin=null("*"),
-  ~origin_callback=null(),
+  ~origin_callback=null,
   ~methods=["GET", "HEAD", "PUT", "PATCH", "POST", "DELETE"],
-  ~allowed_headers=null(),
+  ~allowed_headers=null,
   ~exposed_headers=[],
   ~credentials=false,
-  ~max_age=null(),
+  ~max_age=null,
   ~preflight_continue=false,
   ~options_status_code=204
 ) =
@@ -82,7 +82,7 @@ def harbor.http.middleware.cors(
           then
             req.headers["access-control-request-headers"]
           else
-            null()
+            null
           end
 
         if

--- a/src/libs/extra/http.liq
+++ b/src/libs/extra/http.liq
@@ -11,13 +11,13 @@
 # @param ~preflight_continue Pass the CORS preflight response to the nexnhandler.
 # @param ~options_status_code Provides a status code to use for successful OPTIONS requests, since some legacy browsers (IE11, various SmartTVs) choke on 204.
 def harbor.http.middleware.cors(
-  ~origin=null("*"),
-  ~origin_callback=null,
+  ~origin=null.make("*"),
+  ~origin_callback=null.make(),
   ~methods=["GET", "HEAD", "PUT", "PATCH", "POST", "DELETE"],
-  ~allowed_headers=null,
+  ~allowed_headers=null.make(),
   ~exposed_headers=[],
   ~credentials=false,
-  ~max_age=null,
+  ~max_age=null.make(),
   ~preflight_continue=false,
   ~options_status_code=204
 ) =
@@ -82,7 +82,7 @@ def harbor.http.middleware.cors(
           then
             req.headers["access-control-request-headers"]
           else
-            null
+            null.make()
           end
 
         if

--- a/src/libs/extra/interactive.liq
+++ b/src/libs/extra/interactive.liq
@@ -787,7 +787,7 @@ end
 # @param ~id Id of the source. Variable names are prefixed with this.
 # @param ~bands Number of bands.
 # @param s Source to compress.
-def compress.multiband.interactive(~id=null(), ~bands=5, s) =
+def compress.multiband.interactive(~id=null, ~bands=5, s) =
   id = string.id.default(default="compress.multiband.interactive", id)
   prefix = id ^ "_"
   wet = interactive.float(prefix ^ "wet", min=0., max=1., 1.)

--- a/src/libs/extra/interactive.liq
+++ b/src/libs/extra/interactive.liq
@@ -787,7 +787,7 @@ end
 # @param ~id Id of the source. Variable names are prefixed with this.
 # @param ~bands Number of bands.
 # @param s Source to compress.
-def compress.multiband.interactive(~id=null, ~bands=5, s) =
+def compress.multiband.interactive(~id=null.make(), ~bands=5, s) =
   id = string.id.default(default="compress.multiband.interactive", id)
   prefix = id ^ "_"
   wet = interactive.float(prefix ^ "wet", min=0., max=1., 1.)

--- a/src/libs/extra/metadata.liq
+++ b/src/libs/extra/metadata.liq
@@ -8,7 +8,7 @@
 # @param ~default Default cover file when no cover is available
 # @param ~mime_types Recognized mime types and their corresponding file extensions.
 def file.cover.manager(
-  ~id=null,
+  ~id=null.make(),
   ~mime_types=[
     ("image/gif", "gif"),
     ("image/jpg", "jpeg"),
@@ -39,7 +39,7 @@ def file.cover.manager(
           label=id,
           "File #{string.quote(filename)} has no cover."
         )
-        null
+        null.make()
       else
         cover = null.get(cover)
         extension = mime_types[cover.mime]
@@ -52,7 +52,7 @@ def file.cover.manager(
               string.quote(cover.mime)
             }."
           )
-          null
+          null.make()
         else
           cover_file = file.temp("#{id}_", ".#{extension}")
           file.write(cover_file, data=cover)

--- a/src/libs/extra/metadata.liq
+++ b/src/libs/extra/metadata.liq
@@ -8,7 +8,7 @@
 # @param ~default Default cover file when no cover is available
 # @param ~mime_types Recognized mime types and their corresponding file extensions.
 def file.cover.manager(
-  ~id=null(),
+  ~id=null,
   ~mime_types=[
     ("image/gif", "gif"),
     ("image/jpg", "jpeg"),
@@ -39,7 +39,7 @@ def file.cover.manager(
           label=id,
           "File #{string.quote(filename)} has no cover."
         )
-        null()
+        null
       else
         cover = null.get(cover)
         extension = mime_types[cover.mime]
@@ -52,7 +52,7 @@ def file.cover.manager(
               string.quote(cover.mime)
             }."
           )
-          null()
+          null
         else
           cover_file = file.temp("#{id}_", ".#{extension}")
           file.write(cover_file, data=cover)

--- a/src/libs/extra/native.liq
+++ b/src/libs/extra/native.liq
@@ -16,7 +16,7 @@ end
 # @flag extra
 # @param ~id Force the value of the source ID.
 # @param ~track_sensitive Re-select only on end of tracks.
-def native.fallback(~id=null, ~track_sensitive=true, sources) =
+def native.fallback(~id=null.make(), ~track_sensitive=true, sources) =
   fail = (source.fail() : source)
 
   def s() =
@@ -39,7 +39,7 @@ end
 # @flag extra
 # @param ~id Force the value of the source ID.
 # @param sources List of sources to play tracks from.
-def native.sequence(~id=null, sources) =
+def native.sequence(~id=null.make(), sources) =
   len = list.length(sources)
   n = ref(0)
   fail = source.fail()
@@ -76,7 +76,7 @@ end
 # @param ~id Force the value of the source ID.
 # @param ~track_sensitive Re-select only on end of tracks.
 # @param sources Sources with the predicate telling when they can be played.
-def native.switch(~id=null, ~track_sensitive=true, sources) =
+def native.switch(~id=null.make(), ~track_sensitive=true, sources) =
   sources = list.map(fun (ps) -> source.available(snd(ps), fst(ps)), sources)
   native.fallback(id=id, track_sensitive=track_sensitive, sources)
 end
@@ -95,7 +95,7 @@ def native.request.dynamic(%argsof(request.dynamic), f) =
     try
       f()
     catch _ do
-      null
+      null.make()
     end
   end
 
@@ -127,7 +127,7 @@ def native.request.dynamic(%argsof(request.dynamic), f) =
     list.iter(fun (r) -> ignore(add(r)), l)
   end
 
-  current = ref(null)
+  current = ref(null.make())
 
   def get_current() =
     if
@@ -136,7 +136,7 @@ def native.request.dynamic(%argsof(request.dynamic), f) =
       s = null.get(current())
       s.request
     else
-      null
+      null.make()
     end
   end
 

--- a/src/libs/extra/native.liq
+++ b/src/libs/extra/native.liq
@@ -16,7 +16,7 @@ end
 # @flag extra
 # @param ~id Force the value of the source ID.
 # @param ~track_sensitive Re-select only on end of tracks.
-def native.fallback(~id=null(), ~track_sensitive=true, sources) =
+def native.fallback(~id=null, ~track_sensitive=true, sources) =
   fail = (source.fail() : source)
 
   def s() =
@@ -39,7 +39,7 @@ end
 # @flag extra
 # @param ~id Force the value of the source ID.
 # @param sources List of sources to play tracks from.
-def native.sequence(~id=null(), sources) =
+def native.sequence(~id=null, sources) =
   len = list.length(sources)
   n = ref(0)
   fail = source.fail()
@@ -76,7 +76,7 @@ end
 # @param ~id Force the value of the source ID.
 # @param ~track_sensitive Re-select only on end of tracks.
 # @param sources Sources with the predicate telling when they can be played.
-def native.switch(~id=null(), ~track_sensitive=true, sources) =
+def native.switch(~id=null, ~track_sensitive=true, sources) =
   sources = list.map(fun (ps) -> source.available(snd(ps), fst(ps)), sources)
   native.fallback(id=id, track_sensitive=track_sensitive, sources)
 end
@@ -95,7 +95,7 @@ def native.request.dynamic(%argsof(request.dynamic), f) =
     try
       f()
     catch _ do
-      null()
+      null
     end
   end
 
@@ -127,7 +127,7 @@ def native.request.dynamic(%argsof(request.dynamic), f) =
     list.iter(fun (r) -> ignore(add(r)), l)
   end
 
-  current = ref(null())
+  current = ref(null)
 
   def get_current() =
     if
@@ -136,7 +136,7 @@ def native.request.dynamic(%argsof(request.dynamic), f) =
       s = null.get(current())
       s.request
     else
-      null()
+      null
     end
   end
 

--- a/src/libs/extra/openai.liq
+++ b/src/libs/extra/openai.liq
@@ -30,7 +30,7 @@ def openai.chat(
   ~key,
   ~base_url="https://api.openai.com",
   ~model="gpt-3.5-turbo",
-  ~timeout=null(30.),
+  ~timeout=null.make(30.),
   (
   messages:
   [
@@ -109,7 +109,7 @@ def openai.speech(
   ~key,
   ~base_url="https://api.openai.com",
   ~model="tts-1",
-  ~timeout=null(30.),
+  ~timeout=null.make(30.),
   ~voice,
   ~response_format="mp3",
   ~speed=1.,

--- a/src/libs/extra/server.liq
+++ b/src/libs/extra/server.liq
@@ -2,7 +2,7 @@
 # @flag extra
 # @category Source / Visualization
 # @param ~id Force the value of the source ID.
-def server.rms(~id=null(), s) =
+def server.rms(~id=null, s) =
   let s = rms(id=id, s)
 
   def rms(_) =
@@ -27,7 +27,7 @@ end
 # @flag extra
 # @category Source / Track processing
 # @param ~id Force the value of the source ID.
-def server.insert_metadata(~id=null(), s) =
+def server.insert_metadata(~id=null, s) =
   s = insert_metadata(id=id, s)
   insert = s.insert_metadata
 

--- a/src/libs/extra/server.liq
+++ b/src/libs/extra/server.liq
@@ -2,7 +2,7 @@
 # @flag extra
 # @category Source / Visualization
 # @param ~id Force the value of the source ID.
-def server.rms(~id=null, s) =
+def server.rms(~id=null.make(), s) =
   let s = rms(id=id, s)
 
   def rms(_) =
@@ -27,7 +27,7 @@ end
 # @flag extra
 # @category Source / Track processing
 # @param ~id Force the value of the source ID.
-def server.insert_metadata(~id=null, s) =
+def server.insert_metadata(~id=null.make(), s) =
   s = insert_metadata(id=id, s)
   insert = s.insert_metadata
 

--- a/src/libs/extra/source.liq
+++ b/src/libs/extra/source.liq
@@ -4,7 +4,7 @@
 # @param ~id Force the value of the source ID.
 # @param fn The applied function.
 # @param s The input source.
-def map_first_track(~id=null("map_first_track"), fn, s) =
+def map_first_track(~id=null.make("map_first_track"), fn, s) =
   fallback(id=id, track_sensitive=true, [fn((once(s) : source)), s])
 end
 
@@ -18,7 +18,7 @@ end
 # @param ~weights Weights of the children (padded with 1), defining for each child how many tracks are played from it per round, if that many are actually available.
 # @param sources Sequence of sources to be merged
 def rotate.merge(
-  ~id=null("rotate.merge"),
+  ~id=null.make("rotate.merge"),
   ~transitions=[],
   ~weights=[],
   sources
@@ -72,7 +72,7 @@ end
 # @param ~weights Relative weight of the sources in the sum. The empty list stands for the homogeneous distribution.
 # @param sources Sources to toggle from
 def overlap_sources(
-  ~id=null("overlap_sources"),
+  ~id=null.make("overlap_sources"),
   ~normalize=false,
   ~start_next="liq_start_next",
   ~weights=[],
@@ -185,7 +185,7 @@ def source.say_metadata =
     "say:#{say_metadata}"
   end
 
-  fun (~id=null("source.say_metadata"), ~pattern=pattern, s) ->
+  fun (~id=null.make("source.say_metadata"), ~pattern=pattern, s) ->
     append(id=id, s, fun (m) -> once(single(pattern(m))))
 end
 
@@ -195,7 +195,7 @@ end
 # @param ~every Duration of a track (in seconds).
 # @param ~metadata Metadata for tracks.
 # @param s The stream.
-def chop(~id=null, ~every=getter(3.), ~metadata=getter([]), s) =
+def chop(~id=null.make(), ~every=getter(3.), ~metadata=getter([]), s) =
   s = insert_metadata(s)
 
   # Track time in the source's context:
@@ -246,7 +246,7 @@ let stdlib_fallback = fallback
 # @flag extra
 # @param s The main source.
 # @param ~fallback The fallback source. Defaults to `blank` if `null`.
-def fallback.skip(s, ~fallback=null) =
+def fallback.skip(s, ~fallback=null.make()) =
   fallback = fallback ?? (blank() : source)
   avail = ref(true)
 
@@ -285,15 +285,15 @@ stdlib_file = file
 #                           duplicated metadata.
 # @param ~delete Delete the CUE files when starting if it exists.
 def source.cue(
-  ~title=null,
-  ~performer=null,
-  ~file=null,
-  ~file_type=null,
-  ~comment=null,
-  ~year=null,
-  ~map_metadata=fun (m) -> (m : [(string*string)]),
-  ~last_tracks=null,
-  ~temp_dir=null,
+  ~title=null.make(),
+  ~performer=null.make(),
+  ~file=null.make(),
+  ~file_type=null.make(),
+  ~comment=null.make(),
+  ~year=null.make(),
+  ~map_metadata=fun (m) -> (m : [(string * string)]),
+  ~last_tracks=null.make(),
+  ~temp_dir=null.make(),
   ~deduplicate_using=["title", "artist", "album", "isrc", "cue_year"],
   ~delete=true,
   filename,

--- a/src/libs/extra/source.liq
+++ b/src/libs/extra/source.liq
@@ -195,7 +195,7 @@ end
 # @param ~every Duration of a track (in seconds).
 # @param ~metadata Metadata for tracks.
 # @param s The stream.
-def chop(~id=null(), ~every=getter(3.), ~metadata=getter([]), s) =
+def chop(~id=null, ~every=getter(3.), ~metadata=getter([]), s) =
   s = insert_metadata(s)
 
   # Track time in the source's context:
@@ -246,7 +246,7 @@ let stdlib_fallback = fallback
 # @flag extra
 # @param s The main source.
 # @param ~fallback The fallback source. Defaults to `blank` if `null`.
-def fallback.skip(s, ~fallback=null()) =
+def fallback.skip(s, ~fallback=null) =
   fallback = fallback ?? (blank() : source)
   avail = ref(true)
 
@@ -285,15 +285,15 @@ stdlib_file = file
 #                           duplicated metadata.
 # @param ~delete Delete the CUE files when starting if it exists.
 def source.cue(
-  ~title=null(),
-  ~performer=null(),
-  ~file=null(),
-  ~file_type=null(),
-  ~comment=null(),
-  ~year=null(),
+  ~title=null,
+  ~performer=null,
+  ~file=null,
+  ~file_type=null,
+  ~comment=null,
+  ~year=null,
   ~map_metadata=fun (m) -> (m : [(string*string)]),
-  ~last_tracks=null(),
-  ~temp_dir=null(),
+  ~last_tracks=null,
+  ~temp_dir=null,
   ~deduplicate_using=["title", "artist", "album", "isrc", "cue_year"],
   ~delete=true,
   filename,

--- a/src/libs/extra/spinitron.liq
+++ b/src/libs/extra/spinitron.liq
@@ -9,15 +9,15 @@ def spinitron.submit.raw(
   ~host="https://spinitron.com/api",
   ~api_key,
   ~live=false,
-  ~start=null,
-  ~duration=null,
+  ~start=null.make(),
+  ~duration=null.make(),
   ~artist,
-  ~release=null,
-  ~label=null,
-  ~genre=null,
+  ~release=null.make(),
+  ~label=null.make(),
+  ~genre=null.make(),
   ~song,
-  ~composer=null,
-  ~isrc=null
+  ~composer=null.make(),
+  ~isrc=null.make()
 ) =
   params = [("song", song), ("artist", artist)]
 
@@ -186,8 +186,8 @@ def spinitron.submit.metadata(
         )
       ]
   ),
-  ~artist=null,
-  ~song=null,
+  ~artist=null.make(),
+  ~song=null.make(),
   m
 ) =
   m = [...m, ...mapper(m)]
@@ -197,7 +197,7 @@ def spinitron.submit.metadata(
   end
 
   opt_arg =
-    fun (label, default) -> conv_opt_arg(fun (x) -> null(x), label, default)
+    fun (label, default) -> conv_opt_arg(fun (x) -> null.make(x), label, default)
 
   live = conv_opt_arg(bool_of_string, "live", live)
   start = opt_arg("start", start)
@@ -211,7 +211,7 @@ def spinitron.submit.metadata(
   isrc = opt_arg("isrc", isrc)
 
   if
-    artist == null or song == null
+    artist == null.make() or song == null.make()
   then
     error.raise(
       error.invalid,
@@ -237,7 +237,7 @@ end
 # @param m Metadata to submit. Overrides optional arguments when present.
 # @param ~api_key API key
 def spinitron.submit.on_metadata(
-  ~id=null,
+  ~id=null.make(),
   %argsof(spinitron.submit.metadata),
   s
 ) =

--- a/src/libs/extra/spinitron.liq
+++ b/src/libs/extra/spinitron.liq
@@ -9,15 +9,15 @@ def spinitron.submit.raw(
   ~host="https://spinitron.com/api",
   ~api_key,
   ~live=false,
-  ~start=null(),
-  ~duration=null(),
+  ~start=null,
+  ~duration=null,
   ~artist,
-  ~release=null(),
-  ~label=null(),
-  ~genre=null(),
+  ~release=null,
+  ~label=null,
+  ~genre=null,
   ~song,
-  ~composer=null(),
-  ~isrc=null()
+  ~composer=null,
+  ~isrc=null
 ) =
   params = [("song", song), ("artist", artist)]
 
@@ -186,8 +186,8 @@ def spinitron.submit.metadata(
         )
       ]
   ),
-  ~artist=null(),
-  ~song=null(),
+  ~artist=null,
+  ~song=null,
   m
 ) =
   m = [...m, ...mapper(m)]
@@ -211,7 +211,7 @@ def spinitron.submit.metadata(
   isrc = opt_arg("isrc", isrc)
 
   if
-    artist == null() or song == null()
+    artist == null or song == null
   then
     error.raise(
       error.invalid,
@@ -237,7 +237,7 @@ end
 # @param m Metadata to submit. Overrides optional arguments when present.
 # @param ~api_key API key
 def spinitron.submit.on_metadata(
-  ~id=null(),
+  ~id=null,
   %argsof(spinitron.submit.metadata),
   s
 ) =

--- a/src/libs/extra/video.liq
+++ b/src/libs/extra/video.liq
@@ -11,8 +11,8 @@
 # @param ~mime_types Recognized mime types and their corresponding file extensions.
 def video.add_cover(
   ~fallible=false,
-  ~width=null(),
-  ~height=null(),
+  ~width=null,
+  ~height=null,
   ~x=getter(0),
   ~y=getter(0),
   ~mime_types=[

--- a/src/libs/extra/video.liq
+++ b/src/libs/extra/video.liq
@@ -11,8 +11,8 @@
 # @param ~mime_types Recognized mime types and their corresponding file extensions.
 def video.add_cover(
   ~fallible=false,
-  ~width=null,
-  ~height=null,
+  ~width=null.make(),
+  ~height=null.make(),
   ~x=getter(0),
   ~y=getter(0),
   ~mime_types=[

--- a/src/libs/fades.liq
+++ b/src/libs/fades.liq
@@ -68,7 +68,7 @@ let settings.fade.out.curve =
 # @param ~duration Duration in seconds.
 # @param ~on_done Function to execute when the fade is finished
 def mkfade(
-  ~curve=getter(null()),
+  ~curve=getter(null),
   ~type=getter("lin"),
   ~start=0.,
   ~stop=1.,
@@ -161,7 +161,7 @@ end
 # @category Source / Fade
 # @flag hidden
 def fade.scale(~id="fade.scale", x, s) =
-  amplify(id=id, override=null(), x, s)
+  amplify(id=id, override=null, x, s)
 end
 
 # Fade the end of tracks.
@@ -181,9 +181,9 @@ end
 # @param ~type Fader shape. One of: "lin"", "sin", "log" or "exp". Defaults to `settings.fade.out.type` if `null`.
 def fade.out(
   ~id="fade.out",
-  ~duration=null(),
+  ~duration=null,
   ~delay=0.,
-  ~curve=null(),
+  ~curve=null,
   ~override_duration="liq_fade_out",
   ~override_type="liq_fade_out_type",
   ~override_curve="liq_fade_out_curve",
@@ -191,7 +191,7 @@ def fade.out(
   ~persist_overrides=false,
   ~track_sensitive=false,
   ~initial_metadata=[],
-  ~type=null(),
+  ~type=null,
   s
 ) =
   def log(x) =
@@ -308,12 +308,12 @@ def fade.out(
       if
         m[override_curve] == "default"
       then
-        curve := null()
+        curve := null
       else
         try
           curve := float_of_string(m[override_curve])
         catch _ do
-          curve := null()
+          curve := null
         end
       end
 
@@ -397,7 +397,7 @@ def fade.skip(
   ~id="fade.skip",
   ~duration=5.,
   ~delay=0.,
-  ~curve=null(),
+  ~curve=null,
   ~override_duration="liq_fade_skip",
   ~override_type="liq_fade_skip_type",
   ~override_curve="liq_fade_skip_curve",
@@ -483,12 +483,12 @@ def fade.skip(
       if
         m[override_curve] == "default"
       then
-        curve := null()
+        curve := null
       else
         try
           curve := float_of_string(m[override_curve])
         catch _ do
-          curve := null()
+          curve := null
         end
       end
 
@@ -558,9 +558,9 @@ end
 # @param ~type Fader shape. One of: "lin"", "sin", "log" or "exp". Defaults to `settings.fade.in.type` if `null`.
 def fade.in(
   ~id="fade.in",
-  ~duration=null(),
+  ~duration=null,
   ~delay=0.,
-  ~curve=null(),
+  ~curve=null,
   ~override_duration="liq_fade_in",
   ~override_type="liq_fade_in_type",
   ~override_curve="liq_fade_in_curve",
@@ -568,7 +568,7 @@ def fade.in(
   ~persist_overrides=false,
   ~track_sensitive=false,
   ~initial_metadata=[],
-  ~type=null(),
+  ~type=null,
   s
 ) =
   def log(x) =
@@ -660,12 +660,12 @@ def fade.in(
       if
         m[override_curve] == "default"
       then
-        curve := null()
+        curve := null
       else
         try
           curve := float_of_string(m[override_curve])
         catch _ do
-          curve := null()
+          curve := null
         end
       end
 

--- a/src/libs/fades.liq
+++ b/src/libs/fades.liq
@@ -68,7 +68,7 @@ let settings.fade.out.curve =
 # @param ~duration Duration in seconds.
 # @param ~on_done Function to execute when the fade is finished
 def mkfade(
-  ~curve=getter(null),
+  ~curve=getter(null.make()),
   ~type=getter("lin"),
   ~start=0.,
   ~stop=1.,
@@ -161,7 +161,7 @@ end
 # @category Source / Fade
 # @flag hidden
 def fade.scale(~id="fade.scale", x, s) =
-  amplify(id=id, override=null, x, s)
+  amplify(id=id, override=null.make(), x, s)
 end
 
 # Fade the end of tracks.
@@ -181,9 +181,9 @@ end
 # @param ~type Fader shape. One of: "lin"", "sin", "log" or "exp". Defaults to `settings.fade.out.type` if `null`.
 def fade.out(
   ~id="fade.out",
-  ~duration=null,
+  ~duration=null.make(),
   ~delay=0.,
-  ~curve=null,
+  ~curve=null.make(),
   ~override_duration="liq_fade_out",
   ~override_type="liq_fade_out_type",
   ~override_curve="liq_fade_out_curve",
@@ -191,7 +191,7 @@ def fade.out(
   ~persist_overrides=false,
   ~track_sensitive=false,
   ~initial_metadata=[],
-  ~type=null,
+  ~type=null.make(),
   s
 ) =
   def log(x) =
@@ -308,12 +308,12 @@ def fade.out(
       if
         m[override_curve] == "default"
       then
-        curve := null
+        curve := null.make()
       else
         try
           curve := float_of_string(m[override_curve])
         catch _ do
-          curve := null
+          curve := null.make()
         end
       end
 
@@ -397,7 +397,7 @@ def fade.skip(
   ~id="fade.skip",
   ~duration=5.,
   ~delay=0.,
-  ~curve=null,
+  ~curve=null.make(),
   ~override_duration="liq_fade_skip",
   ~override_type="liq_fade_skip_type",
   ~override_curve="liq_fade_skip_curve",
@@ -483,12 +483,12 @@ def fade.skip(
       if
         m[override_curve] == "default"
       then
-        curve := null
+        curve := null.make()
       else
         try
           curve := float_of_string(m[override_curve])
         catch _ do
-          curve := null
+          curve := null.make()
         end
       end
 
@@ -558,9 +558,9 @@ end
 # @param ~type Fader shape. One of: "lin"", "sin", "log" or "exp". Defaults to `settings.fade.in.type` if `null`.
 def fade.in(
   ~id="fade.in",
-  ~duration=null,
+  ~duration=null.make(),
   ~delay=0.,
-  ~curve=null,
+  ~curve=null.make(),
   ~override_duration="liq_fade_in",
   ~override_type="liq_fade_in_type",
   ~override_curve="liq_fade_in_curve",
@@ -568,7 +568,7 @@ def fade.in(
   ~persist_overrides=false,
   ~track_sensitive=false,
   ~initial_metadata=[],
-  ~type=null,
+  ~type=null.make(),
   s
 ) =
   def log(x) =
@@ -660,12 +660,12 @@ def fade.in(
       if
         m[override_curve] == "default"
       then
-        curve := null
+        curve := null.make()
       else
         try
           curve := float_of_string(m[override_curve])
         catch _ do
-          curve := null
+          curve := null.make()
         end
       end
 

--- a/src/libs/ffmpeg.liq
+++ b/src/libs/ffmpeg.liq
@@ -4,7 +4,7 @@ let ffmpeg.raw.encode = ()
 
 # Encode a source's audio content
 # @category Source / Conversion
-def ffmpeg.encode.audio(~id=null("ffmpeg.encode.audio"), f, s) =
+def ffmpeg.encode.audio(~id=null.make("ffmpeg.encode.audio"), f, s) =
   audio = track.ffmpeg.encode.audio(f, source.tracks(s).audio)
   source(
     id=id,
@@ -18,7 +18,7 @@ end
 
 # Encode a source's audio content
 # @category Source / Conversion
-def ffmpeg.raw.encode.audio(~id=null("ffmpeg.raw.encode.audio"), f, s) =
+def ffmpeg.raw.encode.audio(~id=null.make("ffmpeg.raw.encode.audio"), f, s) =
   audio = track.ffmpeg.raw.encode.audio(f, source.tracks(s).audio)
   source(
     id=id,
@@ -32,7 +32,7 @@ end
 
 # Encode a source's video content
 # @category Source / Conversion
-def ffmpeg.encode.video(~id=null("ffmpeg.encode.video"), f, s) =
+def ffmpeg.encode.video(~id=null.make("ffmpeg.encode.video"), f, s) =
   video = track.ffmpeg.encode.video(f, source.tracks(s).video)
   source(
     id=id,
@@ -46,7 +46,7 @@ end
 
 # Encode a source's video content
 # @category Source / Conversion
-def ffmpeg.raw.encode.video(~id=null("ffmpeg.raw.encode.video"), f, s) =
+def ffmpeg.raw.encode.video(~id=null.make("ffmpeg.raw.encode.video"), f, s) =
   video = track.ffmpeg.raw.encode.video(f, source.tracks(s).video)
   source(
     id=id,
@@ -60,7 +60,7 @@ end
 
 # Encode a source's audio and video content
 # @category Source / Conversion
-def ffmpeg.encode.audio_video(~id=null("ffmpeg.encode.audio_video"), f, s) =
+def ffmpeg.encode.audio_video(~id=null.make("ffmpeg.encode.audio_video"), f, s) =
   let {audio, video} = source.tracks(s)
   audio = track.ffmpeg.encode.audio(f, audio)
   video = track.ffmpeg.encode.video(f, video)
@@ -78,7 +78,7 @@ end
 # Encode a source's audio and video content
 # @category Source / Conversion
 def ffmpeg.raw.encode.audio_video(
-  ~id=null("ffmpeg.raw.encode.audio_video"),
+  ~id=null.make("ffmpeg.raw.encode.audio_video"),
   f,
   s
 ) =
@@ -103,7 +103,7 @@ let ffmpeg.raw.decode = ()
 
 # Decode a source's audio content
 # @category Source / Conversion
-def ffmpeg.decode.audio(~id=null("ffmpeg.decode.audio"), s) =
+def ffmpeg.decode.audio(~id=null.make("ffmpeg.decode.audio"), s) =
   audio = track.ffmpeg.decode.audio(source.tracks(s).audio)
   source(
     id=id,
@@ -117,7 +117,7 @@ end
 
 # Decode a source's audio content
 # @category Source / Conversion
-def ffmpeg.raw.decode.audio(~id=null("ffmpeg.raw.decode.audio"), s) =
+def ffmpeg.raw.decode.audio(~id=null.make("ffmpeg.raw.decode.audio"), s) =
   audio = track.ffmpeg.raw.decode.audio(source.tracks(s).audio)
   source(
     id=id,
@@ -131,7 +131,7 @@ end
 
 # Decode a source's video content
 # @category Source / Conversion
-def ffmpeg.decode.video(~id=null("ffmpeg.decode.video"), s) =
+def ffmpeg.decode.video(~id=null.make("ffmpeg.decode.video"), s) =
   video = track.ffmpeg.decode.video(source.tracks(s).video)
   source(
     id=id,
@@ -145,7 +145,7 @@ end
 
 # Decode a source's video content
 # @category Source / Conversion
-def ffmpeg.raw.decode.video(~id=null("ffmpeg.raw.decode.video"), s) =
+def ffmpeg.raw.decode.video(~id=null.make("ffmpeg.raw.decode.video"), s) =
   video = track.ffmpeg.raw.decode.video(source.tracks(s).video)
   source(
     id=id,
@@ -159,7 +159,7 @@ end
 
 # Decode a source's audio and video content
 # @category Source / Conversion
-def ffmpeg.decode.audio_video(~id=null("ffmpeg.decode.audio_video"), s) =
+def ffmpeg.decode.audio_video(~id=null.make("ffmpeg.decode.audio_video"), s) =
   let {audio, video} = source.tracks(s)
   audio = track.ffmpeg.decode.audio(audio)
   video = track.ffmpeg.decode.video(video)
@@ -177,7 +177,7 @@ end
 # Decode a source's audio and video content
 # @category Source / Conversion
 def ffmpeg.raw.decode.audio_video(
-  ~id=null("ffmpeg.raw.decode.audio_video"),
+  ~id=null.make("ffmpeg.raw.decode.audio_video"),
   s
 ) =
   let {audio, video} = source.tracks(s)
@@ -201,7 +201,7 @@ end
 # @param ~id Force the value of the source ID.
 # @param ~max_buffer Maximum data buffer in seconds
 # @param ~device V4L2 device to use.
-def input.v4l2(~id=null, ~max_buffer=0.5, ~device="/dev/video0") =
+def input.v4l2(~id=null.make(), ~max_buffer=0.5, ~device="/dev/video0") =
   (input.ffmpeg(id=id, format="v4l2", max_buffer=max_buffer, device) :
     source(video=canvas)
   )
@@ -213,10 +213,10 @@ end
 # @param ~max_buffer Maximum data buffer in seconds
 # @param ~duration Duration of the source.
 def video.testsrc.ffmpeg(
-  ~id=null,
+  ~id=null.make(),
   ~pattern="testsrc",
   ~max_buffer=0.5,
-  ~duration=null
+  ~duration=null.make()
 ) =
   size = "size=#{settings.frame.video.width()}x#{settings.frame.video.height()}"
   rate = "rate=#{settings.frame.video.framerate()}"
@@ -232,7 +232,7 @@ end
 # @param ~max_buffer Maximum data buffer in seconds
 # @param ~listen Act as a RTMP server and wait for incoming connection
 # @param url URL to read RTMP from, in the form `rtmp://IP:PORT/ENDPOINT`
-def input.rtmp(~id=null, ~max_buffer=5., ~listen=true, url) =
+def input.rtmp(~id=null.make(), ~max_buffer=5., ~listen=true, url) =
   input.ffmpeg(
     id=id,
     max_buffer=max_buffer,
@@ -268,8 +268,8 @@ let video.add_text.ffmpeg.raw = ()
 def video.add_text.ffmpeg.raw.filter(
   ~color=0xffffff,
   ~cycle=true,
-  ~font=null,
-  ~metadata=null,
+  ~font=null.make(),
+  ~metadata=null.make(),
   ~size=18,
   ~speed=70,
   ~x=getter(10),
@@ -458,8 +458,8 @@ end
 def replaces video.add_text.ffmpeg.raw(
   ~color=0xffffff,
   ~cycle=true,
-  ~font=null,
-  ~metadata=null,
+  ~font=null.make(),
+  ~metadata=null.make(),
   ~size=18,
   ~speed=70,
   ~x=getter(10),
@@ -512,12 +512,12 @@ def replaces video.add_text.ffmpeg.raw(
 end
 
 def video.add_text.ffmpeg.internal(
-  ~id=null,
+  ~id=null.make(),
   ~color=0xffffff,
   ~cycle=true,
-  ~font=null,
-  ~duration=null,
-  ~metadata=null,
+  ~font=null.make(),
+  ~duration=null.make(),
+  ~metadata=null.make(),
   ~size=18,
   ~speed=70,
   ~x=getter(10),
@@ -599,7 +599,7 @@ let ffmpeg.filter.audio_video = ()
 # Return a source with audio and video from a filter's output.
 # @category Source / Output
 # @param id Force the value of the source ID.
-def ffmpeg.filter.audio_video.output(~id=null, graph, audio, video) =
+def ffmpeg.filter.audio_video.output(~id=null.make(), graph, audio, video) =
   audio = ffmpeg.filter.audio.output(graph, audio.tracks().audio)
   video = ffmpeg.filter.video.output(graph, video.tracks().video)
   source(id=id, {audio=audio, video=video})

--- a/src/libs/ffmpeg.liq
+++ b/src/libs/ffmpeg.liq
@@ -201,7 +201,7 @@ end
 # @param ~id Force the value of the source ID.
 # @param ~max_buffer Maximum data buffer in seconds
 # @param ~device V4L2 device to use.
-def input.v4l2(~id=null(), ~max_buffer=0.5, ~device="/dev/video0") =
+def input.v4l2(~id=null, ~max_buffer=0.5, ~device="/dev/video0") =
   (input.ffmpeg(id=id, format="v4l2", max_buffer=max_buffer, device) :
     source(video=canvas)
   )
@@ -213,10 +213,10 @@ end
 # @param ~max_buffer Maximum data buffer in seconds
 # @param ~duration Duration of the source.
 def video.testsrc.ffmpeg(
-  ~id=null(),
+  ~id=null,
   ~pattern="testsrc",
   ~max_buffer=0.5,
-  ~duration=null()
+  ~duration=null
 ) =
   size = "size=#{settings.frame.video.width()}x#{settings.frame.video.height()}"
   rate = "rate=#{settings.frame.video.framerate()}"
@@ -232,7 +232,7 @@ end
 # @param ~max_buffer Maximum data buffer in seconds
 # @param ~listen Act as a RTMP server and wait for incoming connection
 # @param url URL to read RTMP from, in the form `rtmp://IP:PORT/ENDPOINT`
-def input.rtmp(~id=null(), ~max_buffer=5., ~listen=true, url) =
+def input.rtmp(~id=null, ~max_buffer=5., ~listen=true, url) =
   input.ffmpeg(
     id=id,
     max_buffer=max_buffer,
@@ -268,8 +268,8 @@ let video.add_text.ffmpeg.raw = ()
 def video.add_text.ffmpeg.raw.filter(
   ~color=0xffffff,
   ~cycle=true,
-  ~font=null(),
-  ~metadata=null(),
+  ~font=null,
+  ~metadata=null,
   ~size=18,
   ~speed=70,
   ~x=getter(10),
@@ -458,8 +458,8 @@ end
 def replaces video.add_text.ffmpeg.raw(
   ~color=0xffffff,
   ~cycle=true,
-  ~font=null(),
-  ~metadata=null(),
+  ~font=null,
+  ~metadata=null,
   ~size=18,
   ~speed=70,
   ~x=getter(10),
@@ -512,12 +512,12 @@ def replaces video.add_text.ffmpeg.raw(
 end
 
 def video.add_text.ffmpeg.internal(
-  ~id=null(),
+  ~id=null,
   ~color=0xffffff,
   ~cycle=true,
-  ~font=null(),
-  ~duration=null(),
-  ~metadata=null(),
+  ~font=null,
+  ~duration=null,
+  ~metadata=null,
   ~size=18,
   ~speed=70,
   ~x=getter(10),
@@ -599,7 +599,7 @@ let ffmpeg.filter.audio_video = ()
 # Return a source with audio and video from a filter's output.
 # @category Source / Output
 # @param id Force the value of the source ID.
-def ffmpeg.filter.audio_video.output(~id=null(), graph, audio, video) =
+def ffmpeg.filter.audio_video.output(~id=null, graph, audio, video) =
   audio = ffmpeg.filter.audio.output(graph, audio.tracks().audio)
   video = ffmpeg.filter.video.output(graph, video.tracks().video)
   source(id=id, {audio=audio, video=video})

--- a/src/libs/file.liq
+++ b/src/libs/file.liq
@@ -52,7 +52,7 @@ def file.write.stream(
   ~perms=0o644,
   ~append=false,
   ~atomic=false,
-  ~temp_dir=null(),
+  ~temp_dir=null,
   p
 ) =
   let (fd, exec) =
@@ -121,7 +121,7 @@ def replaces file.write(
   ~perms=0o644,
   ~append=false,
   ~atomic=false,
-  ~temp_dir=null(),
+  ~temp_dir=null,
   path
 ) =
   cb =
@@ -183,7 +183,7 @@ def file.iterator(fname) =
   fun () ->
     begin
       s = f()
-      (s == "") ? null() : s
+      (s == "") ? null : s
     end
 end
 
@@ -198,11 +198,11 @@ def file.mime.cli(fname) =
       )
     )
 
-  mime == "" ? null() : mime
+  mime == "" ? null : mime
 end
 
 # Get a file's mime type. Uses libmagic if enabled, otherwise try
-# to get the value using the file binary. Returns `null()` if no value
+# to get the value using the file binary. Returns `null` if no value
 # can be found.
 # @category File
 # @param file The file to test
@@ -283,7 +283,7 @@ def file.metadata.flac.cover.decode(s) =
   height = read_int()
   color_depth = read_int()
   number_of_colors = read_int()
-  number_of_colors = number_of_colors > 0 ? null(number_of_colors) : null()
+  number_of_colors = number_of_colors > 0 ? null(number_of_colors) : null
   data_len = read_int()
   data = string.sub(encoding="ascii", s, start=i(), length=data_len)
   if
@@ -292,7 +292,7 @@ def file.metadata.flac.cover.decode(s) =
     log.info(
       "Failed to read cover metadata"
     )
-    null()
+    null
   else
     null(
       data.{
@@ -317,7 +317,7 @@ def file.metadata.flac.cover.encode(
   ~width,
   ~height,
   ~color_depth,
-  ~number_of_colors=null(),
+  ~number_of_colors=null,
   data
 ) =
   def encode_string(s) =

--- a/src/libs/file.liq
+++ b/src/libs/file.liq
@@ -52,7 +52,7 @@ def file.write.stream(
   ~perms=0o644,
   ~append=false,
   ~atomic=false,
-  ~temp_dir=null,
+  ~temp_dir=null.make(),
   p
 ) =
   let (fd, exec) =
@@ -121,7 +121,7 @@ def replaces file.write(
   ~perms=0o644,
   ~append=false,
   ~atomic=false,
-  ~temp_dir=null,
+  ~temp_dir=null.make(),
   path
 ) =
   cb =
@@ -183,7 +183,7 @@ def file.iterator(fname) =
   fun () ->
     begin
       s = f()
-      (s == "") ? null : s
+      (s == "") ? null.make() : s
     end
 end
 
@@ -198,7 +198,7 @@ def file.mime.cli(fname) =
       )
     )
 
-  mime == "" ? null : mime
+  mime == "" ? null.make() : mime
 end
 
 # Get a file's mime type. Uses libmagic if enabled, otherwise try
@@ -283,7 +283,7 @@ def file.metadata.flac.cover.decode(s) =
   height = read_int()
   color_depth = read_int()
   number_of_colors = read_int()
-  number_of_colors = number_of_colors > 0 ? null(number_of_colors) : null
+  number_of_colors = if number_of_colors > 0 then null.make(number_of_colors) else null.make() end
   data_len = read_int()
   data = string.sub(encoding="ascii", s, start=i(), length=data_len)
   if
@@ -292,9 +292,9 @@ def file.metadata.flac.cover.decode(s) =
     log.info(
       "Failed to read cover metadata"
     )
-    null
+    null.make()
   else
-    null(
+    null.make(
       data.{
         picture_type=pic_type,
         mime=mime,
@@ -317,7 +317,7 @@ def file.metadata.flac.cover.encode(
   ~width,
   ~height,
   ~color_depth,
-  ~number_of_colors=null,
+  ~number_of_colors=null.make(),
   data
 ) =
   def encode_string(s) =

--- a/src/libs/hls.liq
+++ b/src/libs/hls.liq
@@ -50,9 +50,9 @@ end
 # @docof output.file.hls
 def replaces output.file.hls(
   %argsof(output.file.hls[!main_playlist_writer]),
-  ~main_playlist_writer=null(
+  ~main_playlist_writer=null.make(
     fun (~extra_tags, ~prefix, ~version, streams) ->
-      null(
+      null.make(
         hls.playlist.main(
           extra_tags=extra_tags, prefix=prefix, version=version, streams
         )
@@ -79,7 +79,7 @@ let input.hls = ()
 # @param ~reload How often (in seconds) the playlist should be reloaded.
 # @param uri Playlist URI.
 # @flag experimental
-def input.hls.native(~id=null, ~reload=10., uri) =
+def input.hls.native(~id=null.make(), ~reload=10., uri) =
   playlistr = ref([])
   sequence = ref(0)
   playlist_uri = ref(uri)
@@ -152,7 +152,7 @@ def input.hls.native(~id=null, ~reload=10., uri) =
       sequence := sequence() + 1
       request.create(ret)
     else
-      null
+      null.make()
     end
   end
 
@@ -197,7 +197,7 @@ let replaces input.hls = input.ffmpeg
 # @category Source / Input
 # @param ~id Force the value of the source ID.
 # @param uri Playlist URI.
-def input.hls(~id=null, uri) =
+def input.hls(~id=null.make(), uri) =
   input.hls(id=id, uri)
 end
 
@@ -260,7 +260,7 @@ def replaces output.harbor.hls(
   ~headers=[("Access-Control-Allow-Origin", "*")],
   ~port=8000,
   ~path="/",
-  ~tmpdir=null,
+  ~tmpdir=null.make(),
   ~transport=http.transport.unix,
   formats,
   s
@@ -304,7 +304,7 @@ def output.harbor.hls.https(
   ~headers=[("Access-Control-Allow-Origin", "*")],
   ~port=8000,
   ~path="/",
-  ~tmpdir=null,
+  ~tmpdir=null.make(),
   formats,
   s
 ) =

--- a/src/libs/hls.liq
+++ b/src/libs/hls.liq
@@ -79,7 +79,7 @@ let input.hls = ()
 # @param ~reload How often (in seconds) the playlist should be reloaded.
 # @param uri Playlist URI.
 # @flag experimental
-def input.hls.native(~id=null(), ~reload=10., uri) =
+def input.hls.native(~id=null, ~reload=10., uri) =
   playlistr = ref([])
   sequence = ref(0)
   playlist_uri = ref(uri)
@@ -152,7 +152,7 @@ def input.hls.native(~id=null(), ~reload=10., uri) =
       sequence := sequence() + 1
       request.create(ret)
     else
-      null()
+      null
     end
   end
 
@@ -197,7 +197,7 @@ let replaces input.hls = input.ffmpeg
 # @category Source / Input
 # @param ~id Force the value of the source ID.
 # @param uri Playlist URI.
-def input.hls(~id=null(), uri) =
+def input.hls(~id=null, uri) =
   input.hls(id=id, uri)
 end
 
@@ -260,7 +260,7 @@ def replaces output.harbor.hls(
   ~headers=[("Access-Control-Allow-Origin", "*")],
   ~port=8000,
   ~path="/",
-  ~tmpdir=null(),
+  ~tmpdir=null,
   ~transport=http.transport.unix,
   formats,
   s
@@ -304,7 +304,7 @@ def output.harbor.hls.https(
   ~headers=[("Access-Control-Allow-Origin", "*")],
   ~port=8000,
   ~path="/",
-  ~tmpdir=null(),
+  ~tmpdir=null,
   formats,
   s
 ) =

--- a/src/libs/http.liq
+++ b/src/libs/http.liq
@@ -21,7 +21,7 @@ end
 # @category Internet
 # @param ~boundary Specify boundary to use for multipart/form-data.
 # @param data data to insert
-def http.multipart_form_data(~boundary=null(), data) =
+def http.multipart_form_data(~boundary=null, data) =
   def default_boundary() =
     range = [...string.char.ascii.alphabet, ...string.char.ascii.number]
     l = list.init(12, fun (_) -> string.char.ascii.random(range))
@@ -97,10 +97,10 @@ end
 # @method status_message Set response status message
 def http.response(
   ~http_version="1.1",
-  ~status_code=null(),
-  ~status_message=null(),
+  ~status_code=null,
+  ~status_message=null,
   ~headers=[],
-  ~content_type=null(),
+  ~content_type=null,
   ~data=getter("")
 ) =
   status_code =
@@ -290,7 +290,7 @@ def http.response(
     if not status_sent() then socket.write(mk_status()) end
   end
 
-  def multipart_form(~boundary=null(), contents) =
+  def multipart_form(~boundary=null, contents) =
     if
       headers_sent()
     then
@@ -632,7 +632,7 @@ def get_mime_process(file) =
       )
     )
 
-  if mime == "" then null() else mime end
+  if mime == "" then null else mime end
 end
 
 # @flag hidden
@@ -769,13 +769,13 @@ upload_file_fn =
 # @param url URL to post to.
 def http.post.file(
   ~name="file",
-  ~content_type=null(),
+  ~content_type=null,
   ~headers=[],
-  ~boundary=null(),
-  ~filename=null(),
-  ~file=null(),
-  ~contents=null(),
-  ~timeout=null(),
+  ~boundary=null,
+  ~filename=null,
+  ~file=null,
+  ~contents=null,
+  ~timeout=null,
   ~redirect=true,
   url
 ) =
@@ -810,13 +810,13 @@ end
 # @param url URL to put to.
 def http.put.file(
   ~name="file",
-  ~content_type=null(),
+  ~content_type=null,
   ~headers=[],
-  ~boundary=null(),
-  ~filename=null(),
-  ~file=null(),
-  ~contents=null(),
-  ~timeout=null(),
+  ~boundary=null,
+  ~filename=null,
+  ~file=null,
+  ~contents=null,
+  ~timeout=null,
   ~redirect=true,
   url
 ) =
@@ -895,7 +895,7 @@ def http.headers.content_type(headers) =
         headers
       )
     catch _ : [error.not_found] do
-      null()
+      null
     end
 
   mime = null.map(snd, mime)
@@ -930,7 +930,7 @@ def http.headers.content_disposition(headers) =
         headers
       )
     catch _ : [error.not_found] do
-      null()
+      null
     end
 
   def parse_arg(arg) =
@@ -940,9 +940,9 @@ def http.headers.content_disposition(headers) =
 
   def parse_filename(args) =
     plain_filename = args["filename"]
-    plain_filename = plain_filename == "" ? null() : plain_filename
+    plain_filename = plain_filename == "" ? null : plain_filename
     encoded_filename = args["filename*"]
-    encoded_filename = encoded_filename == "" ? null() : encoded_filename
+    encoded_filename = encoded_filename == "" ? null : encoded_filename
     encoded_filename =
       null.map(
         fun (encoded_filename) ->
@@ -971,7 +971,7 @@ def http.headers.content_disposition(headers) =
 
   def parse_name(args) =
     name = args["name"]
-    name = name == "" ? null() : name
+    name = name == "" ? null : name
     name = null.map(fun (name) -> url.decode(string.unquote(name)), name)
     (name, list.filter(fun (v) -> fst(v) != "name", args))
   end
@@ -1009,9 +1009,9 @@ def http.headers.extname(headers) =
       null.defined(content_disposition?.filename)
     then
       extname = file.extension(null.get(content_disposition?.filename))
-      extname == "" ? null() : extname
+      extname == "" ? null : extname
     else
-      null()
+      null
     end
 
   if
@@ -1023,8 +1023,8 @@ def http.headers.extname(headers) =
   then
     extnames = settings.http.mime.extnames()
     extname = extnames[null.get(content_type).mime]
-    extname == "" ? null() : extname
+    extname == "" ? null : extname
   else
-    null()
+    null
   end
 end

--- a/src/libs/http.liq
+++ b/src/libs/http.liq
@@ -21,7 +21,7 @@ end
 # @category Internet
 # @param ~boundary Specify boundary to use for multipart/form-data.
 # @param data data to insert
-def http.multipart_form_data(~boundary=null, data) =
+def http.multipart_form_data(~boundary=null.make(), data) =
   def default_boundary() =
     range = [...string.char.ascii.alphabet, ...string.char.ascii.number]
     l = list.init(12, fun (_) -> string.char.ascii.random(range))
@@ -97,10 +97,10 @@ end
 # @method status_message Set response status message
 def http.response(
   ~http_version="1.1",
-  ~status_code=null,
-  ~status_message=null,
+  ~status_code=null.make(),
+  ~status_message=null.make(),
   ~headers=[],
-  ~content_type=null,
+  ~content_type=null.make(),
   ~data=getter("")
 ) =
   status_code =
@@ -290,7 +290,7 @@ def http.response(
     if not status_sent() then socket.write(mk_status()) end
   end
 
-  def multipart_form(~boundary=null, contents) =
+  def multipart_form(~boundary=null.make(), contents) =
     if
       headers_sent()
     then
@@ -632,7 +632,7 @@ def get_mime_process(file) =
       )
     )
 
-  if mime == "" then null else mime end
+  if mime == "" then null.make() else mime end
 end
 
 # @flag hidden
@@ -769,13 +769,13 @@ upload_file_fn =
 # @param url URL to post to.
 def http.post.file(
   ~name="file",
-  ~content_type=null,
+  ~content_type=null.make(),
   ~headers=[],
-  ~boundary=null,
-  ~filename=null,
-  ~file=null,
-  ~contents=null,
-  ~timeout=null,
+  ~boundary=null.make(),
+  ~filename=null.make(),
+  ~file=null.make(),
+  ~contents=null.make(),
+  ~timeout=null.make(),
   ~redirect=true,
   url
 ) =
@@ -810,13 +810,13 @@ end
 # @param url URL to put to.
 def http.put.file(
   ~name="file",
-  ~content_type=null,
+  ~content_type=null.make(),
   ~headers=[],
-  ~boundary=null,
-  ~filename=null,
-  ~file=null,
-  ~contents=null,
-  ~timeout=null,
+  ~boundary=null.make(),
+  ~filename=null.make(),
+  ~file=null.make(),
+  ~contents=null.make(),
+  ~timeout=null.make(),
   ~redirect=true,
   url
 ) =
@@ -895,7 +895,7 @@ def http.headers.content_type(headers) =
         headers
       )
     catch _ : [error.not_found] do
-      null
+      null.make()
     end
 
   mime = null.map(snd, mime)
@@ -930,7 +930,7 @@ def http.headers.content_disposition(headers) =
         headers
       )
     catch _ : [error.not_found] do
-      null
+      null.make()
     end
 
   def parse_arg(arg) =
@@ -940,9 +940,9 @@ def http.headers.content_disposition(headers) =
 
   def parse_filename(args) =
     plain_filename = args["filename"]
-    plain_filename = plain_filename == "" ? null : plain_filename
+    plain_filename = plain_filename == "" ? null.make() : plain_filename
     encoded_filename = args["filename*"]
-    encoded_filename = encoded_filename == "" ? null : encoded_filename
+    encoded_filename = encoded_filename == "" ? null.make() : encoded_filename
     encoded_filename =
       null.map(
         fun (encoded_filename) ->
@@ -971,7 +971,7 @@ def http.headers.content_disposition(headers) =
 
   def parse_name(args) =
     name = args["name"]
-    name = name == "" ? null : name
+    name = name == "" ? null.make() : name
     name = null.map(fun (name) -> url.decode(string.unquote(name)), name)
     (name, list.filter(fun (v) -> fst(v) != "name", args))
   end
@@ -1009,9 +1009,9 @@ def http.headers.extname(headers) =
       null.defined(content_disposition?.filename)
     then
       extname = file.extension(null.get(content_disposition?.filename))
-      extname == "" ? null : extname
+      extname == "" ? null.make() : extname
     else
-      null
+      null.make()
     end
 
   if
@@ -1023,8 +1023,8 @@ def http.headers.extname(headers) =
   then
     extnames = settings.http.mime.extnames()
     extname = extnames[null.get(content_type).mime]
-    extname == "" ? null : extname
+    extname == "" ? null.make() : extname
   else
-    null
+    null.make()
   end
 end

--- a/src/libs/io.liq
+++ b/src/libs/io.liq
@@ -29,7 +29,7 @@ let replaces output = output.pulseaudio
 # @param ~start Automatically start outputting whenever possible. If `true`, an infallible (normal) output will start as soon as it is created, and a fallible output will (re)start as soon as its source becomes available for streaming.
 # @param s Source to play.
 def replaces output(
-  ~id=null,
+  ~id=null.make(),
   ~fallible=true,
   ~on_start={()},
   ~on_stop={()},
@@ -69,7 +69,7 @@ let output.video = output.graphics
 # @param ~start Automatically start outputting whenever possible. If `true`, an infallible (normal) output will start outputting as soon as it is created, and a fallible output will (re)start as soon as its source becomes available for streaming.
 # @param s Source to play.
 def output.video(
-  ~id=null,
+  ~id=null.make(),
   ~fallible=true,
   ~on_start={()},
   ~on_stop={()},
@@ -92,7 +92,7 @@ end
 # @param ~start Automatically start outputting whenever possible. If `true`, an infallible (normal) output will start outputting as soon as it is created, and a fallible output will (re)start as soon as its source becomes available for streaming.
 # @param s Source to play.
 def output.audio_video(
-  ~id=null,
+  ~id=null.make(),
   ~fallible=true,
   ~on_start={()},
   ~on_stop={()},
@@ -120,7 +120,7 @@ def output.audio_video(
 end
 
 def replaces input(
-  ~id=null,
+  ~id=null.make(),
   ~start=true,
   ~on_start={()},
   ~on_stop={()},
@@ -157,7 +157,7 @@ let replaces input = input.pulseaudio
 # @param ~on_stop Callback executed when outputting stops.
 # @param ~start Automatically start outputting whenever possible. If `true`, an infallible (normal) output will start outputting as soon as it is created, and a fallible output will (re)start as soon as its source becomes available for streaming.
 def replaces input(
-  ~id=null,
+  ~id=null.make(),
   ~start=true,
   ~on_start={()},
   ~on_stop={()},

--- a/src/libs/io.liq
+++ b/src/libs/io.liq
@@ -29,7 +29,7 @@ let replaces output = output.pulseaudio
 # @param ~start Automatically start outputting whenever possible. If `true`, an infallible (normal) output will start as soon as it is created, and a fallible output will (re)start as soon as its source becomes available for streaming.
 # @param s Source to play.
 def replaces output(
-  ~id=null(),
+  ~id=null,
   ~fallible=true,
   ~on_start={()},
   ~on_stop={()},
@@ -69,7 +69,7 @@ let output.video = output.graphics
 # @param ~start Automatically start outputting whenever possible. If `true`, an infallible (normal) output will start outputting as soon as it is created, and a fallible output will (re)start as soon as its source becomes available for streaming.
 # @param s Source to play.
 def output.video(
-  ~id=null(),
+  ~id=null,
   ~fallible=true,
   ~on_start={()},
   ~on_stop={()},
@@ -92,7 +92,7 @@ end
 # @param ~start Automatically start outputting whenever possible. If `true`, an infallible (normal) output will start outputting as soon as it is created, and a fallible output will (re)start as soon as its source becomes available for streaming.
 # @param s Source to play.
 def output.audio_video(
-  ~id=null(),
+  ~id=null,
   ~fallible=true,
   ~on_start={()},
   ~on_stop={()},
@@ -120,7 +120,7 @@ def output.audio_video(
 end
 
 def replaces input(
-  ~id=null(),
+  ~id=null,
   ~start=true,
   ~on_start={()},
   ~on_stop={()},
@@ -157,7 +157,7 @@ let replaces input = input.pulseaudio
 # @param ~on_stop Callback executed when outputting stops.
 # @param ~start Automatically start outputting whenever possible. If `true`, an infallible (normal) output will start outputting as soon as it is created, and a fallible output will (re)start as soon as its source becomes available for streaming.
 def replaces input(
-  ~id=null(),
+  ~id=null,
   ~start=true,
   ~on_start={()},
   ~on_stop={()},

--- a/src/libs/list.liq
+++ b/src/libs/list.liq
@@ -15,7 +15,7 @@ end
 # Return the head (first element) of a list, or `default` if the list is empty.
 # @category List
 # @param ~default Default value if key does not exist.
-def list.hd(~default=null, l) =
+def list.hd(~default=null.make(), l) =
   list.dcase(
     l,
     {
@@ -52,7 +52,7 @@ end
 
 # Return the last element of a list.
 # @category List
-def list.last(~default=null, l) =
+def list.last(~default=null.make(), l) =
   list.nth(default=default, l, list.length(l) - 1)
 end
 
@@ -169,7 +169,7 @@ end
 # `error.not_found` if no default value is specified.
 # @category List
 # @param ~default Value returned if the key is not found.
-def list.assoc(~default=null, key, l) =
+def list.assoc(~default=null.make(), key, l) =
   ret = ref(💣())
   err = error.register("assoc")
   try
@@ -220,7 +220,7 @@ def list.assoc.nullable(key, l) =
   try
     list.assoc(key, l)
   catch _ do
-    null
+    null.make()
   end
 end
 
@@ -312,7 +312,7 @@ end
 # @param ~default Returned value when the predicate is not found.
 # @param p Predicate.
 # @param l List
-def list.find(~default=null, p, l) =
+def list.find(~default=null.make(), p, l) =
   ret = ref(💣())
   err = error.register("find")
   try
@@ -357,7 +357,7 @@ def list.iterator(l) =
   def f() =
     list.case(
       l(),
-      null,
+      null.make(),
       fun (x, t) ->
         begin
           l := t
@@ -415,7 +415,7 @@ end
 # @category List
 # @param ~default Value returned if the list is empty.
 # @param l List in which the element should be picked.
-def list.pick(~default=null, l) =
+def list.pick(~default=null.make(), l) =
   if
     list.is_empty(l)
   then

--- a/src/libs/list.liq
+++ b/src/libs/list.liq
@@ -15,7 +15,7 @@ end
 # Return the head (first element) of a list, or `default` if the list is empty.
 # @category List
 # @param ~default Default value if key does not exist.
-def list.hd(~default=null(), l) =
+def list.hd(~default=null, l) =
   list.dcase(
     l,
     {
@@ -52,7 +52,7 @@ end
 
 # Return the last element of a list.
 # @category List
-def list.last(~default=null(), l) =
+def list.last(~default=null, l) =
   list.nth(default=default, l, list.length(l) - 1)
 end
 
@@ -169,7 +169,7 @@ end
 # `error.not_found` if no default value is specified.
 # @category List
 # @param ~default Value returned if the key is not found.
-def list.assoc(~default=null(), key, l) =
+def list.assoc(~default=null, key, l) =
   ret = ref(💣())
   err = error.register("assoc")
   try
@@ -220,7 +220,7 @@ def list.assoc.nullable(key, l) =
   try
     list.assoc(key, l)
   catch _ do
-    null()
+    null
   end
 end
 
@@ -312,7 +312,7 @@ end
 # @param ~default Returned value when the predicate is not found.
 # @param p Predicate.
 # @param l List
-def list.find(~default=null(), p, l) =
+def list.find(~default=null, p, l) =
   ret = ref(💣())
   err = error.register("find")
   try
@@ -357,7 +357,7 @@ def list.iterator(l) =
   def f() =
     list.case(
       l(),
-      null(),
+      null,
       fun (x, t) ->
         begin
           l := t
@@ -415,7 +415,7 @@ end
 # @category List
 # @param ~default Value returned if the list is empty.
 # @param l List in which the element should be picked.
-def list.pick(~default=null(), l) =
+def list.pick(~default=null, l) =
   if
     list.is_empty(l)
   then

--- a/src/libs/medialib.liq
+++ b/src/libs/medialib.liq
@@ -12,13 +12,13 @@
 # @method add_directory Add a new directory which should be scanned.
 # @method clear Remove all known metadata.
 def medialib(
-  ~id=null(),
-  ~persistency=null(),
-  ~refresh=null(),
+  ~id=null,
+  ~persistency=null,
+  ~refresh=null,
   ~standardize=fun (m) -> m,
   ~initial_progress=true,
   ~directories=[],
-  dir=null()
+  dir=null
 ) =
   id = string.id.default(default="medialib", id)
   refresh_time = refresh
@@ -89,7 +89,7 @@ def medialib(
       if
         not (file.exists(f))
       then
-        null()
+        null
       elsif
         needs_update(f, m)
       then
@@ -194,22 +194,22 @@ def medialib(
   # Find all files matching given criteria.
   def find(
     ~case_sensitive=true,
-    ~artist=null(),
-    ~artist_contains=null(),
-    ~artist_matches=null(),
-    ~album=null(),
-    ~genre=null(),
-    ~title=null(),
-    ~title_contains=null(),
-    ~filename=null(),
-    ~filename_contains=null(),
-    ~filename_matches=null(),
-    ~year=null(),
-    ~year_ge=null(),
-    ~year_lt=null(),
-    ~bpm=null(),
-    ~bpm_ge=null(),
-    ~bpm_lt=null(),
+    ~artist=null,
+    ~artist_contains=null,
+    ~artist_matches=null,
+    ~album=null,
+    ~genre=null,
+    ~title=null,
+    ~title_contains=null,
+    ~filename=null,
+    ~filename_contains=null,
+    ~filename_matches=null,
+    ~year=null,
+    ~year_ge=null,
+    ~year_lt=null,
+    ~bpm=null,
+    ~bpm_ge=null,
+    ~bpm_lt=null,
     ~predicate=(fun (_) -> true)
   ) =
     def p(m) =
@@ -399,13 +399,13 @@ end
 # @method add_directory Add a new directory which should be scanned.
 # @method clear Remove all known metadata.
 def medialib.sqlite(
-  ~id=null(),
+  ~id=null,
   ~database,
-  ~refresh=null(),
+  ~refresh=null,
   ~standardize=fun (m) -> m,
   ~initial_progress=true,
   ~directories=[],
-  dir=null()
+  dir=null
 ) =
   id = string.id.default(default="medialib.sqlite", id)
   refresh_time = refresh
@@ -493,10 +493,10 @@ def medialib.sqlite(
             try
               map(x)
             catch _ do
-              null()
+              null
             end
           end
-          if list.assoc.mem(k, m) then map(list.assoc(k, m)) else null() end
+          if list.assoc.mem(k, m) then map(list.assoc(k, m)) else null end
         end
         id = fun (x) -> x
         m =
@@ -579,23 +579,23 @@ def medialib.sqlite(
   # Find all files matching given criteria.
   def find(
     ~case_sensitive=true,
-    ~artist=null(),
-    ~artist_contains=null(),
-    ~artist_matches=null(),
-    ~album=null(),
-    ~genre=null(),
-    ~title=null(),
-    ~title_contains=null(),
-    ~filename=null(),
-    ~filename_contains=null(),
-    ~filename_matches=null(),
-    ~year=null(),
-    ~year_ge=null(),
-    ~year_lt=null(),
-    ~bpm=null(),
-    ~bpm_ge=null(),
-    ~bpm_lt=null(),
-    ~condition=null()
+    ~artist=null,
+    ~artist_contains=null,
+    ~artist_matches=null,
+    ~album=null,
+    ~genre=null,
+    ~title=null,
+    ~title_contains=null,
+    ~filename=null,
+    ~filename_contains=null,
+    ~filename_matches=null,
+    ~year=null,
+    ~year_ge=null,
+    ~year_lt=null,
+    ~bpm=null,
+    ~bpm_ge=null,
+    ~bpm_lt=null,
+    ~condition=null
   ) =
     predicates = ref([])
     def pred(p) =

--- a/src/libs/medialib.liq
+++ b/src/libs/medialib.liq
@@ -12,13 +12,13 @@
 # @method add_directory Add a new directory which should be scanned.
 # @method clear Remove all known metadata.
 def medialib(
-  ~id=null,
-  ~persistency=null,
-  ~refresh=null,
+  ~id=null.make(),
+  ~persistency=null.make(),
+  ~refresh=null.make(),
   ~standardize=fun (m) -> m,
   ~initial_progress=true,
   ~directories=[],
-  dir=null
+  dir=null.make()
 ) =
   id = string.id.default(default="medialib", id)
   refresh_time = refresh
@@ -89,7 +89,7 @@ def medialib(
       if
         not (file.exists(f))
       then
-        null
+        null.make()
       elsif
         needs_update(f, m)
       then
@@ -194,22 +194,22 @@ def medialib(
   # Find all files matching given criteria.
   def find(
     ~case_sensitive=true,
-    ~artist=null,
-    ~artist_contains=null,
-    ~artist_matches=null,
-    ~album=null,
-    ~genre=null,
-    ~title=null,
-    ~title_contains=null,
-    ~filename=null,
-    ~filename_contains=null,
-    ~filename_matches=null,
-    ~year=null,
-    ~year_ge=null,
-    ~year_lt=null,
-    ~bpm=null,
-    ~bpm_ge=null,
-    ~bpm_lt=null,
+    ~artist=null.make(),
+    ~artist_contains=null.make(),
+    ~artist_matches=null.make(),
+    ~album=null.make(),
+    ~genre=null.make(),
+    ~title=null.make(),
+    ~title_contains=null.make(),
+    ~filename=null.make(),
+    ~filename_contains=null.make(),
+    ~filename_matches=null.make(),
+    ~year=null.make(),
+    ~year_ge=null.make(),
+    ~year_lt=null.make(),
+    ~bpm=null.make(),
+    ~bpm_ge=null.make(),
+    ~bpm_lt=null.make(),
     ~predicate=(fun (_) -> true)
   ) =
     def p(m) =
@@ -399,13 +399,13 @@ end
 # @method add_directory Add a new directory which should be scanned.
 # @method clear Remove all known metadata.
 def medialib.sqlite(
-  ~id=null,
+  ~id=null.make(),
   ~database,
-  ~refresh=null,
+  ~refresh=null.make(),
   ~standardize=fun (m) -> m,
   ~initial_progress=true,
   ~directories=[],
-  dir=null
+  dir=null.make()
 ) =
   id = string.id.default(default="medialib.sqlite", id)
   refresh_time = refresh
@@ -493,10 +493,10 @@ def medialib.sqlite(
             try
               map(x)
             catch _ do
-              null
+              null.make()
             end
           end
-          if list.assoc.mem(k, m) then map(list.assoc(k, m)) else null end
+          if list.assoc.mem(k, m) then map(list.assoc(k, m)) else null.make() end
         end
         id = fun (x) -> x
         m =
@@ -579,23 +579,23 @@ def medialib.sqlite(
   # Find all files matching given criteria.
   def find(
     ~case_sensitive=true,
-    ~artist=null,
-    ~artist_contains=null,
-    ~artist_matches=null,
-    ~album=null,
-    ~genre=null,
-    ~title=null,
-    ~title_contains=null,
-    ~filename=null,
-    ~filename_contains=null,
-    ~filename_matches=null,
-    ~year=null,
-    ~year_ge=null,
-    ~year_lt=null,
-    ~bpm=null,
-    ~bpm_ge=null,
-    ~bpm_lt=null,
-    ~condition=null
+    ~artist=null.make(),
+    ~artist_contains=null.make(),
+    ~artist_matches=null.make(),
+    ~album=null.make(),
+    ~genre=null.make(),
+    ~title=null.make(),
+    ~title_contains=null.make(),
+    ~filename=null.make(),
+    ~filename_contains=null.make(),
+    ~filename_matches=null.make(),
+    ~year=null.make(),
+    ~year_ge=null.make(),
+    ~year_lt=null.make(),
+    ~bpm=null.make(),
+    ~bpm_ge=null.make(),
+    ~bpm_lt=null.make(),
+    ~condition=null.make()
   ) =
     predicates = ref([])
     def pred(p) =

--- a/src/libs/metadata.liq
+++ b/src/libs/metadata.liq
@@ -98,7 +98,7 @@ end
 # @param m Metadata from which the cover should be extracted.
 # @param ~coverart_mime Mime type to use for `"coverart"` metadata. Support disabled if `null`.
 # @method mime MIME type for the cover.
-def metadata.cover(~coverart_mime=null(), m) =
+def metadata.cover(~coverart_mime=null, m) =
   fname = metadata.filename(m)
   if
     list.assoc.mem("coverart", m) and null.defined(coverart_mime)
@@ -117,7 +117,7 @@ def metadata.cover(~coverart_mime=null(), m) =
       log.info(
         "Failed to read cover metadata for #{fname}."
       )
-      null()
+      null
     else
       null.get(cover)
     end
@@ -175,7 +175,7 @@ def metadata.cover(~coverart_mime=null(), m) =
       log.info(
         "No cover found for #{fname}."
       )
-      null()
+      null
     end
   end
 end
@@ -216,7 +216,7 @@ let metadata.json = ()
 # @param ~compact Output compact text.
 # @param ~json5 Use json5 extended spec.
 def metadata.json.stringify(
-  ~coverart_mime=null(),
+  ~coverart_mime=null,
   ~base64=true,
   ~compact=false,
   ~json5=false,

--- a/src/libs/metadata.liq
+++ b/src/libs/metadata.liq
@@ -98,7 +98,7 @@ end
 # @param m Metadata from which the cover should be extracted.
 # @param ~coverart_mime Mime type to use for `"coverart"` metadata. Support disabled if `null`.
 # @method mime MIME type for the cover.
-def metadata.cover(~coverart_mime=null, m) =
+def metadata.cover(~coverart_mime=null.make(), m) =
   fname = metadata.filename(m)
   if
     list.assoc.mem("coverart", m) and null.defined(coverart_mime)
@@ -117,7 +117,7 @@ def metadata.cover(~coverart_mime=null, m) =
       log.info(
         "Failed to read cover metadata for #{fname}."
       )
-      null
+      null.make()
     else
       null.get(cover)
     end
@@ -175,7 +175,7 @@ def metadata.cover(~coverart_mime=null, m) =
       log.info(
         "No cover found for #{fname}."
       )
-      null
+      null.make()
     end
   end
 end
@@ -216,7 +216,7 @@ let metadata.json = ()
 # @param ~compact Output compact text.
 # @param ~json5 Use json5 extended spec.
 def metadata.json.stringify(
-  ~coverart_mime=null,
+  ~coverart_mime=null.make(),
   ~base64=true,
   ~compact=false,
   ~json5=false,

--- a/src/libs/null.liq
+++ b/src/libs/null.liq
@@ -8,7 +8,7 @@ end
 # and no default value was specified.
 # @category Programming
 # @param ~default Returned value when the value is `null`.
-def null.get(~default=null, x) =
+def null.get(~default=null.make(), x) =
   null.case(
     x,
     {
@@ -34,7 +34,7 @@ end
 # otherwise.
 # @category Programming
 def null.map(f, x) =
-  null.case(x, {null}, fun (x) -> f(x))
+  null.case(x, {null.make()}, fun (x) -> f(x))
 end
 
 # Find the first element of a list for which the image of the function is not
@@ -44,7 +44,7 @@ end
 # @param ~default Returned value when no element is found.
 # @param f Function.
 # @param l List.
-def null.find(~default=null, f, l) =
+def null.find(~default=null.make(), f, l) =
   def rec aux(l) =
     f =
       list.case(

--- a/src/libs/null.liq
+++ b/src/libs/null.liq
@@ -8,7 +8,7 @@ end
 # and no default value was specified.
 # @category Programming
 # @param ~default Returned value when the value is `null`.
-def null.get(~default=null(), x) =
+def null.get(~default=null, x) =
   null.case(
     x,
     {
@@ -34,7 +34,7 @@ end
 # otherwise.
 # @category Programming
 def null.map(f, x) =
-  null.case(x, {null()}, fun (x) -> f(x))
+  null.case(x, {null}, fun (x) -> f(x))
 end
 
 # Find the first element of a list for which the image of the function is not
@@ -44,7 +44,7 @@ end
 # @param ~default Returned value when no element is found.
 # @param f Function.
 # @param l List.
-def null.find(~default=null(), f, l) =
+def null.find(~default=null, f, l) =
   def rec aux(l) =
     f =
       list.case(

--- a/src/libs/playlist.liq
+++ b/src/libs/playlist.liq
@@ -8,7 +8,7 @@ let playlist.parse.cue = ()
 # Parse a cue file
 # @category Liquidsoap
 # @param ~pwd Path to use for relative path resolution
-def playlist.parse.cue.full(~pwd=null, content) =
+def playlist.parse.cue.full(~pwd=null.make(), content) =
   content = string.split(separator="[\r\n]+", content)
 
   def parse_file(s) =
@@ -28,7 +28,7 @@ def playlist.parse.cue.full(~pwd=null, content) =
             if
               file_type == ""
             then
-              null
+              null.make()
             else
               string.case(lower=true, file_type)
             end
@@ -57,7 +57,7 @@ def playlist.parse.cue.full(~pwd=null, content) =
       filename = playlist.parse.get_file(pwd=pwd, filename)
       {filename=filename, file_type=file_type}
     catch _ do
-      null
+      null.make()
     end
   end
 
@@ -69,7 +69,7 @@ def playlist.parse.cue.full(~pwd=null, content) =
 
       {position=position, track_type=string.case(lower=true, type)}
     catch _ : [error.not_found] do
-      null
+      null.make()
     end
   end
 
@@ -80,7 +80,7 @@ def playlist.parse.cue.full(~pwd=null, content) =
       value = string.unquote(list.assoc(2, matches))
       (name, value)
     catch _ : [error.not_found] do
-      null
+      null.make()
     end
   end
 
@@ -93,7 +93,7 @@ def playlist.parse.cue.full(~pwd=null, content) =
 
       {minutes=minutes, seconds=seconds, frames=frames}
     catch _ : [error.not_found] do
-      null
+      null.make()
     end
   end
 
@@ -105,7 +105,7 @@ def playlist.parse.cue.full(~pwd=null, content) =
 
       (index, null.get(parse_timecode(timecode)))
     catch _ do
-      null
+      null.make()
     end
   end
 
@@ -358,7 +358,7 @@ def playlist.parse.cue.full(~pwd=null, content) =
     end
   end
 
-  parse_content(file=null, sheet={tracks=[], rem=[]}, content)
+  parse_content(file=null.make(), sheet={tracks=[], rem=[]}, content)
 end
 
 let settings.playlist.cue =
@@ -397,7 +397,7 @@ let settings.playlist.cue.postgap_metadata =
 # Parse a cue file and return a value suitable for playlist parser registration.
 # @category Liquidsoap
 # @param ~pwd Path to use for relative path resolution
-def replaces playlist.parse.cue(~pwd=null, content) =
+def replaces playlist.parse.cue(~pwd=null.make(), content) =
   # Simple test: playlist should have at least one file..
   if
     r/FILE/.test(content)
@@ -619,7 +619,7 @@ def playlist.id(~default, uri) =
   if
     basename == "."
   then
-    string.id.default(default=default, null)
+    string.id.default(default=default, null.make())
   else
     basename
   end
@@ -630,7 +630,12 @@ end
 # @param ~mime_type Default MIME type for the playlist. `null` means automatic detection.
 # @param ~timeout Timeout for resolving the playlist
 # @param uri Path to the playlist
-def playlist.files(~id=null, ~mime_type=null, ~timeout=null, uri) =
+def playlist.files(
+  ~id=null.make(),
+  ~mime_type=null.make(),
+  ~timeout=null.make(),
+  uri
+) =
   id = id ?? playlist.id(default="playlist.files", uri)
 
   if
@@ -713,19 +718,19 @@ let stdlib_native = native
 # @method reload Reload the playlist with given list of songs.
 # @method remaining_files Songs remaining to be played.
 def playlist.list(
-  ~id=null,
-  ~check_next=null,
-  ~prefetch=null,
+  ~id=null.make(),
+  ~check_next=null.make(),
+  ~prefetch=null.make(),
   ~loop=true,
   ~mode="normal",
   ~native=false,
   ~on_loop={()},
   ~on_done={()},
   ~max_fail=10,
-  ~on_fail=null,
-  ~timeout=null,
-  ~cue_in_metadata=null("liq_cue_in"),
-  ~cue_out_metadata=null("liq_cue_out"),
+  ~on_fail=null.make(),
+  ~timeout=null.make(),
+  ~cue_in_metadata=null.make("liq_cue_in"),
+  ~cue_out_metadata=null.make("liq_cue_out"),
   playlist
 ) =
   ignore(native)
@@ -768,7 +773,7 @@ def playlist.list(
 
   # Delay the creation of next after the source because we need it to resolve
   # requests at the right content type.
-  next_fun = ref(fun () -> null)
+  next_fun = ref(fun () -> null.make())
 
   def next() =
     f = next_fun()
@@ -867,7 +872,7 @@ def playlist.list(
       file == "" or (failed_count() >= max_fail and time() < failed_time() + 1.)
     then
       # Playlist failed too many times recently, don't try next for now.
-      null
+      null.make()
     else
       log.debug(
         label=id,
@@ -978,23 +983,23 @@ end
 # @method length Length of the of the playlist (the number of songs it contains).
 # @method remaining_files Songs remaining to be played.
 def replaces playlist(
-  ~id=null,
-  ~check_next=null,
-  ~prefetch=null,
+  ~id=null.make(),
+  ~check_next=null.make(),
+  ~prefetch=null.make(),
   ~loop=true,
   ~max_fail=10,
-  ~mime_type=null,
+  ~mime_type=null.make(),
   ~mode="randomize",
   ~native=false,
   ~on_done={()},
-  ~on_fail=null,
+  ~on_fail=null.make(),
   ~on_reload=(fun (_) -> ()),
   ~prefix="",
   ~reload=0,
   ~reload_mode="seconds",
-  ~timeout=null,
-  ~cue_in_metadata=null("liq_cue_in"),
-  ~cue_out_metadata=null("liq_cue_out"),
+  ~timeout=null.make(),
+  ~cue_in_metadata=null.make("liq_cue_in"),
+  ~cue_out_metadata=null.make("liq_cue_out"),
   ~register_server_commands=true,
   uri
 ) =
@@ -1110,7 +1115,7 @@ def replaces playlist(
     )
 
   # The reload function
-  def s.reload(~empty_queue=true, ~uri=null) =
+  def s.reload(~empty_queue=true, ~uri=null.make()) =
     if
       failed_loads() < max_fail
     then
@@ -1144,9 +1149,9 @@ def replaces playlist(
       if
         file.exists(playlist_uri())
       then
-        ref(null(file.watch(playlist_uri(), s.reload)))
+        ref(null.make(file.watch(playlist_uri(), s.reload)))
       else
-        ref(null)
+        ref(null.make())
       end
 
     watched_uri = ref(playlist_uri())
@@ -1159,7 +1164,13 @@ def replaces playlist(
         if null.defined(w) then null.get(w).unwatch() end
         watched_uri := uri
         watcher :=
-          if file.exists(uri) then file.watch(uri, s.reload) else null end
+          if
+            file.exists(uri)
+          then
+            file.watch(uri, s.reload)
+          else
+            null.make()
+          end
       end
     end
 

--- a/src/libs/playlist.liq
+++ b/src/libs/playlist.liq
@@ -8,7 +8,7 @@ let playlist.parse.cue = ()
 # Parse a cue file
 # @category Liquidsoap
 # @param ~pwd Path to use for relative path resolution
-def playlist.parse.cue.full(~pwd=null(), content) =
+def playlist.parse.cue.full(~pwd=null, content) =
   content = string.split(separator="[\r\n]+", content)
 
   def parse_file(s) =
@@ -28,7 +28,7 @@ def playlist.parse.cue.full(~pwd=null(), content) =
             if
               file_type == ""
             then
-              null()
+              null
             else
               string.case(lower=true, file_type)
             end
@@ -57,7 +57,7 @@ def playlist.parse.cue.full(~pwd=null(), content) =
       filename = playlist.parse.get_file(pwd=pwd, filename)
       {filename=filename, file_type=file_type}
     catch _ do
-      null()
+      null
     end
   end
 
@@ -69,7 +69,7 @@ def playlist.parse.cue.full(~pwd=null(), content) =
 
       {position=position, track_type=string.case(lower=true, type)}
     catch _ : [error.not_found] do
-      null()
+      null
     end
   end
 
@@ -80,7 +80,7 @@ def playlist.parse.cue.full(~pwd=null(), content) =
       value = string.unquote(list.assoc(2, matches))
       (name, value)
     catch _ : [error.not_found] do
-      null()
+      null
     end
   end
 
@@ -93,7 +93,7 @@ def playlist.parse.cue.full(~pwd=null(), content) =
 
       {minutes=minutes, seconds=seconds, frames=frames}
     catch _ : [error.not_found] do
-      null()
+      null
     end
   end
 
@@ -105,7 +105,7 @@ def playlist.parse.cue.full(~pwd=null(), content) =
 
       (index, null.get(parse_timecode(timecode)))
     catch _ do
-      null()
+      null
     end
   end
 
@@ -358,7 +358,7 @@ def playlist.parse.cue.full(~pwd=null(), content) =
     end
   end
 
-  parse_content(file=null(), sheet={tracks=[], rem=[]}, content)
+  parse_content(file=null, sheet={tracks=[], rem=[]}, content)
 end
 
 let settings.playlist.cue =
@@ -397,7 +397,7 @@ let settings.playlist.cue.postgap_metadata =
 # Parse a cue file and return a value suitable for playlist parser registration.
 # @category Liquidsoap
 # @param ~pwd Path to use for relative path resolution
-def replaces playlist.parse.cue(~pwd=null(), content) =
+def replaces playlist.parse.cue(~pwd=null, content) =
   # Simple test: playlist should have at least one file..
   if
     r/FILE/.test(content)
@@ -619,7 +619,7 @@ def playlist.id(~default, uri) =
   if
     basename == "."
   then
-    string.id.default(default=default, null())
+    string.id.default(default=default, null)
   else
     basename
   end
@@ -630,7 +630,7 @@ end
 # @param ~mime_type Default MIME type for the playlist. `null` means automatic detection.
 # @param ~timeout Timeout for resolving the playlist
 # @param uri Path to the playlist
-def playlist.files(~id=null(), ~mime_type=null(), ~timeout=null(), uri) =
+def playlist.files(~id=null, ~mime_type=null, ~timeout=null, uri) =
   id = id ?? playlist.id(default="playlist.files", uri)
 
   if
@@ -713,17 +713,17 @@ let stdlib_native = native
 # @method reload Reload the playlist with given list of songs.
 # @method remaining_files Songs remaining to be played.
 def playlist.list(
-  ~id=null(),
-  ~check_next=null(),
-  ~prefetch=null(),
+  ~id=null,
+  ~check_next=null,
+  ~prefetch=null,
   ~loop=true,
   ~mode="normal",
   ~native=false,
   ~on_loop={()},
   ~on_done={()},
   ~max_fail=10,
-  ~on_fail=null(),
-  ~timeout=null(),
+  ~on_fail=null,
+  ~timeout=null,
   ~cue_in_metadata=null("liq_cue_in"),
   ~cue_out_metadata=null("liq_cue_out"),
   playlist
@@ -768,7 +768,7 @@ def playlist.list(
 
   # Delay the creation of next after the source because we need it to resolve
   # requests at the right content type.
-  next_fun = ref(fun () -> null())
+  next_fun = ref(fun () -> null)
 
   def next() =
     f = next_fun()
@@ -867,7 +867,7 @@ def playlist.list(
       file == "" or (failed_count() >= max_fail and time() < failed_time() + 1.)
     then
       # Playlist failed too many times recently, don't try next for now.
-      null()
+      null
     else
       log.debug(
         label=id,
@@ -978,21 +978,21 @@ end
 # @method length Length of the of the playlist (the number of songs it contains).
 # @method remaining_files Songs remaining to be played.
 def replaces playlist(
-  ~id=null(),
-  ~check_next=null(),
-  ~prefetch=null(),
+  ~id=null,
+  ~check_next=null,
+  ~prefetch=null,
   ~loop=true,
   ~max_fail=10,
-  ~mime_type=null(),
+  ~mime_type=null,
   ~mode="randomize",
   ~native=false,
   ~on_done={()},
-  ~on_fail=null(),
+  ~on_fail=null,
   ~on_reload=(fun (_) -> ()),
   ~prefix="",
   ~reload=0,
   ~reload_mode="seconds",
-  ~timeout=null(),
+  ~timeout=null,
   ~cue_in_metadata=null("liq_cue_in"),
   ~cue_out_metadata=null("liq_cue_out"),
   ~register_server_commands=true,
@@ -1110,7 +1110,7 @@ def replaces playlist(
     )
 
   # The reload function
-  def s.reload(~empty_queue=true, ~uri=null()) =
+  def s.reload(~empty_queue=true, ~uri=null) =
     if
       failed_loads() < max_fail
     then
@@ -1146,7 +1146,7 @@ def replaces playlist(
       then
         ref(null(file.watch(playlist_uri(), s.reload)))
       else
-        ref(null())
+        ref(null)
       end
 
     watched_uri = ref(playlist_uri())
@@ -1159,7 +1159,7 @@ def replaces playlist(
         if null.defined(w) then null.get(w).unwatch() end
         watched_uri := uri
         watcher :=
-          if file.exists(uri) then file.watch(uri, s.reload) else null() end
+          if file.exists(uri) then file.watch(uri, s.reload) else null end
       end
     end
 

--- a/src/libs/protocols.liq
+++ b/src/libs/protocols.liq
@@ -135,7 +135,7 @@ def replaces protocol.process(~rlog=_, ~maxtime, arg) =
         "Removing #{output}."
       )
       file.remove(output)
-      null
+      null.make()
     end
   end
 
@@ -157,7 +157,7 @@ def replaces protocol.process(~rlog=_, ~maxtime, arg) =
         level=3,
         "Failed to resolve #{uri}"
       )
-      null
+      null.make()
     end
   end
 end
@@ -180,7 +180,7 @@ protocol.add(
 # @param cmd Command line to execute
 # @param ~extname Output file extension (with no leading '.')
 # @param ~uri Input uri
-def process.uri(~timeout=null, ~extname, ~uri="", cmd) =
+def process.uri(~timeout=null.make(), ~extname, ~uri="", cmd) =
   timeout = null.case(timeout, {""}, fun (t) -> "timeout=" ^ string(t) ^ ",")
   cmd = r/:/g.replace(fun (_) -> "$(colon)", cmd)
   uri = if uri != "" then ":#{uri}" else "" end
@@ -201,7 +201,7 @@ def protocol.http(proto, ~rlog, ~maxtime, arg) =
   ret = http.head(timeout=timeout, uri)
   code = ret.status_code ?? 999
   extname =
-    200 <= code and code < 300 ? http.headers.extname(ret.headers) : null
+    if 200 <= code and code < 300 then http.headers.extname(ret.headers) else null.make() end
 
   extname =
     if
@@ -253,14 +253,14 @@ def protocol.http(proto, ~rlog, ~maxtime, arg) =
         }"
       )
 
-      null
+      null.make()
     end
   catch err do
     log(
       level=3,
       "Error while fetching http data: #{err}"
     )
-    null
+    null.make()
   end
 end
 
@@ -627,14 +627,14 @@ def protocol.ffmpeg(~rlog, ~maxtime, arg) =
         level=3,
         "Failed to resolve #{uri}"
       )
-      null
+      null.make()
     end
   else
     log(
       level=3,
       "Failed to resolve #{arg}"
     )
-    null
+    null.make()
   end
 end
 
@@ -658,7 +658,7 @@ def protocol.stereo(~rlog=_, ~maxtime=_, arg) =
     log.info(
       "Stereo: failed to resolve request #{arg}"
     )
-    null
+    null.make()
   else
     request.dump(%wav, file, request.create(arg))
     file
@@ -875,21 +875,21 @@ let settings.protocol.aws.profile =
   settings.make(
     description=
       "Use a specific profile from your credential file.",
-    null
+    null.make()
   )
 
 let settings.protocol.aws.endpoint =
   settings.make(
     description=
       "Alternative endpoint URL (useful for other S3 implementations).",
-    null
+    null.make()
   )
 
 let settings.protocol.aws.region =
   settings.make(
     description=
       "AWS Region",
-    null
+    null.make()
   )
 
 let settings.protocol.aws.path =
@@ -1030,7 +1030,7 @@ def synth_protocol(~rlog=_, ~maxtime=_, text) =
   if
     list.exists(fun (l) -> list.length(l) != 2, args)
   then
-    null
+    null.make()
   else
     args =
       list.map(
@@ -1091,7 +1091,7 @@ def synth_protocol(~rlog=_, ~maxtime=_, text) =
       synth(square(duration=duration(), frequency()))
     elsif shape() == "blank" then synth(blank(duration=duration()))
     else
-      null
+      null.make()
     end
   end
 end

--- a/src/libs/protocols.liq
+++ b/src/libs/protocols.liq
@@ -135,7 +135,7 @@ def replaces protocol.process(~rlog=_, ~maxtime, arg) =
         "Removing #{output}."
       )
       file.remove(output)
-      null()
+      null
     end
   end
 
@@ -157,7 +157,7 @@ def replaces protocol.process(~rlog=_, ~maxtime, arg) =
         level=3,
         "Failed to resolve #{uri}"
       )
-      null()
+      null
     end
   end
 end
@@ -180,7 +180,7 @@ protocol.add(
 # @param cmd Command line to execute
 # @param ~extname Output file extension (with no leading '.')
 # @param ~uri Input uri
-def process.uri(~timeout=null(), ~extname, ~uri="", cmd) =
+def process.uri(~timeout=null, ~extname, ~uri="", cmd) =
   timeout = null.case(timeout, {""}, fun (t) -> "timeout=" ^ string(t) ^ ",")
   cmd = r/:/g.replace(fun (_) -> "$(colon)", cmd)
   uri = if uri != "" then ":#{uri}" else "" end
@@ -201,7 +201,7 @@ def protocol.http(proto, ~rlog, ~maxtime, arg) =
   ret = http.head(timeout=timeout, uri)
   code = ret.status_code ?? 999
   extname =
-    200 <= code and code < 300 ? http.headers.extname(ret.headers) : null()
+    200 <= code and code < 300 ? http.headers.extname(ret.headers) : null
 
   extname =
     if
@@ -253,14 +253,14 @@ def protocol.http(proto, ~rlog, ~maxtime, arg) =
         }"
       )
 
-      null()
+      null
     end
   catch err do
     log(
       level=3,
       "Error while fetching http data: #{err}"
     )
-    null()
+    null
   end
 end
 
@@ -627,14 +627,14 @@ def protocol.ffmpeg(~rlog, ~maxtime, arg) =
         level=3,
         "Failed to resolve #{uri}"
       )
-      null()
+      null
     end
   else
     log(
       level=3,
       "Failed to resolve #{arg}"
     )
-    null()
+    null
   end
 end
 
@@ -658,7 +658,7 @@ def protocol.stereo(~rlog=_, ~maxtime=_, arg) =
     log.info(
       "Stereo: failed to resolve request #{arg}"
     )
-    null()
+    null
   else
     request.dump(%wav, file, request.create(arg))
     file
@@ -875,21 +875,21 @@ let settings.protocol.aws.profile =
   settings.make(
     description=
       "Use a specific profile from your credential file.",
-    null()
+    null
   )
 
 let settings.protocol.aws.endpoint =
   settings.make(
     description=
       "Alternative endpoint URL (useful for other S3 implementations).",
-    null()
+    null
   )
 
 let settings.protocol.aws.region =
   settings.make(
     description=
       "AWS Region",
-    null()
+    null
   )
 
 let settings.protocol.aws.path =
@@ -1030,7 +1030,7 @@ def synth_protocol(~rlog=_, ~maxtime=_, text) =
   if
     list.exists(fun (l) -> list.length(l) != 2, args)
   then
-    null()
+    null
   else
     args =
       list.map(
@@ -1091,7 +1091,7 @@ def synth_protocol(~rlog=_, ~maxtime=_, text) =
       synth(square(duration=duration(), frequency()))
     elsif shape() == "blank" then synth(blank(duration=duration()))
     else
-      null()
+      null
     end
   end
 end

--- a/src/libs/replaygain.liq
+++ b/src/libs/replaygain.liq
@@ -4,7 +4,7 @@
 # @category Source / Audio processing
 # @param ~id Force the value of the source ID.
 # @param s Source to be amplified.
-def replaygain(~id=null, s) =
+def replaygain(~id=null.make(), s) =
   amplify(id=id, override="replaygain_track_gain", 1., s)
 end
 
@@ -22,7 +22,7 @@ def file.replaygain.compute(~ratio=50., file_name) =
   if
     request.resolve(_request)
   then
-    get_gain = ref(fun () -> null)
+    get_gain = ref(fun () -> null.make())
     def process(s) =
       s = source.replaygain.compute(s)
       get_gain := {s.gain()}
@@ -34,7 +34,7 @@ def file.replaygain.compute(~ratio=50., file_name) =
     fn = get_gain()
     fn()
   else
-    null
+    null.make()
   end
 end
 
@@ -48,7 +48,7 @@ def metadata.replaygain(_metadata) =
     try
       float_of_string(_metadata["r128_track_gain"]) / 256.
     catch _ do
-      null
+      null.make()
     end
   elsif
     list.assoc.mem("replaygain_track_gain", _metadata)
@@ -58,10 +58,10 @@ def metadata.replaygain(_metadata) =
     try
       float_of_string(list.assoc(1, match))
     catch _ do
-      null
+      null.make()
     end
   else
-    null
+    null.make()
   end
 end
 
@@ -72,7 +72,7 @@ end
 # @param ~ratio Decoding ratio. A value of `50` means try to decode the file `50x` faster than real time, if possible.
 #               Use this setting to lower CPU peaks when computing replaygain tags.
 # @param file_name File name.
-def replaces file.replaygain(~id=null, ~compute=true, ~ratio=50., file_name) =
+def replaces file.replaygain(~id=null.make(), ~compute=true, ~ratio=50., file_name) =
   id = string.id.default(default="file.replaygain", id)
   file_name_quoted = string.quote(file_name)
 
@@ -80,7 +80,7 @@ def replaces file.replaygain(~id=null, ~compute=true, ~ratio=50., file_name) =
   gain = metadata.replaygain(_metadata)
 
   if
-    gain != null
+    gain != null.make()
   then
     log.info(
       label=id,
@@ -98,7 +98,7 @@ def replaces file.replaygain(~id=null, ~compute=true, ~ratio=50., file_name) =
     gain = file.replaygain.compute(ratio=ratio, file_name)
     elapsed_time = time() - start_time
     if
-      gain != null
+      gain != null.make()
     then
       log.info(
         label=id,
@@ -109,7 +109,7 @@ def replaces file.replaygain(~id=null, ~compute=true, ~ratio=50., file_name) =
     end
     gain
   else
-    null
+    null.make()
   end
 end
 
@@ -125,7 +125,7 @@ def enable_replaygain_metadata(~compute=true, ~ratio=50.) =
   def replaygain_metadata(~metadata=_, file_name) =
     gain = file.replaygain(compute=compute, ratio=ratio, file_name)
     if
-      gain != null
+      gain != null.make()
     then
       [
         (

--- a/src/libs/replaygain.liq
+++ b/src/libs/replaygain.liq
@@ -4,7 +4,7 @@
 # @category Source / Audio processing
 # @param ~id Force the value of the source ID.
 # @param s Source to be amplified.
-def replaygain(~id=null(), s) =
+def replaygain(~id=null, s) =
   amplify(id=id, override="replaygain_track_gain", 1., s)
 end
 
@@ -22,7 +22,7 @@ def file.replaygain.compute(~ratio=50., file_name) =
   if
     request.resolve(_request)
   then
-    get_gain = ref(fun () -> null())
+    get_gain = ref(fun () -> null)
     def process(s) =
       s = source.replaygain.compute(s)
       get_gain := {s.gain()}
@@ -34,7 +34,7 @@ def file.replaygain.compute(~ratio=50., file_name) =
     fn = get_gain()
     fn()
   else
-    null()
+    null
   end
 end
 
@@ -48,7 +48,7 @@ def metadata.replaygain(_metadata) =
     try
       float_of_string(_metadata["r128_track_gain"]) / 256.
     catch _ do
-      null()
+      null
     end
   elsif
     list.assoc.mem("replaygain_track_gain", _metadata)
@@ -58,10 +58,10 @@ def metadata.replaygain(_metadata) =
     try
       float_of_string(list.assoc(1, match))
     catch _ do
-      null()
+      null
     end
   else
-    null()
+    null
   end
 end
 
@@ -72,7 +72,7 @@ end
 # @param ~ratio Decoding ratio. A value of `50` means try to decode the file `50x` faster than real time, if possible.
 #               Use this setting to lower CPU peaks when computing replaygain tags.
 # @param file_name File name.
-def replaces file.replaygain(~id=null(), ~compute=true, ~ratio=50., file_name) =
+def replaces file.replaygain(~id=null, ~compute=true, ~ratio=50., file_name) =
   id = string.id.default(default="file.replaygain", id)
   file_name_quoted = string.quote(file_name)
 
@@ -80,7 +80,7 @@ def replaces file.replaygain(~id=null(), ~compute=true, ~ratio=50., file_name) =
   gain = metadata.replaygain(_metadata)
 
   if
-    gain != null()
+    gain != null
   then
     log.info(
       label=id,
@@ -98,7 +98,7 @@ def replaces file.replaygain(~id=null(), ~compute=true, ~ratio=50., file_name) =
     gain = file.replaygain.compute(ratio=ratio, file_name)
     elapsed_time = time() - start_time
     if
-      gain != null()
+      gain != null
     then
       log.info(
         label=id,
@@ -109,7 +109,7 @@ def replaces file.replaygain(~id=null(), ~compute=true, ~ratio=50., file_name) =
     end
     gain
   else
-    null()
+    null
   end
 end
 
@@ -125,7 +125,7 @@ def enable_replaygain_metadata(~compute=true, ~ratio=50.) =
   def replaygain_metadata(~metadata=_, file_name) =
     gain = file.replaygain(compute=compute, ratio=ratio, file_name)
     if
-      gain != null()
+      gain != null
     then
       [
         (

--- a/src/libs/request.liq
+++ b/src/libs/request.liq
@@ -32,12 +32,12 @@ end
 # @method push Push a request on the request queue.
 # @method length Length of the queue.
 def request.queue(
-  ~id=null,
+  ~id=null.make(),
   ~interactive=true,
-  ~prefetch=null,
+  ~prefetch=null.make(),
   ~native=false,
   ~queue=[],
-  ~timeout=null
+  ~timeout=null.make()
 ) =
   ignore(native)
   id = string.id.default(default="request.queue", id)
@@ -54,7 +54,7 @@ def request.queue(
       queue := q
       (r : request)
     else
-      null
+      null.make()
     end
   end
 
@@ -214,7 +214,7 @@ end
 # @category Source / Input
 # @param ~timeout Timeout in seconds for resolving the request.
 # @param r Request to play.
-def request.once(~id=null("request.once"), ~timeout=null, r) =
+def request.once(~id=null.make("request.once"), ~timeout=null.make(), r) =
   id = string.id.default(default="request.once", id)
 
   done = ref(false)
@@ -224,7 +224,7 @@ def request.once(~id=null("request.once"), ~timeout=null, r) =
     if
       done()
     then
-      null
+      null.make()
     else
       done := true
       if
@@ -258,10 +258,10 @@ end
 # @param ~fallible Enforce fallibility of the request.
 # @param r Request
 def request.single(
-  ~id=null("request.single"),
-  ~prefetch=null,
-  ~timeout=null,
-  ~fallible=null,
+  ~id=null.make("request.single"),
+  ~prefetch=null.make(),
+  ~timeout=null.make(),
+  ~fallible=null.make(),
   r
 ) =
   id = string.id.default(default="single", id)
@@ -299,7 +299,7 @@ def request.single(
     )
   end
 
-  static_request = ref(null)
+  static_request = ref(null.make())
 
   def on_wake_up(s) =
     if
@@ -333,7 +333,7 @@ def request.single(
     then
       request.destroy(null.get(static_request()))
     end
-    static_request := null
+    static_request := null.make()
   end
 
   def next() =
@@ -376,10 +376,10 @@ end
 # @param uri URI where to find the file
 def single(
   %argsof(request.single[!id,!fallible]),
-  ~id=null("single"),
+  ~id=null.make("single"),
   ~fallible=false,
-  ~cue_in_metadata=null("liq_cue_in"),
-  ~cue_out_metadata=null("liq_cue_out"),
+  ~cue_in_metadata=null.make("liq_cue_in"),
+  ~cue_out_metadata=null.make("liq_cue_out"),
   uri
 ) =
   r =
@@ -447,11 +447,11 @@ def request.player(~simultaneous=true) =
         }
     }
   else
-    next_source = ref(null)
+    next_source = ref(null.make())
 
     def next() =
       s = next_source()
-      next_source := null
+      next_source := null.make()
       s
     end
 

--- a/src/libs/request.liq
+++ b/src/libs/request.liq
@@ -32,12 +32,12 @@ end
 # @method push Push a request on the request queue.
 # @method length Length of the queue.
 def request.queue(
-  ~id=null(),
+  ~id=null,
   ~interactive=true,
-  ~prefetch=null(),
+  ~prefetch=null,
   ~native=false,
   ~queue=[],
-  ~timeout=null()
+  ~timeout=null
 ) =
   ignore(native)
   id = string.id.default(default="request.queue", id)
@@ -54,7 +54,7 @@ def request.queue(
       queue := q
       (r : request)
     else
-      null()
+      null
     end
   end
 
@@ -214,7 +214,7 @@ end
 # @category Source / Input
 # @param ~timeout Timeout in seconds for resolving the request.
 # @param r Request to play.
-def request.once(~id=null("request.once"), ~timeout=null(), r) =
+def request.once(~id=null("request.once"), ~timeout=null, r) =
   id = string.id.default(default="request.once", id)
 
   done = ref(false)
@@ -224,7 +224,7 @@ def request.once(~id=null("request.once"), ~timeout=null(), r) =
     if
       done()
     then
-      null()
+      null
     else
       done := true
       if
@@ -259,9 +259,9 @@ end
 # @param r Request
 def request.single(
   ~id=null("request.single"),
-  ~prefetch=null(),
-  ~timeout=null(),
-  ~fallible=null(),
+  ~prefetch=null,
+  ~timeout=null,
+  ~fallible=null,
   r
 ) =
   id = string.id.default(default="single", id)
@@ -299,7 +299,7 @@ def request.single(
     )
   end
 
-  static_request = ref(null())
+  static_request = ref(null)
 
   def on_wake_up(s) =
     if
@@ -333,7 +333,7 @@ def request.single(
     then
       request.destroy(null.get(static_request()))
     end
-    static_request := null()
+    static_request := null
   end
 
   def next() =
@@ -447,11 +447,11 @@ def request.player(~simultaneous=true) =
         }
     }
   else
-    next_source = ref(null())
+    next_source = ref(null)
 
     def next() =
       s = next_source()
-      next_source := null()
+      next_source := null
       s
     end
 

--- a/src/libs/source.liq
+++ b/src/libs/source.liq
@@ -32,7 +32,7 @@ end
 # @category Metadata
 def track.metadata.deduplicate(
   ~id=null("track.metadata.deduplicate"),
-  ~using=null(),
+  ~using=null,
   t
 ) =
   last_meta = ref([])
@@ -69,7 +69,7 @@ end
 #               when `null`.
 # @param ~id Source id
 # @param s source
-def metadata.deduplicate(~id=null("metadata.deduplicate"), ~using=null(), s) =
+def metadata.deduplicate(~id=null("metadata.deduplicate"), ~using=null, s) =
   tracks = source.tracks(s)
   source(
     id=id,
@@ -144,7 +144,7 @@ end
 # @param ~delay Time to wait before the first run (in seconds).
 # @param ~every How often to run the function (in seconds). The function is run once if `null`.
 # @param f Function to run.
-def source.run(s, ~delay=0., ~every=null(), f) =
+def source.run(s, ~delay=0., ~every=null, f) =
   next = ref(delay)
 
   def check() =
@@ -170,13 +170,13 @@ end
 # @param ~merge Merge the track with its appended track.
 # @flag extra
 def append(~id=null("append"), ~insert_missing=true, ~merge=false, s, f) =
-  last_meta = ref(null())
-  pending = ref(null())
+  last_meta = ref(null)
+  pending = ref(null)
 
   def next() =
     p = pending()
-    pending := null()
-    last_meta := null()
+    pending := null
+    last_meta := null
 
     if null.defined(p) then null.get(p) else (s : source) end
   end
@@ -193,8 +193,8 @@ def append(~id=null("append"), ~insert_missing=true, ~merge=false, s, f) =
       if
         m["liq_append"] == "false"
       then
-        last_meta := null()
-        pending := null()
+        last_meta := null
+        pending := null
       elsif
         last_meta() != m
       then
@@ -219,12 +219,12 @@ def append(~id=null("append"), ~insert_missing=true, ~merge=false, s, f) =
       fun (s) -> pending.set(s),
     cancel_pending=
       # Cancel any pending appended source.
-      fun () -> pending.set(null()),
+      fun () -> pending.set(null),
     skip=
       # Skip the current track. Pending appended source are cancelled by default. Pass `cancel_pending=false` to keep it.
       fun (~cancel_pending=true) ->
         begin
-          if cancel_pending then pending.set(null()) end
+          if cancel_pending then pending.set(null) end
           s.skip()
         end
   }
@@ -237,18 +237,18 @@ end
 # @param ~merge Merge the track with its appended track.
 # @flag extra
 def prepend(~id=null("prepend"), ~merge=false, s, f) =
-  last_meta = ref(null())
+  last_meta = ref(null)
 
   def on_meta(m) =
     if
       m["liq_prepend"] == "false"
     then
-      last_meta := null()
+      last_meta := null
     elsif last_meta() != m then last_meta := m
     end
   end
 
-  s = source.on_track(s, fun (m) -> m == [] ? last_meta := null() : on_meta(m) )
+  s = source.on_track(s, fun (m) -> m == [] ? last_meta := null : on_meta(m) )
   s = source.on_metadata(s, on_meta)
 
   def next() =
@@ -256,7 +256,7 @@ def prepend(~id=null("prepend"), ~merge=false, s, f) =
       null.defined(last_meta)
     then
       m = last_meta()
-      last_meta := null()
+      last_meta := null
       if
         null.defined(m)
       then

--- a/src/libs/source.liq
+++ b/src/libs/source.liq
@@ -1,7 +1,7 @@
 # Create an audio source from the given track, with
 # metadata and track marks from that same track.
 # @category Source / Track processing
-def source.audio(~id=null("source.audio"), audio) =
+def source.audio(~id=null.make("source.audio"), audio) =
   source(
     id=id,
     {
@@ -15,7 +15,7 @@ end
 # Create a video source from the given track, with
 # metadata and track marks from that same track.
 # @category Source / Track processing
-def source.video(~id=null("source.video"), video) =
+def source.video(~id=null.make("source.video"), video) =
   source(
     id=id,
     {
@@ -31,8 +31,8 @@ end
 #               when `null`.
 # @category Metadata
 def track.metadata.deduplicate(
-  ~id=null("track.metadata.deduplicate"),
-  ~using=null,
+  ~id=null.make("track.metadata.deduplicate"),
+  ~using=null.make(),
   t
 ) =
   last_meta = ref([])
@@ -69,7 +69,7 @@ end
 #               when `null`.
 # @param ~id Source id
 # @param s source
-def metadata.deduplicate(~id=null("metadata.deduplicate"), ~using=null, s) =
+def metadata.deduplicate(~id=null.make("metadata.deduplicate"), ~using=null.make(), s) =
   tracks = source.tracks(s)
   source(
     id=id,
@@ -81,7 +81,7 @@ end
 # @category Source / Track processing
 # @argsof track.metadata.map
 def metadata.map(
-  ~id=null("metadata.map"),
+  ~id=null.make("metadata.map"),
   %argsof(track.metadata.map[!id]),
   f,
   (s:source)
@@ -107,7 +107,7 @@ end
 # Creates a source that plays only one track of the input source.
 # @category Source / Track processing
 # @param s The input source.
-def once(~id=null("once"), s) =
+def once(~id=null.make("once"), s) =
   sequence(id=id, [(s : source), source.fail()])
 end
 
@@ -119,7 +119,7 @@ end
 # @param ~min_noise Minimum duration of noise required to end silence, in seconds.
 # @param ~track_sensitive Reset blank counter at each track.
 def blank.skip(
-  ~id=null("blank.skip"),
+  ~id=null.make("blank.skip"),
   ~threshold=-40.,
   ~max_blank=20.,
   ~min_noise=0.,
@@ -144,7 +144,7 @@ end
 # @param ~delay Time to wait before the first run (in seconds).
 # @param ~every How often to run the function (in seconds). The function is run once if `null`.
 # @param f Function to run.
-def source.run(s, ~delay=0., ~every=null, f) =
+def source.run(s, ~delay=0., ~every=null.make(), f) =
   next = ref(delay)
 
   def check() =
@@ -169,14 +169,14 @@ end
 # @param ~insert_missing Treat track beginnings without metadata as having empty one.
 # @param ~merge Merge the track with its appended track.
 # @flag extra
-def append(~id=null("append"), ~insert_missing=true, ~merge=false, s, f) =
-  last_meta = ref(null)
-  pending = ref(null)
+def append(~id=null.make("append"), ~insert_missing=true, ~merge=false, s, f) =
+  last_meta = ref(null.make())
+  pending = ref(null.make())
 
   def next() =
     p = pending()
-    pending := null
-    last_meta := null
+    pending := null.make()
+    last_meta := null.make()
 
     if null.defined(p) then null.get(p) else (s : source) end
   end
@@ -193,8 +193,8 @@ def append(~id=null("append"), ~insert_missing=true, ~merge=false, s, f) =
       if
         m["liq_append"] == "false"
       then
-        last_meta := null
-        pending := null
+        last_meta := null.make()
+        pending := null.make()
       elsif
         last_meta() != m
       then
@@ -219,12 +219,12 @@ def append(~id=null("append"), ~insert_missing=true, ~merge=false, s, f) =
       fun (s) -> pending.set(s),
     cancel_pending=
       # Cancel any pending appended source.
-      fun () -> pending.set(null),
+      fun () -> pending.set(null.make()),
     skip=
       # Skip the current track. Pending appended source are cancelled by default. Pass `cancel_pending=false` to keep it.
       fun (~cancel_pending=true) ->
         begin
-          if cancel_pending then pending.set(null) end
+          if cancel_pending then pending.set(null.make()) end
           s.skip()
         end
   }
@@ -236,19 +236,19 @@ end
 # @param f Given the metadata, build the source producing the track to append. The function can return `null` to prevent any track prepend.
 # @param ~merge Merge the track with its appended track.
 # @flag extra
-def prepend(~id=null("prepend"), ~merge=false, s, f) =
-  last_meta = ref(null)
+def prepend(~id=null.make("prepend"), ~merge=false, s, f) =
+  last_meta = ref(null.make())
 
   def on_meta(m) =
     if
       m["liq_prepend"] == "false"
     then
-      last_meta := null
+      last_meta := null.make()
     elsif last_meta() != m then last_meta := m
     end
   end
 
-  s = source.on_track(s, fun (m) -> m == [] ? last_meta := null : on_meta(m) )
+  s = source.on_track(s, fun (m) -> m == [] ? last_meta := null.make() : on_meta(m) )
   s = source.on_metadata(s, on_meta)
 
   def next() =
@@ -256,7 +256,7 @@ def prepend(~id=null("prepend"), ~merge=false, s, f) =
       null.defined(last_meta)
     then
       m = last_meta()
-      last_meta := null
+      last_meta := null.make()
       if
         null.defined(m)
       then

--- a/src/libs/sqlite.liq
+++ b/src/libs/sqlite.liq
@@ -36,7 +36,7 @@ def replaces sqlite(file) =
     db.exec(sql)
   end
 
-  def db.select(~table, what="*", ~where="", ~limit=null) =
+  def db.select(~table, what="*", ~where="", ~limit=null.make()) =
     where =
       if
         where == ""

--- a/src/libs/sqlite.liq
+++ b/src/libs/sqlite.liq
@@ -36,7 +36,7 @@ def replaces sqlite(file) =
     db.exec(sql)
   end
 
-  def db.select(~table, what="*", ~where="", ~limit=null()) =
+  def db.select(~table, what="*", ~where="", ~limit=null) =
     where =
       if
         where == ""

--- a/src/libs/string.liq
+++ b/src/libs/string.liq
@@ -49,7 +49,7 @@ end
 
 # Split a string in two at first "separator".
 # @category String
-def string.split.first(~encoding=null, ~separator, s) =
+def string.split.first(~encoding=null.make(), ~separator, s) =
   n = string.length(encoding=encoding, s)
   l = string.length(encoding=encoding, separator)
   i = string.index(substring=separator, s)
@@ -76,7 +76,7 @@ end
 # @param ~suffix Suffix to look for.
 # @param s The string to look into.
 def string.contains(
-  ~encoding=null,
+  ~encoding=null.make(),
   ~prefix="",
   ~substring="",
   ~suffix="",
@@ -139,7 +139,7 @@ end
 # @category String
 # @param ~encoding Encoding used to split characters. Should be one of: `"utf8"` or `"ascii"`
 # @param ~prefix Requested prefix.
-def string.residual(~encoding=null, ~prefix, s) =
+def string.residual(~encoding=null.make(), ~prefix, s) =
   n = string.length(encoding=encoding, prefix)
   if
     string.contains(encoding=encoding, prefix=prefix, s)
@@ -151,7 +151,7 @@ def string.residual(~encoding=null, ~prefix, s) =
       length=string.length(encoding=encoding, s) - n
     )
   else
-    null
+    null.make()
   end
 end
 
@@ -268,7 +268,7 @@ end
 # following JSON and javascript specification.
 # @category String
 # @param ~encoding One of: `"ascii"` or `"utf8"`. If `null`, `utf8` is tried first and `ascii` is used as a fallback if this fails.
-def string.quote(~encoding=null, s) =
+def string.quote(~encoding=null.make(), s) =
   def special_char(~encoding, s) =
     if
       s == "'"
@@ -331,7 +331,7 @@ def string.data_uri.decode(s) =
 
     data.{mime=mime}
   else
-    null
+    null.make()
   end
 end
 

--- a/src/libs/string.liq
+++ b/src/libs/string.liq
@@ -49,7 +49,7 @@ end
 
 # Split a string in two at first "separator".
 # @category String
-def string.split.first(~encoding=null(), ~separator, s) =
+def string.split.first(~encoding=null, ~separator, s) =
   n = string.length(encoding=encoding, s)
   l = string.length(encoding=encoding, separator)
   i = string.index(substring=separator, s)
@@ -76,7 +76,7 @@ end
 # @param ~suffix Suffix to look for.
 # @param s The string to look into.
 def string.contains(
-  ~encoding=null(),
+  ~encoding=null,
   ~prefix="",
   ~substring="",
   ~suffix="",
@@ -139,7 +139,7 @@ end
 # @category String
 # @param ~encoding Encoding used to split characters. Should be one of: `"utf8"` or `"ascii"`
 # @param ~prefix Requested prefix.
-def string.residual(~encoding=null(), ~prefix, s) =
+def string.residual(~encoding=null, ~prefix, s) =
   n = string.length(encoding=encoding, prefix)
   if
     string.contains(encoding=encoding, prefix=prefix, s)
@@ -151,7 +151,7 @@ def string.residual(~encoding=null(), ~prefix, s) =
       length=string.length(encoding=encoding, s) - n
     )
   else
-    null()
+    null
   end
 end
 
@@ -268,7 +268,7 @@ end
 # following JSON and javascript specification.
 # @category String
 # @param ~encoding One of: `"ascii"` or `"utf8"`. If `null`, `utf8` is tried first and `ascii` is used as a fallback if this fails.
-def string.quote(~encoding=null(), s) =
+def string.quote(~encoding=null, s) =
   def special_char(~encoding, s) =
     if
       s == "'"
@@ -331,7 +331,7 @@ def string.data_uri.decode(s) =
 
     data.{mime=mime}
   else
-    null()
+    null
   end
 end
 

--- a/src/libs/switches.liq
+++ b/src/libs/switches.liq
@@ -7,7 +7,7 @@
 # @param ~transition_length Maximum transition duration.
 # @param ~transitions Transition functions, padded with `fun (x,y) -> y` functions.
 def fallback(
-  ~id=null,
+  ~id=null.make(),
   ~override="liq_transition_length",
   ~replay_metadata=true,
   ~track_sensitive=true,
@@ -39,7 +39,7 @@ end
 # @param ~transitions Transition functions, padded with `fun (x,y) -> y` functions.
 # @param ~weights Weights of the children (padded with 1), defining for each child how many tracks are played from it per round, if that many are actually available.
 def rotate(
-  ~id=null,
+  ~id=null.make(),
   ~override="liq_transition_length",
   ~replay_metadata=true,
   ~transition_length=5.,
@@ -157,7 +157,7 @@ end
 # @param ~transitions Transition functions, padded with `fun (x,y) -> y` functions.
 # @param ~weights Weights of the children (padded with 1), defining for each child the probability that it is selected.
 def replaces random(
-  ~id=null,
+  ~id=null.make(),
   ~override="liq_transition_length",
   ~replay_metadata=true,
   ~transition_length=5.,

--- a/src/libs/switches.liq
+++ b/src/libs/switches.liq
@@ -7,7 +7,7 @@
 # @param ~transition_length Maximum transition duration.
 # @param ~transitions Transition functions, padded with `fun (x,y) -> y` functions.
 def fallback(
-  ~id=null(),
+  ~id=null,
   ~override="liq_transition_length",
   ~replay_metadata=true,
   ~track_sensitive=true,
@@ -39,7 +39,7 @@ end
 # @param ~transitions Transition functions, padded with `fun (x,y) -> y` functions.
 # @param ~weights Weights of the children (padded with 1), defining for each child how many tracks are played from it per round, if that many are actually available.
 def rotate(
-  ~id=null(),
+  ~id=null,
   ~override="liq_transition_length",
   ~replay_metadata=true,
   ~transition_length=5.,
@@ -157,7 +157,7 @@ end
 # @param ~transitions Transition functions, padded with `fun (x,y) -> y` functions.
 # @param ~weights Weights of the children (padded with 1), defining for each child the probability that it is selected.
 def replaces random(
-  ~id=null(),
+  ~id=null,
   ~override="liq_transition_length",
   ~replay_metadata=true,
   ~transition_length=5.,

--- a/src/libs/thread.liq
+++ b/src/libs/thread.liq
@@ -9,8 +9,8 @@
 def replaces thread.run(
   ~fast=true,
   ~delay=0.,
-  ~on_error=null,
-  ~every=null,
+  ~on_error=null.make(),
+  ~every=null.make(),
   f
 ) =
   every = every ?? getter(-1.)
@@ -54,7 +54,7 @@ def thread.when(
   ~every=getter(0.5),
   ~once=false,
   ~changed=true,
-  ~on_error=null,
+  ~on_error=null.make(),
   p,
   f
 ) =
@@ -83,4 +83,4 @@ def default_error_handler(~backtrace, err) =
   )
 end
 
-thread.on_error(null, default_error_handler)
+thread.on_error(null.make(), default_error_handler)

--- a/src/libs/thread.liq
+++ b/src/libs/thread.liq
@@ -9,8 +9,8 @@
 def replaces thread.run(
   ~fast=true,
   ~delay=0.,
-  ~on_error=null(),
-  ~every=null(),
+  ~on_error=null,
+  ~every=null,
   f
 ) =
   every = every ?? getter(-1.)
@@ -54,7 +54,7 @@ def thread.when(
   ~every=getter(0.5),
   ~once=false,
   ~changed=true,
-  ~on_error=null(),
+  ~on_error=null,
   p,
   f
 ) =
@@ -83,4 +83,4 @@ def default_error_handler(~backtrace, err) =
   )
 end
 
-thread.on_error(null(), default_error_handler)
+thread.on_error(null, default_error_handler)

--- a/src/libs/tracks.liq
+++ b/src/libs/tracks.liq
@@ -3,34 +3,34 @@ let source.mux.track = ()
 
 # Replace the audio track of a source.
 # @category Source / Track processing
-def source.mux.track.audio(~id=null, ~audio, s) =
+def source.mux.track.audio(~id=null.make(), ~audio, s) =
   source(id=id, source.tracks(s).{audio=audio})
 end
 
 # Replace the video track of a source.
 # @category Source / Track processing
-def source.mux.track.video(~id=null, ~video, s) =
+def source.mux.track.video(~id=null.make(), ~video, s) =
   source(id=id, source.tracks(s).{video=video})
 end
 
 # Replace the audio track of a source by the one of another source.
 # @category Source / Track processing
 # @param ~audio Source whose audio track is to be taken.
-def source.mux.audio(~id=null, ~(audio:source), s) =
+def source.mux.audio(~id=null.make(), ~(audio:source), s) =
   source.mux.track.audio(id=id, audio=source.tracks(audio).audio, s)
 end
 
 # Replace the video track of a source by the one of another source.
 # @category Source / Track processing
 # @param ~audio Source whose video track is to be taken.
-def source.mux.video(~id=null, ~(video:source), s) =
+def source.mux.video(~id=null.make(), ~(video:source), s) =
   source.mux.track.video(id=id, video=source.tracks(video).video, s)
 end
 
 # Replace the midi track of a source by the one of another source.
 # @category Source / Track processing
 # @param ~midi Source whose midi track is to be taken.
-def source.mux.midi(~id=null, ~(midi:source), s) =
+def source.mux.midi(~id=null.make(), ~(midi:source), s) =
   source(id=id, source.tracks(s).{midi=source.tracks(midi).midi})
 end
 
@@ -38,42 +38,42 @@ let source.drop = ()
 
 # Remove the audio track of a source.
 # @category Source / Track processing
-def source.drop.audio(~id=null, s) =
+def source.drop.audio(~id=null.make(), s) =
   let {audio = _, ...tracks} = source.tracks(s)
   source(id=id, tracks)
 end
 
 # Remove the video track of a source.
 # @category Source / Track processing
-def source.drop.video(~id=null, s) =
+def source.drop.video(~id=null.make(), s) =
   let {video = _, ...tracks} = source.tracks(s)
   source(id=id, tracks)
 end
 
 # Remove the midi track of a source.
 # @category Source / Track processing
-def source.drop.midi(~id=null, s) =
+def source.drop.midi(~id=null.make(), s) =
   let {midi = _, ...tracks} = source.tracks(s)
   source(id=id, tracks)
 end
 
 # Remove the metadata track of a source.
 # @category Source / Track processing
-def source.drop.metadata(~id=null, s) =
+def source.drop.metadata(~id=null.make(), s) =
   let {metadata = _, ...tracks} = source.tracks(s)
   source(id=id, tracks)
 end
 
 # Remove the track marks of a source.
 # @category Source / Track processing
-def source.drop.track_marks(~id=null, s) =
+def source.drop.track_marks(~id=null.make(), s) =
   let {track_marks = _, ...tracks} = source.tracks(s)
   source(id=id, tracks)
 end
 
 # Remove the metadata and track marks of a source.
 # @category Source / Track processing
-def source.drop.metadata_track_marks(~id=null, s) =
+def source.drop.metadata_track_marks(~id=null.make(), s) =
   let {metadata = _, track_marks = _, ...tracks} = source.tracks(s)
   source(id=id, tracks)
 end

--- a/src/libs/tracks.liq
+++ b/src/libs/tracks.liq
@@ -3,34 +3,34 @@ let source.mux.track = ()
 
 # Replace the audio track of a source.
 # @category Source / Track processing
-def source.mux.track.audio(~id=null(), ~audio, s) =
+def source.mux.track.audio(~id=null, ~audio, s) =
   source(id=id, source.tracks(s).{audio=audio})
 end
 
 # Replace the video track of a source.
 # @category Source / Track processing
-def source.mux.track.video(~id=null(), ~video, s) =
+def source.mux.track.video(~id=null, ~video, s) =
   source(id=id, source.tracks(s).{video=video})
 end
 
 # Replace the audio track of a source by the one of another source.
 # @category Source / Track processing
 # @param ~audio Source whose audio track is to be taken.
-def source.mux.audio(~id=null(), ~(audio:source), s) =
+def source.mux.audio(~id=null, ~(audio:source), s) =
   source.mux.track.audio(id=id, audio=source.tracks(audio).audio, s)
 end
 
 # Replace the video track of a source by the one of another source.
 # @category Source / Track processing
 # @param ~audio Source whose video track is to be taken.
-def source.mux.video(~id=null(), ~(video:source), s) =
+def source.mux.video(~id=null, ~(video:source), s) =
   source.mux.track.video(id=id, video=source.tracks(video).video, s)
 end
 
 # Replace the midi track of a source by the one of another source.
 # @category Source / Track processing
 # @param ~midi Source whose midi track is to be taken.
-def source.mux.midi(~id=null(), ~(midi:source), s) =
+def source.mux.midi(~id=null, ~(midi:source), s) =
   source(id=id, source.tracks(s).{midi=source.tracks(midi).midi})
 end
 
@@ -38,42 +38,42 @@ let source.drop = ()
 
 # Remove the audio track of a source.
 # @category Source / Track processing
-def source.drop.audio(~id=null(), s) =
+def source.drop.audio(~id=null, s) =
   let {audio = _, ...tracks} = source.tracks(s)
   source(id=id, tracks)
 end
 
 # Remove the video track of a source.
 # @category Source / Track processing
-def source.drop.video(~id=null(), s) =
+def source.drop.video(~id=null, s) =
   let {video = _, ...tracks} = source.tracks(s)
   source(id=id, tracks)
 end
 
 # Remove the midi track of a source.
 # @category Source / Track processing
-def source.drop.midi(~id=null(), s) =
+def source.drop.midi(~id=null, s) =
   let {midi = _, ...tracks} = source.tracks(s)
   source(id=id, tracks)
 end
 
 # Remove the metadata track of a source.
 # @category Source / Track processing
-def source.drop.metadata(~id=null(), s) =
+def source.drop.metadata(~id=null, s) =
   let {metadata = _, ...tracks} = source.tracks(s)
   source(id=id, tracks)
 end
 
 # Remove the track marks of a source.
 # @category Source / Track processing
-def source.drop.track_marks(~id=null(), s) =
+def source.drop.track_marks(~id=null, s) =
   let {track_marks = _, ...tracks} = source.tracks(s)
   source(id=id, tracks)
 end
 
 # Remove the metadata and track marks of a source.
 # @category Source / Track processing
-def source.drop.metadata_track_marks(~id=null(), s) =
+def source.drop.metadata_track_marks(~id=null, s) =
   let {metadata = _, track_marks = _, ...tracks} = source.tracks(s)
   source(id=id, tracks)
 end

--- a/src/libs/video.liq
+++ b/src/libs/video.liq
@@ -26,15 +26,15 @@ end
 # @param ~y y position.
 # @param req Image request
 def request.image(
-  ~id=null,
+  ~id=null.make(),
   ~fallible=false,
-  ~width=null,
-  ~height=null,
+  ~width=null.make(),
+  ~height=null.make(),
   ~x=getter(0),
   ~y=getter(0),
   req
 ) =
-  last_req = ref(null)
+  last_req = ref(null.make())
 
   def next() =
     req = (getter.get(req) : request)
@@ -47,7 +47,7 @@ def request.image(
       image = video.crop(image)
       video.resize(id=id, x=x, y=y, width=width, height=height, image)
     else
-      null
+      null.make()
     end
   end
 
@@ -83,10 +83,10 @@ let orig_request = request
 # @param ~y y position.
 # @param ~request Request to add to the video track
 def track.video.add_request(
-  ~id=null("track.video.add_request"),
+  ~id=null.make("track.video.add_request"),
   ~fallible=false,
-  ~width=null,
-  ~height=null,
+  ~width=null.make(),
+  ~height=null.make(),
   ~x=getter(0),
   ~y=getter(0),
   ~request,
@@ -111,10 +111,10 @@ end
 # @param ~y y position.
 # @param ~file Path to the image file.
 def track.video.add_image(
-  ~id=null("track.video.add_image"),
+  ~id=null.make("track.video.add_image"),
   ~fallible=false,
-  ~width=null,
-  ~height=null,
+  ~width=null.make(),
+  ~height=null.make(),
   ~x=getter(0),
   ~y=getter(0),
   ~file,
@@ -137,10 +137,10 @@ end
 # @param ~y y position.
 # @param ~request Request to add to the video channel
 def video.add_request(
-  ~id=null("video.add_request"),
+  ~id=null.make("video.add_request"),
   ~fallible=false,
-  ~width=null,
-  ~height=null,
+  ~width=null.make(),
+  ~height=null.make(),
   ~x=getter(0),
   ~y=getter(0),
   ~request,
@@ -171,10 +171,10 @@ end
 # @param ~y y position.
 # @param ~file Path to the image file.
 def video.add_image(
-  ~id=null("video.add_image"),
+  ~id=null.make("video.add_image"),
   ~fallible=false,
-  ~width=null,
-  ~height=null,
+  ~width=null.make(),
+  ~height=null.make(),
   ~x=getter(0),
   ~y=getter(0),
   ~file,
@@ -194,7 +194,7 @@ end
 # @category Source / Video processing
 # @param s Audio source whose metadata contain cover-art.
 def video.cover(s) =
-  last_filename = ref(null)
+  last_filename = ref(null.make())
   fail = (source.fail() : source)
 
   def next() =
@@ -228,7 +228,7 @@ def video.cover(s) =
         fail
       end
     else
-      null
+      null.make()
     end
   end
 
@@ -249,7 +249,7 @@ let output.youtube.live = ()
 # @param ~encoder Encoder to use (most likely a `%ffmpeg` encoder)
 # @param ~key Your secret youtube key
 def output.youtube.live.rtmp(
-  ~id=null,
+  ~id=null.make(),
   ~fallible=false,
   ~on_start={()},
   ~on_stop={()},
@@ -285,7 +285,7 @@ end
 # @param ~encoder Encoder to use (most likely a `%ffmpeg` encoder)
 # @param ~key Your secret youtube key
 def output.youtube.live.hls(
-  ~id=null,
+  ~id=null.make(),
   ~fallible=false,
   ~on_start={()},
   ~on_stop={()},
@@ -349,12 +349,12 @@ end
 # @flag hidden
 def add_text_builder(f) =
   def at(
-    ~id=null,
-    ~duration=null,
+    ~id=null.make(),
+    ~duration=null.make(),
     ~color=getter(0xffffff),
     ~cycle=true,
-    ~font=null,
-    ~metadata=null,
+    ~font=null.make(),
+    ~metadata=null.make(),
     ~size=getter(18),
     ~speed=0,
     ~x=getter(10),
@@ -547,10 +547,10 @@ thread.run(
 # @param ~size Font size.
 # @param text Text to display.
 def replaces video.text(
-  ~id=null,
+  ~id=null.make(),
   ~color=getter(0xffffff),
-  ~duration=null,
-  ~font=null,
+  ~duration=null.make(),
+  ~font=null.make(),
   ~size=getter(18),
   text
 ) =
@@ -579,12 +579,12 @@ end
 # @param ~on_cycle Function called when text is cycling.
 # @params d Text to display.
 def replaces video.add_text(
-  ~id=null,
-  ~duration=null,
+  ~id=null.make(),
+  ~duration=null.make(),
   ~color=0xffffff,
   ~cycle=true,
-  ~font=null,
-  ~metadata=null,
+  ~font=null.make(),
+  ~metadata=null.make(),
   ~size=18,
   ~speed=0,
   ~x=getter(10),
@@ -652,7 +652,7 @@ end
 # @method prev Go to previous file.
 # @method current Currently displayed file.
 def video.slideshow(
-  ~id=null,
+  ~id=null.make(),
   ~cyclic=getter(true),
   ~advance=getter(-1.),
   l=[]
@@ -661,11 +661,11 @@ def video.slideshow(
   l = ref(l)
   n = ref(-1)
 
-  next_source = ref(null)
+  next_source = ref(null.make())
 
   def next() =
     s = next_source()
-    next_source := null
+    next_source := null.make()
     s
   end
 
@@ -754,7 +754,7 @@ end
 # @argsof track.video.tile
 # @argsof track.audio.add[!id]
 def video.tile(
-  ~id=null("video.tile"),
+  ~id=null.make("video.tile"),
   %argsof(track.audio.add[!id]),
   %argsof(track.video.tile[!id]),
   ~weights=[],

--- a/src/libs/video.liq
+++ b/src/libs/video.liq
@@ -26,15 +26,15 @@ end
 # @param ~y y position.
 # @param req Image request
 def request.image(
-  ~id=null(),
+  ~id=null,
   ~fallible=false,
-  ~width=null(),
-  ~height=null(),
+  ~width=null,
+  ~height=null,
   ~x=getter(0),
   ~y=getter(0),
   req
 ) =
-  last_req = ref(null())
+  last_req = ref(null)
 
   def next() =
     req = (getter.get(req) : request)
@@ -47,7 +47,7 @@ def request.image(
       image = video.crop(image)
       video.resize(id=id, x=x, y=y, width=width, height=height, image)
     else
-      null()
+      null
     end
   end
 
@@ -85,8 +85,8 @@ let orig_request = request
 def track.video.add_request(
   ~id=null("track.video.add_request"),
   ~fallible=false,
-  ~width=null(),
-  ~height=null(),
+  ~width=null,
+  ~height=null,
   ~x=getter(0),
   ~y=getter(0),
   ~request,
@@ -113,8 +113,8 @@ end
 def track.video.add_image(
   ~id=null("track.video.add_image"),
   ~fallible=false,
-  ~width=null(),
-  ~height=null(),
+  ~width=null,
+  ~height=null,
   ~x=getter(0),
   ~y=getter(0),
   ~file,
@@ -139,8 +139,8 @@ end
 def video.add_request(
   ~id=null("video.add_request"),
   ~fallible=false,
-  ~width=null(),
-  ~height=null(),
+  ~width=null,
+  ~height=null,
   ~x=getter(0),
   ~y=getter(0),
   ~request,
@@ -173,8 +173,8 @@ end
 def video.add_image(
   ~id=null("video.add_image"),
   ~fallible=false,
-  ~width=null(),
-  ~height=null(),
+  ~width=null,
+  ~height=null,
   ~x=getter(0),
   ~y=getter(0),
   ~file,
@@ -194,7 +194,7 @@ end
 # @category Source / Video processing
 # @param s Audio source whose metadata contain cover-art.
 def video.cover(s) =
-  last_filename = ref(null())
+  last_filename = ref(null)
   fail = (source.fail() : source)
 
   def next() =
@@ -228,7 +228,7 @@ def video.cover(s) =
         fail
       end
     else
-      null()
+      null
     end
   end
 
@@ -249,7 +249,7 @@ let output.youtube.live = ()
 # @param ~encoder Encoder to use (most likely a `%ffmpeg` encoder)
 # @param ~key Your secret youtube key
 def output.youtube.live.rtmp(
-  ~id=null(),
+  ~id=null,
   ~fallible=false,
   ~on_start={()},
   ~on_stop={()},
@@ -285,7 +285,7 @@ end
 # @param ~encoder Encoder to use (most likely a `%ffmpeg` encoder)
 # @param ~key Your secret youtube key
 def output.youtube.live.hls(
-  ~id=null(),
+  ~id=null,
   ~fallible=false,
   ~on_start={()},
   ~on_stop={()},
@@ -349,12 +349,12 @@ end
 # @flag hidden
 def add_text_builder(f) =
   def at(
-    ~id=null(),
-    ~duration=null(),
+    ~id=null,
+    ~duration=null,
     ~color=getter(0xffffff),
     ~cycle=true,
-    ~font=null(),
-    ~metadata=null(),
+    ~font=null,
+    ~metadata=null,
     ~size=getter(18),
     ~speed=0,
     ~x=getter(10),
@@ -547,10 +547,10 @@ thread.run(
 # @param ~size Font size.
 # @param text Text to display.
 def replaces video.text(
-  ~id=null(),
+  ~id=null,
   ~color=getter(0xffffff),
-  ~duration=null(),
-  ~font=null(),
+  ~duration=null,
+  ~font=null,
   ~size=getter(18),
   text
 ) =
@@ -579,12 +579,12 @@ end
 # @param ~on_cycle Function called when text is cycling.
 # @params d Text to display.
 def replaces video.add_text(
-  ~id=null(),
-  ~duration=null(),
+  ~id=null,
+  ~duration=null,
   ~color=0xffffff,
   ~cycle=true,
-  ~font=null(),
-  ~metadata=null(),
+  ~font=null,
+  ~metadata=null,
   ~size=18,
   ~speed=0,
   ~x=getter(10),
@@ -652,7 +652,7 @@ end
 # @method prev Go to previous file.
 # @method current Currently displayed file.
 def video.slideshow(
-  ~id=null(),
+  ~id=null,
   ~cyclic=getter(true),
   ~advance=getter(-1.),
   l=[]
@@ -661,11 +661,11 @@ def video.slideshow(
   l = ref(l)
   n = ref(-1)
 
-  next_source = ref(null())
+  next_source = ref(null)
 
   def next() =
     s = next_source()
-    next_source := null()
+    next_source := null
     s
   end
 

--- a/tests/harbor/http.liq
+++ b/tests/harbor/http.liq
@@ -252,7 +252,7 @@ def f() =
       "HTTP/1.0 201 YYR\r\nFoo: bar\r\n\r\n"
     )
     req.socket.close()
-    null()
+    null.make()
   end
 
   harbor.http.register.simple("/custom", port=3456, handler)

--- a/tests/harbor/http2.liq
+++ b/tests/harbor/http2.liq
@@ -5,7 +5,7 @@ def f() =
     )
 
   test.equal(content_disposition.type, "inline")
-  test.equal(content_disposition?.filename, null())
+  test.equal(content_disposition?.filename, null.make())
   test.equal(content_disposition.args, [])
   content_disposition =
     null.get(

--- a/tests/language/json.liq
+++ b/tests/language/json.liq
@@ -52,7 +52,7 @@ def f() =
   test.equal(json.stringify(json5=true, nan), 'NaN')
   let b = json()
   b.add("b", 1)
-  s = json.stringify({a=null({a=1}), b=null(b)})
+  s = json.stringify({a=null.make({a=1}), b=null.make(b)})
   test.equal(
     s,
     "{ \"a\": { \"a\": 1 }, \"b\": { \"b\": 1 } }"
@@ -100,12 +100,12 @@ def f() =
       gni_gno=true,
       nested=
         {
-          tuple=(null(), 3.14),
+          tuple=(null.make(), 3.14),
           list=[44., 55., 66.12],
-          nullable_list=[null(), 23, null()],
+          nullable_list=[null.make(), 23, null.make()],
           object_as_list=[("foo", 123.), ("gni", 456.0), ("gno", 3.14)],
           arbitrary_object_key=true,
-          not_present=null()
+          not_present=null.make()
         }
     }
   )
@@ -120,8 +120,8 @@ def f() =
   test.equal(t1, 123)
   test.equal(t2, 3.14)
   test.equal(t3, false)
-  test.equal(l1, null())
-  test.equal(tl, [23, null()])
+  test.equal(l1, null.make())
+  test.equal(tl, [23, null.make()])
   let json.parse x = data
   ignore(x.foo + 1.0)
   let (x, y, _) = x.nested.tuple
@@ -234,13 +234,13 @@ def f() =
   data =
     '{ "foo": 123 }'
   let json.parse (x : {foo: string}?) = data
-  test.equal(x, null())
+  test.equal(x, null.make())
   data =
     '[ "gni", 123 ]'
   let json.parse (x : [int]?) = data
-  test.equal(x, null())
+  test.equal(x, null.make())
   let json.parse (x : (string*int*bool)?) = data
-  test.equal(x, null())
+  test.equal(x, null.make())
   data =
     '[ "gni", 123, "gno" ]'
   let json.parse (x : (string*int)) = data
@@ -253,15 +253,15 @@ def f() =
     }
   }'
   let json.parse x = data
-  test.equal(x?.foo.gni?.bla, null(123))
+  test.equal(x?.foo.gni?.bla, null.make(123))
   data = '{
     "foo": {}
   }'
   let json.parse x = data
-  test.equal(x?.foo.gni?.bla, null())
+  test.equal(x?.foo.gni?.bla, null.make())
   data = '{}'
   let json.parse x = data
-  test.equal(x?.foo?.gni?.bla, null())
+  test.equal(x?.foo?.gni?.bla, null.make())
 
   # Test escaping of invalid utf8 strings.
   s =
@@ -292,7 +292,7 @@ def f() =
 }'
   )
 
-  e = ref(null())
+  e = ref(null.make())
 
   def f(data) =
     try

--- a/tests/language/list.liq
+++ b/tests/language/list.liq
@@ -38,7 +38,7 @@ def f() =
   test.equal(list.assoc(default=0, "", [("a", 1), ("b", 2)]), 0)
   test.equal(list.assoc("b", [("a", 1), ("b", 2)]), 2)
   test.equal(list.assoc.nullable("b", [("a", 1), ("b", 2)]), 2)
-  test.equal(list.assoc.nullable("x", [("a", 1), ("b", 2)]), null())
+  test.equal(list.assoc.nullable("x", [("a", 1), ("b", 2)]), null.make())
   test.equal(
     list.assoc.remove("a", [("b", 2), ("a", 1), ("a", 3)]), [("b", 2), ("a", 3)]
   )

--- a/tests/language/metadata.liq
+++ b/tests/language/metadata.liq
@@ -65,7 +65,7 @@ def f() =
       width=0,
       height=0,
       color_depth=0,
-      number_of_colors=null()
+      number_of_colors=null.make()
     }
   )
 

--- a/tests/language/null.liq
+++ b/tests/language/null.liq
@@ -1,14 +1,14 @@
 def f() =
-  test.equal(null() ?? "bla", "bla")
-  test.equal(null("foo") ?? "bla", "foo")
-  test.equal(null.case(null(), {true}, fun (_) -> false), true)
+  test.equal(null.make() ?? "bla", "bla")
+  test.equal(null.make("foo") ?? "bla", "foo")
+  test.equal(null.case(null.make(), {true}, fun (_) -> false), true)
   test.equal(null.case("x", {true}, fun (_) -> false), false)
   test.equal(null.get("x"), "x")
   test.equal(null.get(default="x", "y"), "y")
-  test.equal(null.get(default="x", null()), "x")
+  test.equal(null.get(default="x", null.make()), "x")
   test.equal(
     null.find(
-      fun (x) -> if x mod 2 == 0 then 2 * x else null() end, [1, 3, 2, 5]
+      fun (x) -> if x mod 2 == 0 then 2 * x else null.make() end, [1, 3, 2, 5]
     ),
     4
   )
@@ -18,20 +18,20 @@ def f() =
   end
 
   def g() =
-    if true then null() else (1 : int?) end
+    if true then null.make() else (1 : int?) end
   end
 
   # Subtyping
   def f() =
-    if true then null() else 1 end
+    if true then null.make() else 1 end
   end
 
   def f() =
-    if true then 1 else null() end
+    if true then 1 else null.make() end
   end
 
-  _ = [null(), 3]
-  _ = [3, null()]
+  _ = [null.make(), 3]
+  _ = [3, null.make()]
   test.pass()
 end
 

--- a/tests/language/record.liq
+++ b/tests/language/record.liq
@@ -106,7 +106,7 @@ def f() =
   test.equal(f(()), 3)
   test.equal(f({}), 3)
   test.equal(f({foo=1}), 2)
-  test.equal(f({foo=null()}), 3)
+  test.equal(f({foo=null.make()}), 3)
 
   def f(x) =
     ret = x?.foo(123)
@@ -116,7 +116,7 @@ def f() =
   test.equal(f(()), 1)
   test.equal(f({}), 1)
   test.equal(f({foo=(fun (x) -> x)}), 123)
-  test.equal(f({foo=null()}), 1)
+  test.equal(f({foo=null.make()}), 1)
 
   def f(x) =
     [x, {foo=123}]
@@ -168,7 +168,7 @@ def f() =
     x.foo?.gni.bla(1, 2, 3)
   end
 
-  test.equal(f({foo=null()}), null())
+  test.equal(f({foo=null.make()}), null.make())
 
   # We want to make sure that:
   def f(x) =
@@ -176,13 +176,13 @@ def f() =
   end
 
   # is properly typed as: ('B.{foo? : 'A}) -> 'A?
-  test.equal(f({}), null())
-  x = ({foo=null()} : {foo: int?})
-  test.equal(f(x), null())
-  x = ({foo=null()} : {foo?: int?})
-  test.equal(f(x), null())
-  test.equal(f(true), null())
-  test.equal(f({foo=1}), null(1))
+  test.equal(f({}), null.make())
+  x = ({foo=null.make()} : {foo: int?})
+  test.equal(f(x), null.make())
+  x = ({foo=null.make()} : {foo?: int?})
+  test.equal(f(x), null.make())
+  test.equal(f(true), null.make())
+  test.equal(f({foo=1}), null.make(1))
 
   # We want to make sure that:
   def f(x) =
@@ -191,10 +191,10 @@ def f() =
 
   # is properly typed as: ('A.{foo? : (int) -> 'B.{gni? : 'C}}) -> 'C?
   # i.e. that { foo = (fun (_) -> { } ) } is a valid argument
-  test.equal(f({foo=(fun (_) -> {})}), null())
-  test.equal(f(112.{foo=(fun (_) -> false)}), null())
-  test.equal(f({foo=(fun (_) -> {gni=2})}), null(2))
-  test.equal(f(345.{foo=(fun (_) -> "aabb".{gni=2})}), null(2))
+  test.equal(f({foo=(fun (_) -> {})}), null.make())
+  test.equal(f(112.{foo=(fun (_) -> false)}), null.make())
+  test.equal(f({foo=(fun (_) -> {gni=2})}), null.make(2))
+  test.equal(f(345.{foo=(fun (_) -> "aabb".{gni=2})}), null.make(2))
 
   # We want to make sure that:
   def f(x) =
@@ -216,24 +216,24 @@ def f() =
   test.equal(foo, 123)
   test.equal(y.gni, "aabb")
   test.equal(y, {gni="aabb"})
-  test.equal(y?.foo, null())
+  test.equal(y?.foo, null.make())
   x = 1.{foo=123, gni="aabb"}
   let {foo, ...y} = x
   test.equal(foo, 123)
   test.equal(y.gni, "aabb")
   test.equal(y, 1)
-  test.equal(y?.foo, null())
+  test.equal(y?.foo, null.make())
   x = 1.{foo=123, gni="aabb"}
   let {foo, ...y} = x
   test.equal(foo, 123)
   test.equal(y.gni, "aabb")
   test.equal(y, 1)
-  test.equal(y?.foo, null())
+  test.equal(y?.foo, null.make())
   x = {foo=3.14}.{foo=123, gni="aabb"}
   let {foo, ...y} = x
   test.equal(foo, 123)
   test.equal(y, {gni="aabb"})
-  test.equal(y?.foo, null())
+  test.equal(y?.foo, null.make())
   x = {foo=123, gni="aabb"}
   y = {bla=3.14, ...x}
   test.equal(y, {gni="aabb", foo=123, bla=3.14})
@@ -264,7 +264,7 @@ def f() =
 
   # Allow optional method extraction
   let {x?} = ()
-  test.equal(x, null())
+  test.equal(x, null.make())
 
   let {x?} = {x=123}
   test.equal(x, 123)
@@ -302,14 +302,14 @@ def f() =
   test.equal({...y, ...x}, {foo=1})
 
   x = {foo=1}
-  y = {foo=null()}
-  test.equal({...x, ...y}, {foo=null()})
+  y = {foo=null.make()}
+  test.equal({...x, ...y}, {foo=null.make()})
   test.equal({...y, ...x}, {foo=1})
 
-  x = {foo=null()}
-  y = {foo=null()}
-  test.equal({...x, ...y}, {foo=null()})
-  test.equal({...y, ...x}, {foo=null()})
+  x = {foo=null.make()}
+  y = {foo=null.make()}
+  test.equal({...x, ...y}, {foo=null.make()})
+  test.equal({...y, ...x}, {foo=null.make()})
 
   x = {foo=1}
   y = {foo="a"}
@@ -325,7 +325,7 @@ def f() =
   def f(x) =
     x.foo() ?? 123
   end
-  test.equal(f({foo=fun () -> null()}), 123)
+  test.equal(f({foo=fun () -> null.make()}), 123)
 
   def f(x) =
     x = (x : {foo: int})

--- a/tests/language/replaygain.liq
+++ b/tests/language/replaygain.liq
@@ -8,7 +8,7 @@ def test_metadata_replaygain() =
     metadata.replaygain([("r128_track_gain", "-32768")]), -32768. / 256.
   )
 
-  test.equal(metadata.replaygain([("r128_track_gain", "foo")]), null())
+  test.equal(metadata.replaygain([("r128_track_gain", "foo")]), null.make())
   test.equal(
     metadata.replaygain(
       [
@@ -18,9 +18,9 @@ def test_metadata_replaygain() =
         )
       ]
     ),
-    null()
+    null.make()
   )
-  test.equal(metadata.replaygain([("r128_track_gain", "")]), null())
+  test.equal(metadata.replaygain([("r128_track_gain", "")]), null.make())
 
   test.equal(
     metadata.replaygain(
@@ -131,21 +131,23 @@ def test_metadata_replaygain() =
     1.
   )
 
-  test.equal(metadata.replaygain([("replaygain_track_gain", "")]), null())
-  test.equal(metadata.replaygain([("replaygain_track_gain", "foo")]), null())
+  test.equal(metadata.replaygain([("replaygain_track_gain", "")]), null.make())
+  test.equal(
+    metadata.replaygain([("replaygain_track_gain", "foo")]), null.make()
+  )
 
-  test.equal(metadata.replaygain([]), null())
+  test.equal(metadata.replaygain([]), null.make())
   test.equal(
     metadata.replaygain(
       [("r128_track_gain", "foo"), ("replaygain_track_gain", "1")]
     ),
-    null()
+    null.make()
   )
   test.equal(
     metadata.replaygain(
       [("replaygain_track_gain", "1"), ("r128_track_gain", "foo")]
     ),
-    null()
+    null.make()
   )
 
   test.pass()

--- a/tests/language/sqlite.liq
+++ b/tests/language/sqlite.liq
@@ -33,7 +33,7 @@ def f() =
   db.insert(table="test", {n=5, s="bla", f=2.5})
   db.insert(table="test", {n=5, s="bli", f=1.})
   db.insert(table="test", {n=20, s="blu", f=0.2})
-  db.insert(table="test", {n=666, s="blu", f=null()})
+  db.insert(table="test", {n=666, s="blu", f=null.make()})
   db.exec(
     "INSERT INTO test VALUES (5,#{sqlite.escape('hello')},1.2)"
   )

--- a/tests/language/string.liq
+++ b/tests/language/string.liq
@@ -82,7 +82,7 @@ def f() =
   )
   test.equal(string.quote("aa'bb"), "\"aa'bb\"")
   test.equal(string.residual(prefix="ab", "abcd"), "cd")
-  test.equal(string.residual(prefix="xx", "abcd"), null())
+  test.equal(string.residual(prefix="xx", "abcd"), null.make())
   test.equal(string.nth("abcde", 2), 99)
   test.equal(string.index(substring="cd", "abcde"), 2)
   test.equal(string.index(substring="e", "abcde"), 4)
@@ -122,11 +122,11 @@ def f() =
 
   test.equal(
     string.data_uri.decode("data:foo/bar;base64,4pyo"),
-    null("✨".{mime="foo/bar"})
+    null.make("✨".{mime="foo/bar"})
   )
 
   test.equal(
-    string.data_uri.decode("data:foo/bar,✨"), null("✨".{mime="foo/bar"})
+    string.data_uri.decode("data:foo/bar,✨"), null.make("✨".{mime="foo/bar"})
   )
 
   test.equal(

--- a/tests/language/type_errors.liq
+++ b/tests/language/type_errors.liq
@@ -112,7 +112,7 @@ def f() =
 
   # Invalid type generalization
   incorrect(
-    'def f(x=null()) = ref(x) end r = f(); r.set(1); r.set("aabb")'
+    'def f(x=null.make()) = ref(x) end r = f(); r.set(1); r.set("aabb")'
   )
 
   incorrect('fallback(transitions=[fun(~l)->1],[blank()])')
@@ -363,7 +363,7 @@ def f() =
     "fun (x) -> x.foo.gni?.bla(1,2,3).blo"
   )
   correct(
-    "fun (x) -> x?.foo(123).gni ?? null()"
+    "fun (x) -> x?.foo(123).gni ?? null.make()"
   )
   section("EVAL")
   incorrect("let eval x = '123'

--- a/tests/language/typing.liq
+++ b/tests/language/typing.liq
@@ -216,9 +216,9 @@ def f() =
   (() : unit.{  })
   ({foo=123} : {foo?: int})
   ({} : {foo?: int})
-  ({foo=null()} : {foo?: int})
+  ({foo=null.make()} : {foo?: int})
   ({foo=123} : {foo?: int})
-  ({foo=null(null())} : {foo?: int?})
+  ({foo=null.make(null.make())} : {foo?: int?})
   ([({} : {foo?: int}), (), {foo=123}] : [{foo?: int}])
   ([(), {foo=123}] : [{foo?: int}])
 

--- a/tests/language/xml_test.liq
+++ b/tests/language/xml_test.liq
@@ -31,7 +31,7 @@ def f() =
           ble=123,
           blu=false,
           blo=1.23,
-          bar=(null(), "bla".{xml_params=[("option", "aab")]}),
+          bar=(null.make(), "bla".{xml_params=[("option", "aab")]}),
           foo="gni".{xml_params={opt=12.3}}
         }
     }

--- a/tests/regression/GH2756-2.liq
+++ b/tests/regression/GH2756-2.liq
@@ -3,7 +3,7 @@ def f() =
   on_cleanup({file.remove(tmp)})
   s = insert_metadata(sine())
   insert_metadata = s.insert_metadata
-  err = ref(null())
+  err = ref(null.make())
 
   def on_frame() =
     null.case(
@@ -11,7 +11,7 @@ def f() =
       {()},
       fun (e) ->
         begin
-          err := null()
+          err := null.make()
           error.raise(e)
         end
     )
@@ -33,7 +33,7 @@ def f() =
       "Got error!"
     )
     callstack := [...(callstack()), "error"]
-    null()
+    null.make()
   end
 
   clock.assign_new(

--- a/tests/regression/GH2756.liq
+++ b/tests/regression/GH2756.liq
@@ -3,7 +3,7 @@ def f() =
   on_cleanup({file.remove(tmp)})
   s = insert_metadata(sine())
   insert_metadata = s.insert_metadata
-  err = ref(null())
+  err = ref(null.make())
 
   def on_frame() =
     null.case(
@@ -11,7 +11,7 @@ def f() =
       {()},
       fun (e) ->
         begin
-          err := null()
+          err := null.make()
           error.raise(e)
         end
     )

--- a/tests/regression/GH3134.liq
+++ b/tests/regression/GH3134.liq
@@ -6,7 +6,7 @@ def f() =
     0.1
   end
 
-  last_call = ref(null())
+  last_call = ref(null.make())
   def next() =
     t = time()
     called_at = last_call()
@@ -19,7 +19,7 @@ def f() =
       if 2 < retry_delay_called_count() then test.pass() end
       request.create("invalid")
     else
-      null()
+      null.make()
     end
   end
 

--- a/tests/regression/GH3303.liq
+++ b/tests/regression/GH3303.liq
@@ -1,9 +1,9 @@
 def f() =
   def a(_, res) =
-    res.json({a=null()})
+    res.json({a=null.make()})
   end
   def b(_, res) =
-    res.json({b=null()})
+    res.json({b=null.make()})
   end
   harbor.http.register(port=3303, "/a", a)
   harbor.http.register(port=3303, "/b", b)

--- a/tests/regression/LS354-1.liq
+++ b/tests/regression/LS354-1.liq
@@ -1,7 +1,7 @@
 s = blank(duration=1.)
 s.on_track(fun (_) -> test.pass())
 r = ref(false)
-d = source.dynamic({if !r then s else null() end})
+d = source.dynamic({if !r then s else null.make() end})
 output.dummy(mksafe(d))
 thread.run(delay=2., {r := true})
 thread.run(delay=4., test.fail)

--- a/tests/regression/LS354-2.liq
+++ b/tests/regression/LS354-2.liq
@@ -6,7 +6,7 @@ s2.on_track(fun (_) -> test.pass())
 
 r = ref(0)
 
-d = source.dynamic({if r() == 1 then s1 elsif r() == 2 then s2 else null() end})
+d = source.dynamic({if r() == 1 then s1 elsif r() == 2 then s2 else null.make() end})
 
 output.dummy(mksafe(d))
 

--- a/tests/regression/source_dynamic.liq
+++ b/tests/regression/source_dynamic.liq
@@ -5,7 +5,7 @@ s_ref = ref((fallback([]) : source))
 def next() =
   r = request.create("../streams/file1.png")
   ignore(request.resolve(r))
-  s = request.dynamic(id="image-dyn", fun () -> null())
+  s = request.dynamic(id="image-dyn", fun () -> null.make())
   s.set_queue([r])
   s
 end
@@ -24,7 +24,7 @@ s_ref = ref((fallback([]) : source))
 def next() =
   r = request.create("../streams/file1.mp3")
   ignore(request.resolve(r))
-  s = request.dynamic(id="audio-dyn", fun () -> null())
+  s = request.dynamic(id="audio-dyn", fun () -> null.make())
   s.set_queue([r])
   s
 end

--- a/tests/streams/ctype2.liq
+++ b/tests/streams/ctype2.liq
@@ -11,7 +11,7 @@ def f() =
     first := false
     sine(id="sineF", 880.)
   else
-    null()
+    null.make()
   end
 end
 

--- a/tests/streams/hls_id3v2.liq
+++ b/tests/streams/hls_id3v2.liq
@@ -8,13 +8,13 @@ def run_check() =
   to_check =
     ref(
       {
-        aac=null(),
-        shine=null(),
-        lame=null(),
-        fdkaac=null(),
-        ts_with_meta=null(),
-        ts=null(),
-        mp4=null()
+        aac=null.make(),
+        shine=null.make(),
+        lame=null.make(),
+        fdkaac=null.make(),
+        ts_with_meta=null.make(),
+        ts=null.make(),
+        mp4=null.make()
       }
     )
 

--- a/tests/streams/no-cue-cut.liq
+++ b/tests/streams/no-cue-cut.liq
@@ -1,7 +1,7 @@
 s =
   playlist(
-    cue_in_metadata=null(),
-    cue_out_metadata=null(),
+    cue_in_metadata=null.make(),
+    cue_out_metadata=null.make(),
     prefix="annotate:liq_cue_in=1.,liq_cue_out=3.:",
     "playlist"
   )

--- a/tests/streams/replaygain.liq
+++ b/tests/streams/replaygain.liq
@@ -2,43 +2,43 @@
 
 def test_file_replaygain() =
   g = file.replaygain("replaygain_track_gain.mp3")
-  test.not.equal(g, null())
+  test.not.equal(g, null.make())
   test.almost_equal(null.get(g), -32.)
 
   g = file.replaygain("r128_track_gain.mp3")
-  test.not.equal(g, null())
+  test.not.equal(g, null.make())
   test.almost_equal(null.get(g), -16.)
 
   g = file.replaygain("replaygain_r128_track_gain.mp3")
-  test.not.equal(g, null())
+  test.not.equal(g, null.make())
   test.almost_equal(null.get(g), -16.)
 
   g = file.replaygain("replaygain_track_gain.opus")
-  test.not.equal(g, null())
+  test.not.equal(g, null.make())
   test.almost_equal(null.get(g), -32.)
 
   g = file.replaygain("r128_track_gain.opus")
-  test.not.equal(g, null())
+  test.not.equal(g, null.make())
   test.almost_equal(null.get(g), -16.)
 
   g = file.replaygain("replaygain_r128_track_gain.opus")
-  test.not.equal(g, null())
+  test.not.equal(g, null.make())
   test.almost_equal(null.get(g), -16.)
 
   g = file.replaygain("replaygain_track_gain.mp3", compute=true)
-  test.not.equal(g, null())
+  test.not.equal(g, null.make())
   test.almost_equal(null.get(g), -32.)
 
   g = file.replaygain("replaygain_track_gain.mp3", compute=false)
-  test.not.equal(g, null())
+  test.not.equal(g, null.make())
   test.almost_equal(null.get(g), -32.)
 
   g = file.replaygain("without_replaygain_track_gain.mp3", compute=true)
-  test.not.equal(g, null())
+  test.not.equal(g, null.make())
   test.almost_equal(null.get(g), 7.39)
 
   g = file.replaygain("without_replaygain_track_gain.mp3", compute=false)
-  test.equal(g, null())
+  test.equal(g, null.make())
 
   test.pass()
 end

--- a/tests/streams/say.liq
+++ b/tests/streams/say.liq
@@ -1,8 +1,8 @@
 s =
   if
-    file.which(null.get(settings.protocol.gtts.path())) == null()
+    file.which(null.get(settings.protocol.gtts.path())) == null.make()
   and
-    file.which(null.get(settings.protocol.text2wave.path())) == null()
+    file.which(null.get(settings.protocol.text2wave.path())) == null.make()
   then
     print(
       "Could not test gtts"

--- a/tests/streams/srt_listen_callback.liq
+++ b/tests/streams/srt_listen_callback.liq
@@ -4,7 +4,7 @@ settings.srt.prefer_address := "ipv4"
 
 def fn() =
   def listen_callback(~hs_version=_, ~peeraddr=_, ~streamid, _) =
-    if streamid == null("foobar") then test.pass() end
+    if streamid == null.make("foobar") then test.pass() end
     false
   end
 

--- a/tests/test.liq
+++ b/tests/test.liq
@@ -20,7 +20,7 @@ def test.pass() =
 end
 
 # End test with a failure.
-def test.fail(reason=null()) =
+def test.fail(reason=null.make()) =
   reason =
     if
       null.defined(reason)
@@ -191,7 +191,7 @@ def test.not_almost_equal(~digits=7, first, second) =
   end
 end
 
-def test.raises(fn, e=null()) =
+def test.raises(fn, e=null.make()) =
   try
     ignore(fn())
     error.raise(
@@ -226,7 +226,7 @@ def test.check(f) =
 end
 
 # Add a metric
-def test.metric(~category, ~name, ~value, ~unit, ~min=null()) =
+def test.metric(~category, ~name, ~value, ~unit, ~min=null.make()) =
   min =
     null.defined(min)
     ?
@@ -248,4 +248,4 @@ def on_error(~backtrace, error) =
   test.fail()
 end
 
-thread.on_error(null(), on_error)
+thread.on_error(null.make(), on_error)


### PR DESCRIPTION
A lot of users get confused by the fact that you need to call `null()` and cannot used `null` directly.

This PR adds a syntactic sugar making it possible to directly use `null` instead.

It:
* Deprecate all use of `null()` and issue a warning when they are encountered
* Moves the function generation to `null.make`

`null.make` should still be used when e.g. passing optional arguments to functions otherwise the full module type gets added to the function argument type..