### PR TITLE
Add support for sparse streams decoding in ffmpeg decoder

### DIFF
--- a/src/core/optionals/ffmpeg/ffmpeg_copy_decoder.mli
+++ b/src/core/optionals/ffmpeg/ffmpeg_copy_decoder.mli
@@ -46,6 +46,5 @@ val mk_subtitle_decoder :
   stream:(Avutil.input, Avutil.subtitle, [ `Packet ]) Av.stream ->
   field:int ->
   Avutil.subtitle Avcodec.params ->
-  buffer:Decoder.buffer ->
-  [ `Packet of Avutil.subtitle Avcodec.Packet.t | `Flush ] ->
-  unit
+  [ `Subtitle of Avutil.subtitle Avcodec.Packet.t | `Flush ]
+  Ffmpeg_decoder_common.sparse_decoder

--- a/src/core/optionals/ffmpeg/ffmpeg_decoder_common.ml
+++ b/src/core/optionals/ffmpeg/ffmpeg_decoder_common.ml
@@ -22,6 +22,11 @@
 
 (** Decode and read metadata using ffmpeg. *)
 
+type 'a sparse_decoder = {
+  decoder : buffer:Decoder.buffer -> 'a -> unit;
+  advance : buffer:Decoder.buffer -> int -> unit;
+}
+
 let log = Log.make ["decoder"; "ffmpeg"]
 
 let conf_ffmpeg_decoder =

--- a/src/core/optionals/ffmpeg/ffmpeg_io.ml
+++ b/src/core/optionals/ffmpeg/ffmpeg_io.ml
@@ -157,10 +157,10 @@ class input ?(name = "input.ffmpeg") ~autostart ~self_sync ~poll_delay ~debug
         let get_metadata () =
           normalize_metadata
             (Ffmpeg_decoder.Streams.fold
-               (fun _ stream m ->
+               (fun _ s m ->
                  m
                  @
-                   match stream with
+                   match s.Ffmpeg_decoder.decoder with
                    | `Audio_frame (stream, _) -> get_metadata stream
                    | `Audio_packet (stream, _) -> get_metadata stream
                    | `Video_frame (stream, _) -> get_metadata stream

--- a/src/core/optionals/ffmpeg/ffmpeg_utils.mli
+++ b/src/core/optionals/ffmpeg/ffmpeg_utils.mli
@@ -79,3 +79,9 @@ module Duration : sig
   val push : 'a t -> 'a -> (int * (int * 'a) list) option
   val flush : 'a t -> int * (int * 'a) list
 end
+
+val mk_subtitle_decoder :
+  output:(?data:'a -> buffer:Decoder.buffer -> length:int -> unit -> unit) ->
+  process:('b -> int * int * 'a) ->
+  unit ->
+  [ `Flush | `Subtitle of 'b ] Ffmpeg_decoder_common.sparse_decoder


### PR DESCRIPTION
When working with sparse content such as subtitles, we need to update the decoder logic to match our streaming model.

In our streaming model, we expect all decoders to create content chunks, possibly with empty data inside.

However, with subtitles (and data packets though this is handled directly as metadata at the moment, more on this later), we might not see any packet/frame for a long while which would prevent the decoder from creating content from its own packets/frames in time.

Instead, we need to separate between _sparse_ and non _sparse_ streams. Non sparse streams are expected to have continuous content and can drive the decoding position.

Thus, as we decode, we keep track of the last common position for all non-sparse content and ask the sparse decoder to advance by creating the same amount of content, ensuring that we keep the content buffer moving smoothly.

The general assumption is that, if all continuous contents have reached the same timestamp then they are ready to be presented to any encoder etc so, when advancing sparse decoder, if no packet or frame are available to cover the advanced time span, then any packet or frame that would arrive afterward would already have been too late to be inserted at the current timestamp. It might still be inserted later on.

The code is also factored out to make it more clear and attached all the required variables on the decoder streams.