### PR TITLE
fix: prevent frame duplication during manual skip in cross operator

### DIFF
--- a/src/core/base/operators/cross.ml
+++ b/src/core/base/operators/cross.ml
@@ -590,9 +590,13 @@ class cross val_source ~end_duration_getter ~override_end_duration
     method abort_track =
       match status with
         | `Idle -> self#source#abort_track
-        | `Before s | `After s ->
+        | `Before _ | `After _ ->
+            (* Clean up the current transition before starting a new one.
+               This prevents frame duplication when abort_track is called
+               during an active transition (e.g., manual skip). *)
+            self#set_status `Idle;
+            self#reset_analysis;
             self#source#abort_track;
-            status <- `After s;
             ignore self#prepare_before
   end
 


### PR DESCRIPTION
## Summary

When `abort_track` is called during an active transition (Before or After state), the previous implementation kept the old transition state while simultaneously starting to buffer for a new transition. This caused audio frame duplication and stuttering, particularly noticeable on resource-constrained devices like Raspberry Pi 4.

## Problem

On manual track skip with crossfade enabled:
- Stutter/glitch occurs at a consistent point during the crossfade
- Issue happens even without ALSA underruns
- Root cause: frame duplication in the audio data during transition creation

## Fix

The fix properly cleans up the current transition state by:
1. Calling `set_status \`Idle` to properly tear down the old transition
2. Calling `reset_analysis` to clear the old buffers  
3. Then proceeding with `abort_track` and `prepare_before`

This ensures that when a manual skip triggers a new crossfade, the old transition is fully cleaned up before the new one begins.

## Test Plan

- [x] Compiles successfully on x86_64
- [ ] Test on ARM64 (Raspberry Pi 4) with manual skip during crossfade
- [ ] Verify no audio stutter during skip
- [ ] Verify natural track transitions still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)