### PR TITLE
Weak activation list part deux

### DIFF
--- a/src/core/clock.mli
+++ b/src/core/clock.mli
@@ -59,10 +59,7 @@ module MkSyncSource (S : SyncSource) : sig
   val make : S.t -> sync_source
 end
 
-type activation =
-  < id : string
-  ; source_type : [ source_type | `Clock ]
-  ; sleep : activation -> unit >
+type activation = < id : string >
 
 type source =
   < id : string
@@ -71,7 +68,7 @@ type source =
   ; source_type : source_type
   ; active : bool
   ; activations : activation list
-  ; wake_up : activation -> unit
+  ; wake_up : source -> activation
   ; sleep : activation -> unit
   ; is_ready : bool
   ; get_frame : Frame.t >
@@ -99,7 +96,6 @@ val sources : t -> source list
 val clocks : unit -> t list
 val id : t -> string
 val set_id : t -> string -> unit
-val activation : t -> activation
 val descr : t -> string
 val sync : t -> sync_mode
 val start : ?force:bool -> t -> unit

--- a/src/core/clock_base.ml
+++ b/src/core/clock_base.ml
@@ -123,10 +123,7 @@ let () =
         Some (Buffer.contents buf)
     | _ -> None)
 
-type activation =
-  < id : string
-  ; source_type : [ source_type | `Clock ]
-  ; sleep : activation -> unit >
+type activation = < id : string >
 
 type source =
   < id : string
@@ -135,7 +132,7 @@ type source =
   ; source_type : source_type
   ; active : bool
   ; activations : activation list
-  ; wake_up : activation -> unit
+  ; wake_up : source -> activation
   ; sleep : activation -> unit
   ; is_ready : bool
   ; get_frame : Frame.t >

--- a/src/core/lang_source.ml
+++ b/src/core/lang_source.ml
@@ -904,7 +904,6 @@ let add_operator ~(category : Doc.Value.source) ~descr ?(flags = [])
               (fun s ->
                 val_fun [] (fun _ ->
                     Clock.detach s#clock (s :> Clock.source);
-                    s#sleep (Clock.activation s#clock);
                     unit));
           };
         ]

--- a/src/core/operators/cross.ml
+++ b/src/core/operators/cross.ml
@@ -213,22 +213,31 @@ class cross val_source ~end_duration_getter ~override_end_duration
     (* The played source. We _need_ exclusive control on that source,
      * since we are going to pull data from it at a higher rate around
      * track limits. *)
-    val source = s
-    method private prepare_source s = s#wake_up (self :> Clock.activation)
+    val mutable source = (None, s)
+    method private source = snd source
+    method private prepare_source s = s#wake_up (self :> Clock.source)
 
     initializer
       self#on_wake_up (fun () ->
-          source#wake_up (self :> Clock.activation);
-          self#reset_analysis)
+          let a, s = source in
+          assert (a = None);
+          source <- (Some (s#wake_up (self :> Clock.source)), s);
+          self#reset_analysis);
+      self#on_sleep (fun () ->
+          let a, s = source in
+          s#sleep (Option.get a);
+          source <- (None, s))
 
     val mutable status
-        : [ `Idle | `Before of Source.source | `After of Source.source ] =
+        : [ `Idle
+          | `Before of Clock.activation * Source.source
+          | `After of Clock.activation * Source.source ] =
       `Idle
 
     method set_status v =
       (match status with
         | `Idle -> ()
-        | `Before s | `After s -> s#sleep (self :> Clock.activation));
+        | `Before (a, s) | `After (a, s) -> s#sleep a);
       status <- v
 
     method! child_clock_controller =
@@ -316,36 +325,38 @@ class cross val_source ~end_duration_getter ~override_end_duration
 
     method private prepare_before =
       self#log#info "Buffering end of track...";
-      let before = new consumer ~clock:source#clock gen_before in
+      let before = new consumer ~clock:self#source#clock gen_before in
       Typing.(before#frame_type <: self#frame_type);
-      self#prepare_source before;
-      self#set_status (`Before (before :> Source.source));
+      let a = self#prepare_source before in
+      self#set_status (`Before (a, (before :> Source.source)));
       self#buffer_before ~is_first:true ();
       match status with
-        | `After s | `Before s -> if s#is_ready then Some s else None
+        | `After (_, s) | `Before (_, s) -> if s#is_ready then Some s else None
         | _ -> assert false
 
     method private get_source ~reselect () =
       let reselect = match reselect with `Force -> `Ok | _ -> reselect in
       match status with
-        | `Idle when source#is_ready -> self#prepare_before
+        | `Idle when self#source#is_ready -> self#prepare_before
         | `Idle -> None
         | `Before _ -> (
             self#buffer_before ~is_first:false ();
             match status with
               | `Idle -> assert false
-              | `Before before_source
+              | `Before (_, before_source)
                 when self#can_reselect ~reselect before_source ->
                   Some before_source
               | `Before _ -> None
-              | `After after_source -> Some after_source)
-        | `After after_source when self#can_reselect ~reselect after_source ->
+              | `After (_, after_source) -> Some after_source)
+        | `After (_, after_source) when self#can_reselect ~reselect after_source
+          ->
             Some after_source
         | `After _ -> self#prepare_before
 
     method private buffer_before ~is_first () =
-      if Generator.length gen_before < end_main_duration && source#is_ready then (
-        let buf_frame = self#child_get ~is_first source in
+      if Generator.length gen_before < end_main_duration && self#source#is_ready
+      then (
+        let buf_frame = self#child_get ~is_first self#source in
         self#append `Before buf_frame;
         (* Analyze them *)
         let pcm = AFrame.pcm buf_frame in
@@ -376,9 +387,9 @@ class cross val_source ~end_duration_getter ~override_end_duration
         let expected_start_duration = self#expected_start_duration in
         if
           Generator.length gen_after < expected_start_duration
-          && source#is_ready
+          && self#source#is_ready
         then (
-          let buf_frame = self#child_get ~is_first source in
+          let buf_frame = self#child_get ~is_first self#source in
           self#append `After buf_frame;
           if Generator.length gen_after <= rms_width then (
             let pcm = AFrame.pcm buf_frame in
@@ -466,7 +477,7 @@ class cross val_source ~end_duration_getter ~override_end_duration
             let head_gen =
               Generator.create ~content:head (Generator.content_type gen_before)
             in
-            let s = new consumer ~clock:source#clock head_gen in
+            let s = new consumer ~clock:self#source#clock head_gen in
             s#set_id (self#id ^ "_before_head");
             Typing.(s#frame_type <: self#frame_type);
             Some s)
@@ -475,7 +486,7 @@ class cross val_source ~end_duration_getter ~override_end_duration
         let before =
           new Replay_metadata.replay
             before_metadata
-            (new consumer ~clock:source#clock gen_before)
+            (new consumer ~clock:self#source#clock gen_before)
         in
         Typing.(before#frame_type <: self#frame_type);
         let after_tail =
@@ -486,7 +497,7 @@ class cross val_source ~end_duration_getter ~override_end_duration
             in
             let tail_gen = gen_after in
             gen_after <- head_gen;
-            let s = new consumer ~clock:source#clock tail_gen in
+            let s = new consumer ~clock:self#source#clock tail_gen in
             Typing.(s#frame_type <: self#frame_type);
             s#set_id (self#id ^ "_after_tail");
             Some s)
@@ -495,7 +506,7 @@ class cross val_source ~end_duration_getter ~override_end_duration
         let after =
           new Replay_metadata.replay
             after_metadata
-            (new consumer ~clock:source#clock gen_after)
+            (new consumer ~clock:self#source#clock gen_after)
         in
         Typing.(after#frame_type <: self#frame_type);
         before#set_id (self#id ^ "_before");
@@ -541,29 +552,29 @@ class cross val_source ~end_duration_getter ~override_end_duration
         Typing.(compound#frame_type <: self#frame_type);
         compound
       in
-      self#prepare_source compound;
+      let a = self#prepare_source compound in
       self#reset_analysis;
-      self#set_status (`After compound)
+      self#set_status (`After (a, compound))
 
     method remaining =
       match status with
-        | `Idle -> source#remaining
-        | `Before s -> (
-            match (s#remaining, source#remaining) with
+        | `Idle -> self#source#remaining
+        | `Before (_, s) -> (
+            match (s#remaining, self#source#remaining) with
               | -1, _ | _, -1 -> -1
               | r, r' -> r + r')
-        | `After s -> s#remaining
+        | `After (_, s) -> s#remaining
 
     method effective_source =
       match status with
-        | `Idle -> source#effective_source
-        | `Before s | `After s -> s#effective_source
+        | `Idle -> self#source#effective_source
+        | `Before (_, s) | `After (_, s) -> s#effective_source
 
     method abort_track =
       match status with
-        | `Idle -> source#abort_track
+        | `Idle -> self#source#abort_track
         | `Before s | `After s ->
-            source#abort_track;
+            self#source#abort_track;
             status <- `After s;
             ignore self#prepare_before
   end

--- a/src/core/operators/pipe.ml
+++ b/src/core/operators/pipe.ml
@@ -240,8 +240,9 @@ class pipe ~replay_delay ~data_len ~process ~bufferize ~max ~restart
             | _, `Nothing -> restart)
 
     initializer
+      let a = ref None in
       self#on_wake_up (fun () ->
-          source#wake_up (self :> Clock.activation);
+          a := Some (source#wake_up (self :> Clock.source));
           converter <-
             Decoder_utils.from_iff ~format:`Wav ~channels:self#audio_channels
               ~samplesize;
@@ -255,7 +256,8 @@ class pipe ~replay_delay ~data_len ~process ~bufferize ~max ~restart
                  ~on_stdout:self#on_stdout ~on_stdin:self#on_stdin
                  ~priority:`Blocking ~on_stderr:self#on_stderr ~log process));
       self#on_sleep (fun () ->
-          source#sleep (self :> Clock.activation);
+          source#sleep (Option.get !a);
+          a := None;
           Mutex_utils.mutexify mutex
             (fun () ->
               try

--- a/src/core/source.mli
+++ b/src/core/source.mli
@@ -150,14 +150,15 @@ object
   (** Register a callback when wake_up is called. *)
   method on_wake_up : (unit -> unit) -> unit
 
-  (** Called when the source must be ready. Each call to [wake_up] must be *
-      matched by a corresponding call to [sleep] to allow the source to skip. *
-      Can be called multiple times *)
-  method wake_up : Clock.activation -> unit
+  (** Called when the source must be ready. Each call to [wake_up] must be
+      matched by a corresponding call to [sleep] with the returned activation to
+      allow the source to sleep and be collected. Can be called multiple times
+  *)
+  method wake_up : Clock.source -> Clock.activation
 
   (** Same as [wake_up] but without the need to call [sleep]. This is intended
       for * special situations only. *)
-  method wake_up_no_register : unit
+  method get_up : string -> unit
 
   (** Register a callback when sleep is called. *)
   method on_sleep : (unit -> unit) -> unit

--- a/tests/core/output_test.ml
+++ b/tests/core/output_test.ml
@@ -5,7 +5,7 @@ class dummy ~clock ~autostart source =
         ~clock ~autostart ~infallible:false ~register_telnet:false
         (Lang.source (source :> Source.source))
 
-    method test_wake_up = self#wake_up (self :> Clock.activation)
+    method test_wake_up = self#wake_up (self :> Clock.source)
     val mutable test_can_generate_frame = false
     method test_set_can_generate_frame = test_can_generate_frame <- true
     method! can_generate_frame = test_can_generate_frame
@@ -31,7 +31,7 @@ let () =
   o#on_start (fun () -> started := true);
   o#content_type_computation_allowed;
   assert (not o#can_generate_frame);
-  o#test_wake_up;
+  let a = o#test_wake_up in
   assert (not !started);
   Clock.tick clock;
   o#test_set_can_generate_frame;
@@ -40,4 +40,5 @@ let () =
   assert test_source#is_ready;
   o#test_output;
   assert !started;
+  o#sleep a;
   ()


### PR DESCRIPTION
This is a redo of https://github.com/savonet/liquidsoap/pull/4804 which fixed a leak in wake_up/sleep and introduced a new one..

The issue with the original PR is that, at the top level, the activation for outputs needs to stay in memory. So, if we register a `Gc` finaliser relying on them then we essentially make the source checking on it stay forever in memory.

In this PR we:
* Use a generic notion of activation variable that is created and returned when calling `#wake_up`
* The same activation need to be passed to `#sleep`.
* A `Gc` tracking is installed on this activation and the source is forcefully put to sleep when the activation is collected with a warning if `#sleep` had not been called with it.

This logic forces the users of the `#wake_up`/`#sleep` paradigm to keep track of their calls and hold onto the activation variable.