### PR TITLE
Change inner type for `null` to be non-nullable to allow its use to protect a type from being unified as nullable.

### DIFF
--- a/src/lang/base/builtins_null.ml
+++ b/src/lang/base/builtins_null.ml
@@ -24,7 +24,7 @@ let null =
   let a = Lang.univ_t () in
   Lang.add_builtin "_null" ~category:`Programming
     ~descr:"Create a nullable value."
-    [("", Lang.nullable_t a, Some Lang.null, Some "Value to make nullable.")]
+    [("", a, Some Lang.null, Some "Value to make nullable.")]
     (Lang.nullable_t a)
     (fun p ->
       match Lang.to_option (List.assoc "" p) with

--- a/src/libs/list.liq
+++ b/src/libs/list.liq
@@ -218,7 +218,7 @@ end
 # @category List
 def list.assoc.nullable(key, l) =
   try
-    list.assoc(key, l)
+    null(list.assoc(key, l))
   catch _ do
     null
   end


### PR DESCRIPTION
Fixes: #4928