### PR TITLE
Temporary fix for amplify type.

### DIFF
--- a/src/core/operators/amplify.ml
+++ b/src/core/operators/amplify.ml
@@ -89,7 +89,8 @@ class amplify ~field ~override_field (source : source) coeff =
   end
 
 let _ =
-  let frame_t = Lang.pcm_audio_t () in
+  (* let frame_t = Lang.pcm_audio_t () in *)
+  let frame_t = Format_type.audio () in
   Lang.add_track_operator ~base:Modules.track_audio "amplify"
     [
       ( "override",

--- a/tests/regression/GH3239-bis.liq
+++ b/tests/regression/GH3239-bis.liq
@@ -1,0 +1,16 @@
+# Simpler version of GH3239 to work on a specific issue with
+# source,dynamic
+
+tmp = file.temp("foo", "mp3")
+on_cleanup({file.remove(tmp)})
+
+def f() =
+  s = once(sine(duration=2.))
+  let {audio = a} = source.tracks(s)
+  track.audio.amplify(1., a)
+end
+
+s = source({audio=f()})
+
+o = output.file(fallible=true, %mp3(mono), tmp, s)
+o.on_stop(synchronous=true, test.pass)

--- a/tests/regression/dune.inc
+++ b/tests/regression/dune.inc
@@ -483,6 +483,22 @@
  (alias citest)
  (package liquidsoap)
  (deps
+  GH3239-bis.liq
+  ../media/all_media_files
+  ../../src/bin/liquidsoap.exe
+  ../streams/file1.png
+  ../streams/file1.mp3
+  ./theora-test.mp4
+  (package liquidsoap)
+  (source_tree ../../src/libs)
+  (:test_liq ../test.liq)
+  (:run_test ../run_test.exe))
+ (action (run %{run_test} GH3239-bis.liq liquidsoap %{test_liq} GH3239-bis.liq)))
+  
+(rule
+ (alias citest)
+ (package liquidsoap)
+ (deps
   GH3239.liq
   ../media/all_media_files
   ../../src/bin/liquidsoap.exe


### PR DESCRIPTION
There is a problem with variables with constraints being generalized away when used in functions in ways that are not working with our new source content type system as implemented.

This PR is a quick work-around to allow to move forward with another important fix. It will limit `amplify` to operate on internal `pcm` content only instead of all `pcm`, `pcm_s16le` and etc.