### PR TITLE
Add ref type annotation support

### DIFF
--- a/src/lang/base/parser_helper.ml
+++ b/src/lang/base/parser_helper.ml
@@ -111,6 +111,23 @@ let mk_json_assoc_object_ty ~pos = function
   | `Tuple [`Named "string"; ty], "as", "json", "object" -> `Json_object ty
   | _ -> raise (Term_base.Parse_error (pos, "Invalid type constructor"))
 
+let mk_source_ty ~pos name tracks =
+  match name with
+    | "source" -> `Source (name, tracks)
+    | _ ->
+        raise (Term_base.Parse_error (pos, "Invalid type constructor: " ^ name))
+
+let mk_named_ty ~pos name ty =
+  match (name, ty) with
+    | "ref", Some t -> `Ref t
+    | "ref", None ->
+        raise
+          (Term_base.Parse_error (pos, "ref type requires a type parameter"))
+    | "source", _ ->
+        mk_source_ty ~pos name { Parsed_term.extensible = false; tracks = [] }
+    | _, _ ->
+        raise (Term_base.Parse_error (pos, "Invalid type constructor: " ^ name))
+
 type let_opt_el = string * Term.t
 
 let let_decoration_of_lexer_let_decoration = function

--- a/src/lang/base/parser_helper.mli
+++ b/src/lang/base/parser_helper.mli
@@ -70,6 +70,12 @@ val mk_json_assoc_object_ty :
   Parsed_term.type_annotation * string * string * string ->
   Term.type_annotation
 
+val mk_source_ty :
+  pos:pos -> string -> Term.source_annotation -> Term.type_annotation
+
+val mk_named_ty :
+  pos:pos -> string -> Term.type_annotation option -> Term.type_annotation
+
 val mk :
   ?comments:(pos * Parsed_term.comment) list ->
   ?annotations:Parsed_term.term_annotation list ->

--- a/src/lang/base/term/parsed_term.ml
+++ b/src/lang/base/term/parsed_term.ml
@@ -170,6 +170,7 @@ and type_annotation =
   [ `Named of string
   | `Nullable of type_annotation
   | `List of type_annotation
+  | `Ref of type_annotation
   | `Json_object of type_annotation
   | `Tuple of type_annotation list
   | `Arrow of argument list * type_annotation

--- a/src/lang/base/term/term_reducer.ml
+++ b/src/lang/base/term/term_reducer.ml
@@ -88,6 +88,10 @@ let rec mk_parsed_ty ?pos ~env ~to_term = function
         make
           ?pos:(Option.map Pos.of_lexing_pos pos)
           (List { t = mk_parsed_ty ?pos ~env ~to_term t; json_repr = `Tuple }))
+  | `Ref t ->
+      Ref_type.reference
+        ?pos:(Option.map Pos.of_lexing_pos pos)
+        (mk_parsed_ty ?pos ~env ~to_term t)
   | `Json_object t ->
       Type.(
         make

--- a/src/lang/tooling/parsed_json.ml
+++ b/src/lang/tooling/parsed_json.ml
@@ -125,6 +125,7 @@ let rec json_of_type_annotation = function
   | `Named n -> type_node ~typ:"named" (`String n)
   | `Nullable t -> type_node ~typ:"nullable" (json_of_type_annotation t)
   | `List t -> type_node ~typ:"list" (json_of_type_annotation t)
+  | `Ref t -> type_node ~typ:"ref" (json_of_type_annotation t)
   | `Json_object t -> type_node ~typ:"json_object" (json_of_type_annotation t)
   | `Tuple l ->
       type_node ~typ:"tuple" (`Tuple (List.map json_of_type_annotation l))

--- a/tests/language/typing.liq
+++ b/tests/language/typing.liq
@@ -212,6 +212,11 @@ def f() =
   # Nullable type with methods:
   (123.{foo="aabb"} : int?.{ foo: string })
 
+  # Ref type annotation:
+  (ref(123) : ref(int))
+  (ref("foo") : ref(string))
+  (ref(null) : ref(int?))
+
   (() : {})
   (() : unit.{  })
   ({foo=123} : {foo?: int})


### PR DESCRIPTION
## Summary
- Adds support for `ref(type)` type annotations in the language
- Enables explicit typing of references, e.g., `(ref(123) : ref(int))`

## Test plan
- Added typing tests in `tests/language/typing.liq`