### PR TITLE
Call wake_up before sleep in source.dynamic to make sure sources re-used in the new source are never inadvertently cleaned up.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,8 @@
 
 ## Fixed:
 
+- Make sure that sources re-used in `source.dynamic` are never
+  inadvertently cleaned up (#4713)
 - Raise a proper error on parse error raised during `%include`
   parsing.
 - Fixed start/stop logic in `output.harbor` (#4666)

--- a/src/core/operators/dyn_op.ml
+++ b/src/core/operators/dyn_op.ml
@@ -59,8 +59,9 @@ class dyn ~init ~track_sensitive ~infallible ~self_sync ~merge next_fn =
       match self#current_source with
         | Some s' when s == s' -> Some s
         | Some s' ->
+            let ret = self#switch s in
             s'#sleep (self :> Clock.source);
-            self#switch s
+            ret
         | None -> self#switch s
 
     method private get_next reselect =


### PR DESCRIPTION
Fixes: #4713