### PR TITLE
Fix CAMLparam definitions in C stubs

### DIFF
--- a/src/core/operators/defer_c.c
+++ b/src/core/operators/defer_c.c
@@ -6,7 +6,7 @@
 
 // Single bigarray not registered with the GC.
 CAMLprim value liquidsoap_alloc_managed_int16_ba(value _len) {
-  CAMLparam0();
+  CAMLparam1(_len);
   intnat out_size = Int_val(_len);
   void *data = malloc(out_size * caml_ba_element_size[CAML_BA_SINT16]);
   if (!data)

--- a/src/core/operators/lufs_c.c
+++ b/src/core/operators/lufs_c.c
@@ -37,7 +37,8 @@ static struct custom_operations iir_ops = {
 CAMLprim value liquidsoap_lufs_create_native(value _channels, value _a1,
                                              value _a2, value _b0, value _b1,
                                              value _b2) {
-  CAMLparam5(_a1, _a2, _b0, _b1, _b2);
+  CAMLparam5(_channels, _a1, _a2, _b0, _b1);
+  CAMLxparam1(_b2);
   CAMLlocal1(ans);
   int channels = Int_val(_channels);
 

--- a/src/modules/duppy/duppy_stubs.c
+++ b/src/modules/duppy/duppy_stubs.c
@@ -51,7 +51,7 @@
 #include <poll.h>
 
 CAMLprim value caml_poll(value _read, value _write, value _err, value _timeout) {
-  CAMLparam3(_read, _write, _err);
+  CAMLparam4(_read, _write, _err, _timeout);
   CAMLlocal4(_pread, _pwrite, _perr, _ret);
 
   struct pollfd *fds;
@@ -151,7 +151,7 @@ CAMLprim value caml_poll(value _read, value _write, value _err, value _timeout) 
 
 CAMLprim value ocaml_duppy_write_ba(value _fd, value ba, value _ofs, value _len)
 {
-  CAMLparam2(ba,_fd) ;
+  CAMLparam4(_fd, ba, _ofs, _len);
   int fd = Fd_val(_fd);
   long ofs = Long_val(_ofs);
   long len = Long_val(_len);


### PR DESCRIPTION
Possible fix for https://github.com/savonet/liquidsoap/issues/4708