### PR TITLE
Use a weak map to track source.dynamic pending activations.

### DIFF
--- a/src/core/clock.mli
+++ b/src/core/clock.mli
@@ -63,6 +63,7 @@ type activation = < id : string >
 
 type source =
   < id : string
+  ; hash : int
   ; stack : Pos.t list
   ; self_sync : self_sync
   ; source_type : source_type

--- a/src/core/clock_base.ml
+++ b/src/core/clock_base.ml
@@ -127,6 +127,7 @@ type activation = < id : string >
 
 type source =
   < id : string
+  ; hash : int
   ; stack : Pos.t list
   ; self_sync : self_sync
   ; source_type : source_type

--- a/src/core/operators/dyn_op.ml
+++ b/src/core/operators/dyn_op.ml
@@ -28,8 +28,8 @@ type activation_map = {
 module ActivationMap = Weak.Make (struct
   type t = activation_map
 
-  let equal { s } { s = s' } = Oo.id s == Oo.id s'
-  let hash { s } = Oo.id s
+  let equal { s } { s = s' } = s#hash == s'#hash
+  let hash { s } = s#hash
 end)
 
 class dyn ~init ~track_sensitive ~infallible ~self_sync ~merge next_fn =

--- a/src/core/source.ml
+++ b/src/core/source.ml
@@ -93,6 +93,8 @@ let check_sleep ~activations ~s =
       s#id src#id;
     s#sleep src)
 
+let hash = Atomic.make 0
+
 class virtual operator ?(stack = []) ?clock ~name sources =
   let frame_type = Type.var () in
   let clock = match clock with Some c -> c | None -> Clock.create ~stack () in
@@ -131,6 +133,8 @@ class virtual operator ?(stack = []) ?clock ~name sources =
     method log = log
     val mutable id = Lang_string.generate_id ~category:"source" name
     method id = id
+    val hash = Atomic.fetch_and_add hash 1
+    method hash = hash
 
     method set_id ?(force = true) s =
       let s =

--- a/src/core/source.mli
+++ b/src/core/source.mli
@@ -108,6 +108,10 @@ object
 
   method set_id : ?force:bool -> string -> unit
 
+  (* Unique int allocated at initialization. Can be used to
+     hash the source and use it in a weak map. *)
+  method hash : int
+
   (** Position in script *)
   method pos : Pos.Option.t
 


### PR DESCRIPTION
This is a much better approach. `source.dynamic` may required lopsided activations where the script asks it to prepare a source in advance.

Thus, we store all activations in a weak map. If the user ends up submitting the source for the next source, it will go through the proper `sleep`/`wake_up` pattern with one extra activations to cleanup. If not, the activations are released and the source can be freed via the new weak activations queue.