### PR TITLE
Add support for automatically detected video dimensions.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # 2.4.3 (unreleased)
 
+## New:
+
+- Video dimensions (`video.frame.width`/`height`) are now automatically detected
+  from the first decoded video file. This can be disabled by setting `settings.video.detect_dimensions`
+  to `false` or by explicitly setting the video dimensions.
+
 ## Changed:
 
 - Make sure script fails on `on_close` errors in `output.file` to prevent

--- a/doc/content/stream_content.md
+++ b/doc/content/stream_content.md
@@ -78,6 +78,11 @@ video.frame.height := 240
 video.frame.rate := 25
 ```
 
+By default, video dimensions are automatically detected from the first decoded
+video file. This behavior can be disabled by setting
+`settings.video.detect_dimensions` to `false` or by explicitly setting
+`video.frame.width` or `video.frame.height`.
+
 ## Checking stream contents
 
 Checking the consistency of use of stream contents is done as part

--- a/src/core/base/decoder/decoder.ml
+++ b/src/core/base/decoder/decoder.ml
@@ -457,6 +457,7 @@ let mk_buffer ~ctype generator =
     with Not_found ->
       let handler =
         if Frame.Fields.mem field ctype then (
+          let video_width, video_height = Frame.video_dimensions () in
           let video_resample = Decoder_utils.video_resample () in
           let video_scale =
             let width, height =
@@ -465,7 +466,7 @@ let mk_buffer ~ctype generator =
                   (Option.get (Frame.Fields.find_opt Frame.Fields.video ctype))
               with Content.Invalid ->
                 (* We might have encoded contents *)
-                (Lazy.force Frame.video_width, Lazy.force Frame.video_height)
+                (Lazy.force video_width, Lazy.force video_height)
             in
             Decoder_utils.video_scale ~width ~height ()
           in
@@ -474,8 +475,8 @@ let mk_buffer ~ctype generator =
           in
           let params =
             {
-              Content.Video.width = Some Frame.video_width;
-              height = Some Frame.video_height;
+              Content.Video.width = Some video_width;
+              height = Some video_height;
             }
           in
           let interval = Frame.main_of_video 1 in

--- a/src/core/base/decoder/image_decoder.ml
+++ b/src/core/base/decoder/image_decoder.ml
@@ -28,8 +28,9 @@ let log = Log.make ["image"; "decoder"]
 
 (** Function to retrieve width an height from parameters. *)
 let wh iw ih w h =
-  let frame_w = Lazy.force Frame.video_width in
-  let frame_h = Lazy.force Frame.video_height in
+  let frame_w, frame_h = Frame.video_dimensions () in
+  let frame_w = Lazy.force frame_w in
+  let frame_h = Lazy.force frame_h in
   match (w, h) with
     | None, None ->
         (* By default resize anamorphically to the maximum size wrt the frame *)
@@ -48,8 +49,9 @@ let wh iw ih w h =
     | Some w, Some h -> (w, h)
 
 let wh_string iw ih w h =
-  let frame_w = Lazy.force Frame.video_width in
-  let frame_h = Lazy.force Frame.video_height in
+  let frame_w, frame_h = Frame.video_dimensions () in
+  let frame_w = Lazy.force frame_w in
+  let frame_h = Lazy.force frame_h in
   let f d i l =
     if l = "" then None
     else if l.[String.length l - 1] = '%' then (
@@ -67,8 +69,9 @@ let wh_string iw ih w h =
 (* TODO: negative used to mean from right but I don't think it's a good idea
    anymore (for instance to have a scrolling image). *)
 let off_string iw ih ox oy =
-  let frame_w = Lazy.force Frame.video_width in
-  let frame_h = Lazy.force Frame.video_height in
+  let frame_w, frame_h = Frame.video_dimensions () in
+  let frame_w = Lazy.force frame_w in
+  let frame_h = Lazy.force frame_h in
   let f d frame l =
     if l = "" then d
     else if l.[String.length l - 1] = '%' then (

--- a/src/core/base/encoder/lang/lang_avi.ml
+++ b/src/core/base/encoder/lang/lang_avi.ml
@@ -23,14 +23,15 @@
 open Value
 
 let make params =
+  let video_width, video_height = Frame.video_dimensions () in
   let defaults =
     {
       (* We use a hardcoded value in order not to force the evaluation of the
          number of channels too early, see #933. *)
       Avi_format.channels = 2;
       samplerate = Frame.audio_rate;
-      width = Frame.video_width;
-      height = Frame.video_height;
+      width = video_width;
+      height = video_height;
     }
   in
   let avi =

--- a/src/core/base/encoder/lang/lang_external_encoder.ml
+++ b/src/core/base/encoder/lang/lang_external_encoder.ml
@@ -69,7 +69,7 @@ let make params =
         | `Labelled ("video", Value.Bool { value = b; _ }) ->
             let w, h =
               match f.External_encoder_format.video with
-                | None -> (Frame.video_width, Frame.video_height)
+                | None -> Frame.video_dimensions ()
                 | Some (w, h) -> (w, h)
             in
             {
@@ -79,7 +79,7 @@ let make params =
         | `Labelled ("width", Int { value = w; _ }) ->
             let _, h =
               match f.External_encoder_format.video with
-                | None -> (Frame.video_width, Frame.video_height)
+                | None -> Frame.video_dimensions ()
                 | Some (w, h) -> (w, h)
             in
             let w = Lazy.from_val w in
@@ -87,7 +87,7 @@ let make params =
         | `Labelled ("height", Int { value = h }) ->
             let w, _ =
               match f.External_encoder_format.video with
-                | None -> (Frame.video_width, Frame.video_height)
+                | None -> Frame.video_dimensions ()
                 | Some (w, h) -> (w, h)
             in
             let h = Lazy.from_val h in

--- a/src/core/base/encoder/lang/lang_theora.ml
+++ b/src/core/base/encoder/lang/lang_theora.ml
@@ -25,14 +25,15 @@ open Value
 let type_of_encoder _ = Encoder.video_type ()
 
 let make params =
+  let video_width, video_height = Frame.video_dimensions () in
   let defaults =
     {
       Theora_format.bitrate_control = Theora_format.Quality 40;
       fill = None;
-      width = Frame.video_width;
-      height = Frame.video_height;
-      picture_width = Frame.video_width;
-      picture_height = Frame.video_height;
+      width = video_width;
+      height = video_height;
+      picture_width = video_width;
+      picture_height = video_height;
       picture_x = 0;
       picture_y = 0;
       aspect_numerator = 1;

--- a/src/core/base/operators/add.ml
+++ b/src/core/base/operators/add.ml
@@ -293,8 +293,9 @@ let tile_pos n =
           x := !x + dx;
           (!x, y, dx, y' - y)))
   in
-  let x' = Lazy.force Frame.video_width in
-  let y' = Lazy.force Frame.video_height in
+  let video_width, video_height = Frame.video_dimensions () in
+  let x' = Lazy.force video_width in
+  let y' = Lazy.force video_height in
   let horiz m n =
     Array.append (vert m 0 0 x' (y' / 2)) (vert n 0 (y' / 2) x' y')
   in

--- a/src/core/base/operators/video_effects.ml
+++ b/src/core/base/operators/video_effects.ml
@@ -597,15 +597,14 @@ let _ =
         List.assoc "height" p |> Lang.to_option |> Option.map Lang.to_int
       in
       let s = List.assoc "" p |> Lang.to_source in
+      let video_width, video_height = Frame.video_dimensions () in
       let width =
-        match width with
-          | Some width -> width
-          | None -> Lazy.force Frame.video_width
+        match width with Some width -> width | None -> Lazy.force video_width
       in
       let height =
         match height with
           | Some height -> height
-          | None -> Lazy.force Frame.video_height
+          | None -> Lazy.force video_height
       in
       new effect_map ~name:"video.viewport" s (fun buf ->
           Video.Canvas.Image.viewport ~x ~y width height buf))

--- a/src/core/base/sources/external_input_video.ml
+++ b/src/core/base/sources/external_input_video.ml
@@ -122,8 +122,9 @@ let _ =
                 let src = of_string data in
                 let in_width = Video.Image.width src in
                 let in_height = Video.Image.height src in
-                let out_width = Lazy.force Frame.video_width in
-                let out_height = Lazy.force Frame.video_height in
+                let video_width, video_height = Frame.video_dimensions () in
+                let out_width = Lazy.force video_width in
+                let out_height = Lazy.force video_height in
                 if
                   out_width = in_width && out_height = in_height
                   && video_format = `I420
@@ -220,8 +221,9 @@ let _ =
     ~return_t
     (fun p ->
       let command = Lang.to_string_getter (List.assoc "" p) in
-      let width = Lazy.force Frame.video_width in
-      let height = Lazy.force Frame.video_height in
+      let video_width, video_height = Frame.video_dimensions () in
+      let width = Lazy.force video_width in
+      let height = Lazy.force video_height in
       let buflen = width * height * 3 in
       let buf = Bytes.create buflen in
       let on_data ~buffer reader =

--- a/src/core/base/sources/video_board.ml
+++ b/src/core/base/sources/video_board.ml
@@ -202,15 +202,14 @@ let _ =
       let height =
         List.assoc "height" p |> Lang.to_option |> Option.map Lang.to_int
       in
+      let video_width, video_height = Frame.video_dimensions () in
       let width =
-        match width with
-          | Some width -> width
-          | None -> Lazy.force Frame.video_width
+        match width with Some width -> width | None -> Lazy.force video_width
       in
       let height =
         match height with
           | Some height -> height
-          | None -> Lazy.force Frame.video_height
+          | None -> Lazy.force video_height
       in
       let img = Video.YUV420.create width height in
       Printf.printf "image: %dx%d\nx%!" width height;

--- a/src/core/base/stream/content.ml
+++ b/src/core/base/stream/content.ml
@@ -89,15 +89,14 @@ module Video = struct
   }
 
   let make_generator params =
+    let default_width, default_height = Frame_settings.video_dimensions () in
     let width =
       Lazy.force
-        (Option.value ~default:Frame_settings.video_width
-           params.Content_video.Specs.width)
+        (Option.value ~default:default_width params.Content_video.Specs.width)
     in
     let height =
       Lazy.force
-        (Option.value ~default:Frame_settings.video_height
-           params.Content_video.Specs.height)
+        (Option.value ~default:default_height params.Content_video.Specs.height)
     in
     {
       params =

--- a/src/core/base/stream/content_video.ml
+++ b/src/core/base/stream/content_video.ml
@@ -95,8 +95,9 @@ module Specs = struct
       ]
 
   let make ?(length = 0) params =
-    let width = !!(Option.value ~default:video_width params.width) in
-    let height = !!(Option.value ~default:video_height params.height) in
+    let default_width, default_height = video_dimensions () in
+    let width = !!(Option.value ~default:default_width params.width) in
+    let height = !!(Option.value ~default:default_height params.height) in
     let interval = main_of_video 1 in
     let img = Video.Canvas.Image.create width height in
     let data =
@@ -179,12 +180,9 @@ let kind = lift_kind `Canvas
 
 let dimensions_of_format p =
   let p = get_params p in
-  let width =
-    Lazy.force (Option.value ~default:Frame_settings.video_width p.width)
-  in
-  let height =
-    Lazy.force (Option.value ~default:Frame_settings.video_height p.height)
-  in
+  let default_width, default_height = Frame_settings.video_dimensions () in
+  let width = Lazy.force (Option.value ~default:default_width p.width) in
+  let height = Lazy.force (Option.value ~default:default_height p.height) in
   (width, height)
 
 let lift_canvas ?(offset = 0) ?length data =

--- a/src/core/base/stream/frame.mli
+++ b/src/core/base/stream/frame.mli
@@ -218,11 +218,13 @@ val default_video_enabled : bool Lazy.t
 (** Default number of MIDI channels. *)
 val midi_channels : int Lazy.t
 
-(** Width of video images. *)
-val video_width : int Lazy.t
+(** Ideal video size for auto-detection. *)
+type ideal_size = { width : int; height : int; source : string }
 
-(** Height of video images. *)
-val video_height : int Lazy.t
+(** Get video dimensions as a pair of lazy values. Forcing one forces the other.
+    If [~ideal_size] is provided and the dimensions haven't been explicitly set
+    by the user or forced yet, use the ideal dimensions as the default. *)
+val video_dimensions : ?ideal_size:ideal_size -> unit -> int Lazy.t * int Lazy.t
 
 (** Rate of audio (in samples per second). *)
 val audio_rate : int Lazy.t

--- a/src/core/optionals/ffmpeg/builtins_ffmpeg_decoder.ml
+++ b/src/core/optionals/ffmpeg/builtins_ffmpeg_decoder.ml
@@ -194,8 +194,9 @@ let decode_audio_frame ~field ~mode generator =
     | `Raw -> convert ~decoder:(mk_raw_decoder ())
 
 let decode_video_frame ~field ~mode generator =
-  let internal_width = Lazy.force Frame.video_width in
-  let internal_height = Lazy.force Frame.video_height in
+  let video_width, video_height = Frame.video_dimensions () in
+  let internal_width = Lazy.force video_width in
+  let internal_height = Lazy.force video_height in
   let target_fps = Lazy.force Frame.video_rate in
 
   let mk_converter () =

--- a/src/core/optionals/ffmpeg/builtins_ffmpeg_encoder.ml
+++ b/src/core/optionals/ffmpeg/builtins_ffmpeg_encoder.ml
@@ -198,8 +198,9 @@ let encode_video_frame ~source_idx ~type_t ~mode ~opts ?codec ~format ~field
     generator =
   let internal_fps = Lazy.force Frame.video_rate in
   let internal_time_base = { Avutil.num = 1; den = internal_fps } in
-  let internal_width = Lazy.force Frame.video_width in
-  let internal_height = Lazy.force Frame.video_height in
+  let video_width, video_height = Frame.video_dimensions () in
+  let internal_width = Lazy.force video_width in
+  let internal_height = Lazy.force video_height in
 
   let target_fps = Lazy.force format.Ffmpeg_format.framerate in
   let target_frame_rate = { Avutil.num = target_fps; den = 1 } in

--- a/src/core/optionals/ffmpeg/ffmpeg_decoder.ml
+++ b/src/core/optionals/ffmpeg/ffmpeg_decoder.ml
@@ -1227,6 +1227,18 @@ let mk_streams ~ctype ~decode_first_metadata container =
                   streams,
                 pos + 1 )
           | Some format when Content.Video.is_format format ->
+              (* Set ideal video dimensions from source file *)
+              let src_width = Avcodec.Video.get_width params in
+              let src_height = Avcodec.Video.get_height params in
+              let ideal_size =
+                Frame.
+                  {
+                    width = src_width;
+                    height = src_height;
+                    source = "ffmpeg decoder";
+                  }
+              in
+              ignore (Frame.video_dimensions ~ideal_size ());
               let width, height = Content.Video.dimensions_of_format format in
               ( add_stream ~sparse:`False idx stream
                   (`Video_frame

--- a/src/core/optionals/ffmpeg/ffmpeg_internal_encoder.ml
+++ b/src/core/optionals/ffmpeg/ffmpeg_internal_encoder.ml
@@ -464,8 +464,9 @@ let mk_video ~pos ~on_keyframe ~mode ~codec ~params ~options ~field output =
   in
 
   let internal_converter cb =
-    let src_width = Lazy.force Frame.video_width in
-    let src_height = Lazy.force Frame.video_height in
+    let video_width, video_height = Frame.video_dimensions () in
+    let src_width = Lazy.force video_width in
+    let src_height = Lazy.force video_height in
     let scaler =
       InternalScaler.create [flag] src_width src_height
         Ffmpeg_utils.liq_frame_pixel_format target_width target_height

--- a/src/core/optionals/ffmpeg/lang_ffmpeg.ml
+++ b/src/core/optionals/ffmpeg/lang_ffmpeg.ml
@@ -308,11 +308,12 @@ let ffmpeg_gen params =
     }
   in
 
+  let video_width, video_height = Frame.video_dimensions () in
   let default_video =
     {
       Ffmpeg_format.framerate = Frame.video_rate;
-      width = Frame.video_width;
-      height = Frame.video_height;
+      width = video_width;
+      height = video_height;
       pixel_format = None;
       hwaccel = `Auto;
       hwaccel_device = None;

--- a/src/core/optionals/frei0r/frei0r_op.ml
+++ b/src/core/optionals/frei0r/frei0r_op.ml
@@ -332,8 +332,9 @@ let register_plugin fname =
     (Lang.add_operator ~base:video_frei0r name liq_params ~return_t
        ~category:`Video ~flags:[`Extra] ~descr (fun p ->
          let instance =
-           let width = Lazy.force Frame.video_width in
-           let height = Lazy.force Frame.video_height in
+           let video_width, video_height = Frame.video_dimensions () in
+           let width = Lazy.force video_width in
+           let height = Lazy.force video_height in
            Frei0r.create plugin width height
          in
          let f v = List.assoc v p in

--- a/src/core/optionals/ndi/ndi_out.ml
+++ b/src/core/optionals/ndi/ndi_out.ml
@@ -39,8 +39,9 @@ class output ~self_sync ~register_telnet ~name ~groups ~infallible ~handler
   ~format source start =
   let sample_rate = Lazy.force Frame.audio_rate in
   let frame_rate = Lazy.force Frame.video_rate in
-  let video_height = Lazy.force Frame.video_height in
-  let video_width = Lazy.force Frame.video_width in
+  let video_width, video_height = Frame.video_dimensions () in
+  let video_height = Lazy.force video_height in
+  let video_width = Lazy.force video_width in
   (* Timecode is in increment of 100 ns *)
   let timecode_base =
     Int64.div 10_000_000L (Int64.of_int (Lazy.force Frame.main_rate))

--- a/src/core/optionals/ogg/liq_ogg_decoder.ml
+++ b/src/core/optionals/ogg/liq_ogg_decoder.ml
@@ -53,9 +53,10 @@ let converter () =
 (** Convert a video frame to YUV *)
 let video_convert scale =
   let converter = converter () in
+  let video_width, video_height = Frame.video_dimensions () in
   fun buf ->
-    let width = Lazy.force Frame.video_width in
-    let height = Lazy.force Frame.video_height in
+    let width = Lazy.force video_width in
+    let height = Lazy.force video_height in
     if buf.Ogg_decoder.format <> Ogg_decoder.Yuvj_420 then (
       let img =
         Image.YUV420.make buf.Ogg_decoder.frame_width

--- a/src/modules/dtools/dtools.mli
+++ b/src/modules/dtools/dtools.mli
@@ -56,6 +56,7 @@ module Conf : sig
     ; get_d : 'a option
     ; set : 'a -> unit
     ; get : 'a
+    ; is_set : bool
     ; validate : ('a -> bool) -> unit
     ; on_change : ('a -> unit) -> unit >
 

--- a/src/modules/dtools/dtools_impl.ml
+++ b/src/modules/dtools/dtools_impl.ml
@@ -44,6 +44,7 @@ module Conf = struct
     ; get_d : 'a option
     ; set : 'a -> unit
     ; get : 'a
+    ; is_set : bool
     ; validate : ('a -> bool) -> unit
     ; on_change : ('a -> unit) -> unit >
 
@@ -156,6 +157,7 @@ module Conf = struct
         value := Some v;
         List.iter (fun fn -> fn v) listeners
 
+      method is_set : bool = !value <> None
       method validate (fn : 'a -> bool) : unit = validators <- fn :: validators
       method on_change (fn : 'a -> unit) : unit = listeners <- fn :: listeners
     end

--- a/tests/streams/dune
+++ b/tests/streams/dune
@@ -540,6 +540,49 @@
    "sine=frequency=220:duration=1"
    %{target})))
 
+(rule
+ (alias citest)
+ (target nola_test_size.mp4)
+ (action
+  (run
+   ffmpeg
+   -hide_banner
+   -loglevel
+   error
+   -f
+   lavfi
+   -i
+   "testsrc=duration=2:size=504x504:rate=25"
+   -f
+   lavfi
+   -i
+   "sine=frequency=440:duration=2"
+   -c:v
+   libx264
+   -c:a
+   aac
+   -shortest
+   %{target})))
+
+(rule
+ (alias video_size_autodetect)
+ (package liquidsoap)
+ (deps
+  nola_test_size.mp4
+  video_size_autodetect.liq
+  ../../src/bin/liquidsoap.exe
+  (package liquidsoap)
+  (source_tree ../../src/libs)
+  (:test_liq ../test.liq)
+  (:run_test ../run_test.exe))
+ (action
+  (run
+   %{run_test}
+   "Video size auto-detection"
+   liquidsoap
+   %{test_liq}
+   video_size_autodetect.liq)))
+
 (alias
  (name citest)
  (deps
@@ -548,4 +591,5 @@
   (alias icecast_ssl_tls)
   (alias icecast_tls_ssl)
   (alias crossfade-plot)
-  (alias autocue-plot)))
+  (alias autocue-plot)
+  (alias video_size_autodetect)))

--- a/tests/streams/dune.inc
+++ b/tests/streams/dune.inc
@@ -2158,6 +2158,36 @@
   (:test_liq ../test.liq)
   (:run_test ../run_test.exe))
  (action (run %{run_test} test_subtitles_track_insert.liq liquidsoap %{test_liq} test_subtitles_track_insert.liq)))
+  
+(rule
+ (alias video_size_autodetect)
+ (package liquidsoap)
+ (deps
+  video_size_autodetect.liq
+  ./file1.mp3
+  ./file2.mp3
+  ./file3.mp3
+  ./jingle1.mp3
+  ./jingle2.mp3
+  ./jingle3.mp3
+  ./file1.png
+  ./file2.png
+  ./jingles
+  ./playlist
+  ./huge_playlist
+  ./replaygain_track_gain.mp3
+  ./r128_track_gain.mp3
+  ./replaygain_r128_track_gain.mp3
+  ./replaygain_track_gain.opus
+  ./r128_track_gain.opus
+  ./replaygain_r128_track_gain.opus
+  ./without_replaygain_track_gain.mp3
+  ../media/test-subtitle.srt
+  ../../src/bin/liquidsoap.exe
+  (package liquidsoap)
+  (:test_liq ../test.liq)
+  (:run_test ../run_test.exe))
+ (action (run %{run_test} video_size_autodetect.liq liquidsoap %{test_liq} video_size_autodetect.liq)))
   (alias
   (name citest)
   (deps
@@ -2232,4 +2262,5 @@
     (alias test_on_subtitle)
     (alias test_subtitles_insert)
     (alias test_subtitles_map)
-    (alias test_subtitles_track_insert)))
+    (alias test_subtitles_track_insert)
+    (alias video_size_autodetect)))

--- a/tests/streams/video_size_autodetect.liq
+++ b/tests/streams/video_size_autodetect.liq
@@ -1,0 +1,29 @@
+# Test that video dimensions are auto-detected from the first decoded file
+
+s = once(single("nola_test_size.mp4"))
+
+output_file = file.temp("liq", ".mp4", cleanup=true)
+
+def on_close(_) =
+  # Check the output file dimensions using ffprobe
+  result =
+    process.read(
+      "ffprobe -v error -select_streams v:0 -show_entries stream=width,height \
+       -of csv=s=x:p=0 #{process.quote(output_file)}"
+    )
+  result = string.trim(result)
+  print(
+    "Detected output dimensions: #{result}"
+  )
+
+  if result == "504x504" then test.pass() else test.fail() end
+end
+
+clock.assign_new(sync='none', [s])
+output.file(
+  fallible=true,
+  on_close=on_close,
+  %ffmpeg(format = "mp4", %video(codec = "libx264"), %audio(codec = "aac")),
+  output_file,
+  s
+)


### PR DESCRIPTION
This is a user-friendly feature!

In most cases, when a user as e.g. the following script:

```
s = playlist("/path/to/video/files")

output.file(
  %ffmpeg(%audio(codec="aac"), %video(codec="libx264")),
  "/path/to/file.mp4",
  mksafe(s)
 )
 ```

The user-friendly assumption should be that the output video dimensions (`width`/`height`) are set to match those of the first decoded file.

This is what this PR does but wrapping an intermediary API to the frame's width and height lazy config that makes it possible to specify an ideal dimension when requesting the frame's size.

If the user manually sets `width` or `height` or if they set `settings.video.detect_dimensions` to `false`, this mechanism is disabled.

It will also not apply if the video dimensions are required before the first file is decoded.

### TODO:

- [x] Check documentation to add explanation of this mechanism and cleanup existing mention of frame video size.