### PR TITLE
Delay encoder creation in `output.file` until we have data to encode.

### DIFF
--- a/tests/media/encoder_audio_only.liq.in
+++ b/tests/media/encoder_audio_only.liq.in
@@ -70,5 +70,4 @@ end
 
 output.file(
   fallible=true,on_close=on_close,
-  reopen_on_error=fun (_) -> begin test.fail(); null end,
   @FORMAT@,file,s)

--- a/tests/media/encoder_audio_subtitle.liq.in
+++ b/tests/media/encoder_audio_subtitle.liq.in
@@ -83,5 +83,4 @@ end
 
 output.file(
   fallible=true,on_close=on_close,
-  reopen_on_error=fun (_) -> begin test.fail(); null end,
   @FORMAT@,file,s)

--- a/tests/media/encoder_audio_video.liq.in
+++ b/tests/media/encoder_audio_video.liq.in
@@ -82,5 +82,4 @@ end
 
 output.file(
   fallible=true,on_close=on_close,
-  reopen_on_error=fun (_) -> begin test.fail(); null end,
   @FORMAT@,file,s)

--- a/tests/media/encoder_audio_video_subtitle.liq.in
+++ b/tests/media/encoder_audio_video_subtitle.liq.in
@@ -94,5 +94,4 @@ end
 
 output.file(
   fallible=true,on_close=on_close,
-  reopen_on_error=fun (_) -> begin test.fail(); null end,
   @FORMAT@,file,s)

--- a/tests/media/encoder_multitrack.liq.in
+++ b/tests/media/encoder_multitrack.liq.in
@@ -69,5 +69,4 @@ end
 
 output.file(
   fallible=true,on_close=on_close,
-  reopen_on_error=fun (_) -> begin test.fail(); null end,
   @FORMAT@,file,s)

--- a/tests/media/encoder_video_only.liq.in
+++ b/tests/media/encoder_video_only.liq.in
@@ -70,5 +70,4 @@ end
 
 output.file(
   fallible=true,on_close=on_close,
-  reopen_on_error=fun (_) -> begin test.fail(); null end,
   @FORMAT@,file,s)

--- a/tests/media/encoder_video_subtitle.liq.in
+++ b/tests/media/encoder_video_subtitle.liq.in
@@ -83,5 +83,4 @@ end
 
 output.file(
   fallible=true,on_close=on_close,
-  reopen_on_error=fun (_) -> begin test.fail(); null end,
   @FORMAT@,file,s)


### PR DESCRIPTION
This avoids cases where the source produces no data, resulting in a file being created with headers but no data.