### PR TITLE
Don't assign foo in `let { foo = gni } = v`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -27,6 +27,8 @@ Changed:
   and LUFS (#4545)
 - BREAKING: Error methods have been removed by default.
   Use `error.methods` to get them! (#4537)
+- Make sure that `let { foo = gni } = v` assigns a value to
+  `gni` but not to `foo` (#4561)
 
 Fixed:
 

--- a/src/lang/term/term_reducer.ml
+++ b/src/lang/term/term_reducer.ml
@@ -412,10 +412,6 @@ let rec pattern_reducer (pat : Parsed_term.pattern) =
                       mk (mk_term ~body (invoke (Some (mk `Null))))
                   | `Pattern pat ->
                       let mk_term = pattern_reducer pat in
-                      let body = mk (mk_term ~body (mk (`Var name))) in
-                      let mk_term =
-                        pattern_reducer { pat with pat_entry = `PVar [name] }
-                      in
                       mk (mk_term ~body (invoke None)))
               body (List.rev meths)
           in

--- a/tests/language/eval.liq
+++ b/tests/language/eval.liq
@@ -59,7 +59,7 @@ def f() =
   t("20", {x.id() == "bla"})
 
   # Eval with patterns
-  let eval {foo, gni = [x, y]} =
+  let eval {foo, gni, gni = [x, y]} =
     "{foo = 123, gni = [1,2]}"
   t("21", {foo == 123})
   t("22", {gni == [1, 2]})

--- a/tests/language/pattern.liq
+++ b/tests/language/pattern.liq
@@ -41,29 +41,30 @@ def f() =
   c(z, [3])
 
   # Record
-  record = {foo=123, gni="gno", bla=3.24}
-  let {foo, gni, bla} = record
+  r = {foo=123, gni="gno", bla=3.24}
+  let {foo, gni, bla} = r
   c(foo, 123)
   c(gni, "gno")
   c(bla, 3.24)
 
   # Values with methods
-  record = 123.{foo=123, gni="gno", bla=3.24}
-  let {foo, gni, bla, ...v} = record
+  r = 123.{foo=123, gni="gno", bla=3.24}
+  let {foo, gni, bla, ...v} = r
   c(v, 123)
   c(foo, 123)
   c(gni, "gno")
   c(bla, 3.24)
-  record = 123.{foo=321, gni="gnu", bla=4.12}
-  let {foo, gni, bla, ..._} = record
+  r = 123.{foo=321, gni="gnu", bla=4.12}
+  let {foo, gni, bla, ..._} = r
   c(foo, 321)
   c(gni, "gnu")
   c(bla, 4.12)
 
   # Combined patterns
   # Patterns inside records
-  record' = {foo=tuple, gni=l, r=record}
-  let {foo = (x, y, z, t), gni = [a, b, ...s, d], r = {gni, ...v}} = record'
+  r' = {foo=tuple, gni=l, r=r}
+  old_r = r
+  let {foo, foo = (x, y, z, t), gni = [a, b, ...s, d], r, r = {gni, ...v}} = r'
   c(foo, tuple)
   c(x, 123)
   c(y, "aabbcc")
@@ -73,7 +74,7 @@ def f() =
   c(b, 2)
   c(s, [3, 4, 5, 6, 7, 8])
   c(d, 9)
-  c(r, record)
+  c(r, old_r)
   c(v, 123)
   c(gni, "gnu")
   x = {foo=123, gni="gno", bla=3.24}

--- a/tests/language/record.liq
+++ b/tests/language/record.liq
@@ -339,6 +339,33 @@ def f() =
   x = ({} : {bla?: int})
   test.equal(x?.bla == x?.bla, true)
 
+  # Test destructuring of record
+  x = {foo={gni="aabb"}}
+  foo = 123
+
+  let {foo = {gni}} = x
+  test.equal(foo, 123)
+  test.equal(gni, "aabb")
+
+  gni = 123
+  let {foo = {gni = gno}, foo, foo = gna} = x
+  test.equal(foo, {gni="aabb"})
+  test.equal(gni, 123)
+  test.equal(gno, "aabb")
+  test.equal(gna, {gni="aabb"})
+
+  x = {gni=123, bla=true}
+  let {gni = _, ...rest} = x
+  test.equal(rest, {bla=true})
+
+  x = {gni={foo="aabb"}, bla="blo"}
+  gni = 345
+  let {gni = {foo}, gni = gno, ...rest} = x
+  test.equal(gni, 345)
+  test.equal(foo, "aabb")
+  test.equal(gno, {foo="aabb"})
+  test.equal(rest, {bla="blo"})
+
   test.pass()
 end
 

--- a/tests/regression/GH3840.liq
+++ b/tests/regression/GH3840.liq
@@ -19,7 +19,7 @@ def on_stop() =
       "ffprobe -v quiet -print_format json -show_streams #{out_file}"
     )
 
-  let json.parse ({streams = [s1, s2]} : {streams: [{codec_name: string}]}) = j
+  let json.parse ({streams} : {streams: [{codec_name: string}]}) = j
   if
     not list.exists(fun (s) -> s.codec_name == "mp3", streams)
   then


### PR DESCRIPTION
This clarifies the semantics of the language and makes it possible to avoid assigning unwanted variable. It is still possible to assign both the destructured variable and top-level one by repeating the field.

Example:

```liquidsoap
x = { foo = { gni = 123 } }

# Just assign the inner field:
let { foo = { gni } } = x
- gni: 123

# Assign the inner field with a custom name:
let { foo = { gni = gno } } = x
- gno: 123

# Assign both inner field and top-level:
let { foo, foo = { gni } } = x
- foo: { gni = 123 }
  gni: 123
```