### PR TITLE
Fix inline encoders by removing the need for a full child clock.

### DIFF
--- a/src/core/builtins/builtins_ffmpeg_bitstream_filters.ml
+++ b/src/core/builtins/builtins_ffmpeg_bitstream_filters.ml
@@ -208,7 +208,7 @@ let register_filters () =
                     details.")
                ~flags:[`Extra] args_t ~return_t:source_t
                (fun p ->
-                 let source = List.assoc "" p in
+                 let source = Lang.to_source (List.assoc "" p) in
 
                  let filter_opts = args_of_args (args_parser p []) in
 
@@ -295,19 +295,7 @@ let register_filters () =
                    | `Flush -> flush ~put_data
                  in
 
-                 let consumer =
-                   new Producer_consumer.consumer
-                     ~write_frame:encode_frame ~name:(name ^ ".consumer")
-                     ~source ()
-                 in
-
-                 let producer =
-                   new Producer_consumer.producer
-                     ~check_self_sync:false ~consumers:[consumer]
-                     ~name:(name ^ ".producer") ()
-                 in
-                 Typing.(producer#frame_type <: consumer#frame_type);
-                 producer)))
+                 new Simple_encoder.encoder ~name ~encode:encode_frame source)))
         modes)
     Avcodec.BitstreamFilter.filters
 

--- a/src/core/builtins/builtins_ffmpeg_decoder.ml
+++ b/src/core/builtins/builtins_ffmpeg_decoder.ml
@@ -487,25 +487,7 @@ let mk_decoder mode =
                  decode_frame_ref := None
          in
 
-         let consumer =
-           new Producer_consumer.consumer
-             ~always_enabled:true ~write_frame:decode_frame
-             ~name:(id ^ ".consumer") ~source:(Lang.source source) ()
-         in
-         let stack = Liquidsoap_lang.Lang_core.pos p in
-         consumer#set_stack stack;
-
-         let input_frame_t = Type.fresh input_frame_t in
-         Typing.(
-           consumer#frame_type
-           <: Lang.frame_t (Lang.univ_t ())
-                (Frame.Fields.add field input_frame_t Frame.Fields.empty));
-
-         ( field,
-           new Producer_consumer.producer
-           (* We are expecting real-rate with a couple of hickups.. *)
-             ~stack ~check_self_sync:false ~consumers:[consumer]
-             ~name:(id ^ ".producer") () )))
+         (field, new Simple_encoder.encoder ~name:id ~encode:decode_frame source)))
 
 let () =
   List.iter mk_decoder [`Audio_encoded; `Audio_raw; `Video_encoded; `Video_raw]

--- a/src/core/builtins/builtins_ffmpeg_encoder.ml
+++ b/src/core/builtins/builtins_ffmpeg_encoder.ml
@@ -552,25 +552,7 @@ let mk_encoder mode =
                  encode_frame_ref := None
          in
 
-         let consumer =
-           new Producer_consumer.consumer
-             ~always_enabled:true ~write_frame:encode_frame
-             ~name:(id ^ ".consumer") ~source:(Lang.source source) ()
-         in
-         let stack = Liquidsoap_lang.Lang_core.pos p in
-         consumer#set_stack stack;
-
-         let input_frame_t = Type.fresh input_frame_t in
-         Typing.(
-           consumer#frame_type
-           <: Lang.frame_t (Lang.univ_t ())
-                (Frame.Fields.add field input_frame_t Frame.Fields.empty));
-
-         ( field,
-           new Producer_consumer.producer
-           (* We are expecting real-rate with a couple of hickups.. *)
-             ~stack ~check_self_sync:false ~consumers:[consumer]
-             ~name:(id ^ ".producer") () )))
+         (field, new Simple_encoder.encoder ~name:id ~encode:encode_frame source)))
 
 let () =
   List.iter mk_encoder [`Audio_encoded; `Audio_raw; `Video_encoded; `Video_raw]

--- a/src/core/dune
+++ b/src/core/dune
@@ -94,6 +94,7 @@
   dyn_op
   echo
   encoder
+  simple_encoder
   encoder_formats
   encoder_utils
   error

--- a/src/core/operators/accelerate.ml
+++ b/src/core/operators/accelerate.ml
@@ -26,7 +26,7 @@ class accelerate ~ratio ~randomize source_val =
   let source = Lang.to_source source_val in
   object (self)
     inherit operator ~name:"accelerate" []
-    inherit Child_support.base ~check_self_sync:true [source_val]
+    inherit Child_support.base [source_val]
     method self_sync = source#self_sync
     method fallible = source#fallible
     method seek_source = source#seek_source

--- a/src/core/operators/cross.ml
+++ b/src/core/operators/cross.ml
@@ -66,7 +66,7 @@ class cross val_source ~end_duration_getter ~override_end_duration
         ~track_sensitive:(fun () -> false)
         ()
 
-    inherit Child_support.base ~check_self_sync:true [val_source]
+    inherit Child_support.base [val_source]
     initializer Typing.(s#frame_type <: self#frame_type)
     method fallible = true
 

--- a/src/core/operators/noblank.ml
+++ b/src/core/operators/noblank.ml
@@ -155,7 +155,7 @@ class eat ~track_sensitive ~at_beginning ~start_blank ~max_blank ~min_noise
     (* Eating blank is trickier than stripping. *)
     inherit operator ~name:"blank.eat" []
     inherit base ~track_sensitive ~start_blank ~max_blank ~min_noise ~threshold
-    inherit Child_support.base ~check_self_sync:true [source_val]
+    inherit Child_support.base [source_val]
 
     (** We strip when the source is silent, but only at the beginning of tracks
         if [at_beginning] is passed. *)

--- a/src/core/operators/resample.ml
+++ b/src/core/operators/resample.ml
@@ -34,7 +34,7 @@ class resample ~field ~ratio source =
   let () = Typing.(consumer#frame_type <: source#frame_type) in
   object (self)
     inherit operator ~name:"stretch" []
-    inherit Child_support.base ~check_self_sync:true [source_val]
+    inherit Child_support.base [source_val]
     method self_sync = source#self_sync
     method fallible = source#fallible
 

--- a/src/core/operators/simple_encoder.ml
+++ b/src/core/operators/simple_encoder.ml
@@ -1,0 +1,72 @@
+(*****************************************************************************
+
+  Liquidsoap, a programmable stream generator.
+  Copyright 2003-2024 Savonet team
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details, fully stated in the COPYING
+  file at the root of the liquidsoap distribution.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA
+
+ *****************************************************************************)
+
+(* Synchronous encoder with room for initial buffer. *)
+
+(* Base class to inherit from. Should write to self#buffer. *)
+class virtual base ?bufferize ~name source =
+  let bufferize = Option.value ~default:0 bufferize in
+  object (self)
+    inherit Source.operator ~name [source]
+    method fallible = true
+    method virtual encode : [ `Frame of Frame.t | `Flush ] -> unit
+    val mutable flushed = false
+    val mutable started = false
+
+    method flush =
+      if not flushed then (
+        flushed <- true;
+        started <- false;
+        self#encode `Flush)
+
+    method private feed =
+      flushed <- false;
+      let frame = source#get_frame in
+      self#encode (`Frame frame);
+      if Frame.is_partial frame then self#flush
+
+    method private can_generate_frame =
+      if source#is_ready && Generator.length self#buffer <= bufferize then
+        self#feed;
+      if not source#is_ready then self#flush;
+      if started then 0 < Generator.length self#buffer
+      else bufferize < Generator.length self#buffer
+
+    method remaining =
+      match source#remaining with
+        | -1 -> -1
+        | n -> n + Generator.length self#buffer
+
+    method seek_source = source#seek_source
+    method abort_track = source#abort_track
+    method self_sync = source#self_sync
+
+    method generate_frame =
+      started <- true;
+      Generator.slice self#buffer (Lazy.force Frame.size)
+  end
+
+class encoder ~name ~encode source =
+  object (self)
+    inherit base ~name source
+    method encode = encode self#buffer
+  end

--- a/src/core/operators/soundtouch_op.ml
+++ b/src/core/operators/soundtouch_op.ml
@@ -37,7 +37,7 @@ class soundtouch source_val rate tempo pitch =
   in
   object (self)
     inherit operator ~name:"soundtouch" []
-    inherit Child_support.base ~check_self_sync:true [source_val]
+    inherit Child_support.base [source_val]
     val mutable st = None
     method fallible = source#fallible
     method self_sync = source#self_sync

--- a/src/core/tools/child_support.ml
+++ b/src/core/tools/child_support.ml
@@ -23,20 +23,19 @@
 (** Utility for operators that need to control child source clocks. See
     [clock.mli] for a more detailed description. *)
 
-class virtual base ~check_self_sync children_val =
+class virtual base children_val =
   let children = List.map Lang.to_source children_val in
   object (self)
     initializer
-      if check_self_sync then
-        List.iter
-          (fun c ->
-            if (Lang.to_source c)#self_sync <> (`Static, None) then
-              raise
-                (Error.Invalid_value
-                   ( c,
-                     "This source may control its own latency and cannot be \
-                      used with this operator." )))
-          children_val
+      List.iter
+        (fun c ->
+          if (Lang.to_source c)#self_sync <> (`Static, None) then
+            raise
+              (Error.Invalid_value
+                 ( c,
+                   "This source may control its own latency and cannot be used \
+                    with this operator." )))
+        children_val
 
     method virtual id : string
     method virtual clock : Clock.t

--- a/src/core/tools/producer_consumer.ml
+++ b/src/core/tools/producer_consumer.ml
@@ -29,11 +29,7 @@ type write_frame = write_payload -> unit
    - We want to opt-out of the generic child_process
      clock animation framework.
    Thus, we manually mark this operator as ready only
-   before we're about to pull from it.
-
-   There is one exception: when we're expeciting the operator
-   to mostly follow real-time. In this case, we set [always_enabled]
-   to [true] and [check_self_sync] to [false] on the producer. *)
+   before we're about to pull from it. *)
 class consumer ?(always_enabled = false) ~write_frame ~name ~source () =
   let s = Lang.to_source source in
   let infallible = not s#fallible in
@@ -57,7 +53,7 @@ class consumer ?(always_enabled = false) ~write_frame ~name ~source () =
 (** The source which produces data by reading the buffer. We do NOT want to use
     [operator] here b/c the [consumers] may have different content-kind when
     this is used in the muxers. *)
-class producer ?stack ~check_self_sync ~consumers ~name () =
+class producer ?stack ~consumers ~name () =
   let infallible = List.for_all (fun s -> not s#fallible) consumers in
   let self_sync = Clock_base.self_sync consumers in
   object (self)
@@ -65,7 +61,6 @@ class producer ?stack ~check_self_sync ~consumers ~name () =
 
     inherit
       Child_support.base
-        ~check_self_sync
         (List.map (fun s -> Lang.source (s :> Source.source)) consumers)
 
     method self_sync = self_sync ~source:self ()

--- a/tests/media/ffmpeg_drop_tracks.liq
+++ b/tests/media/ffmpeg_drop_tracks.liq
@@ -53,10 +53,10 @@ def check_stream() =
   then
     is_done := true
 
-    process.run("sync")
-
     def check_stream(name) =
       stream = process.quote("#{output_dir}/#{name}.m3u8")
+
+      file.write(append=true, data="\r\n#EXT-X-ENDLIST\r\n", stream)
 
       ojson =
         process.read(

--- a/tests/media/ffmpeg_raw_hls.liq
+++ b/tests/media/ffmpeg_raw_hls.liq
@@ -47,7 +47,9 @@ def check_stream() =
   then
     is_done := true
 
-    process.run("sync")
+    file.write(
+      append=true, data="\r\n#EXT-X-ENDLIST\r\n", "#{output_dir}/mp4.m3u8"
+    )
 
     ojson =
       process.read(
@@ -74,9 +76,7 @@ def check_stream() =
       list.find((fun (stream) -> stream.codec_name == "h264"), parsed.streams)
 
     audio_stream =
-      list.find(
-        (fun (stream) -> stream.codec_name == "aac"), parsed.streams
-      )
+      list.find((fun (stream) -> stream.codec_name == "aac"), parsed.streams)
 
     if
       null.get(video_stream.codec_name) == "h264"
@@ -98,20 +98,21 @@ end
 
 def segment_name(metadata) =
   let {position, extname, stream_name} = metadata
-  if position > 1 then check_stream() end
+  if position == 2 then check_stream() end
   timestamp = int_of_float(time())
   "#{stream_name}_#{timestamp}_#{position}.#{extname}"
 end
 
 clock.assign_new(sync='none', [raw])
-output.file.hls(
-  playlist="live.m3u8",
-  segment_duration=2.0,
-  segments=5,
-  segments_overhead=5,
-  segment_name=segment_name,
-  output_dir,
-  streams,
-  fallible=true,
-  raw
-)
+o =
+  output.file.hls(
+    playlist="live.m3u8",
+    segment_duration=2.0,
+    segments=5,
+    segments_overhead=5,
+    segment_name=segment_name,
+    output_dir,
+    streams,
+    fallible=true,
+    raw
+  )


### PR DESCRIPTION
With the new clock model, these operators don't need their own child clock anymore. This simplifies their use greatly.