### PR TITLE
Make sure that we read all stdout/stderr before considering a process closed.

### DIFF
--- a/tests/core/dune
+++ b/tests/core/dune
@@ -124,3 +124,17 @@
   (diff
    all_media_file_descriptions.json
    all_media_file_descriptions.json.gen)))
+
+(executable
+ (name ffprobe_process_test)
+ (modules ffprobe_process_test)
+ (libraries liquidsoap_core liquidsoap_optionals))
+
+(rule
+ (alias ffprobe_process_test)
+ (package liquidsoap)
+ (deps
+  (:media ../media/long-video.mp4)
+  (:test ffprobe_process_test.exe))
+ (action
+  (run %{test} %{media})))

--- a/tests/core/dune.inc
+++ b/tests/core/dune.inc
@@ -171,6 +171,19 @@
   (run %{json_test})))
 
 (executable
+ (name large_process_stdout_test)
+ (modules large_process_stdout_test)
+ (libraries liquidsoap_core liquidsoap_optionals))
+
+(rule
+ (alias large_process_stdout_test)
+ (package liquidsoap)
+ (deps
+  (:large_process_stdout_test large_process_stdout_test.exe))
+ (action
+  (run %{large_process_stdout_test})))
+
+(executable
  (name meth)
  (modules meth)
  (libraries liquidsoap_core liquidsoap_optionals))
@@ -412,6 +425,7 @@
   (alias http_test)
   (alias is_url)
   (alias json_test)
+  (alias large_process_stdout_test)
   (alias meth)
   (alias more_types)
   (alias output_encoded_test)

--- a/tests/core/ffprobe_process_test.ml
+++ b/tests/core/ffprobe_process_test.ml
@@ -1,0 +1,105 @@
+(*****************************************************************************
+
+  Liquidsoap, a programmable stream generator.
+  Copyright 2003-2026 Savonet team
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details, fully stated in the COPYING
+  file at the root of the liquidsoap distribution.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA
+
+ *****************************************************************************)
+
+(* Test that Process_handler correctly captures ffprobe JSON output.
+   This tests a real-world use case with potentially large JSON output. *)
+
+let m = Mutex.create ()
+let finished = Condition.create ()
+let collected_output = Buffer.create 1024
+let test_finished = ref false
+
+let on_stdout pull =
+  let buf = Bytes.create 4096 in
+  let n = pull buf 0 4096 in
+  Buffer.add_subbytes collected_output buf 0 n;
+  `Continue
+
+let on_stop _ =
+  Mutex.lock m;
+  test_finished := true;
+  Condition.signal finished;
+  Mutex.unlock m;
+  false
+
+let () =
+  let media_file =
+    match Sys.argv with
+      | [| _; file |] -> file
+      | _ ->
+          Printf.eprintf "Usage: %s <media_file>\n" Sys.argv.(0);
+          exit 1
+  in
+  if not (Sys.file_exists media_file) then begin
+    Printf.eprintf "FAIL: Media file not found: %s\n%!" media_file;
+    exit 1
+  end;
+  Printf.printf "Testing ffprobe on: %s\n%!" media_file;
+  Tutils.start ();
+  let command =
+    Printf.sprintf
+      "ffprobe -v quiet -print_format json -show_format -show_streams %s"
+      (Filename.quote media_file)
+  in
+  ignore
+    (Process_handler.run ~on_stdout ~on_stop
+       ~log:(fun msg -> Printf.eprintf "Process: %s\n%!" msg)
+       command);
+  Mutex.lock m;
+  while not !test_finished do
+    Condition.wait finished m
+  done;
+  Mutex.unlock m;
+  let collected = Buffer.contents collected_output in
+  let collected_len = String.length collected in
+  Printf.printf "Received %d bytes of output\n%!" collected_len;
+  if collected_len = 0 then begin
+    Printf.eprintf "FAIL: No output received from ffprobe\n%!";
+    Tutils.shutdown 1
+  end;
+  (* Parse as JSON to verify completeness *)
+  let json =
+    match Json.from_string collected with
+      | json -> json
+      | exception Json.Parse_error { message; _ } ->
+          Printf.eprintf "FAIL: Invalid JSON output: %s\n%!" message;
+          Printf.eprintf "Output was:\n%s\n%!" collected;
+          Tutils.shutdown 1;
+          assert false
+  in
+  (* Verify expected ffprobe structure *)
+  (match json with
+    | `Assoc fields ->
+        if not (List.mem_assoc "streams" fields) then begin
+          Printf.eprintf "FAIL: JSON missing 'streams' field\n%!";
+          Tutils.shutdown 1
+        end;
+        if not (List.mem_assoc "format" fields) then begin
+          Printf.eprintf "FAIL: JSON missing 'format' field\n%!";
+          Tutils.shutdown 1
+        end
+    | _ ->
+        Printf.eprintf "FAIL: JSON is not an object\n%!";
+        Tutils.shutdown 1);
+  Printf.printf "OK: Received valid ffprobe JSON output (%d bytes)\n%!"
+    collected_len;
+  Tutils.shutdown 0

--- a/tests/core/gen_dune.ml
+++ b/tests/core/gen_dune.ml
@@ -12,7 +12,13 @@ let test_params =
   ]
 
 (* Tests with custom rules that are not auto-generated *)
-let skip_tests = ["ffmpeg_stream_description_test"; "ffmpeg_get_type_test"]
+let skip_tests =
+  [
+    "ffmpeg_stream_description_test";
+    "ffmpeg_get_type_test";
+    "ffprobe_process_test";
+  ]
+
 let test_names = ref []
 
 let test_name s =

--- a/tests/core/large_process_stdout_test.ml
+++ b/tests/core/large_process_stdout_test.ml
@@ -1,0 +1,96 @@
+(*****************************************************************************
+
+  Liquidsoap, a programmable stream generator.
+  Copyright 2003-2026 Savonet team
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details, fully stated in the COPYING
+  file at the root of the liquidsoap distribution.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA
+
+ *****************************************************************************)
+
+(* Test that Process_handler correctly captures all stdout data even when
+   a process outputs a large amount of data and exits immediately.
+
+   Usage:
+     process_handler_test.exe --generate-output <size>
+       Outputs <size> bytes of 'x' characters to stdout and exits.
+
+     process_handler_test.exe
+       Runs the actual test using Process_handler. *)
+
+(* Size of test output - should be large enough to potentially overflow
+   pipe buffers and trigger the race condition if present *)
+let output_size = 1_000_000
+
+let generate_output size =
+  let chunk_size = 4096 in
+  let chunk = String.make chunk_size 'x' in
+  let remaining = ref size in
+  while !remaining > 0 do
+    let to_write = min !remaining chunk_size in
+    output_substring stdout chunk 0 to_write;
+    remaining := !remaining - to_write
+  done;
+  flush stdout
+
+let run_test () =
+  let m = Mutex.create () in
+  let finished = Condition.create () in
+  let collected_output = Buffer.create 1024 in
+  let test_finished = ref false in
+  let on_stdout pull =
+    let buf = Bytes.create 4096 in
+    let n = pull buf 0 4096 in
+    Buffer.add_subbytes collected_output buf 0 n;
+    `Continue
+  in
+  let on_stop _ =
+    Mutex.lock m;
+    test_finished := true;
+    Condition.signal finished;
+    Mutex.unlock m;
+    false
+  in
+  Tutils.start ();
+  let exe = Sys.executable_name in
+  let command = Printf.sprintf "%s --generate-output %d" exe output_size in
+  ignore
+    (Process_handler.run ~on_stdout ~on_stop
+       ~log:(fun msg -> Printf.eprintf "Process: %s\n%!" msg)
+       command);
+  Mutex.lock m;
+  while not !test_finished do
+    Condition.wait finished m
+  done;
+  Mutex.unlock m;
+  let collected = Buffer.contents collected_output in
+  let collected_len = String.length collected in
+  if collected_len <> output_size then begin
+    Printf.eprintf
+      "FAIL: Expected %d bytes, got %d bytes (missing %d bytes)\n%!" output_size
+      collected_len
+      (output_size - collected_len);
+    Tutils.shutdown 1
+  end;
+  Printf.printf "OK: Received all %d bytes of output\n%!" collected_len;
+  Tutils.shutdown 0
+
+let () =
+  match Array.to_list Sys.argv with
+    | [_; "--generate-output"; size] -> generate_output (int_of_string size)
+    | [_] -> run_test ()
+    | _ ->
+        Printf.eprintf "Usage: %s [--generate-output <size>]\n" Sys.argv.(0);
+        exit 1

--- a/tests/language/process.liq
+++ b/tests/language/process.liq
@@ -1,5 +1,3 @@
-test.skip()
-
 first = ref(true)
 thread.run.recurrent(
   {


### PR DESCRIPTION
Fixes: #4912