### PR TITLE
fix: Prevent trailing '&' in request payload for when updating interactive variables

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -36,6 +36,7 @@ Fixed:
 
 - Fix error when loading script path having non-ascii characters in them
   (#4343)
+- Fix error with interactive variables (#4592, @myeungdev)
 - Prevent concurrent reload and request fetch in playlists (#4316)
 - Don't mark source as ready until their clock has started. (#4496)
 - Fixed mutex deadlock caused by aggressive inlining (#4540)

--- a/src/libs/extra/interactive.liq
+++ b/src/libs/extra/interactive.liq
@@ -515,7 +515,7 @@ def interactive.harbor(
           }
         }
         if (interactive[i].type != 'button') {
-          data = data.concat(interactive[i].name+'='+encodeURIComponent(interactive[i].value))+'&';
+          data = data.concat(interactive[i].name+'='+encodeURIComponent(interactive[i].value))+(i < interactive.length - 1 ? '&' : '')
         }
       }
       console.log('Posting: ' + data);

--- a/src/libs/utils.liq
+++ b/src/libs/utils.liq
@@ -20,15 +20,21 @@ end
 # @category String
 # @param args Argument string to split.
 def url.split_args(args) =
-  def f(x) =
-    ret = r/=/.split(x)
-    arg = url.decode(list.nth(default="", ret, 0))
-    val = url.decode(list.nth(default="", ret, 1))
-    (arg, val)
+  def f(args, x) =
+    if
+      x == ""
+    then
+      args
+    else
+      ret = r/=/.split(x)
+      arg = url.decode(list.nth(default="", ret, 0))
+      val = url.decode(list.nth(default="", ret, 1))
+      [...args, (arg, val)]
+    end
   end
 
   l = r/&/.split(args)
-  list.map(f, l)
+  list.fold(f, [], l)
 end
 
 # Split an url of the form `foo?arg=bar&arg2=bar2` into

--- a/tests/language/url.liq
+++ b/tests/language/url.liq
@@ -7,6 +7,12 @@ def f() =
     ("abc", [("a", "aa"), ("b", ""), ("c", "cc")])
   )
 
+  # Trailing & (#4592)
+  test.equal(
+    url.split("abc?a=aa&b=&c=cc&"),
+    ("abc", [("a", "aa"), ("b", ""), ("c", "cc")])
+  )
+
   # No argument (#3126).
   test.equal(url.split("/bla"), ("/bla", []))
   test.pass()


### PR DESCRIPTION
First of all, thank you for this fantastic project! 

Currently, whenever an interactive variable is updated through the web interface, Liquidsoap throws the following error, even though the update is successful:

```
  [interactive.harbor:3] Could not update variable  (not_found: no default value for list.assoc).
```

This was very confusing for me, as it led me to believe my variables were not being updated successfully, and I ended up spending a lot of time debugging my script. After some investigation, I discovered that the error occurs because Liquidsoap attempts to find a variable with an empty string name after each update request, caused by a trailing `&` in the request body.

This pull request adds a conditional check to only append `&` if it’s not the last parameter, preventing this issue from happening again.

This error also caused confusion for one of the users:
https://github.com/savonet/liquidsoap/issues/4194