### PR TITLE
Fail when `on_close` errors.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # 2.4.3 (unreleased)
 
+## Changed:
+
+- Make sure script fails on `on_close` errors in `output.file` to prevent
+  fatal errors from being ignored. Use `reopen_on_error` to ignore errors
+  from the callback.
+
 ## Fixed:
 
 - Fixed `fMP4` HLS support for audio+video streams (#4841)

--- a/src/core/base/outputs/pipe_output.ml
+++ b/src/core/base/outputs/pipe_output.ml
@@ -540,7 +540,10 @@ class file_output_using_encoder ?clock ~format_val p =
 
     method! close_encoder =
       let ret = base#close_encoder in
-      (try on_close (Option.get (Atomic.get current_filename)) with _ -> ());
+      (try on_close (Option.get (Atomic.get current_filename))
+       with exn ->
+         let bt = Printexc.get_raw_backtrace () in
+         self#reopen_on_error ~bt exn);
       Atomic.set current_filename None;
       ret
 


### PR DESCRIPTION
In https://github.com/savonet/liquidsoap/commit/d324eb14534eb1ff99f7ecef7fcbab0e5f5ddd97, `output.file` `on_close` handler was switched to ignore all errors.

This is not a great idea because this will ignore potential fatal errors.

This PR changes it back to raising errors by default. You can use the `reopen_on_error` callback to ignore them again.