### PR TITLE
Unbreak notify_metadata

### DIFF
--- a/src/libs/extra/externals.liq
+++ b/src/libs/extra/externals.liq
@@ -165,7 +165,7 @@ def osd_metadata(
     )
   end
 
-  s.on_metadata(feedback)
+  s.on_metadata(synchronous=false, feedback)
 end
 
 # Use notify to display metadata info.


### PR DESCRIPTION
Using notify_metadata causes a typecheck error in Liquidsoap 2.4.0; this adds the now-required synchronous= argument.