### PR TITLE
Make sure timed content is unique.

### DIFF
--- a/src/core/stream/content_timed.ml
+++ b/src/core/stream/content_timed.ml
@@ -41,8 +41,11 @@ module Specs = struct
   let clear d = d.data <- []
   let is_empty { data } = data = []
 
+  (* Make sure content is unique per position, keeping the last
+     entry for each position. *)
   let sort : 'a. (int * 'a) list -> (int * 'a) list =
-   fun data -> List.stable_sort (fun (p, _) (p', _) -> compare p p') data
+   fun data ->
+    List.sort_uniq (fun (p, _) (p', _) -> compare p' p) (List.rev data)
 
   let sub c ofs length =
     let len = match length with Infinite -> max_int | Finite len -> len in


### PR DESCRIPTION
Timed content is content indexed by offset position such as `metadata` and `track_marks`. 

This kind of content should be unique per-position which this PR makes sure of.