### PR TITLE
Check and unify main clock when unifying child clocks.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -62,6 +62,7 @@
   inline with its expectation but can change existing script's output (#4605)
 - Fix error when loading script path having non-ascii characters in them
   (#4343)
+- Fix concurrent inline encoders (#4638)
 - Fix error with interactive variables (#4592, @myeungdev)
 - Prevent concurrent reload and request fetch in playlists (#4316)
 - Don't mark source as ready until their clock has started. (#4496)

--- a/src/core/clock.ml
+++ b/src/core/clock.ml
@@ -127,6 +127,7 @@ type state =
 
 type clock = {
   id : string option Unifier.t;
+  main_clock : t option;
   sub_ids : string list;
   stack : Pos.t list Atomic.t;
   state : state Atomic.t;
@@ -257,7 +258,7 @@ let descr clock =
       | _ -> "")
 
 let unify =
-  let unify c c' =
+  let _unify c c' =
     let clock = Unifier.deref c in
     let clock' = Unifier.deref c' in
     Queue.flush_iter clock.pending_activations
@@ -275,20 +276,37 @@ let unify =
     Unifier.(c <-- c');
     Queue.filter_out clocks (fun el -> el == c)
   in
-  fun ~pos c c' ->
+  let rec unify ~pos c c' =
     let _c = Unifier.deref c in
     let _c' = Unifier.deref c' in
+    (match (_c.main_clock, _c'.main_clock) with
+      | Some x, Some x' -> (
+          try unify ~pos x x'
+          with _ ->
+            raise
+              Liquidsoap_lang.Error.(
+                Clock_main
+                  {
+                    pos;
+                    left_main = descr x;
+                    left_child = descr c;
+                    right_main = descr x';
+                    right_child = descr c';
+                  }))
+      | _ -> ());
     match (_c == _c', Atomic.get _c.state, Atomic.get _c'.state) with
       | true, _, _ -> ()
-      | _, `Stopped s, `Stopped s' when s = s' -> unify c c'
+      | _, `Stopped s, `Stopped s' when s = s' -> _unify c c'
       | _, `Stopped s, _
         when s = `Automatic || (s :> sync_mode) = _sync ~pending:true _c' ->
-          unify c c'
+          _unify c c'
       | _, _, `Stopped s'
         when s' = `Automatic || _sync ~pending:true _c = (s' :> sync_mode) ->
-          unify c' c
+          _unify c' c
       | _ ->
           raise (Liquidsoap_lang.Error.Clock_conflict (pos, descr c, descr c'))
+  in
+  unify
 
 let () =
   Lifecycle.before_core_shutdown ~name:"Clocks stop" (fun () ->
@@ -612,13 +630,15 @@ let add_pending_clock =
     Gc.finalise finalise c;
     WeakQueue.push pending_clocks c
 
-let create ?(stack = []) ?on_error ?id ?(sub_ids = []) ?(sync = `Automatic) () =
+let create ?(stack = []) ?main_clock ?on_error ?id ?(sub_ids = [])
+    ?(sync = `Automatic) () =
   let on_error_queue = Queue.create () in
   (match on_error with None -> () | Some fn -> Queue.push on_error_queue fn);
   let c =
     Unifier.make
       {
         id = Unifier.make (Option.map generate_id id);
+        main_clock;
         sub_ids;
         stack = Atomic.make stack;
         pending_activations = Queue.create ();
@@ -684,13 +704,13 @@ let set_stack c stack =
   ignore (Atomic.compare_and_set (Unifier.deref c).stack [] stack)
 
 let create_sub_clock ~id clock =
-  let clock = Unifier.deref clock in
+  let _clock = Unifier.deref clock in
   let sub_clock =
-    create ~stack:(Atomic.get clock.stack) ~id
-      ~sub_ids:(clock.sub_ids @ ["child"])
+    create ~stack:(Atomic.get _clock.stack) ~id ~main_clock:clock
+      ~sub_ids:(_clock.sub_ids @ ["child"])
       ~sync:`Passive ()
   in
-  Queue.push clock.sub_clocks sub_clock;
+  Queue.push _clock.sub_clocks sub_clock;
   sub_clock
 
 let create ?stack ?on_error ?id ?sync () = create ?stack ?on_error ?id ?sync ()

--- a/src/lang/error.ml
+++ b/src/lang/error.ml
@@ -25,13 +25,32 @@ exception Invalid_value of Value.t * string
 
 exception Clock_conflict of (Pos.Option.t * string * string)
 
+type clock_main = {
+  pos : Pos.Option.t;
+  left_main : string;
+  left_child : string;
+  right_main : string;
+  right_child : string;
+}
+
+exception Clock_main of clock_main
+
 let () =
   Printexc.register_printer (function
     | Clock_conflict (pos, a, b) ->
         let pos = Pos.Option.to_string pos in
         Some
           (Printf.sprintf
-             "Clock_conflict: At position: %s, a source cannot belong to two \
-              clocks (%s, %s)"
+             "Clock unification error: At position: %s, clocks %s and %s \
+              cannot be unified"
              pos a b)
+    | Clock_main { pos; left_main; left_child; right_main; right_child } ->
+        let pos = Pos.Option.to_string pos in
+        Some
+          (Printf.sprintf
+             "Clock unification error: At position: %s, clocks %s and %s \
+              cannot be unified: clock %s is controlled by clock %s while \
+              clock %s is controlled by %s."
+             pos left_child right_child left_child left_main right_child
+             right_main)
     | _ -> None)

--- a/src/lang/error.mli
+++ b/src/lang/error.mli
@@ -24,3 +24,13 @@
 exception Invalid_value of Value.t * string
 
 exception Clock_conflict of (Pos.Option.t * string * string)
+
+type clock_main = {
+  pos : Pos.Option.t;
+  left_main : string;
+  left_child : string;
+  right_main : string;
+  right_child : string;
+}
+
+exception Clock_main of clock_main


### PR DESCRIPTION
Child clocks can be unified if they belong to the same main clock. This PR implements that.