### PR TITLE
ci: add Docker security scanning with Trivy

### DIFF
--- a/.github/workflows/docker-security.yml
+++ b/.github/workflows/docker-security.yml
@@ -1,0 +1,38 @@
+name: Docker Security
+
+on:
+  schedule:
+    # Weekly on Sunday at 4 AM UTC
+    - cron: '0 4 * * 0'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  scan:
+    name: Trivy Security Scan
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        image:
+          - savonet/liquidsoap:latest
+          - savonet/liquidsoap:latest-minimal
+    steps:
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@c1824fd6edce30d7ab345a9989de00bbd46ef284 # 0.34.0
+        with:
+          image-ref: ${{ matrix.image }}
+          format: 'sarif'
+          output: 'trivy-results.sarif'
+          severity: 'CRITICAL,HIGH,MEDIUM'
+          scanners: 'vuln'
+          ignore-unfixed: true
+
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@9da17a5aa4abec2340d6e6c8d8efb0770b1c9cb8 # v4.32.3
+        if: always()
+        with:
+          sarif_file: 'trivy-results.sarif'


### PR DESCRIPTION
Add automated vulnerability scanning for published Docker images using Trivy.

## What this does

- Adds weekly security scanning for `savonet/liquidsoap:latest` and `savonet/liquidsoap:latest-minimal`
- Uploads results to GitHub Security tab
- Checks for CRITICAL, HIGH, and MEDIUM severity vulnerabilities

## Why

I maintain a downstream project using `savonet/liquidsoap` as base image. After adding Trivy scanning, it detected 12 OpenSSL vulnerabilities including 3 CRITICAL RCE issues:

- CVE-2025-15467 - Remote code execution via CMS parsing
- CVE-2025-69419 - Arbitrary code execution in PKCS#12 processing  
- CVE-2025-11187 - Arbitrary code execution via crafted PKCS#12 file

Full list: https://github.com/oszuidwest/zwfm-liquidsoap/security/code-scanning?query=is%3Aclosed+branch%3Amain

Since liquidsoap images inherit from `debian:13-slim` and `alpine:edge`, automated scanning helps catch these issues early.