### PR TITLE
Better once implementation.

### DIFF
--- a/src/libs/source.liq
+++ b/src/libs/source.liq
@@ -114,14 +114,13 @@ end
 # @param s The input source.
 def once(~id=null("once"), s) =
   fail = source.fail()
-  s_ref = ref(s)
-  def next() =
-    s = s_ref()
-    if source.methods(s).is_ready() then s_ref := fail end
-    s
-  end
-  d = source.dynamic(id=id, track_sensitive=true, next)
-  d.on_wake_up(synchronous=true, fun () -> s_ref.set(d.prepare(s)))
+  s_ref = ref(source.methods(s))
+  d = source.dynamic(id=id, track_sensitive=true, s_ref)
+  d.on_wake_up(
+    synchronous=true,
+    fun () -> s_ref.set(source.methods(d.prepare(s)))
+  )
+  d.on_track(synchronous=true, fun (_) -> s_ref.set(fail))
   d
 end
 

--- a/src/libs/source.liq
+++ b/src/libs/source.liq
@@ -116,10 +116,6 @@ def once(~id=null("once"), s) =
   fail = source.fail()
   s_ref = ref(source.methods(s))
   d = source.dynamic(id=id, track_sensitive=true, s_ref)
-  d.on_wake_up(
-    synchronous=true,
-    fun () -> s_ref.set(source.methods(d.prepare(s)))
-  )
   d.on_track(synchronous=true, fun (_) -> s_ref.set(fail))
   d
 end

--- a/src/libs/source.liq
+++ b/src/libs/source.liq
@@ -113,7 +113,16 @@ end
 # @category Source / Track processing
 # @param s The input source.
 def once(~id=null("once"), s) =
-  sequence(id=id, [(s : source), source.fail()])
+  fail = source.fail()
+  s_ref = ref(s)
+  def next() =
+    s = s_ref()
+    if source.methods(s).is_ready() then s_ref := fail end
+    s
+  end
+  d = source.dynamic(id=id, track_sensitive=true, next)
+  d.on_wake_up(synchronous=true, fun () -> s_ref.set(d.prepare(s)))
+  d
 end
 
 # Skip track when detecting a blank.


### PR DESCRIPTION
The current `once` implementation has a race condition: if the source to play from is not readily available, the `sequence` moves to the next source and never comes back.

This can be fixed with either a `switch` or `source.dynamic`. I chose `source.dynamic` because we want to use this operator as the base operator for a bunch on higher level things from now on.

The whole `prepare` source reference round trip still isn't super easy but it's a good compromise for now.