### PR TITLE
Suport explicit logs flush

### DIFF
--- a/src/core/builtins/builtins_sys.ml
+++ b/src/core/builtins/builtins_sys.ml
@@ -168,7 +168,7 @@ let _ =
   Lang.add_builtin ~base:Modules.process "pid" ~category:`System [] Lang.int_t
     ~descr:"Get the process' pid." (fun _ -> Lang.int (Unix.getpid ()))
 
-let _ =
+let log_builtin =
   Lang.add_builtin "log" ~category:`Liquidsoap ~descr:"Log a message."
     [
       ("label", Lang.string_t, Some (Lang.string "lang"), None);
@@ -181,6 +181,12 @@ let _ =
       let label = Lang.to_string (List.assoc "label" p) in
       let level = Lang.to_int (List.assoc "level" p) in
       (Log.make [label])#f level "%s" msg;
+      Lang.unit)
+
+let _ =
+  Lang.add_builtin ~base:log_builtin "flush" ~category:`Liquidsoap
+    ~descr:"Flush all pending log messages." [] Lang.unit_t (fun _ ->
+      Dtools.Log.flush ();
       Lang.unit)
 
 let _ =

--- a/src/modules/dtools/dtools.mli
+++ b/src/modules/dtools/dtools.mli
@@ -271,6 +271,9 @@ module Log : sig
   (** An atom that stops the logging. *)
   val stop : Init.t
 
+  (** Force flush all pending log entries. *)
+  val flush : unit -> unit
+
   val conf : Conf.ut
   val conf_level : int Conf.t
   val conf_unix_timestamps : bool Conf.t

--- a/src/modules/dtools/dtools_impl.ml
+++ b/src/modules/dtools/dtools_impl.ml
@@ -727,6 +727,8 @@ module Log = struct
     in
     flush (rotate_queue ())
 
+  let flush () = flush_queue ()
+
   let log_thread_fn () =
     let rec f () =
       flush_queue ();

--- a/tests/test.liq
+++ b/tests/test.liq
@@ -32,6 +32,7 @@ def test.fail(reason=null) =
   print(
     "Test failed#{reason}"
   )
+  log.flush()
   exit(1)
 end
 


### PR DESCRIPTION
Add Log.flush function to force flush pending log entries.

Exposes the internal flush_queue mechanism as a public API, allowing callers to flush all pending logs without stopping the logger.