### PR TITLE
FFmpeg copy and raw content improvement.

### DIFF
--- a/src/core/base/stream/content_base.ml
+++ b/src/core/base/stream/content_base.ml
@@ -187,7 +187,7 @@ let dummy_handler =
     append = (fun _ _ -> raise Invalid);
   }
 
-let data_handlers = Array.make 12 dummy_handler
+let data_handlers = Array.make 16 dummy_handler
 
 let register_data_handler t h =
   if Array.length data_handlers - 1 < t then

--- a/src/core/optionals/ffmpeg/FFMPEG_CONTENT.md
+++ b/src/core/optionals/ffmpeg/FFMPEG_CONTENT.md
@@ -1,0 +1,351 @@
+# FFmpeg Content Structure
+
+This document explains how Liquidsoap handles FFmpeg content—audio frames, video frames, and encoded packets.
+
+## Why This Structure?
+
+The content structure addresses three main challenges:
+
+1. **Sparse streams** – Subtitles often have long gaps with no data. We need to track that a stream exists even when nothing is happening.
+
+2. **Multiple sources** – Content can come from different decoders, each with its own `stream_idx`. These shouldn't get mixed together.
+
+3. **Efficient operations** – Blit, copy, and sub operations need to respect stream boundaries and handle gaps correctly.
+
+## Core Types
+
+The `Ffmpeg_content_base` module defines the fundamental types:
+
+```ocaml
+(* A chunk of data from a single stream *)
+type 'b data = {
+  length : int;                 (* Duration in main ticks *)
+  stream_idx : Int64.t;         (* Unique identifier for the source stream *)
+  time_base : Avutil.rational;  (* Time base for timestamps *)
+  data : (int * 'b) list;       (* List of (position, payload) pairs *)
+}
+
+(* Top-level content container *)
+type ('a, 'b) content = {
+  mutable params : 'a;          (* Format parameters *)
+  mutable chunks : 'b data list;  (* List of data chunks *)
+}
+```
+
+## Visual Examples
+
+### Basic Structure
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│ content                                                         │
+├─────────────────────────────────────────────────────────────────┤
+│ params: { channel_layout: stereo, sample_rate: 44100, ... }     │
+├─────────────────────────────────────────────────────────────────┤
+│ chunks:                                                         │
+│   ┌─────────────────────────────────────────────────────────┐   │
+│   │ chunk 0                                                 │   │
+│   │   stream_idx: 1                                         │   │
+│   │   time_base: 1/44100                                    │   │
+│   │   length: 1024                                          │   │
+│   │   data: [(0, frame), (512, frame), (768, frame)]        │   │
+│   └─────────────────────────────────────────────────────────┘   │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+### Dense Audio (Single Source)
+
+```
+Time:        0       256      512      768     1024
+             |--------|--------|--------|--------|
+
+content.chunks = [
+  ┌────────────────────────────────────────────────┐
+  │ stream_idx: 1, length: 1024                    │
+  │ data: [                                        │
+  │   (0,   ♪ audio frame 1),                      │
+  │   (256, ♪ audio frame 2),                      │
+  │   (512, ♪ audio frame 3),                      │
+  │   (768, ♪ audio frame 4)                       │
+  │ ]                                              │
+  └────────────────────────────────────────────────┘
+]
+```
+
+### Dense Video with Variable Frame Rate (Encoded)
+
+In copy mode, encoded video packets retain their frame types. With variable frame rate (VFR), frames aren't evenly spaced:
+
+```
+Time:        0       100      200      300      400      500      600
+             |--------|--------|--------|--------|--------|--------|
+             I      P     P            P         I          P
+             0      80    140          290       400        520
+
+content.chunks = [
+  ┌──────────────────────────────────────────────────────────────┐
+  │ stream_idx: 7, length: 600                                   │
+  │ data: [                                                      │
+  │   (0,   🎬 I-frame),   ← keyframe, can be decoded alone      │
+  │   (80,  🎬 P-frame),   ← predicted, depends on previous      │
+  │   (140, 🎬 P-frame),                                         │
+  │   (290, 🎬 P-frame),   ← note the gap: VFR in action         │
+  │   (400, 🎬 I-frame),   ← new keyframe                        │
+  │   (520, 🎬 P-frame)                                          │
+  │ ]                                                            │
+  └──────────────────────────────────────────────────────────────┘
+]
+
+Frame intervals vary: 80, 60, 150, 110, 120 ticks.
+I-frames appear periodically for seeking and error recovery.
+```
+
+### Sparse Subtitles
+
+```
+Time:        0       500     1000     1500     2000
+             |--------|--------|--------|--------|
+                           ▼              ▼
+                        "Hello"        "World"
+
+content.chunks = [
+  ┌────────────────────────────────────────────────┐
+  │ stream_idx: 42, length: 2000                   │
+  │ data: [                                        │
+  │   (800,  📝 "Hello"),                          │
+  │   (1200, 📝 "World")                           │
+  │ ]                                              │
+  │                                                │
+  │ (No subtitles from 0-799, 801-1199, 1201-2000) │
+  └────────────────────────────────────────────────┘
+]
+```
+
+### Multiple Sources
+
+When blitting from different sources (e.g., track changes), chunks keep their distinct `stream_idx`:
+
+```
+Time:        0              500            1000
+             |---------------|---------------|
+             ← Source A →    ← Source B →
+
+content.chunks = [
+  ┌────────────────────────────────────────────────┐
+  │ AUDIO CHUNK (from source A)                    │
+  │ stream_idx: 1, length: 500                     │
+  │ time_base: 1/44100                             │
+  │ data: [(0, ♪), (128, ♪), (256, ♪), (384, ♪)]   │
+  └────────────────────────────────────────────────┘
+  ┌────────────────────────────────────────────────┐
+  │ AUDIO CHUNK (from source B)                    │
+  │ stream_idx: 2, length: 500                     │
+  │ time_base: 1/44100                             │
+  │ data: [(0, ♪), (128, ♪), (256, ♪), (384, ♪)]   │
+  └────────────────────────────────────────────────┘
+]
+
+These chunks won't be collapsed—different stream_idx values are kept separate.
+Total length: 500 + 500 = 1000
+```
+
+### Empty Chunk
+
+A chunk can exist without any data. This is useful for tracking that a stream is present during a silent period:
+
+```
+Time:        0              1000
+             |----------------|
+
+content.chunks = [
+  ┌────────────────────────────────────────────────┐
+  │ SUBTITLE CHUNK (empty - no subtitles yet)      │
+  │ stream_idx: 5, length: 1000                    │
+  │ time_base: 1/1000                              │
+  │ data: []   ← empty list, but chunk exists!     │
+  └────────────────────────────────────────────────┘
+]
+
+This says: "We have a subtitle stream spanning 1000 ticks,
+            but no subtitles appear during this period."
+```
+
+## Key Concepts
+
+### Stream Index (`stream_idx`)
+
+Each chunk carries a `stream_idx` identifying its source:
+
+- Data from different sources should never be mixed
+- Adjacent chunks with the same `stream_idx` get merged automatically during blit
+- Different values mean the data came from different decoders
+
+Generate a new unique `stream_idx` with `Ffmpeg_content_base.new_stream_idx()`.
+
+### Data Positions
+
+The `data` field holds a list of `(position, payload)` pairs:
+
+- Positions are **relative to the chunk start** (ranging from 0 to `length`)
+- Positions are always sorted
+- Sparse content (like subtitles) will have gaps between positions
+
+### Dense vs Sparse Streams
+
+A chunk's `length` is its time duration, but `data` may have fewer entries than you'd expect:
+
+- **Dense streams** (audio/video): Each packet or frame is immediately followed by another. But a dense stream can still have gaps if its data rate is lower than the chunk duration. For example, 25fps video produces one frame every 40ms—a chunk shorter than 40ms might have no frames at all.
+
+  In practice, **audio streams have no gaps** because sample rates (e.g., 44100 Hz) are higher than Liquidsoap's internal tick rate.
+
+- **Sparse streams** (subtitles): Data appears only at specific moments, with long gaps in between. A subtitle might show up once every few seconds.
+
+- **Empty chunks**: A chunk with `data = []` but positive `length` is valid. It represents stream presence without content—common for sparse streams during quiet periods.
+
+## Content Types
+
+### Raw Content (`Ffmpeg_raw_content`)
+
+Decoded frames that can optionally be processed through FFmpeg filters. The key advantage is that raw FFmpeg content can flow through the entire pipeline—from decoding to encoding—without being converted to Liquidsoap's native internal format. This can save significant memory and CPU.
+
+The trade-off: most of Liquidsoap's internal operators aren't available for this content type. Things like crossfade, LUFS measurement, amplitude adjustment, and other audio/video processing tools require native content.
+
+**Audio** (`Ffmpeg_raw_content.Audio`):
+
+- Payload: `Avutil.audio Avutil.frame`
+- Parameters: `channel_layout`, `sample_format`, `sample_rate`
+
+**Video** (`Ffmpeg_raw_content.Video`):
+
+- Payload: `Avutil.video Avutil.frame`
+- Parameters: `width`, `height`, `pixel_format`, `pixel_aspect`
+
+### Copy Content (`Ffmpeg_copy_content`)
+
+Encoded packets for copy/passthrough mode—packets aren't decoded, just remuxed. This is the most efficient way to handle media when you don't need to modify the content, preserving both CPU and memory.
+
+However, proper remuxing can get tricky. It may require a solid understanding of the underlying bitstream structure, and you might need to use bitstream filters to ensure compatibility between container formats.
+
+- Payload: `packet` (audio, video, or subtitle)
+- Parameters: codec-specific (`codec_params`)
+
+## Operations
+
+### `blit`
+
+```ocaml
+val blit : src -> src_pos -> dst -> dst_pos -> len -> unit
+```
+
+Copies a range of data from source to destination. Extracts `len` ticks starting at `src_pos` and writes them to `dst` starting at `dst_pos`.
+
+What happens:
+
+- Overlapping data in `dst` gets replaced
+- Positions are adjusted to be relative to their new chunk
+- Adjacent chunks with the same `stream_idx` are merged
+- Source's `params` are copied to `dst`
+
+### Blit Example: Basic Operation
+
+```
+SOURCE (stream_idx=2):
+  Position:  0    10   20   30   40   50   60   70   80   90  100
+             |----|----|----|----|----|----|----|----|----|----|
+  chunks: [
+    ┌──────────────────────────────────────────────────────────┐
+    │ stream_idx: 2, length: 100                               │
+    │ data: [(15, ♪A), (35, ♪B), (55, ♪C), (75, ♪D)]           │
+    └──────────────────────────────────────────────────────────┘
+  ]
+
+DESTINATION (stream_idx=1, has existing data):
+  Position:  0    10   20   30   40   50   60   70   80   90  100
+             |----|----|----|----|----|----|----|----|----|----|
+  chunks: [
+    ┌──────────────────────────────────────────────────────────┐
+    │ stream_idx: 1, length: 100                               │
+    │ data: [(5, ♪X), (25, ♪Y), (50, ♪Z), (85, ♪W)]            │
+    └──────────────────────────────────────────────────────────┘
+  ]
+
+
+OPERATION: blit src 20 dst 20 40
+           ─────────────────────────
+           Copy 40 ticks from src[20..60] into dst[20..60]
+
+  dst before:
+             0         20──────────────────60               100
+             |          [====blit region====]                |
+             ♪X           ♪Y          ♪Z             ♪W
+             5            25          50             85
+                          ↑           ↑
+                          └─ overlaps ┘ (these will be removed)
+
+  src:       0         20──────────────────60               100
+             |          [====blit region====]                |
+                           ♪B          ♪C
+                           35          55
+                           ↓           ↓
+                   positions adjusted: 35-20=15, 55-20=35
+                           ↓           ↓
+                  in dst:  20+15=35    20+35=55
+
+
+RESULT - dst.chunks after blit:
+  Position:  0    10   20   30   40   50   60   70   80   90  100
+             |----|----|----|----|----|----|----|----|----|----|
+  chunks: [
+    ┌─────────────────────┐
+    │ stream_idx: 1       │  ← preserved (before blit region)
+    │ length: 20          │
+    │ data: [(5, ♪X)]     │
+    └─────────────────────┘
+    ┌─────────────────────────────┐
+    │ stream_idx: 2               │  ← inserted from src (starts at 20)
+    │ length: 40                  │
+    │ data: [(15, ♪B), (35, ♪C)]  │     (relative: 35-20=15, 55-20=35)
+    └─────────────────────────────┘
+    ┌─────────────────────┐
+    │ stream_idx: 1       │  ← preserved (starts at 60)
+    │ length: 40          │
+    │ data: [(25, ♪W)]    │     (relative: 85-60=25)
+    └─────────────────────┘
+  ]
+
+  ♪Y and ♪Z were in the blit region and got replaced.
+  Chunks aren't merged because stream_idx differs (1 vs 2).
+  All positions are relative to their chunk's start.
+```
+
+### `collapse_chunks`
+
+Merges adjacent chunks with the same `stream_idx`. Called automatically during `blit`.
+
+```
+BEFORE:
+  ┌─────────────────┐ ┌─────────────────┐ ┌─────────────────┐
+  │ stream_idx: 1   │ │ stream_idx: 1   │ │ stream_idx: 2   │
+  │ length: 25      │ │ length: 25      │ │ length: 50      │
+  └─────────────────┘ └─────────────────┘ └─────────────────┘
+          │                   │                   │
+          └─────────┬─────────┘                   │
+                    ↓                             ↓
+AFTER:
+  ┌─────────────────────────────────────┐ ┌─────────────────┐
+  │ stream_idx: 1                       │ │ stream_idx: 2   │
+  │ length: 50                          │ │ length: 50      │
+  └─────────────────────────────────────┘ └─────────────────┘
+```
+
+## Invariants
+
+1. **Data is sorted** – The `data` list is always sorted by position
+2. **Positions are relative** – Positions range from 0 to `length`, relative to chunk start
+3. **Adjacent chunks collapse** – Same `stream_idx` + adjacent = merged during blit
+4. **Non-adjacent chunks stay separate** – Chunks with the same `stream_idx` but separated by other sources remain distinct
+5. **Empty data is valid** – `data = []` with positive `length` represents stream presence without content
+
+## Configuration
+
+- `settings.ffmpeg.content.copy.relaxed_compatibility_check` – When `true`, allows mixing streams with different parameters (e.g., different sample rates or resolutions)

--- a/src/core/optionals/ffmpeg/ffmpeg_content_base.ml
+++ b/src/core/optionals/ffmpeg/ffmpeg_content_base.ml
@@ -30,3 +30,121 @@ let stream_idx = ref 0L
 let new_stream_idx () =
   stream_idx := Int64.succ !stream_idx;
   !stream_idx
+
+type 'b data = {
+  length : int;
+  stream_idx : Int64.t;
+  time_base : Avutil.rational;
+  data : (int * 'b) list;
+}
+
+type ('a, 'b) content = { mutable params : 'a; mutable chunks : 'b data list }
+
+let sort_data data = List.sort (fun (p1, _) (p2, _) -> compare p1 p2) data
+
+let make_data ?(length = 0) ?(stream_idx = 0L)
+    ?(time_base = { Avutil.num = 1; den = 1 }) ?(data = []) () =
+  { length; stream_idx; time_base; data = sort_data data }
+
+let make params : ('a, 'b) content = { params; chunks = [] }
+let params { params; _ } = params
+
+let length { chunks; _ } =
+  List.fold_left (fun cur chunk -> cur + chunk.length) 0 chunks
+
+let copy_data ~copy { length; stream_idx; time_base; data } =
+  {
+    length;
+    stream_idx;
+    time_base;
+    data = sort_data (List.map (fun (pos, p) -> (pos, copy p)) data);
+  }
+
+let copy ~copy ({ params; chunks } : ('a, 'b) content) : ('a, 'b) content =
+  { params; chunks = List.map (copy_data ~copy) chunks }
+
+let sub_data ~copy { stream_idx; time_base; data; _ } offset len =
+  let stop = offset + len in
+  let filtered =
+    List.filter_map
+      (fun (pos, p) ->
+        if offset <= pos && pos < stop then Some (pos - offset, copy p)
+        else None)
+      data
+  in
+  { length = len; stream_idx; time_base; data = sort_data filtered }
+
+let collapse_chunks chunks =
+  let rec aux acc = function
+    | [] -> List.rev acc
+    | (dst_offset, chunk) :: rest -> (
+        match acc with
+          | (prev_offset, prev_chunk) :: acc_rest
+            when prev_chunk.stream_idx = chunk.stream_idx ->
+              let prev_end = prev_offset + prev_chunk.length in
+              let chunk_end = dst_offset + chunk.length in
+              let new_start = min prev_offset dst_offset in
+              let new_end = max prev_end chunk_end in
+              let prev_data =
+                List.map
+                  (fun (pos, p) -> (prev_offset - new_start + pos, p))
+                  prev_chunk.data
+              in
+              let chunk_data =
+                List.map
+                  (fun (pos, p) -> (dst_offset - new_start + pos, p))
+                  chunk.data
+              in
+              let merged =
+                {
+                  length = new_end - new_start;
+                  stream_idx = chunk.stream_idx;
+                  time_base = chunk.time_base;
+                  data = sort_data (prev_data @ chunk_data);
+                }
+              in
+              aux ((new_start, merged) :: acc_rest) rest
+          | _ -> aux ((dst_offset, chunk) :: acc) rest)
+  in
+  List.map snd (aux [] chunks)
+
+let blit ~copy (src : ('a, 'b) content) src_pos (dst : ('a, 'b) content) dst_pos
+    len =
+  dst.params <- src.params;
+  let dst_stop = dst_pos + len in
+  (* Keep dst chunks that don't overlap with the blit region, with their positions *)
+  let _, dst_chunks_with_offset =
+    List.fold_left
+      (fun (pos, acc) chunk ->
+        let chunk_end = pos + chunk.length in
+        let new_pos = chunk_end in
+        if chunk_end <= dst_pos || dst_stop <= pos then
+          (new_pos, (pos, chunk) :: acc)
+        else (new_pos, acc))
+      (0, []) dst.chunks
+  in
+  (* Extract chunks from src and place at dst_pos *)
+  let _, new_chunks_with_offset =
+    List.fold_left
+      (fun (pos, acc) chunk ->
+        let chunk_end = pos + chunk.length in
+        let new_pos = chunk_end in
+        if chunk_end <= src_pos || src_pos + len <= pos then (new_pos, acc)
+        else (
+          let start = max 0 (src_pos - pos) in
+          let stop = min chunk.length (src_pos + len - pos) in
+          let new_len = stop - start in
+          let new_data = sub_data ~copy chunk start new_len in
+          let dst_offset = dst_pos + (pos + start - src_pos) in
+          (new_pos, (dst_offset, new_data) :: acc)))
+      (0, []) src.chunks
+  in
+  (* Combine all chunks and sort by position, then collapse *)
+  let all_chunks =
+    List.rev dst_chunks_with_offset @ List.rev new_chunks_with_offset
+  in
+  let sorted_chunks =
+    List.sort (fun (p1, _) (p2, _) -> compare p1 p2) all_chunks
+  in
+  let collapsed = collapse_chunks sorted_chunks in
+  dst.chunks <- collapsed

--- a/src/core/optionals/ffmpeg/ffmpeg_decoder.ml
+++ b/src/core/optionals/ffmpeg/ffmpeg_decoder.ml
@@ -807,7 +807,11 @@ let get_type ~ctype ~format ~url container =
                 (Content.merge format
                    (Ffmpeg_copy_content.lift_params
                       (Some
-                         (`Video { Ffmpeg_copy_content.avg_frame_rate; params }))));
+                         (`Video
+                            {
+                              Ffmpeg_copy_content.avg_frame_rate;
+                              codec_params = params;
+                            }))));
               Frame.Fields.add field format content_type
           | p, Some format when Ffmpeg_raw_content.Video.is_format format ->
               ignore
@@ -831,7 +835,11 @@ let get_type ~ctype ~format ~url container =
                 (Content.merge format
                    (Ffmpeg_copy_content.lift_params
                       (Some
-                         (`Subtitle { Ffmpeg_copy_content.time_base; params }))));
+                         (`Subtitle
+                            {
+                              Ffmpeg_copy_content.time_base;
+                              codec_params = params;
+                            }))));
               Frame.Fields.add field format content_type
           | _ -> content_type)
       content_type subtitle_streams

--- a/tests/core/dune.inc
+++ b/tests/core/dune.inc
@@ -42,6 +42,34 @@
 
 
 (executable
+ (name ffmpeg_content_base_test)
+ (modules ffmpeg_content_base_test)
+ (libraries liquidsoap_core liquidsoap_optionals))
+
+(rule
+ (alias ffmpeg_content_base_test)
+ (package liquidsoap)
+ (deps
+  
+  (:ffmpeg_content_base_test ffmpeg_content_base_test.exe))
+ (action (run %{ffmpeg_content_base_test} )))
+
+
+(executable
+ (name ffmpeg_dummy_content_test)
+ (modules ffmpeg_dummy_content_test)
+ (libraries liquidsoap_core liquidsoap_optionals))
+
+(rule
+ (alias ffmpeg_dummy_content_test)
+ (package liquidsoap)
+ (deps
+  
+  (:ffmpeg_dummy_content_test ffmpeg_dummy_content_test.exe))
+ (action (run %{ffmpeg_dummy_content_test} )))
+
+
+(executable
  (name ffmpeg_quality)
  (modules ffmpeg_quality)
  (libraries liquidsoap_core liquidsoap_optionals))
@@ -396,6 +424,8 @@
     (alias clock_utils_test)
     (alias content_test)
     (alias decoder_test)
+    (alias ffmpeg_content_base_test)
+    (alias ffmpeg_dummy_content_test)
     (alias ffmpeg_quality)
     (alias flush_test)
     (alias frame_checksum_test)

--- a/tests/core/ffmpeg_content_base_test.ml
+++ b/tests/core/ffmpeg_content_base_test.ml
@@ -1,0 +1,261 @@
+(*****************************************************************************
+
+  Liquidsoap, a programmable stream generator.
+  Copyright 2003-2026 Savonet team
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details, fully stated in the COPYING
+  file at the root of the liquidsoap distribution.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA
+
+ *****************************************************************************)
+
+(* Tests for Ffmpeg_content_base operations *)
+
+let time_base = { Avutil.num = 1; den = 1000 }
+let copy x = x
+
+(* Helper to create data with packets at specific positions *)
+let mk_data ?(stream_idx = 1L) ?(time_base = time_base) ~length data =
+  { Ffmpeg_content_base.length; stream_idx; time_base; data }
+
+(* Helper to create content with chunks *)
+let mk_content params chunks : (unit option, int) Ffmpeg_content_base.content =
+  { Ffmpeg_content_base.params; chunks }
+
+(* Test basic content creation *)
+let () =
+  let content = Ffmpeg_content_base.make None in
+  assert (Ffmpeg_content_base.length content = 0);
+  assert (Ffmpeg_content_base.params content = None);
+  assert (content.chunks = [])
+
+(* Test content length calculation with multiple chunks *)
+let () =
+  let chunk1 = mk_data ~length:100 [(0, 1); (50, 2)] in
+  let chunk2 = mk_data ~length:200 [(0, 3); (100, 4)] in
+  let content = mk_content (Some ()) [chunk1; chunk2] in
+  assert (Ffmpeg_content_base.length content = 300)
+
+(* Test content with empty data list but positive length (sparse streams) *)
+let () =
+  let chunk = mk_data ~length:1000 [] in
+  let content = mk_content (Some ()) [chunk] in
+  assert (Ffmpeg_content_base.length content = 1000);
+  assert (List.length (List.hd content.chunks).data = 0)
+
+(* Test copy preserves structure *)
+let () =
+  let chunk = mk_data ~length:100 [(0, 1); (50, 2)] in
+  let content = mk_content (Some ()) [chunk] in
+  let copied = Ffmpeg_content_base.copy ~copy content in
+  assert (Ffmpeg_content_base.length copied = 100);
+  assert (List.length copied.chunks = 1);
+  let copied_chunk = List.hd copied.chunks in
+  assert (copied_chunk.length = 100);
+  assert (List.length copied_chunk.data = 2)
+
+(* Test sub_data filters by position *)
+let () =
+  let chunk = mk_data ~length:100 [(10, 1); (30, 2); (50, 3); (70, 4)] in
+  (* Sub from 20 to 60 (length 40) should include positions 30 and 50 *)
+  let sub = Ffmpeg_content_base.sub_data ~copy chunk 20 40 in
+  assert (sub.length = 40);
+  assert (sub.stream_idx = chunk.stream_idx);
+  assert (sub.time_base = chunk.time_base);
+  (* Positions should be adjusted: 30->10, 50->30 *)
+  assert (List.length sub.data = 2);
+  assert (List.assoc 10 sub.data = 2);
+  assert (List.assoc 30 sub.data = 3)
+
+(* Test sub_data with empty result *)
+let () =
+  let chunk = mk_data ~length:100 [(10, 1); (30, 2)] in
+  (* Sub from 50 to 100 should have no data *)
+  let sub = Ffmpeg_content_base.sub_data ~copy chunk 50 50 in
+  assert (sub.length = 50);
+  assert (List.length sub.data = 0)
+
+(* Test blit: basic copy *)
+let () =
+  let src_chunk = mk_data ~length:100 [(0, 1); (50, 2)] in
+  let src = mk_content (Some ()) [src_chunk] in
+  let dst = mk_content None [] in
+  Ffmpeg_content_base.blit ~copy src 0 dst 0 100;
+  assert (Ffmpeg_content_base.length dst = 100);
+  assert (Ffmpeg_content_base.params dst = Some ())
+
+(* Test blit: partial source copy *)
+let () =
+  let src_chunk = mk_data ~length:100 [(10, 1); (30, 2); (50, 3); (70, 4)] in
+  let src = mk_content (Some ()) [src_chunk] in
+  let dst = mk_content None [] in
+  (* Copy from position 20 to 60 (40 samples) *)
+  Ffmpeg_content_base.blit ~copy src 20 dst 0 40;
+  assert (Ffmpeg_content_base.length dst = 40);
+  assert (List.length dst.chunks = 1);
+  let dst_chunk = List.hd dst.chunks in
+  (* Should have positions 30 and 50, adjusted to 10 and 30 *)
+  assert (List.length dst_chunk.data = 2)
+
+(* Test blit: into middle of destination removes overlapping chunks *)
+let () =
+  let src_chunk = mk_data ~length:50 [(0, 99)] in
+  let src = mk_content (Some ()) [src_chunk] in
+  let dst_chunk = mk_data ~length:200 [(0, 1); (100, 2); (150, 3)] in
+  let dst = mk_content None [dst_chunk] in
+  (* Blit 50 samples into position 50-100 *)
+  (* The original chunk overlaps so it gets entirely removed *)
+  Ffmpeg_content_base.blit ~copy src 0 dst 50 50;
+  (* Only the new 50-sample chunk remains *)
+  assert (Ffmpeg_content_base.length dst = 50)
+
+(* Test stream boundaries: chunks with different stream_idx *)
+let () =
+  let chunk1 = mk_data ~stream_idx:1L ~length:100 [(0, 1); (50, 2)] in
+  let chunk2 = mk_data ~stream_idx:2L ~length:100 [(0, 3); (50, 4)] in
+  let content = mk_content (Some ()) [chunk1; chunk2] in
+  assert (Ffmpeg_content_base.length content = 200);
+  (* Each chunk maintains its own stream_idx *)
+  assert ((List.nth content.chunks 0).stream_idx = 1L);
+  assert ((List.nth content.chunks 1).stream_idx = 2L)
+
+(* Test blit preserves stream_idx in new chunks *)
+let () =
+  let src_chunk = mk_data ~stream_idx:42L ~length:100 [(0, 1)] in
+  let src = mk_content (Some ()) [src_chunk] in
+  let dst = mk_content None [] in
+  Ffmpeg_content_base.blit ~copy src 0 dst 0 100;
+  assert ((List.hd dst.chunks).stream_idx = 42L)
+
+(* Test blit with multiple source chunks *)
+let () =
+  let chunk1 = mk_data ~stream_idx:1L ~length:50 [(0, 1); (25, 2)] in
+  let chunk2 = mk_data ~stream_idx:2L ~length:50 [(0, 3); (25, 4)] in
+  let src = mk_content (Some ()) [chunk1; chunk2] in
+  let dst = mk_content None [] in
+  (* Blit entire content *)
+  Ffmpeg_content_base.blit ~copy src 0 dst 0 100;
+  assert (Ffmpeg_content_base.length dst = 100);
+  (* Should have 2 chunks, one from each source chunk *)
+  assert (List.length dst.chunks = 2)
+
+(* Test blit spanning partial chunks *)
+let () =
+  let chunk1 = mk_data ~stream_idx:1L ~length:100 [(25, 1); (75, 2)] in
+  let chunk2 = mk_data ~stream_idx:2L ~length:100 [(25, 3); (75, 4)] in
+  let src = mk_content (Some ()) [chunk1; chunk2] in
+  let dst = mk_content None [] in
+  (* Blit from 50 to 150 (spanning both chunks) *)
+  Ffmpeg_content_base.blit ~copy src 50 dst 0 100;
+  assert (Ffmpeg_content_base.length dst = 100);
+  (* Should have 2 chunks *)
+  assert (List.length dst.chunks = 2);
+  (* First chunk: from position 50-100 of chunk1, contains position 75 -> adjusted to 25 *)
+  let first = List.nth dst.chunks 0 in
+  assert (first.stream_idx = 1L);
+  assert (first.length = 50);
+  assert (List.length first.data = 1);
+  (* Second chunk: from position 0-50 of chunk2, contains position 25 -> stays at 25 *)
+  let second = List.nth dst.chunks 1 in
+  assert (second.stream_idx = 2L);
+  assert (second.length = 50);
+  assert (List.length second.data = 1)
+
+(* Test concat via repeated blit *)
+let () =
+  let chunk1 = mk_data ~stream_idx:1L ~length:100 [(0, 1)] in
+  let chunk2 = mk_data ~stream_idx:2L ~length:100 [(0, 2)] in
+  let src1 = mk_content (Some ()) [chunk1] in
+  let src2 = mk_content (Some ()) [chunk2] in
+  let dst = mk_content None [] in
+  Ffmpeg_content_base.blit ~copy src1 0 dst 0 100;
+  Ffmpeg_content_base.blit ~copy src2 0 dst 100 100;
+  assert (Ffmpeg_content_base.length dst = 200);
+  assert (List.length dst.chunks = 2);
+  assert ((List.nth dst.chunks 0).stream_idx = 1L);
+  assert ((List.nth dst.chunks 1).stream_idx = 2L)
+
+(* Test blit overwrites overlapping destination chunks *)
+let () =
+  let dst_chunk = mk_data ~stream_idx:1L ~length:100 [(0, 1); (50, 2)] in
+  let dst = mk_content None [dst_chunk] in
+  let src_chunk = mk_data ~stream_idx:2L ~length:50 [(0, 99)] in
+  let src = mk_content (Some ()) [src_chunk] in
+  (* Blit into 25-75, overlapping the dst chunk *)
+  Ffmpeg_content_base.blit ~copy src 0 dst 25 50;
+  (* The original chunk overlaps with blit region [25,75) so it's removed *)
+  (* Only the new 50-sample chunk remains *)
+  assert (Ffmpeg_content_base.length dst = 50);
+  assert ((List.hd dst.chunks).stream_idx = 2L)
+
+(* Test empty content blit *)
+let () =
+  let src = mk_content (Some ()) [] in
+  let dst = mk_content None [] in
+  Ffmpeg_content_base.blit ~copy src 0 dst 0 0;
+  assert (Ffmpeg_content_base.length dst = 0)
+
+(* Test different time_bases are preserved *)
+let () =
+  let time_base1 = { Avutil.num = 1; den = 1000 } in
+  let time_base2 = { Avutil.num = 1; den = 48000 } in
+  let chunk1 = mk_data ~time_base:time_base1 ~length:100 [(0, 1)] in
+  let chunk2 = mk_data ~time_base:time_base2 ~length:100 [(0, 2)] in
+  let content = mk_content (Some ()) [chunk1; chunk2] in
+  assert ((List.nth content.chunks 0).time_base = time_base1);
+  assert ((List.nth content.chunks 1).time_base = time_base2)
+
+(* Test sparse stream: multiple empty data chunks *)
+let () =
+  let chunk1 = mk_data ~stream_idx:1L ~length:1000 [] in
+  let chunk2 = mk_data ~stream_idx:1L ~length:500 [] in
+  let content = mk_content (Some ()) [chunk1; chunk2] in
+  assert (Ffmpeg_content_base.length content = 1500);
+  let copied = Ffmpeg_content_base.copy ~copy content in
+  assert (Ffmpeg_content_base.length copied = 1500)
+
+(* Test blit of sparse content *)
+let () =
+  let src_chunk = mk_data ~length:1000 [] in
+  let src = mk_content (Some ()) [src_chunk] in
+  let dst = mk_content None [] in
+  Ffmpeg_content_base.blit ~copy src 0 dst 0 1000;
+  assert (Ffmpeg_content_base.length dst = 1000);
+  assert (List.length dst.chunks = 1);
+  assert (List.length (List.hd dst.chunks).data = 0)
+
+(* Test partial blit of sparse content *)
+let () =
+  let src_chunk = mk_data ~length:1000 [] in
+  let src = mk_content (Some ()) [src_chunk] in
+  let dst = mk_content None [] in
+  Ffmpeg_content_base.blit ~copy src 200 dst 0 500;
+  assert (Ffmpeg_content_base.length dst = 500);
+  assert (List.length (List.hd dst.chunks).data = 0)
+
+(* Test make_data helper *)
+let () =
+  let data = Ffmpeg_content_base.make_data () in
+  assert (data.length = 0);
+  assert (data.stream_idx = 0L);
+  assert (data.time_base.Avutil.num = 1);
+  assert (data.time_base.Avutil.den = 1);
+  assert (data.data = [])
+
+let () =
+  let data = Ffmpeg_content_base.make_data ~length:500 ~stream_idx:42L () in
+  assert (data.length = 500);
+  assert (data.stream_idx = 42L)
+
+let () = print_endline "All ffmpeg_content_base tests passed!"

--- a/tests/core/ffmpeg_dummy_content_test.ml
+++ b/tests/core/ffmpeg_dummy_content_test.ml
@@ -1,0 +1,667 @@
+(*****************************************************************************
+
+  Liquidsoap, a programmable stream generator.
+  Copyright 2003-2026 Savonet team
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details, fully stated in the COPYING
+  file at the root of the liquidsoap distribution.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA
+
+ *****************************************************************************)
+
+(* Tests for high-level content operations using a dummy FFmpeg content module *)
+
+let () =
+  Frame_settings.conf_duration#set 0.04;
+  Frame_settings.lazy_config_eval := true
+
+(* Dummy packet type *)
+type packet = int
+
+(* Dummy params type *)
+type params = { name : string }
+
+(* Content type using Ffmpeg_content_base *)
+type data = (params option, packet) Ffmpeg_content_base.content
+
+let time_base = { Avutil.num = 1; den = 1000 }
+
+(* Dummy Specs module *)
+module DummySpecs = struct
+  type kind = [ `Dummy ]
+  type nonrec params = params option
+  type nonrec data = data
+
+  let name = "ffmpeg.dummy"
+  let kind = `Dummy
+  let parse_param _ _ = None
+  let string_of_kind = function `Dummy -> "ffmpeg.dummy"
+  let kind_of_string = function "ffmpeg.dummy" -> Some `Dummy | _ -> None
+
+  let string_of_params = function
+    | None -> "none"
+    | Some p -> Printf.sprintf "name=%s" p.name
+
+  let compatible p p' =
+    match (p, p') with
+      | None, _ | _, None -> true
+      | Some p, Some p' -> p.name = p'.name
+
+  let merge p p' =
+    match (p, p') with
+      | None, p | p, None -> p
+      | p, p' when compatible p p' -> p
+      | _ -> failwith "Incompatible format!"
+
+  let length = Ffmpeg_content_base.length
+  let params = Ffmpeg_content_base.params
+  let copy_packet x = x
+
+  let blit src src_pos dst dst_pos len =
+    Ffmpeg_content_base.blit ~copy:copy_packet src src_pos dst dst_pos len
+
+  let copy src = Ffmpeg_content_base.copy ~copy:copy_packet src
+  let default_params _ = None
+  let make ?length:_ params : data = Ffmpeg_content_base.make params
+
+  let checksum (d : data) =
+    let chunk_checksums =
+      List.map
+        (fun (data : packet Ffmpeg_content_base.data) ->
+          let packets_data =
+            List.map
+              (fun (pos, packet) ->
+                Printf.sprintf "%d:%Ld:%d/%d:%d" pos data.stream_idx
+                  data.time_base.Avutil.num data.time_base.Avutil.den packet)
+              data.data
+          in
+          String.concat "|" packets_data)
+        d.chunks
+    in
+    Digest.string (String.concat "||" chunk_checksums) |> Digest.to_hex
+end
+
+(* Apply the Content functor *)
+module DummyContent = Content.MkContent (DummySpecs)
+
+(* Helper to create data with packets at specific positions *)
+let mk_data ?(stream_idx = 1L) ?(time_base = time_base) ~length data =
+  { Ffmpeg_content_base.length; stream_idx; time_base; data }
+
+let mk_content params chunks : data = { Ffmpeg_content_base.params; chunks }
+
+(* Test lift_data and get_data round-trip *)
+let () =
+  let chunk = mk_data ~stream_idx:42L ~length:100 [(0, 1); (50, 2)] in
+  let content = mk_content (Some { name = "test" }) [chunk] in
+  let lifted = DummyContent.lift_data content in
+  let retrieved = DummyContent.get_data lifted in
+  assert (Ffmpeg_content_base.length retrieved = 100);
+  assert (List.length retrieved.chunks = 1);
+  let c = List.hd retrieved.chunks in
+  assert (c.stream_idx = 42L);
+  assert (c.length = 100);
+  assert (c.time_base = time_base);
+  assert (c.data = [(0, 1); (50, 2)])
+
+(* Test lift_params and get_params round-trip *)
+let () =
+  let params = Some { name = "test_params" } in
+  let lifted = DummyContent.lift_params params in
+  let retrieved = DummyContent.get_params lifted in
+  assert (retrieved = params)
+
+(* Test Content.sub with offset and length *)
+let () =
+  let chunk =
+    mk_data ~stream_idx:5L ~length:100 [(10, 1); (30, 2); (50, 3); (70, 4)]
+  in
+  let content = mk_content (Some { name = "test" }) [chunk] in
+  let lifted = DummyContent.lift_data content in
+  (* Sub from 20 to 60 (length 40) - includes positions 30 and 50 *)
+  let sub = Content.sub lifted 20 40 in
+  assert (Content.length sub = 40);
+  let retrieved = DummyContent.get_data sub in
+  assert (List.length retrieved.chunks = 1);
+  let c = List.hd retrieved.chunks in
+  assert (c.stream_idx = 5L);
+  assert (c.length = 40);
+  (* Positions 30 and 50 adjusted by -20 become 10 and 30 *)
+  assert (c.data = [(10, 2); (30, 3)])
+
+(* Test Content.sub preserves stream boundaries *)
+let () =
+  let chunk1 = mk_data ~stream_idx:1L ~length:50 [(10, 11); (30, 12)] in
+  let chunk2 = mk_data ~stream_idx:2L ~length:50 [(10, 21); (30, 22)] in
+  let content = mk_content (Some { name = "test" }) [chunk1; chunk2] in
+  let lifted = DummyContent.lift_data content in
+  (* Sub spanning both chunks: positions 25-75 *)
+  let sub = Content.sub lifted 25 50 in
+  assert (Content.length sub = 50);
+  let retrieved = DummyContent.get_data sub in
+  assert (List.length retrieved.chunks = 2);
+  (* First chunk: position 30 from chunk1, adjusted to 5 *)
+  let c1 = List.nth retrieved.chunks 0 in
+  assert (c1.stream_idx = 1L);
+  assert (c1.length = 25);
+  assert (c1.data = [(5, 12)]);
+  (* Second chunk: position 10 from chunk2, adjusted to 10 (since chunk2 starts at pos 50, sub starts at 25, offset into chunk2 is 0) *)
+  let c2 = List.nth retrieved.chunks 1 in
+  assert (c2.stream_idx = 2L);
+  assert (c2.length = 25);
+  assert (c2.data = [(10, 21)])
+
+(* Test Content.copy creates independent copy with same values *)
+let () =
+  let chunk = mk_data ~stream_idx:99L ~length:100 [(0, 42); (75, 99)] in
+  let content = mk_content (Some { name = "original" }) [chunk] in
+  let lifted = DummyContent.lift_data content in
+  let copied = Content.copy lifted in
+  assert (Content.length copied = 100);
+  let retrieved = DummyContent.get_data copied in
+  let c = List.hd retrieved.chunks in
+  assert (c.stream_idx = 99L);
+  assert (c.length = 100);
+  assert (c.data = [(0, 42); (75, 99)]);
+  (* Modifying original shouldn't affect copy *)
+  content.chunks <- [];
+  assert (Content.length copied = 100)
+
+(* Test Content.append concatenates content *)
+let () =
+  let chunk1 = mk_data ~stream_idx:1L ~length:100 [(0, 11); (50, 12)] in
+  let chunk2 = mk_data ~stream_idx:2L ~length:100 [(25, 21); (75, 22)] in
+  let content1 = mk_content (Some { name = "first" }) [chunk1] in
+  let content2 = mk_content (Some { name = "second" }) [chunk2] in
+  let lifted1 = DummyContent.lift_data content1 in
+  let lifted2 = DummyContent.lift_data content2 in
+  let appended = Content.append lifted1 lifted2 in
+  assert (Content.length appended = 200);
+  let retrieved = DummyContent.get_data appended in
+  assert (List.length retrieved.chunks = 2);
+  let c1 = List.nth retrieved.chunks 0 in
+  assert (c1.stream_idx = 1L);
+  assert (c1.length = 100);
+  assert (c1.data = [(0, 11); (50, 12)]);
+  let c2 = List.nth retrieved.chunks 1 in
+  assert (c2.stream_idx = 2L);
+  assert (c2.length = 100);
+  assert (c2.data = [(25, 21); (75, 22)])
+
+(* Test Content.append with multiple stream boundaries *)
+let () =
+  let chunk1a = mk_data ~stream_idx:1L ~length:50 [(10, 1)] in
+  let chunk1b = mk_data ~stream_idx:2L ~length:50 [(20, 2)] in
+  let chunk2a = mk_data ~stream_idx:3L ~length:50 [(30, 3)] in
+  let chunk2b = mk_data ~stream_idx:4L ~length:50 [(40, 4)] in
+  let content1 = mk_content (Some { name = "first" }) [chunk1a; chunk1b] in
+  let content2 = mk_content (Some { name = "second" }) [chunk2a; chunk2b] in
+  let lifted1 = DummyContent.lift_data content1 in
+  let lifted2 = DummyContent.lift_data content2 in
+  let appended = Content.append lifted1 lifted2 in
+  assert (Content.length appended = 200);
+  let retrieved = DummyContent.get_data appended in
+  assert (List.length retrieved.chunks = 4);
+  assert ((List.nth retrieved.chunks 0).stream_idx = 1L);
+  assert ((List.nth retrieved.chunks 0).data = [(10, 1)]);
+  assert ((List.nth retrieved.chunks 1).stream_idx = 2L);
+  assert ((List.nth retrieved.chunks 1).data = [(20, 2)]);
+  assert ((List.nth retrieved.chunks 2).stream_idx = 3L);
+  assert ((List.nth retrieved.chunks 2).data = [(30, 3)]);
+  assert ((List.nth retrieved.chunks 3).stream_idx = 4L);
+  assert ((List.nth retrieved.chunks 3).data = [(40, 4)])
+
+(* Test empty data with positive length (sparse streams) *)
+let () =
+  let chunk = mk_data ~stream_idx:7L ~length:1000 [] in
+  let content = mk_content (Some { name = "sparse" }) [chunk] in
+  let lifted = DummyContent.lift_data content in
+  assert (Content.length lifted = 1000);
+  (* Sub should work on sparse content *)
+  let sub = Content.sub lifted 100 500 in
+  assert (Content.length sub = 500);
+  let retrieved = DummyContent.get_data sub in
+  assert (List.length retrieved.chunks = 1);
+  let c = List.hd retrieved.chunks in
+  assert (c.stream_idx = 7L);
+  assert (c.length = 500);
+  assert (c.data = [])
+
+(* Test Content.is_empty *)
+let () =
+  let empty_content = mk_content None [] in
+  let lifted = DummyContent.lift_data empty_content in
+  assert (Content.is_empty lifted);
+  let chunk = mk_data ~length:100 [] in
+  let non_empty = mk_content None [chunk] in
+  let lifted2 = DummyContent.lift_data non_empty in
+  assert (not (Content.is_empty lifted2))
+
+(* Test Content.truncate - drops first N samples *)
+let () =
+  let chunk = mk_data ~stream_idx:3L ~length:100 [(10, 1); (50, 2); (90, 3)] in
+  let content = mk_content (Some { name = "test" }) [chunk] in
+  let lifted = DummyContent.lift_data content in
+  (* Truncate drops first 60 samples, leaving positions 60-100 *)
+  let truncated = Content.truncate lifted 60 in
+  assert (Content.length truncated = 40);
+  let retrieved = DummyContent.get_data truncated in
+  assert (List.length retrieved.chunks = 1);
+  let c = List.hd retrieved.chunks in
+  assert (c.stream_idx = 3L);
+  assert (c.length = 40);
+  (* Only position 90 remains, adjusted to 30 (90 - 60) *)
+  assert (c.data = [(30, 3)])
+
+(* Test checksum changes with different packet values *)
+let () =
+  let chunk1 = mk_data ~stream_idx:1L ~length:100 [(0, 1)] in
+  let chunk2 = mk_data ~stream_idx:1L ~length:100 [(0, 2)] in
+  let content1 = mk_content None [chunk1] in
+  let content2 = mk_content None [chunk2] in
+  let lifted1 = DummyContent.lift_data content1 in
+  let lifted2 = DummyContent.lift_data content2 in
+  assert (Content.checksum lifted1 <> Content.checksum lifted2)
+
+(* Test checksum is same for identical data *)
+let () =
+  let chunk = mk_data ~stream_idx:5L ~length:100 [(0, 42); (50, 99)] in
+  let content = mk_content None [chunk] in
+  let lifted = DummyContent.lift_data content in
+  let copied = Content.copy lifted in
+  assert (Content.checksum lifted = Content.checksum copied)
+
+(* Test format compatibility *)
+let () =
+  let params1 = Some { name = "audio" } in
+  let params2 = Some { name = "audio" } in
+  let params3 = Some { name = "video" } in
+  let format1 = DummyContent.lift_params params1 in
+  let format2 = DummyContent.lift_params params2 in
+  let format3 = DummyContent.lift_params params3 in
+  assert (Content.compatible format1 format2);
+  assert (not (Content.compatible format1 format3))
+
+(* Test format with None is compatible with everything *)
+let () =
+  let params1 = None in
+  let params2 = Some { name = "anything" } in
+  let format1 = DummyContent.lift_params params1 in
+  let format2 = DummyContent.lift_params params2 in
+  assert (Content.compatible format1 format2);
+  assert (Content.compatible format2 format1)
+
+(* Test Content.make creates empty content *)
+let () =
+  let format = DummyContent.lift_params (Some { name = "new" }) in
+  let content = Content.make ~length:500 format in
+  let retrieved = DummyContent.get_data content in
+  assert (Ffmpeg_content_base.length retrieved = 0);
+  assert (retrieved.chunks = [])
+
+(* Test multiple sub operations preserve stream boundaries and data *)
+let () =
+  let chunk1 = mk_data ~stream_idx:1L ~length:100 [(25, 11); (75, 12)] in
+  let chunk2 = mk_data ~stream_idx:2L ~length:100 [(10, 21); (75, 22)] in
+  let content = mk_content None [chunk1; chunk2] in
+  let lifted = DummyContent.lift_data content in
+  (* First sub: 50-150 (spans both chunks) *)
+  let sub1 = Content.sub lifted 50 100 in
+  assert (Content.length sub1 = 100);
+  (* After first sub:
+     - From chunk1 (0-100): positions 50-100, so pos 75 -> 25
+     - From chunk2 (100-200): positions 0-50, so pos 10 -> 10 *)
+  (* Second sub of the result: 25-75 *)
+  let sub2 = Content.sub sub1 25 50 in
+  assert (Content.length sub2 = 50);
+  let retrieved = DummyContent.get_data sub2 in
+  assert (List.length retrieved.chunks = 2);
+  (* From chunk1: position 75 -> after first sub at 25 -> after second sub at 0 *)
+  let c1 = List.nth retrieved.chunks 0 in
+  assert (c1.stream_idx = 1L);
+  assert (c1.length = 25);
+  assert (c1.data = [(0, 12)]);
+  let c2 = List.nth retrieved.chunks 1 in
+  assert (c2.stream_idx = 2L);
+  assert (c2.length = 25);
+  assert (c2.data = [(10, 21)])
+
+(* Test lift_data with offset and length parameters *)
+let () =
+  let chunk =
+    mk_data ~stream_idx:8L ~length:200 [(50, 1); (100, 2); (150, 3)]
+  in
+  let content = mk_content None [chunk] in
+  (* Lift with offset=50 and length=100 means positions [50, 150) *)
+  let lifted = DummyContent.lift_data ~offset:50 ~length:100 content in
+  assert (Content.length lifted = 100);
+  let retrieved = DummyContent.get_data lifted in
+  assert (List.length retrieved.chunks = 1);
+  let c = List.hd retrieved.chunks in
+  assert (c.stream_idx = 8L);
+  assert (c.length = 100);
+  (* Positions 50 and 100 are in range [50, 150), adjusted to 0 and 50 *)
+  (* Position 150 is excluded (not < 150) *)
+  assert (c.data = [(0, 1); (50, 2)])
+
+(* Test time_base preservation through operations *)
+let () =
+  let time_base1 = { Avutil.num = 1; den = 48000 } in
+  let time_base2 = { Avutil.num = 1; den = 44100 } in
+  let chunk1 =
+    mk_data ~stream_idx:1L ~time_base:time_base1 ~length:100 [(50, 1)]
+  in
+  let chunk2 =
+    mk_data ~stream_idx:2L ~time_base:time_base2 ~length:100 [(50, 2)]
+  in
+  let content = mk_content None [chunk1; chunk2] in
+  let lifted = DummyContent.lift_data content in
+  let copied = Content.copy lifted in
+  let retrieved = DummyContent.get_data copied in
+  assert (List.length retrieved.chunks = 2);
+  let c1 = List.nth retrieved.chunks 0 in
+  assert (c1.stream_idx = 1L);
+  assert (c1.time_base = time_base1);
+  assert (c1.data = [(50, 1)]);
+  let c2 = List.nth retrieved.chunks 1 in
+  assert (c2.stream_idx = 2L);
+  assert (c2.time_base = time_base2);
+  assert (c2.data = [(50, 2)])
+
+(* Test sub at exact chunk boundary *)
+let () =
+  let chunk1 = mk_data ~stream_idx:1L ~length:100 [(0, 1); (99, 2)] in
+  let chunk2 = mk_data ~stream_idx:2L ~length:100 [(0, 3); (99, 4)] in
+  let content = mk_content None [chunk1; chunk2] in
+  let lifted = DummyContent.lift_data content in
+  (* Sub exactly the first chunk *)
+  let sub = Content.sub lifted 0 100 in
+  assert (Content.length sub = 100);
+  let retrieved = DummyContent.get_data sub in
+  assert (List.length retrieved.chunks = 1);
+  let c = List.hd retrieved.chunks in
+  assert (c.stream_idx = 1L);
+  assert (c.length = 100);
+  assert (c.data = [(0, 1); (99, 2)])
+
+(* Test sub exactly the second chunk *)
+let () =
+  let chunk1 = mk_data ~stream_idx:1L ~length:100 [(0, 1)] in
+  let chunk2 = mk_data ~stream_idx:2L ~length:100 [(0, 2)] in
+  let content = mk_content None [chunk1; chunk2] in
+  let lifted = DummyContent.lift_data content in
+  let sub = Content.sub lifted 100 100 in
+  assert (Content.length sub = 100);
+  let retrieved = DummyContent.get_data sub in
+  assert (List.length retrieved.chunks = 1);
+  let c = List.hd retrieved.chunks in
+  assert (c.stream_idx = 2L);
+  assert (c.length = 100);
+  assert (c.data = [(0, 2)])
+
+(* Test multiple stream_idx: interleaved streams *)
+let () =
+  let chunk1 = mk_data ~stream_idx:1L ~length:30 [(0, 1); (15, 2)] in
+  let chunk2 = mk_data ~stream_idx:2L ~length:40 [(5, 3); (25, 4)] in
+  let chunk3 = mk_data ~stream_idx:1L ~length:30 [(10, 5)] in
+  let content = mk_content None [chunk1; chunk2; chunk3] in
+  let lifted = DummyContent.lift_data content in
+  assert (Content.length lifted = 100);
+  let retrieved = DummyContent.get_data lifted in
+  assert (List.length retrieved.chunks = 3);
+  (* Verify each chunk maintains its stream_idx *)
+  assert ((List.nth retrieved.chunks 0).stream_idx = 1L);
+  assert ((List.nth retrieved.chunks 1).stream_idx = 2L);
+  assert ((List.nth retrieved.chunks 2).stream_idx = 1L);
+  (* Verify data integrity *)
+  assert ((List.nth retrieved.chunks 0).data = [(0, 1); (15, 2)]);
+  assert ((List.nth retrieved.chunks 1).data = [(5, 3); (25, 4)]);
+  assert ((List.nth retrieved.chunks 2).data = [(10, 5)])
+
+(* Test multiple stream_idx: sub operation crossing stream boundaries *)
+let () =
+  let chunk1 = mk_data ~stream_idx:10L ~length:50 [(20, 1); (40, 2)] in
+  let chunk2 = mk_data ~stream_idx:20L ~length:50 [(10, 3); (30, 4)] in
+  let chunk3 = mk_data ~stream_idx:30L ~length:50 [(15, 5); (45, 6)] in
+  let content = mk_content None [chunk1; chunk2; chunk3] in
+  let lifted = DummyContent.lift_data content in
+  (* Sub from 40 to 110 (length 70), crossing all three chunks *)
+  let sub = Content.sub lifted 40 70 in
+  assert (Content.length sub = 70);
+  let retrieved = DummyContent.get_data sub in
+  assert (List.length retrieved.chunks = 3);
+  (* chunk1[40:50] -> 10 samples, pos 40 -> 0 *)
+  let c1 = List.nth retrieved.chunks 0 in
+  assert (c1.stream_idx = 10L);
+  assert (c1.length = 10);
+  assert (c1.data = [(0, 2)]);
+  (* chunk2[0:50] -> 50 samples, positions stay *)
+  let c2 = List.nth retrieved.chunks 1 in
+  assert (c2.stream_idx = 20L);
+  assert (c2.length = 50);
+  assert (c2.data = [(10, 3); (30, 4)]);
+  (* chunk3[0:10] -> 10 samples *)
+  let c3 = List.nth retrieved.chunks 2 in
+  assert (c3.stream_idx = 30L);
+  assert (c3.length = 10);
+  assert (c3.data = [])
+(* positions 15 and 45 not in [0, 10) *)
+
+(* Test multiple stream_idx: append preserves order *)
+let () =
+  let chunk_a1 = mk_data ~stream_idx:1L ~length:25 [(5, 11)] in
+  let chunk_a2 = mk_data ~stream_idx:2L ~length:25 [(10, 12)] in
+  let chunk_b1 = mk_data ~stream_idx:3L ~length:25 [(15, 21)] in
+  let chunk_b2 = mk_data ~stream_idx:4L ~length:25 [(20, 22)] in
+  let content_a = mk_content None [chunk_a1; chunk_a2] in
+  let content_b = mk_content None [chunk_b1; chunk_b2] in
+  let lifted_a = DummyContent.lift_data content_a in
+  let lifted_b = DummyContent.lift_data content_b in
+  let appended = Content.append lifted_a lifted_b in
+  assert (Content.length appended = 100);
+  let retrieved = DummyContent.get_data appended in
+  assert (List.length retrieved.chunks = 4);
+  (* Verify stream_idx order is preserved *)
+  let stream_ids =
+    List.map (fun c -> c.Ffmpeg_content_base.stream_idx) retrieved.chunks
+  in
+  assert (stream_ids = [1L; 2L; 3L; 4L]);
+  (* Verify data values *)
+  assert ((List.nth retrieved.chunks 0).data = [(5, 11)]);
+  assert ((List.nth retrieved.chunks 1).data = [(10, 12)]);
+  assert ((List.nth retrieved.chunks 2).data = [(15, 21)]);
+  assert ((List.nth retrieved.chunks 3).data = [(20, 22)])
+
+(* Test multiple stream_idx with different time_bases *)
+let () =
+  let tb1 = { Avutil.num = 1; den = 48000 } in
+  let tb2 = { Avutil.num = 1; den = 44100 } in
+  let tb3 = { Avutil.num = 1; den = 90000 } in
+  let chunk1 = mk_data ~stream_idx:1L ~time_base:tb1 ~length:100 [(50, 1)] in
+  let chunk2 = mk_data ~stream_idx:2L ~time_base:tb2 ~length:100 [(50, 2)] in
+  let chunk3 = mk_data ~stream_idx:3L ~time_base:tb3 ~length:100 [(25, 3)] in
+  let content = mk_content None [chunk1; chunk2; chunk3] in
+  let lifted = DummyContent.lift_data content in
+  (* Sub spanning all three: [50, 250) of [0, 300) *)
+  let sub = Content.sub lifted 50 200 in
+  assert (Content.length sub = 200);
+  let retrieved = DummyContent.get_data sub in
+  assert (List.length retrieved.chunks = 3);
+  (* Verify each chunk keeps its time_base *)
+  assert ((List.nth retrieved.chunks 0).time_base = tb1);
+  assert ((List.nth retrieved.chunks 1).time_base = tb2);
+  assert ((List.nth retrieved.chunks 2).time_base = tb3);
+  (* Verify stream_idx preserved *)
+  assert ((List.nth retrieved.chunks 0).stream_idx = 1L);
+  assert ((List.nth retrieved.chunks 1).stream_idx = 2L);
+  assert ((List.nth retrieved.chunks 2).stream_idx = 3L);
+  (* Verify chunk lengths: chunk1[50:100]=50, chunk2[0:100]=100, chunk3[0:50]=50 *)
+  assert ((List.nth retrieved.chunks 0).length = 50);
+  assert ((List.nth retrieved.chunks 1).length = 100);
+  assert ((List.nth retrieved.chunks 2).length = 50);
+  (* Verify data positions adjusted correctly *)
+  assert ((List.nth retrieved.chunks 0).data = [(0, 1)]);
+  (* 50-50=0 *)
+  assert ((List.nth retrieved.chunks 1).data = [(50, 2)]);
+  (* stays at 50 within chunk *)
+  assert ((List.nth retrieved.chunks 2).data = [(25, 3)])
+(* 25 is in [0,50), stays at 25 *)
+
+(* Test stream_idx: copy preserves all stream metadata *)
+let () =
+  let chunk1 = mk_data ~stream_idx:100L ~length:50 [(10, 1); (40, 2)] in
+  let chunk2 = mk_data ~stream_idx:200L ~length:50 [(20, 3); (30, 4)] in
+  let content = mk_content (Some { name = "multi" }) [chunk1; chunk2] in
+  let lifted = DummyContent.lift_data content in
+  let copied = Content.copy lifted in
+  let retrieved = DummyContent.get_data copied in
+  assert (List.length retrieved.chunks = 2);
+  let c1 = List.nth retrieved.chunks 0 in
+  let c2 = List.nth retrieved.chunks 1 in
+  assert (c1.stream_idx = 100L);
+  assert (c2.stream_idx = 200L);
+  assert (c1.length = 50);
+  assert (c2.length = 50);
+  assert (c1.data = [(10, 1); (40, 2)]);
+  assert (c2.data = [(20, 3); (30, 4)])
+
+(* Test stream_idx: sparse streams with different stream_idx *)
+let () =
+  let chunk1 = mk_data ~stream_idx:1L ~length:500 [] in
+  (* sparse audio *)
+  let chunk2 = mk_data ~stream_idx:2L ~length:500 [(100, 1)] in
+  (* sparse subtitle *)
+  let chunk3 = mk_data ~stream_idx:1L ~length:500 [] in
+  (* more sparse audio *)
+  let content = mk_content None [chunk1; chunk2; chunk3] in
+  let lifted = DummyContent.lift_data content in
+  assert (Content.length lifted = 1500);
+  (* Sub in the middle *)
+  let sub = Content.sub lifted 400 700 in
+  assert (Content.length sub = 700);
+  let retrieved = DummyContent.get_data sub in
+  assert (List.length retrieved.chunks = 3);
+  (* chunk1[400:500] -> 100 samples, empty *)
+  assert ((List.nth retrieved.chunks 0).stream_idx = 1L);
+  assert ((List.nth retrieved.chunks 0).length = 100);
+  assert ((List.nth retrieved.chunks 0).data = []);
+  (* chunk2[0:500] -> 500 samples, has data at 100 *)
+  assert ((List.nth retrieved.chunks 1).stream_idx = 2L);
+  assert ((List.nth retrieved.chunks 1).length = 500);
+  assert ((List.nth retrieved.chunks 1).data = [(100, 1)]);
+  (* chunk3[0:100] -> 100 samples, empty *)
+  assert ((List.nth retrieved.chunks 2).stream_idx = 1L);
+  assert ((List.nth retrieved.chunks 2).length = 100);
+  assert ((List.nth retrieved.chunks 2).data = [])
+
+(* Test blit collapses adjacent chunks with same stream_idx *)
+let () =
+  (* Source has: stream_idx=1, stream_idx=1, stream_idx=2, stream_idx=2 *)
+  let chunk1 = mk_data ~stream_idx:1L ~length:25 [(5, 11)] in
+  let chunk2 = mk_data ~stream_idx:1L ~length:25 [(10, 12)] in
+  let chunk3 = mk_data ~stream_idx:2L ~length:25 [(15, 21)] in
+  let chunk4 = mk_data ~stream_idx:2L ~length:25 [(20, 22)] in
+  let src = mk_content None [chunk1; chunk2; chunk3; chunk4] in
+  let dst = mk_content None [] in
+  DummySpecs.blit src 0 dst 0 100;
+  (* After blit, should have 2 chunks: one for stream_idx=1, one for stream_idx=2 *)
+  assert (List.length dst.chunks = 2);
+  let c1 = List.nth dst.chunks 0 in
+  assert (c1.stream_idx = 1L);
+  assert (c1.length = 50);
+  (* Data from chunk1 at 5 and chunk2 at 10 (offset by 25) = 35 *)
+  assert (c1.data = [(5, 11); (35, 12)]);
+  let c2 = List.nth dst.chunks 1 in
+  assert (c2.stream_idx = 2L);
+  assert (c2.length = 50);
+  (* Data from chunk3 at 15 and chunk4 at 20 (offset by 25) = 45 *)
+  assert (c2.data = [(15, 21); (45, 22)])
+
+(* Test blit does NOT collapse non-adjacent chunks with same stream_idx *)
+let () =
+  (* Source has: stream_idx=1, stream_idx=2, stream_idx=1 (interleaved) *)
+  let chunk1 = mk_data ~stream_idx:1L ~length:30 [(10, 11)] in
+  let chunk2 = mk_data ~stream_idx:2L ~length:40 [(20, 21)] in
+  let chunk3 = mk_data ~stream_idx:1L ~length:30 [(5, 12)] in
+  let src = mk_content None [chunk1; chunk2; chunk3] in
+  let dst = mk_content None [] in
+  DummySpecs.blit src 0 dst 0 100;
+  (* After blit, should have 3 chunks (not collapsed because not adjacent) *)
+  assert (List.length dst.chunks = 3);
+  assert ((List.nth dst.chunks 0).stream_idx = 1L);
+  assert ((List.nth dst.chunks 0).length = 30);
+  assert ((List.nth dst.chunks 0).data = [(10, 11)]);
+  assert ((List.nth dst.chunks 1).stream_idx = 2L);
+  assert ((List.nth dst.chunks 1).length = 40);
+  assert ((List.nth dst.chunks 1).data = [(20, 21)]);
+  assert ((List.nth dst.chunks 2).stream_idx = 1L);
+  assert ((List.nth dst.chunks 2).length = 30);
+  assert ((List.nth dst.chunks 2).data = [(5, 12)])
+
+(* Test blit partial range collapses correctly *)
+let () =
+  let chunk1 = mk_data ~stream_idx:1L ~length:50 [(10, 11); (40, 12)] in
+  let chunk2 = mk_data ~stream_idx:1L ~length:50 [(20, 13); (45, 14)] in
+  let src = mk_content None [chunk1; chunk2] in
+  let dst = mk_content None [] in
+  (* Blit from position 30 to 80 (length 50) *)
+  DummySpecs.blit src 30 dst 0 50;
+  assert (List.length dst.chunks = 1);
+  let c = List.hd dst.chunks in
+  assert (c.stream_idx = 1L);
+  assert (c.length = 50);
+  (* chunk1[30:50] has pos 40 -> adjusted to 10
+     chunk2[0:30] has pos 20 -> adjusted to 20+20=40 (dst offset 20) *)
+  assert (c.data = [(10, 12); (40, 13)])
+
+(* Test sequential blits to same dst collapse adjacent same-stream_idx chunks *)
+let () =
+  (* This tests the scenario where multiple blits are done sequentially,
+     and chunks with the same stream_idx that become adjacent should be collapsed.
+     This is the typical pattern when a generator does multiple blits to fill a frame. *)
+  let src1 = mk_content None [mk_data ~stream_idx:1L ~length:100 [(10, 11)]] in
+  let src2 = mk_content None [mk_data ~stream_idx:1L ~length:100 [(20, 12)]] in
+  let dst = mk_content None [] in
+  (* First blit: src1[80:100] -> dst[0:20] *)
+  DummySpecs.blit src1 80 dst 0 20;
+  (* After first blit: one chunk at position 0, length 20, no data (pos 10 is outside [80,100)) *)
+  assert (List.length dst.chunks = 1);
+  assert ((List.hd dst.chunks).length = 20);
+  assert ((List.hd dst.chunks).data = []);
+  (* Second blit: src2[0:80] -> dst[20:100] *)
+  DummySpecs.blit src2 0 dst 20 80;
+  (* After second blit: should have ONE collapsed chunk since both have stream_idx=1 *)
+  assert (List.length dst.chunks = 1);
+  let c = List.hd dst.chunks in
+  assert (c.stream_idx = 1L);
+  assert (c.length = 100);
+  (* Data: src2's pos 20 is at dst position 20 + 20 = 40 *)
+  assert (c.data = [(40, 12)])
+
+(* Test sequential blits with different stream_idx do not collapse *)
+let () =
+  let src1 = mk_content None [mk_data ~stream_idx:1L ~length:100 [(10, 11)]] in
+  let src2 = mk_content None [mk_data ~stream_idx:2L ~length:100 [(20, 12)]] in
+  let dst = mk_content None [] in
+  DummySpecs.blit src1 80 dst 0 20;
+  DummySpecs.blit src2 0 dst 20 80;
+  (* Should have TWO chunks since stream_idx differs *)
+  assert (List.length dst.chunks = 2);
+  assert ((List.nth dst.chunks 0).stream_idx = 1L);
+  assert ((List.nth dst.chunks 0).length = 20);
+  assert ((List.nth dst.chunks 1).stream_idx = 2L);
+  assert ((List.nth dst.chunks 1).length = 80);
+  assert ((List.nth dst.chunks 1).data = [(20, 12)])
+
+let () = print_endline "All ffmpeg_dummy_content tests passed!"


### PR DESCRIPTION
Move ffmpeg copy and raw content params outside of the content list to be acessible even when there is no content.

This is useful when trying to reason about the produced content even when no frame or packets have been produced.

The trick is to preserve stream bondaries inside the data, which is why we're using a chunked structure similar to how `Content_base` works.

Up until now, raw and copy (encoded) ffmpeg content was represented as an array of:

```ocaml
{ length: <...>, data: [(<pos>, { stream_idx, time_base, <packet or frame>})] }
```

This format repeated `stream_idx` and `time_base` on each packet or frame even if there were from the same stream but supported an array containing adjacent streams.

This has worked well for non-sparse streams where the stream always starts with a first packet or frame. However, with subtitle streams, we are dealing with streams where there might be a very long initial content with no packet or frame. Think about a movie where the first subtitle comes after 20 min.

In this case, we really need to be able to handle chunks of content with no data. So in this PR, we switch the content structure to:
```ocaml
[
  { length: <..>, stream_idx: 123, time_base, data: [<content>]}, 
  { length: <..>, stream_idx: 234, time_base, data: [<content>]}
]
```
This way, we are able to account for chunks of content for e.g. stream `123` where no packets or frames are present, i.e. `data = []`.

I have known about this being a better approach for a while but this is a fairly large change due to the requirement to tackle all impacted code so I got helped from the robots on that part..