### PR TITLE
Refine request.dynamic concurrency.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -27,6 +27,11 @@ Changed:
   and LUFS (#4545)
 - BREAKING: Error methods have been removed by default.
   Use `error.methods` to get them! (#4537)
+- Force `request.dynamic` (and derived sources such as `playlist`)
+  to resolve their requests in the order they are provided.
+  Old `synchronous` option is thus merged into a new `concurrency`
+  option that allows to set the source concurrency to synchronous,
+  sequential async or concurrent async.
 
 Fixed:
 

--- a/src/core/builtins/builtins_request.ml
+++ b/src/core/builtins/builtins_request.ml
@@ -325,7 +325,7 @@ class process ~name r =
         ~name
         ~retry_delay:(fun _ -> 0.1)
         ~available:(fun _ -> true)
-        ~prefetch:1 ~timeout:None ~synchronous:true
+        ~prefetch:1 ~timeout:None ~concurrency:`Synchronous
         (Lang.val_fun [] (fun _ -> Lang.null))
 
     initializer

--- a/src/libs/extra/native.liq
+++ b/src/libs/extra/native.liq
@@ -89,7 +89,7 @@ def native.request.dynamic(%argsof(request.dynamic), f) =
   ignore(available)
   ignore(timeout)
   ignore(native)
-  ignore(synchronous)
+  ignore(concurrency)
 
   def f() =
     try

--- a/src/libs/request.liq
+++ b/src/libs/request.liq
@@ -341,8 +341,10 @@ def request.single(
     static_request() ?? getter.get(r)
   end
 
+  concurrency = infallible ? "synchronous" : "sequential_async"
+
   def mk_source(id) =
-    request.dynamic(id=id, prefetch=prefetch, synchronous=infallible, next)
+    request.dynamic(id=id, prefetch=prefetch, concurrency=concurrency, next)
   end
 
   # We want to mark infallible source as such. `source.dynamic` is a nice


### PR DESCRIPTION
This PR refines the logic for `request.dynamic` to prevent concurrent resolution of requests unless explicitely told to.

Fixes: #4316