### PR TITLE
Support custom element name aliases in XML parsing

### DIFF
--- a/doc/content/xml.md
+++ b/doc/content/xml.md
@@ -46,6 +46,26 @@ Things to note:
 - When a tag contains a single ground value (`string`, `bool`, `float` or `integer`), the mapping is from tag name to the corresponding value, with xml attributes attached as methods
 - Tag parameters can be converted to ground values and omitted.
 
+### Custom element names
+
+XML element names often contain characters like hyphens that aren't valid Liquidsoap variable names. You can map them to valid names using the `as` syntax:
+
+```liquidsoap
+s = '<config><listen-socket><port>8000</port></listen-socket></config>'
+
+let xml.parse (config :
+  {
+    config: {
+      "listen-socket" as listen_socket: {port: int}
+    }
+  }
+) = s
+
+print("Port is: #{config.config.listen_socket.port}")
+```
+
+This maps the XML element `listen-socket` to the variable `listen_socket`.
+
 The parsing is driven by the type annotation and is intended to be permissive. For instance, this will work:
 
 ```liquidsoaop

--- a/src/lang/base/builtins_xml.ml
+++ b/src/lang/base/builtins_xml.ml
@@ -62,8 +62,9 @@ let rec check_value v ty =
   in
   let meths =
     List.fold_left
-      (fun checked_meths { Type.meth; scheme = _, ty } ->
-        let v = List.assoc meth meths in
+      (fun checked_meths { Type.meth; json_name; scheme = _, ty } ->
+        let lbl = Option.value ~default:meth json_name in
+        let v = List.assoc lbl meths in
         (meth, check_value v ty) :: checked_meths)
       [] typ_meths
   in

--- a/tests/language/xml_test.liq
+++ b/tests/language/xml_test.liq
@@ -126,6 +126,25 @@ def f() =
 </bla>'
   )
 
+  # Test custom label with "as" syntax for hyphenated element names
+  s2 =
+    '<config>
+<listen-socket><port>8000</port></listen-socket>
+<source-password>hackme</source-password>
+</config>'
+
+  let xml.parse (config :
+    {
+      config: {
+        "listen-socket" as listen_socket: {port: int},
+        "source-password" as source_password: string
+      }
+    }
+  ) = s2
+
+  test.equal(config.config.listen_socket.port, 8000)
+  test.equal(config.config.source_password, "hackme")
+
   test.pass()
 end
 


### PR DESCRIPTION
## Summary
- Add support for `"element-name" as variable_name` syntax in XML parsing
- This allows mapping XML element names (like hyphenated names) to valid Liquidsoap variable names
- Matches existing behavior in the JSON and YAML parsers

## Test plan
- Added test case in `tests/language/xml_test.liq` for hyphenated element names
- Manual verification with icecast-style config parsing