### PR TITLE
Add callbacks as documentation section.

### DIFF
--- a/src/core/lang.mli
+++ b/src/core/lang.mli
@@ -84,6 +84,7 @@ val add_builtin :
   descr:string ->
   ?flags:Doc.Value.flag list ->
   ?meth:value meth list ->
+  ?callbacks:string list ->
   ?examples:string list ->
   ?base:module_name ->
   string ->

--- a/src/core/lang_source.ml
+++ b/src/core/lang_source.ml
@@ -198,13 +198,7 @@ let callback { name; params; descr; arg_t; register } =
               (fun { name; typ; default } -> (default <> None, name, typ))
               params)
           unit_t );
-    descr =
-      Printf.sprintf
-        "Call a given handler %s. If `synchronous` is `true`, the function is \
-         executed immediately. Otherwise, it is sent to the slow task queue. \
-         Default is set via `settings.source.synchronous_callbacks`. \
-         `on_error` can be used to catch errors raised during the execution."
-        descr;
+    descr = Printf.sprintf "Call a given handler %s." descr;
     value =
       (fun s ->
         val_fun
@@ -881,7 +875,9 @@ let add_operator ~(category : Doc.Value.source) ~descr ?(flags = [])
       (List.map (fun { name; scheme; descr } -> (name, scheme, descr)) meth)
   in
   let category = `Source category in
-  add_builtin ~category ~descr ~flags ?base name arguments return_t f
+  add_builtin ~category ~descr ~flags
+    ~callbacks:(List.map (fun { name } -> name) source_callbacks)
+    ?base name arguments return_t f
 
 let add_track_operator ~(category : Doc.Value.source) ~descr ?(flags = [])
     ?(meth = ([] : ('a -> value) meth list)) ?base name arguments ~return_t f =

--- a/src/core/lang_source.ml
+++ b/src/core/lang_source.ml
@@ -186,17 +186,17 @@ let callback { name; params; descr; arg_t; register } =
     scheme =
       ( [],
         fun_t
-          ([
-             (true, "synchronous", Lang.(nullable_t bool_t));
-             ( true,
-               "on_error",
-               Lang.nullable_t
-                 (Lang.fun_t [(false, "", Lang.error_t)] Lang.float_t) );
-             (false, "", fun_t arg_t unit_t);
-           ]
-          @ List.map
-              (fun { name; typ; default } -> (default <> None, name, typ))
-              params)
+          (List.map
+             (fun { name; typ; default } -> (default <> None, name, typ))
+             params
+          @ [
+              (true, "synchronous", Lang.(nullable_t bool_t));
+              ( true,
+                "on_error",
+                Lang.nullable_t
+                  (Lang.fun_t [(false, "", Lang.error_t)] Lang.float_t) );
+              (false, "", fun_t arg_t unit_t);
+            ])
           unit_t );
     descr = Printf.sprintf "Call a given handler %s." descr;
     value =

--- a/src/lang/doc.ml
+++ b/src/lang/doc.ml
@@ -188,6 +188,7 @@ module Value = struct
     examples : string list;
     arguments : (string option * argument) list;
     methods : (string * meth) list;
+    callbacks : (string * meth) list;
   }
 
   let db = ref Map.empty
@@ -312,7 +313,15 @@ module Value = struct
           print (" * " ^ label_color l ^ " : " ^ type_color m.meth_type ^ "\n");
           Option.iter (fun d -> print (reflow ~indent:5 d)) m.meth_description;
           print "\n\n")
-        (List.sort compare f.methods))
+        (List.sort compare f.methods));
+    if f.callbacks <> [] then (
+      print (title_color "Callbacks:\n\n");
+      List.iter
+        (fun (l, m) ->
+          print (" * " ^ label_color l ^ " : " ^ type_color m.meth_type ^ "\n");
+          Option.iter (fun d -> print (reflow ~indent:5 d)) m.meth_description;
+          print "\n\n")
+        (List.sort compare f.callbacks))
 
   let to_json () : Json.t =
     !db |> Map.to_seq
@@ -335,20 +344,28 @@ module Value = struct
                f.arguments
            in
            let arguments = `Assoc arguments in
-           let methods =
-             List.map
-               (fun (l, m) ->
-                 ( l,
+           let methods, callbacks =
+             match
+               List.map
+                 (fun m ->
                    `Assoc
-                     [
-                       ("type", `String m.meth_type);
-                       ( "description",
-                         `String (Option.value ~default:"" m.meth_description)
-                       );
-                     ] ))
-               f.methods
+                     (List.map
+                        (fun (l, m) ->
+                          ( l,
+                            `Assoc
+                              [
+                                ("type", `String m.meth_type);
+                                ( "description",
+                                  `String
+                                    (Option.value ~default:"" m.meth_description)
+                                );
+                              ] ))
+                        m))
+                 [f.methods; f.callbacks]
+             with
+               | [x; v] -> (x, v)
+               | _ -> assert false
            in
-           let methods = `Assoc methods in
            ( l,
              `Assoc
                [
@@ -362,6 +379,7 @@ module Value = struct
                  ("examples", `Tuple (List.map (fun s -> `String s) f.examples));
                  ("arguments", arguments);
                  ("methods", methods);
+                 ("callbacks", callbacks);
                ] ))
     |> List.of_seq
     |> fun l -> `Assoc l
@@ -443,6 +461,19 @@ module Value = struct
                     Printf.ksprintf print "- `%s` (of type `%s`)%s\n" l t s)
                   (List.sort compare d.methods);
                 print "\n");
+              if d.callbacks <> [] then (
+                print "Callbacks:\n\n";
+                List.iter
+                  (fun (l, m) ->
+                    let t = m.meth_type in
+                    let s =
+                      match m.meth_description with
+                        | None -> ""
+                        | Some s -> ": " ^ s
+                    in
+                    Printf.ksprintf print "- `%s` (of type `%s`)%s\n" l t s)
+                  (List.sort compare d.methods);
+                print "\n");
               if List.mem `Experimental d.flags then
                 print "This function is experimental.\n\n"))
           !db)
@@ -465,6 +496,14 @@ end
 
 type doc_type = [ `Full | `Argsof of string list ]
 
+type doc = {
+  main : string list;
+  special : [ `Category of string | `Flag of string ] list;
+  params : (string option * string) list;
+  methods : (string * string) list;
+  callbacks : (string * string) list;
+}
+
 let parse_doc ~pos doc =
   let doc = String.split_on_char '\n' doc in
   let doc =
@@ -475,8 +514,9 @@ let parse_doc ~pos doc =
   in
   if doc = [] then None
   else (
-    let rec parse_doc (main, special, params, methods) = function
-      | [] -> (main, special, params, methods)
+    let rec parse_doc ({ main; special; params; methods; callbacks } as _doc) =
+      function
+      | [] -> _doc
       | line :: lines -> (
           try
             let sub =
@@ -510,7 +550,7 @@ let parse_doc ~pos doc =
                          doc.flags
                   in
                   parse_doc
-                    (main, doc_specials @ special, params, methods)
+                    { _doc with main; special = doc_specials @ special; params }
                     lines
               | "argsof" ->
                   let s, only, except =
@@ -561,13 +601,11 @@ let parse_doc ~pos doc =
                         Option.map (fun d -> (n, d)) a.Value.arg_description)
                       args
                   in
-                  parse_doc (main, special, args @ params, methods) lines
+                  parse_doc { _doc with main; params = args @ params } lines
               | "category" ->
-                  parse_doc
-                    (main, `Category s :: special, params, methods)
-                    lines
+                  parse_doc { _doc with special = `Category s :: special } lines
               | "flag" ->
-                  parse_doc (main, `Flag s :: special, params, methods) lines
+                  parse_doc { _doc with special = `Flag s :: special } lines
               | "param" ->
                   let sub =
                     Re.Pcre.exec
@@ -600,7 +638,7 @@ let parse_doc ~pos doc =
                   in
                   let descr, lines = parse_descr [] (descr :: lines) in
                   parse_doc
-                    (main, special, (label, descr) :: params, methods)
+                    { _doc with params = (label, descr) :: params }
                     lines
               | "method" ->
                   let sub =
@@ -611,13 +649,27 @@ let parse_doc ~pos doc =
                   let label = Re.Pcre.get_substring sub 1 in
                   let descr = Re.Pcre.get_substring sub 2 in
                   parse_doc
-                    (main, special, params, (label, descr) :: methods)
+                    { _doc with methods = (label, descr) :: methods }
+                    lines
+              | "callback" ->
+                  let sub =
+                    Re.Pcre.exec
+                      ~rex:(Re.Pcre.regexp "^(~?[a-zA-Z0-9_.]+)\\s*(.*)$")
+                      s
+                  in
+                  let label = Re.Pcre.get_substring sub 1 in
+                  let descr = Re.Pcre.get_substring sub 2 in
+                  parse_doc
+                    { _doc with callbacks = (label, descr) :: callbacks }
                     lines
               | d -> failwith ("Unknown documentation item: " ^ d)
-          with Not_found ->
-            parse_doc (line :: main, special, params, methods) lines)
+          with Not_found -> parse_doc { _doc with main = line :: main } lines)
     in
-    let main, special, params, methods = parse_doc ([], [], [], []) doc in
+    let { main; special; params; methods; callbacks } =
+      parse_doc
+        { main = []; special = []; params = []; methods = []; callbacks = [] }
+        doc
+    in
     let main = List.rev main in
     let params =
       List.map
@@ -633,6 +685,12 @@ let parse_doc ~pos doc =
         (fun (l, d) ->
           (l, Value.{ meth_type = "???"; meth_description = Some d }))
         (List.rev methods)
+    in
+    let callbacks =
+      List.map
+        (fun (l, d) ->
+          (l, Value.{ meth_type = "???"; meth_description = Some d }))
+        (List.rev callbacks)
     in
     let main = String.concat "\n" main in
     let main = Lang_string.unbreak_md main in
@@ -674,4 +732,5 @@ let parse_doc ~pos doc =
           examples = [];
           arguments = params;
           methods;
+          callbacks;
         })

--- a/src/lang/lang.mli
+++ b/src/lang/lang.mli
@@ -59,6 +59,7 @@ val add_builtin :
   descr:string ->
   ?flags:Doc.Value.flag list ->
   ?meth:value meth list ->
+  ?callbacks:string list ->
   ?examples:string list ->
   ?base:module_name ->
   string ->


### PR DESCRIPTION
This PR adds a new "Callbacks" documentation section:

![Screenshot 2025-07-05 at 7 11 20 PM](https://github.com/user-attachments/assets/9f2ab211-5d56-47aa-a2b4-30ea7c5efa08)

This should be pretty useful to be able to quickly glance what kind of callbacks can be used on each source.