### PR TITLE
Support optional fields with custom element name aliases in XML parsing

### DIFF
--- a/src/lang/base/builtins_xml.ml
+++ b/src/lang/base/builtins_xml.ml
@@ -62,10 +62,12 @@ let rec check_value v ty =
   in
   let meths =
     List.fold_left
-      (fun checked_meths { Type.meth; json_name; scheme = _, ty } ->
+      (fun checked_meths { Type.meth; json_name; optional; scheme = _, ty } ->
         let lbl = Option.value ~default:meth json_name in
-        let v = List.assoc lbl meths in
-        (meth, check_value v ty) :: checked_meths)
+        match List.assoc_opt lbl meths with
+          | Some v -> (meth, check_value v ty) :: checked_meths
+          | None when optional -> (meth, Lang.null) :: checked_meths
+          | None -> raise Not_found)
       [] typ_meths
   in
   let v = Lang.meth v meths in

--- a/tests/language/xml_test.liq
+++ b/tests/language/xml_test.liq
@@ -145,6 +145,18 @@ def f() =
   test.equal(config.config.listen_socket.port, 8000)
   test.equal(config.config.source_password, "hackme")
 
+  # Test optional fields with "as" syntax
+  s3 = '<limits>
+<sources>10</sources>
+</limits>'
+
+  let xml.parse (limits_config :
+    {limits: {sources?: int, "queue-size" as queue_size?: int}}
+  ) = s3
+
+  test.equal(limits_config.limits?.sources, 10)
+  test.equal(limits_config.limits?.queue_size, null())
+
   test.pass()
 end
 


### PR DESCRIPTION
## Summary
- Fixes XML parsing to handle optional fields with the `as` syntax
- Previously, optional fields with `json_name` aliases would fail when the element was not present

## Example
```liquidsoap
let xml.parse (config : {
  limits: {
    sources?: int,
    "queue-size" as queue_size?: int
  }
}) = s
```

## Test plan
- [x] Added test case to `tests/language/xml_test.liq`
- [x] `dune build @xml_test` passes