### PR TITLE
Add active stereotool and output.stereotool.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
   when creating a `%ffmpeg` encoder (#4667)
 - Added start/stop telnet commands for outputs.
 - Added `settings.syslog.level` to set syslog level (#4686)
+- Added `active` parameter to `stereotool` and `output.stereotool` (#4749)
 
 ## Changed:
 

--- a/src/libs/audio.liq
+++ b/src/libs/audio.liq
@@ -367,6 +367,20 @@ def stereotool(
 
   s
 end
+
+# Output an audio source using stereotool
+# @argsof track.audio.stereotool[!active]
+# @category Source / Output
+def output.stereotool(
+  ~id=null("output.stereotool"),
+  %argsof(track.audio.stereotool[!id,!active]),
+  s
+) =
+  s = stereotool(%argsof(track.audio.stereotool[!id,!active]), active=false, s)
+  let replaces s = output.dummy(id=id, s)
+
+  s
+end
 %endif
 
 # Defer the source's audio track by a given amount of time. Source will be


### PR DESCRIPTION
This makes it possible to keep `stereotool` processing active even when not being actively pulled by an output (`active` parameter in `stereotool` operator) or to make it a proper output (`output.stereotool`).

This can be used when the audio processed by `stereotool` is meant to also be sent by stereotool to e.g. a FM transmitter.

Fixes: #4724