### PR TITLE
Explicit deprecated, fix stdlib inclusion logic.

### DIFF
--- a/liquidsoap
+++ b/liquidsoap
@@ -4,4 +4,4 @@
 DIR="$(dirname "$0")"
 export DIR
 
-opam exec dune -- exec --display=quiet --no-print-directory --root="$DIR" src/bin/liquidsoap.exe -- --stdlib "$DIR"/src/libs/stdlib.liq "$@"
+opam exec dune -- exec --display=quiet --no-print-directory --root="$DIR" src/bin/liquidsoap.exe -- --disable-deprecated --stdlib "$DIR"/src/libs/stdlib.liq "$@"

--- a/src/lang/lang_eval.ml
+++ b/src/lang/lang_eval.ml
@@ -8,13 +8,13 @@ let type_term ?name ?(cache = true) ?(trim = true) ?(deprecated = false) ?ty
       | `Disabled -> (parsed_term, None)
       | #check_stdlib as stdlib ->
           let parsed_term, env =
-            let libs, error_on_no_stdlib =
+            let stdlib, error_on_no_stdlib =
               match stdlib with
-                | `Override s -> (Some [s], true)
+                | `Override s -> (Some s, true)
                 | `If_present -> (None, false)
                 | `Force -> (None, true)
             in
-            Term_stdlib.prepare ?libs ~cache ~error_on_no_stdlib ~deprecated
+            Term_stdlib.prepare ~stdlib ~cache ~error_on_no_stdlib ~deprecated
               parsed_term
           in
           (parsed_term, Some env)

--- a/src/lang/runtime.ml
+++ b/src/lang/runtime.ml
@@ -432,21 +432,19 @@ let interactive () =
   in
   loop ()
 
-let libs ?(stdlib = "stdlib.liq") ?(error_on_no_stdlib = true)
-    ?(deprecated = true) () =
-  let dir = !Hooks.liq_libs_dir () in
-  let file = Filename.concat dir stdlib in
+let libs ?(error_on_no_stdlib = true) ?(deprecated = true) ~stdlib () =
   let libs =
-    if not (Sys.file_exists file) then
+    if not (Sys.file_exists stdlib) then
       if error_on_no_stdlib then
         failwith (Printf.sprintf "Could not find default %s library!" stdlib)
       else []
-    else [file]
+    else [stdlib]
   in
+  let dir = Filename.dirname stdlib in
   let file = Filename.concat (Filename.concat dir "extra") "deprecations.liq" in
   if deprecated && Sys.file_exists file then libs @ [file] else libs
 
-let load_libs ?stdlib () =
+let load_libs ~stdlib () =
   List.iter
     (fun fname ->
       let filename = Lang_string.home_unrelate fname in
@@ -466,4 +464,4 @@ let load_libs ?stdlib () =
               parsed_term
           in
           ignore (eval_term ~name:"stdlib" ~toplevel:true term)))
-    (libs ?stdlib ())
+    (libs ~stdlib ())

--- a/src/lang/runtime.mli
+++ b/src/lang/runtime.mli
@@ -51,14 +51,14 @@ val raw_errors : bool ref
 
 (** Return the list of external libraries. *)
 val libs :
-  ?stdlib:string ->
   ?error_on_no_stdlib:bool ->
   ?deprecated:bool ->
+  stdlib:string ->
   unit ->
   string list
 
 (** Load the external libraries. *)
-val load_libs : ?stdlib:string -> unit -> unit
+val load_libs : stdlib:string -> unit -> unit
 
 (* Wrapper for format language errors. Re-raises [Error]
    after printing language errors. *)

--- a/src/lang/term/term_stdlib.ml
+++ b/src/lang/term/term_stdlib.ml
@@ -52,12 +52,15 @@ let rec prepend_parsed_stdlib =
     the full env using it. Next, we append the user script to the resulting term
     and typecheck the user script only using the standard library environment.
 *)
-let prepare ?libs ~cache ~error_on_no_stdlib ~deprecated parsed_term =
-  let libs =
-    match libs with
-      | Some libs -> libs
-      | None -> Runtime.libs ~error_on_no_stdlib ~deprecated ()
+let prepare ~stdlib ~cache ~error_on_no_stdlib ~deprecated parsed_term =
+  let stdlib =
+    match stdlib with
+      | Some stdlib -> stdlib
+      | None ->
+          let dir = !Hooks.liq_libs_dir () in
+          Filename.concat dir "stdlib.liq"
   in
+  let libs = Runtime.libs ~stdlib ~error_on_no_stdlib ~deprecated () in
   let script = List.fold_left (Printf.sprintf "%s\n%%include %S") "" libs in
   let lexbuf = Sedlexing.Utf8.from_string script in
   let parsed_stdlib, stdlib =

--- a/src/lang/term/term_stdlib.mli
+++ b/src/lang/term/term_stdlib.mli
@@ -1,5 +1,5 @@
 val prepare :
-  ?libs:string list ->
+  stdlib:string option ->
   cache:bool ->
   error_on_no_stdlib:bool ->
   deprecated:bool ->

--- a/src/runtime/main.ml
+++ b/src/runtime/main.ml
@@ -385,9 +385,20 @@ let options =
         ( ["--stdlib"],
           Arg.String (fun s -> stdlib := `Override s),
           "Override the location of the standard library." );
-        ( ["--no-deprecated"],
+        ( ["--disable-deprecated"],
           Arg.Clear deprecated,
           "Do not load wrappers for deprecated operators." );
+        ( ["--no-deprecated"],
+          Arg.Unit
+            (fun _ ->
+              Printf.eprintf
+                "`--no-deprecated` is, ahem.. deprecated! Please use \
+                 `--disable-deprecated`!";
+              deprecated := false),
+          "Deprecated: use `--disable-deprecated`" );
+        ( ["--enable-deprecated"],
+          Arg.Set deprecated,
+          "Load wrappers for deprecated operators." );
         ( ["-i"],
           Arg.Set Liquidsoap_lang.Typechecking.display_types,
           "Display inferred types." );


### PR DESCRIPTION
There was a glitch after the work on caching scripts where the deprecated layer was not loaded if an explicit `--stdlib` was passed, such as what we do in the root `liquidsoap` wrapper.

This PR cleans things up:
* Load deprecated from `<stdlib dir>/extra/deprecated.liq` if present, using the effective `stdlib` directory (default or user-provided)
* Add explicit `--<enable/disable>-deprecated` options, deprecate `--no-deprecated` option.
* Explicitly mark the top-level `liquidsoap` wrapper as `--disable-deprecated`.

Having the top-level wrapper not loading the deprecated APIs by default is great when developing (which is its purpose) as it allows to quickly error on missing changes in the standard library.