### PR TITLE
Advanced function argument syntaxes.

### DIFF
--- a/doc/content/language.md
+++ b/doc/content/language.md
@@ -753,6 +753,10 @@ def f((_:int)) = 123 end
 def f((foo:int) = 123) = foo end
 # f : (?int) -> int = <fun>
 
+# Ignored anonymous argument with default value
+def f(_ = 123) = 456 end
+# f : (?int) -> int = fun (_=123) -> 456
+
 # Typed ignored anonymous argument with default value
 def f((_:int) = 123) = 456 end
 # f : (?int) -> int = fun (_=123) -> 456

--- a/doc/content/language.md
+++ b/doc/content/language.md
@@ -725,6 +725,71 @@ corresponding label with "`?`", so that the type of the above function is
 (samples : float, ?duration : float) -> float
 ```
 
+### Advanced argument syntax
+
+Arguments can be ignored, typed, named (and renamed) and given default values
+and all these possibilities can be combined.
+
+Here is the syntax to do it:
+
+```liquidsoap
+# Ignored anonymous argument
+def f(_) = 123 end
+# f : ('a) -> int = fun (_) -> 123
+
+# Typed anonymous argument
+def f((foo:int)) = foo end
+# f : (int) -> int = <fun>
+
+# Anonymous argument with default value
+def f(foo = 123) = foo end
+# f : (?int) -> int = <fun>
+
+# Typed ignored anonymous argument
+def f((_:int)) = 123 end
+# f : (int) -> int = fun (_) -> 123
+
+# Typed anonymous argument with default value
+def f((foo:int) = 123) = foo end
+# f : (?int) -> int = <fun>
+
+# Typed ignored anonymous argument with default value
+def f((_:int) = 123) = 456 end
+# f : (?int) -> int = fun (_=123) -> 456
+
+# Typed named argument
+def f(~(foo:int)) = foo end
+# f : (foo : int) -> int = <fun>
+
+# Named argument with rename
+def f(~foo:bla) = bla end
+# f : (foo : 'a) -> 'a = <fun>
+
+# Ignored named argument
+def f(~foo:_) = 123 end
+# f : (foo : 'a) -> int = fun (~foo=_) -> 123
+
+# Named argument with default value
+def f(~foo=123) = foo end
+# f : (?foo : int) -> int = <fun>
+
+# Typed named argument with default value
+ def f(~(foo:int)=123) = foo end
+# f : (?foo : int) -> int = <fun>
+
+# Typed named argument with rename and default value
+def f(~foo:(bla:int)=123) = bla end
+# f : (?foo : int) -> int = <fun>
+
+# Typed ignored named argument with default value
+def f(~foo:(_:int)=123) = 456 end
+# f : (?foo : int) -> int = fun (~foo=123) -> 456
+
+# Ignored argument with default value
+def f(~foo:_=123) = 456 end
+# f : (?foo : int) -> int = fun (~foo=123) -> 456
+```
+
 ### Getters
 
 We often want to be able to dynamically modify some parameters in a script. For

--- a/doc/content/language.md
+++ b/doc/content/language.md
@@ -773,8 +773,12 @@ def f(~foo:_) = 123 end
 def f(~foo=123) = foo end
 # f : (?foo : int) -> int = <fun>
 
+# Typed named argument with rename
+def f(~foo:(bla:int)) = bla end
+# f : (foo : int) -> int = <fun>
+
 # Typed named argument with default value
- def f(~(foo:int)=123) = foo end
+def f(~(foo:int)=123) = foo end
 # f : (?foo : int) -> int = <fun>
 
 # Typed named argument with rename and default value

--- a/src/lang/parser.mly
+++ b/src/lang/parser.mly
@@ -513,6 +513,10 @@ subfield_lpar:
   | VARLPAR               { [$1] }
   | VAR DOT subfield_lpar { $1::$3 }
 
+var_or_underscore:
+  | UNDERSCORE            { "_" }
+  | VAR                   { $1 }
+
 arglist:
   |                       { [] }
   | arg                   { [$1] }
@@ -524,6 +528,12 @@ arg:
                  }
   | TILD VAR GETS UNDERSCORE opt {
                    `Term {label = $2; as_variable = Some "_"; typ = None; default = $5}
+                 }
+  | TILD VAR COLON var_or_underscore {
+                   `Term {label = $2; as_variable = Some $4; typ =  None; default = None}
+                 }
+  | TILD VAR COLON LPAR var_or_underscore COLON ty opt RPAR {
+                   `Term {label = $2; as_variable = Some $5; typ =  Some $7; default = $8}
                  }
   | optvar opt   { `Term {label = ""; as_variable = Some $1; typ = None; default = $2} }
   | LPAR optvar COLON ty RPAR opt {

--- a/src/lang/parser.mly
+++ b/src/lang/parser.mly
@@ -522,22 +522,23 @@ arglist:
   | arg                   { [$1] }
   | arg COMMA arglist     { $1::$3 }
 arg:
-  | TILD VAR opt { `Term {label = $2; as_variable = None; typ = None; default = $3} }
+  | TILD VAR opt { `Term {label = $2; as_variable = None; typ = None; default = $3; annotations = [] } }
   | TILD LPAR VAR COLON ty RPAR opt {
-                   `Term {label = $3; as_variable = None; typ =  Some $5; default = $7}
+                   `Term {label = $3; as_variable = None; typ =  Some $5; default = $7; annotations = []}
                  }
   | TILD VAR GETS UNDERSCORE opt {
-                   `Term {label = $2; as_variable = Some "_"; typ = None; default = $5}
+                    `Term {label = $2; as_variable = Some "_"; typ = None; default = $5;
+                           annotations = [`Deprecated (Printf.sprintf "Use `~%s:_`" $2)] }
                  }
   | TILD VAR COLON var_or_underscore {
-                   `Term {label = $2; as_variable = Some $4; typ =  None; default = None}
+                   `Term {label = $2; as_variable = Some $4; typ =  None; default = None; annotations = []}
                  }
   | TILD VAR COLON LPAR var_or_underscore COLON ty opt RPAR {
-                   `Term {label = $2; as_variable = Some $5; typ =  Some $7; default = $8}
+                  `Term {label = $2; as_variable = Some $5; typ =  Some $7; default = $8; annotations = []}
                  }
-  | optvar opt   { `Term {label = ""; as_variable = Some $1; typ = None; default = $2} }
+  | optvar opt   { `Term {label = ""; as_variable = Some $1; typ = None; default = $2; annotations = []} }
   | LPAR optvar COLON ty RPAR opt {
-                   `Term {label = ""; as_variable =  Some $2; typ = Some $4; default =  $6}
+                   `Term {label = ""; as_variable =  Some $2; typ = Some $4; default =  $6; annotations = []}
                  }
   | ARGS_OF LPAR VAR RPAR {
                    `Argsof {only = []; except = []; source = $3 }

--- a/src/lang/parser.mly
+++ b/src/lang/parser.mly
@@ -513,10 +513,6 @@ subfield_lpar:
   | VARLPAR               { [$1] }
   | VAR DOT subfield_lpar { $1::$3 }
 
-var_or_underscore:
-  | UNDERSCORE            { "_" }
-  | VAR                   { $1 }
-
 arglist:
   |                       { [] }
   | arg                   { [$1] }
@@ -530,11 +526,11 @@ arg:
                     `Term {label = $2; as_variable = Some "_"; typ = None; default = $5;
                            annotations = [`Deprecated (Printf.sprintf "Use `~%s:_`" $2)] }
                  }
-  | TILD VAR COLON var_or_underscore {
-                   `Term {label = $2; as_variable = Some $4; typ =  None; default = None; annotations = []}
+  | TILD VAR COLON optvar opt {
+                   `Term {label = $2; as_variable = Some $4; typ =  None; default = $5; annotations = []}
                  }
-  | TILD VAR COLON LPAR var_or_underscore COLON ty opt RPAR {
-                  `Term {label = $2; as_variable = Some $5; typ =  Some $7; default = $8; annotations = []}
+  | TILD VAR COLON LPAR optvar COLON ty RPAR opt {
+                  `Term {label = $2; as_variable = Some $5; typ =  Some $7; default = $9; annotations = []}
                  }
   | optvar opt   { `Term {label = ""; as_variable = Some $1; typ = None; default = $2; annotations = []} }
   | LPAR optvar COLON ty RPAR opt {

--- a/src/lang/parser_helper.mli
+++ b/src/lang/parser_helper.mli
@@ -72,6 +72,7 @@ val mk_json_assoc_object_ty :
 
 val mk :
   ?comments:(pos * Parsed_term.comment) list ->
+  ?annotations:Parsed_term.term_annotation list ->
   pos:pos ->
   Term.parsed_ast ->
   Term.t

--- a/src/libs/autocue.liq
+++ b/src/libs/autocue.liq
@@ -1070,7 +1070,7 @@ end
 
 # Define autocue protocol
 # @flag hidden
-def protocol.autocue(~rlog=_, ~maxtime=_, arg) =
+def protocol.autocue(~rlog:_, ~maxtime:_, arg) =
   cue_metadata = file.autocue.metadata(request_metadata=[], arg)
 
   if

--- a/src/libs/extra/externals.liq
+++ b/src/libs/extra/externals.liq
@@ -249,7 +249,7 @@ def enable_external_flac_decoder() =
       "Enabling EXTERNAL_FLAC metadata resolver."
     )
 
-    def flac_meta(~metadata=_, fname) =
+    def flac_meta(~metadata:_, fname) =
       ret =
         process.read.lines(
           "#{metaflac} --export-tags-to=- #{process.quote(fname)}"
@@ -399,7 +399,7 @@ def enable_external_faad_decoder() =
       faad_p
     )
 
-    def faad_meta(~metadata=_, file) =
+    def faad_meta(~metadata:_, file) =
       if
         faad_test(file)
       then

--- a/src/libs/ffmpeg.liq
+++ b/src/libs/ffmpeg.liq
@@ -326,11 +326,11 @@ def video.add_text.ffmpeg.raw.filter(
     )
 
   def escape =
-    def special_char(~encoding=_, s) =
+    def special_char(~encoding:_, s) =
       string.contains(substring=s, "(',%,\\,:,{,})")
     end
 
-    def escape_char(~encoding=_, s) =
+    def escape_char(~encoding:_, s) =
       "\\#{s}"
     end
 

--- a/src/libs/protocols.liq
+++ b/src/libs/protocols.liq
@@ -19,7 +19,7 @@ let settings.protocol.replaygain.tag =
 
 # Register the replaygain protocol.
 # @flag hidden
-def protocol.replaygain(~rlog=_, ~maxtime=_, arg) =
+def protocol.replaygain(~rlog:_, ~maxtime:_, arg) =
   gain = file.replaygain(arg)
   tag = settings.protocol.replaygain.tag()
   if
@@ -86,7 +86,7 @@ end
 # [("input",<input file>),("output",<output file>),("colon",":")]
 # See say: protocol for an example.
 # @flag hidden
-def replaces protocol.process(~rlog=_, ~maxtime, arg) =
+def replaces protocol.process(~rlog:_, ~maxtime, arg) =
   log.info(
     "Processing #{arg}"
   )
@@ -346,7 +346,7 @@ protocol.add(
 # Register the youtube-pl protocol.
 # Syntax: youtube-pl:<ID>
 # @flag hidden
-def protocol.youtube_pl(~rlog=_, ~maxtime, arg) =
+def protocol.youtube_pl(~rlog:_, ~maxtime, arg) =
   binary = settings.protocol.youtube_dl.path()
   delay = maxtime - time()
   cmd =
@@ -375,7 +375,7 @@ protocol.add(
 
 # Register tmp
 # @flag hidden
-def protocol.tmp(~rlog=_, ~maxtime=_, arg) =
+def protocol.tmp(~rlog:_, ~maxtime:_, arg) =
   arg
 end
 
@@ -390,7 +390,7 @@ protocol.add(
 
 # Register fallible
 # @flag hidden
-def protocol.fallible(~rlog=_, ~maxtime=_, arg) =
+def protocol.fallible(~rlog:_, ~maxtime:_, arg) =
   arg
 end
 
@@ -649,7 +649,7 @@ protocol.add(
 # Register stereo protocol which converts a file to stereo (currently decodes as
 # wav).
 # @flag hidden
-def protocol.stereo(~rlog=_, ~maxtime=_, arg) =
+def protocol.stereo(~rlog:_, ~maxtime:_, arg) =
   file = file.temp("liq-stereo", ".wav")
   r = request.create(arg)
   if
@@ -678,7 +678,7 @@ protocol.add(
 # Copy
 
 # @flag hidden
-def protocol.copy(~rlog=_, ~maxtime=_, arg) =
+def protocol.copy(~rlog:_, ~maxtime:_, arg) =
   extname = file.extension(arg)
   tmpfile = file.temp("tmp", extname)
   file.copy(force=true, arg, tmpfile)
@@ -705,7 +705,7 @@ let settings.protocol.text2wave.path =
 
 # Register the text2wave: protocol using text2wave
 # @flag hidden
-def protocol.text2wave(~rlog=_, ~maxtime=_, arg) =
+def protocol.text2wave(~rlog:_, ~maxtime:_, arg) =
   binary = settings.protocol.text2wave.path()
   process.uri(
     extname="wav",
@@ -741,7 +741,7 @@ let settings.protocol.pico2wave.lang =
   )
 
 # @flag hidden
-def protocol.pico2wave(~rlog=_, ~maxtime=_, arg) =
+def protocol.pico2wave(~rlog:_, ~maxtime:_, arg) =
   binary = settings.protocol.pico2wave.path()
   lang = settings.protocol.pico2wave.lang()
   process.uri(
@@ -785,7 +785,7 @@ let settings.protocol.gtts.options =
 
 # Register the gtts: protocol using gtts
 # @flag hidden
-def protocol.gtts(~rlog=_, ~maxtime=_, arg) =
+def protocol.gtts(~rlog:_, ~maxtime:_, arg) =
   binary = settings.protocol.gtts.path()
   lang = settings.protocol.gtts.lang()
   options = settings.protocol.gtts.options()
@@ -824,7 +824,7 @@ let settings.protocol.macos_say.options =
 
 # Register the macos_say: protocol using the say command available on macos
 # @flag hidden
-def protocol.macos_say(~rlog=_, ~maxtime=_, arg) =
+def protocol.macos_say(~rlog:_, ~maxtime:_, arg) =
   binary = settings.protocol.macos_say.path()
   options = settings.protocol.macos_say.options()
   process.uri(
@@ -856,7 +856,7 @@ let settings.protocol.say.implementation =
 
 # Register the legacy say: protocol
 # @flag hidden
-def protocol.say(~rlog=_, ~maxtime=_, arg) =
+def protocol.say(~rlog:_, ~maxtime:_, arg) =
   "#{settings.protocol.say.implementation()}:#{arg}"
 end
 
@@ -957,7 +957,7 @@ end
 
 # Register the s3:// protocol
 # @flag hidden
-def s3_protocol(~rlog=_, ~maxtime=_, arg) =
+def s3_protocol(~rlog:_, ~maxtime:_, arg) =
   extname = file.extension(leading_dot=false, dir_sep="/", arg)
   arg = process.quote("s3:#{arg}")
   process.uri(
@@ -977,7 +977,7 @@ protocol.add(
 # Register the polly: protocol using AWS Polly
 # speech synthesis services. Syntax: polly:<text>
 # @flag hidden
-def polly_protocol(~rlog=_, ~maxtime=_, text) =
+def polly_protocol(~rlog:_, ~maxtime:_, text) =
   aws = aws_base()
   format = settings.protocol.aws.polly.format()
   extname =
@@ -1020,7 +1020,7 @@ protocol.add(
 
 # Protocol to synthesize audio.
 # @flag hidden
-def synth_protocol(~rlog=_, ~maxtime=_, text) =
+def synth_protocol(~rlog:_, ~maxtime:_, text) =
   log.debug(
     label="synth",
     "Synthesizing request: #{text}"
@@ -1108,7 +1108,7 @@ protocol.add(
 
 # File protocol
 # @flag hidden
-def file_protocol(~rlog=_, ~maxtime=_, arg) =
+def file_protocol(~rlog:_, ~maxtime:_, arg) =
   path = list.nth(default="", r/:/.split(arg), 1)
   segments = r/\//.split(path)
   segments =

--- a/src/libs/replaygain.liq
+++ b/src/libs/replaygain.liq
@@ -122,7 +122,7 @@ end
 #               Use this setting to lower CPU peaks when computing replaygain tags.
 # @category Liquidsoap
 def enable_replaygain_metadata(~compute=true, ~ratio=50.) =
-  def replaygain_metadata(~metadata=_, file_name) =
+  def replaygain_metadata(~metadata:_, file_name) =
     gain = file.replaygain(compute=compute, ratio=ratio, file_name)
     if
       gain != null

--- a/src/libs/string.liq
+++ b/src/libs/string.liq
@@ -453,11 +453,11 @@ def string.escape.html(%argsof(string.escape[encoding]), s) =
       ("'", "&#39;")
     ]
 
-  def special_char(~encoding=_, c) =
+  def special_char(~encoding:_, c) =
     list.assoc.mem(c, escaped)
   end
 
-  def escape_char(~encoding=_, c) =
+  def escape_char(~encoding:_, c) =
     escaped[c]
   end
 

--- a/src/tooling/parsed_json.ml
+++ b/src/tooling/parsed_json.ml
@@ -260,7 +260,7 @@ let json_of_of { only; except; source } =
 let json_of_fun_arg ~to_json : Parsed_term.fun_arg -> (string * Json.t) list =
   function
   | `Argsof _of -> ast_node ~typ:"argsof" (json_of_of _of)
-  | `Term { Term_base.label; as_variable; typ; default } ->
+  | `Term { Parsed_term.label; as_variable; typ; default } ->
       ast_node ~typ:"term"
         [
           ( "value",

--- a/tests/harbor/http.liq
+++ b/tests/harbor/http.liq
@@ -292,7 +292,7 @@ def f() =
   end
 
   # Response ended
-  read = ref(fun (~timeout=_) -> error.raise(error.assertion))
+  read = ref(fun (~timeout:_) -> error.raise(error.assertion))
 
   def handler(req, _) =
     read := req.data

--- a/tests/language/functions.liq
+++ b/tests/language/functions.liq
@@ -98,8 +98,12 @@ def f() =
   def f(~foo=123) = foo end
   # f : (?foo : int) -> int = <fun>
 
+  # Typed named argument with rename
+  def f(~foo:(bla:int)) = bla end
+  # f : (foo : int) -> int = <fun>
+
   # Typed named argument with default value
-   def f(~(foo:int)=123) = foo end
+  def f(~(foo:int)=123) = foo end
   # f : (?foo : int) -> int = <fun>
 
   # Typed named argument with rename and default value

--- a/tests/language/functions.liq
+++ b/tests/language/functions.liq
@@ -58,6 +58,62 @@ def f() =
   test.equal(fn({gni=1}), {foo=1})
   test.equal(fn({gni="aabb"}), {foo="aabb"})
 
+  # Ignored anonymous argument
+  def f(_) = 123 end
+  # f : ('a) -> int = fun (_) -> 123
+
+  # Typed anonymous argument
+  def f((foo:int)) = foo end
+  # f : (int) -> int = <fun>
+
+  # Anonymous argument with default value
+  def f(foo = 123) = foo end
+  # f : (?int) -> int = <fun>
+
+  # Typed ignored anonymous argument
+  def f((_:int)) = 123 end
+  # f : (int) -> int = fun (_) -> 123
+
+  # Typed anonymous argument with default value
+  def f((foo:int) = 123) = foo end
+  # f : (?int) -> int = <fun>
+
+  # Typed ignored anonymous argument with default value
+  def f((_:int) = 123) = 456 end
+  # f : (?int) -> int = fun (_=123) -> 456
+
+  # Typed named argument
+  def f(~(foo:int)) = foo end
+  # f : (foo : int) -> int = <fun>
+
+  # Named argument with rename
+  def f(~foo:bla) = bla end
+  # f : (foo : 'a) -> 'a = <fun>
+
+  # Ignored named argument
+  def f(~foo:_) = 123 end
+  # f : (foo : 'a) -> int = fun (~foo=_) -> 123
+
+  # Named argument with default value
+  def f(~foo=123) = foo end
+  # f : (?foo : int) -> int = <fun>
+
+  # Typed named argument with default value
+   def f(~(foo:int)=123) = foo end
+  # f : (?foo : int) -> int = <fun>
+
+  # Typed named argument with rename and default value
+  def f(~foo:(bla:int)=123) = bla end
+  # f : (?foo : int) -> int = <fun>
+
+  # Typed ignored named argument with default value
+  def f(~foo:(_:int)=123) = 456 end
+  # f : (?foo : int) -> int = fun (~foo=123) -> 456
+
+  # Ignored argument with default value
+  def f(~foo:_=123) = 456 end
+  # f : (?foo : int) -> int = fun (~foo=123) -> 456
+
   test.pass()
 end
 

--- a/tests/language/functions.liq
+++ b/tests/language/functions.liq
@@ -78,6 +78,10 @@ def f() =
   def f((foo:int) = 123) = foo end
   # f : (?int) -> int = <fun>
 
+  # Ignored anonymous argument with default value
+  def f(_ = 123) = 456 end
+  # f : (?int) -> int = fun (_=123) -> 456
+
   # Typed ignored anonymous argument with default value
   def f((_:int) = 123) = 456 end
   # f : (?int) -> int = fun (_=123) -> 456

--- a/tests/regression/GH3960.liq
+++ b/tests/regression/GH3960.liq
@@ -1,6 +1,6 @@
 call_counts = ref([])
 
-def test_decoder(~metadata=_, filename) =
+def test_decoder(~metadata:_, filename) =
   call_count = list.assoc(default=ref(0), filename, call_counts())
 
   ref.incr(call_count)

--- a/tests/regression/metadata-resolvers-metadata.liq
+++ b/tests/regression/metadata-resolvers-metadata.liq
@@ -1,6 +1,6 @@
 dir = file.temp_dir(cleanup=true, "metadata-resolver")
 
-def media_protocol(~rlog=_, ~maxtime=_, arg) =
+def media_protocol(~rlog:_, ~maxtime:_, arg) =
   "#{dir}/#{arg}"
 end
 

--- a/tests/streams/hls_discontinuity.liq
+++ b/tests/streams/hls_discontinuity.liq
@@ -25,7 +25,7 @@ second_playlist =
 third_playlist =
   "#EXTM3U\r\n#EXT-X-TARGETDURATION:2\r\n#EXT-X-VERSION:3\r\n#EXT-X-MEDIA-SEQUENCE:6\r\n#EXT-X-DISCONTINUITY-SEQUENCE:1\r\n#EXTINF:2.000,\r\nstream_7.ts\r\n#EXTINF:1.980,\r\nstream_8.ts\r\n#EXTINF:1.980,\r\nstream_9.ts\r\n#EXTINF:1.960,\r\nstream_10.ts\r\n"
 
-def on_file_change(~state=_, fname) =
+def on_file_change(~state:_, fname) =
   if
     path.basename(fname) == "stream.m3u8"
   then

--- a/tests/streams/hls_global_headers.liq
+++ b/tests/streams/hls_global_headers.liq
@@ -5,7 +5,7 @@ s = video.testsrc.ffmpeg(duration=10.)
 
 s = mksafe(s)
 
-def main_playlist_writer(~extra_tags=_, ~prefix=_, ~version=_, streams) =
+def main_playlist_writer(~extra_tags:_, ~prefix:_, ~version:_, streams) =
   let [{codecs = c1, ..._}, {codecs = c2, ..._}] = streams
   if
     c1 == "avc1.64001f" and c2 == "avc1.64001f"

--- a/tests/streams/hls_large_frame.liq
+++ b/tests/streams/hls_large_frame.liq
@@ -24,7 +24,7 @@ streams = [("radio", enc)]
 
 output.file.hls(
   segment_duration=2.0,
-  on_file_change=(fun (~state=_, _) -> test.pass()),
+  on_file_change=(fun (~state:_, _) -> test.pass()),
   tmp_dir,
   streams,
   s

--- a/tests/streams/metadata-override.liq
+++ b/tests/streams/metadata-override.liq
@@ -33,7 +33,7 @@ def f() =
   decoder.metadata.add(
     priority=-1,
     "test-no-override",
-    fun (~metadata=_, _) ->
+    fun (~metadata:_, _) ->
       [
         (
           "title",
@@ -71,7 +71,7 @@ def f() =
   decoder.metadata.add(
     priority=4,
     "test-override",
-    fun (~metadata=_, _) ->
+    fun (~metadata:_, _) ->
       [
         (
           "title",
@@ -109,7 +109,7 @@ def f() =
   decoder.metadata.add(
     priority=10,
     "test-override-annotate",
-    fun (~metadata=_, _) ->
+    fun (~metadata:_, _) ->
       [
         (
           "title",

--- a/tests/streams/srt_listen_callback.liq
+++ b/tests/streams/srt_listen_callback.liq
@@ -3,7 +3,7 @@ port = 8001
 settings.srt.prefer_address := "ipv4"
 
 def fn() =
-  def listen_callback(~hs_version=_, ~peeraddr=_, ~streamid, _) =
+  def listen_callback(~hs_version:_, ~peeraddr:_, ~streamid, _) =
     if streamid == null("foobar") then test.pass() end
     false
   end


### PR DESCRIPTION
Before merging https://github.com/savonet/liquidsoap/pull/4518, I'd like to be able to accept a named argument for a function using one of the protected top-level names but rename it to a safe variable name inside the function. Something like:

```liquidsoap
def f(~request:r) =
  print(request.uri(r))
end
```

This PR cleans up the current function arguments. It:
* Deprecates `def f(~foo=_) = ... end`. This syntax is clashing with default values: `def f(~foo=123) = foo end`.
* Adds the combination of typed and renamed named argument
* Documents the full (?) list of possible syntaxes. Here it is:
```liquidsoap
# Ignored anonymous argument
def f(_) = 123 end
# f : ('a) -> int = fun (_) -> 123

# Typed anonymous argument
def f((foo:int)) = foo end
# f : (int) -> int = <fun>

# Anonymous argument with default value
def f(foo = 123) = foo end
# f : (?int) -> int = <fun>

# Typed ignored anonymous argument
def f((_:int)) = 123 end
# f : (int) -> int = fun (_) -> 123

# Typed anonymous argument with default value
def f((foo:int) = 123) = foo end
# f : (?int) -> int = <fun>

# Ignored anonymous argument with default value
def f(_ = 123) = 456 end
# f : (?int) -> int = fun (_=123) -> 456

# Typed ignored anonymous argument with default value
def f((_:int) = 123) = 456 end
# f : (?int) -> int = fun (_=123) -> 456

# Typed named argument
def f(~(foo:int)) = foo end
# f : (foo : int) -> int = <fun>

# Named argument with rename
def f(~foo:bla) = bla end
# f : (foo : 'a) -> 'a = <fun>

# Ignored named argument
def f(~foo:_) = 123 end
# f : (foo : 'a) -> int = fun (~foo=_) -> 123

# Named argument with default value
def f(~foo=123) = foo end
# f : (?foo : int) -> int = <fun>

# Typed named argument with rename
def f(~foo:(bla:int)) = bla end
# f : (foo : int) -> int = <fun>

# Typed named argument with default value
def f(~(foo:int)=123) = foo end
# f : (?foo : int) -> int = <fun>

# Typed named argument with rename and default value
def f(~foo:(bla:int)=123) = bla end
# f : (?foo : int) -> int = <fun>

# Typed ignored named argument with default value
def f(~foo:(_:int)=123) = 456 end
# f : (?foo : int) -> int = fun (~foo=123) -> 456

# Ignored argument with default value
def f(~foo:_=123) = 456 end
# f : (?foo : int) -> int = fun (~foo=123) -> 456
```