### PR TITLE
Add raw string syntax {|...|} and {id|...|id}

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,7 +26,7 @@ repos:
         exclude: dune.inc
 
   - repo: https://github.com/savonet/pre-commit-liquidsoap
-    rev: d436ed7e2f095da97f2c279d6fe45fa3daf08ba6
+    rev: 9faad7d141f99a45d9597ebe8e42e880d2c68d65
     hooks:
       - id: liquidsoap-prettier
       - id: prettier

--- a/doc/content/language.md
+++ b/doc/content/language.md
@@ -144,6 +144,27 @@ print("The number #{random.float()} is random.")
 will print `The number 0.663455738438 is random.` (at least it did last time I
 tried).
 
+#### Raw strings
+
+When a string should be taken verbatim — without any interpolation or escape
+processing — use the _raw string_ syntax `{|...|}`.:
+
+```{.liquidsoap include="raw-string.liq"}
+
+```
+
+will print `no interpolation: #{expr} here`.
+
+If the content itself contains `|}`, use a delimited form `{id|...|id}` where
+`id` is any sequence of lowercase letters and underscores:
+
+```{.liquidsoap include="raw-string-delimited.liq"}
+
+```
+
+will print `this |} is fine`. The opening `{id|` and closing `|id}` must use
+the same `id`, which can be empty (as in the basic `{|...|}` form).
+
 #### Escaping strings
 
 Liquidsoap strings follow the most common lexical conventions from `C` and `javascript` and `JSON`, in particular,

--- a/doc/content/liq/raw-string-delimited.liq
+++ b/doc/content/liq/raw-string-delimited.liq
@@ -1,0 +1,1 @@
+print({foo|this |} is fine|foo})

--- a/doc/content/liq/raw-string.liq
+++ b/doc/content/liq/raw-string.liq
@@ -1,0 +1,1 @@
+print({|no interpolation: #{expr} here|})

--- a/doc/dune.inc
+++ b/doc/dune.inc
@@ -173,6 +173,8 @@
   content/liq/prometheus-callback.liq
   content/liq/prometheus-settings.liq
   content/liq/radiopi.liq
+  content/liq/raw-string-delimited.liq
+  content/liq/raw-string.liq
   content/liq/re-encode.liq
   content/liq/regular.liq
   content/liq/replaygain-playlist.liq
@@ -313,6 +315,8 @@
   content/liq/prometheus-callback.liq
   content/liq/prometheus-settings.liq
   content/liq/radiopi.liq
+  content/liq/raw-string-delimited.liq
+  content/liq/raw-string.liq
   content/liq/re-encode.liq
   content/liq/regular.liq
   content/liq/replaygain-playlist.liq
@@ -453,6 +457,8 @@
   content/liq/prometheus-callback.liq
   content/liq/prometheus-settings.liq
   content/liq/radiopi.liq
+  content/liq/raw-string-delimited.liq
+  content/liq/raw-string.liq
   content/liq/re-encode.liq
   content/liq/regular.liq
   content/liq/replaygain-playlist.liq
@@ -593,6 +599,8 @@
   content/liq/prometheus-callback.liq
   content/liq/prometheus-settings.liq
   content/liq/radiopi.liq
+  content/liq/raw-string-delimited.liq
+  content/liq/raw-string.liq
   content/liq/re-encode.liq
   content/liq/regular.liq
   content/liq/replaygain-playlist.liq
@@ -733,6 +741,8 @@
   content/liq/prometheus-callback.liq
   content/liq/prometheus-settings.liq
   content/liq/radiopi.liq
+  content/liq/raw-string-delimited.liq
+  content/liq/raw-string.liq
   content/liq/re-encode.liq
   content/liq/regular.liq
   content/liq/replaygain-playlist.liq
@@ -873,6 +883,8 @@
   content/liq/prometheus-callback.liq
   content/liq/prometheus-settings.liq
   content/liq/radiopi.liq
+  content/liq/raw-string-delimited.liq
+  content/liq/raw-string.liq
   content/liq/re-encode.liq
   content/liq/regular.liq
   content/liq/replaygain-playlist.liq
@@ -1013,6 +1025,8 @@
   content/liq/prometheus-callback.liq
   content/liq/prometheus-settings.liq
   content/liq/radiopi.liq
+  content/liq/raw-string-delimited.liq
+  content/liq/raw-string.liq
   content/liq/re-encode.liq
   content/liq/regular.liq
   content/liq/replaygain-playlist.liq
@@ -1153,6 +1167,8 @@
   content/liq/prometheus-callback.liq
   content/liq/prometheus-settings.liq
   content/liq/radiopi.liq
+  content/liq/raw-string-delimited.liq
+  content/liq/raw-string.liq
   content/liq/re-encode.liq
   content/liq/regular.liq
   content/liq/replaygain-playlist.liq
@@ -1293,6 +1309,8 @@
   content/liq/prometheus-callback.liq
   content/liq/prometheus-settings.liq
   content/liq/radiopi.liq
+  content/liq/raw-string-delimited.liq
+  content/liq/raw-string.liq
   content/liq/re-encode.liq
   content/liq/regular.liq
   content/liq/replaygain-playlist.liq
@@ -1433,6 +1451,8 @@
   content/liq/prometheus-callback.liq
   content/liq/prometheus-settings.liq
   content/liq/radiopi.liq
+  content/liq/raw-string-delimited.liq
+  content/liq/raw-string.liq
   content/liq/re-encode.liq
   content/liq/regular.liq
   content/liq/replaygain-playlist.liq
@@ -1573,6 +1593,8 @@
   content/liq/prometheus-callback.liq
   content/liq/prometheus-settings.liq
   content/liq/radiopi.liq
+  content/liq/raw-string-delimited.liq
+  content/liq/raw-string.liq
   content/liq/re-encode.liq
   content/liq/regular.liq
   content/liq/replaygain-playlist.liq
@@ -1713,6 +1735,8 @@
   content/liq/prometheus-callback.liq
   content/liq/prometheus-settings.liq
   content/liq/radiopi.liq
+  content/liq/raw-string-delimited.liq
+  content/liq/raw-string.liq
   content/liq/re-encode.liq
   content/liq/regular.liq
   content/liq/replaygain-playlist.liq
@@ -1853,6 +1877,8 @@
   content/liq/prometheus-callback.liq
   content/liq/prometheus-settings.liq
   content/liq/radiopi.liq
+  content/liq/raw-string-delimited.liq
+  content/liq/raw-string.liq
   content/liq/re-encode.liq
   content/liq/regular.liq
   content/liq/replaygain-playlist.liq
@@ -1993,6 +2019,8 @@
   content/liq/prometheus-callback.liq
   content/liq/prometheus-settings.liq
   content/liq/radiopi.liq
+  content/liq/raw-string-delimited.liq
+  content/liq/raw-string.liq
   content/liq/re-encode.liq
   content/liq/regular.liq
   content/liq/replaygain-playlist.liq
@@ -2133,6 +2161,8 @@
   content/liq/prometheus-callback.liq
   content/liq/prometheus-settings.liq
   content/liq/radiopi.liq
+  content/liq/raw-string-delimited.liq
+  content/liq/raw-string.liq
   content/liq/re-encode.liq
   content/liq/regular.liq
   content/liq/replaygain-playlist.liq
@@ -2273,6 +2303,8 @@
   content/liq/prometheus-callback.liq
   content/liq/prometheus-settings.liq
   content/liq/radiopi.liq
+  content/liq/raw-string-delimited.liq
+  content/liq/raw-string.liq
   content/liq/re-encode.liq
   content/liq/regular.liq
   content/liq/replaygain-playlist.liq
@@ -2413,6 +2445,8 @@
   content/liq/prometheus-callback.liq
   content/liq/prometheus-settings.liq
   content/liq/radiopi.liq
+  content/liq/raw-string-delimited.liq
+  content/liq/raw-string.liq
   content/liq/re-encode.liq
   content/liq/regular.liq
   content/liq/replaygain-playlist.liq
@@ -2553,6 +2587,8 @@
   content/liq/prometheus-callback.liq
   content/liq/prometheus-settings.liq
   content/liq/radiopi.liq
+  content/liq/raw-string-delimited.liq
+  content/liq/raw-string.liq
   content/liq/re-encode.liq
   content/liq/regular.liq
   content/liq/replaygain-playlist.liq
@@ -2693,6 +2729,8 @@
   content/liq/prometheus-callback.liq
   content/liq/prometheus-settings.liq
   content/liq/radiopi.liq
+  content/liq/raw-string-delimited.liq
+  content/liq/raw-string.liq
   content/liq/re-encode.liq
   content/liq/regular.liq
   content/liq/replaygain-playlist.liq
@@ -2833,6 +2871,8 @@
   content/liq/prometheus-callback.liq
   content/liq/prometheus-settings.liq
   content/liq/radiopi.liq
+  content/liq/raw-string-delimited.liq
+  content/liq/raw-string.liq
   content/liq/re-encode.liq
   content/liq/regular.liq
   content/liq/replaygain-playlist.liq
@@ -2973,6 +3013,8 @@
   content/liq/prometheus-callback.liq
   content/liq/prometheus-settings.liq
   content/liq/radiopi.liq
+  content/liq/raw-string-delimited.liq
+  content/liq/raw-string.liq
   content/liq/re-encode.liq
   content/liq/regular.liq
   content/liq/replaygain-playlist.liq
@@ -3113,6 +3155,8 @@
   content/liq/prometheus-callback.liq
   content/liq/prometheus-settings.liq
   content/liq/radiopi.liq
+  content/liq/raw-string-delimited.liq
+  content/liq/raw-string.liq
   content/liq/re-encode.liq
   content/liq/regular.liq
   content/liq/replaygain-playlist.liq
@@ -3253,6 +3297,8 @@
   content/liq/prometheus-callback.liq
   content/liq/prometheus-settings.liq
   content/liq/radiopi.liq
+  content/liq/raw-string-delimited.liq
+  content/liq/raw-string.liq
   content/liq/re-encode.liq
   content/liq/regular.liq
   content/liq/replaygain-playlist.liq
@@ -3393,6 +3439,8 @@
   content/liq/prometheus-callback.liq
   content/liq/prometheus-settings.liq
   content/liq/radiopi.liq
+  content/liq/raw-string-delimited.liq
+  content/liq/raw-string.liq
   content/liq/re-encode.liq
   content/liq/regular.liq
   content/liq/replaygain-playlist.liq
@@ -3533,6 +3581,8 @@
   content/liq/prometheus-callback.liq
   content/liq/prometheus-settings.liq
   content/liq/radiopi.liq
+  content/liq/raw-string-delimited.liq
+  content/liq/raw-string.liq
   content/liq/re-encode.liq
   content/liq/regular.liq
   content/liq/replaygain-playlist.liq
@@ -3673,6 +3723,8 @@
   content/liq/prometheus-callback.liq
   content/liq/prometheus-settings.liq
   content/liq/radiopi.liq
+  content/liq/raw-string-delimited.liq
+  content/liq/raw-string.liq
   content/liq/re-encode.liq
   content/liq/regular.liq
   content/liq/replaygain-playlist.liq
@@ -3813,6 +3865,8 @@
   content/liq/prometheus-callback.liq
   content/liq/prometheus-settings.liq
   content/liq/radiopi.liq
+  content/liq/raw-string-delimited.liq
+  content/liq/raw-string.liq
   content/liq/re-encode.liq
   content/liq/regular.liq
   content/liq/replaygain-playlist.liq
@@ -3953,6 +4007,8 @@
   content/liq/prometheus-callback.liq
   content/liq/prometheus-settings.liq
   content/liq/radiopi.liq
+  content/liq/raw-string-delimited.liq
+  content/liq/raw-string.liq
   content/liq/re-encode.liq
   content/liq/regular.liq
   content/liq/replaygain-playlist.liq
@@ -4093,6 +4149,8 @@
   content/liq/prometheus-callback.liq
   content/liq/prometheus-settings.liq
   content/liq/radiopi.liq
+  content/liq/raw-string-delimited.liq
+  content/liq/raw-string.liq
   content/liq/re-encode.liq
   content/liq/regular.liq
   content/liq/replaygain-playlist.liq
@@ -4233,6 +4291,8 @@
   content/liq/prometheus-callback.liq
   content/liq/prometheus-settings.liq
   content/liq/radiopi.liq
+  content/liq/raw-string-delimited.liq
+  content/liq/raw-string.liq
   content/liq/re-encode.liq
   content/liq/regular.liq
   content/liq/replaygain-playlist.liq
@@ -4373,6 +4433,8 @@
   content/liq/prometheus-callback.liq
   content/liq/prometheus-settings.liq
   content/liq/radiopi.liq
+  content/liq/raw-string-delimited.liq
+  content/liq/raw-string.liq
   content/liq/re-encode.liq
   content/liq/regular.liq
   content/liq/replaygain-playlist.liq
@@ -4513,6 +4575,8 @@
   content/liq/prometheus-callback.liq
   content/liq/prometheus-settings.liq
   content/liq/radiopi.liq
+  content/liq/raw-string-delimited.liq
+  content/liq/raw-string.liq
   content/liq/re-encode.liq
   content/liq/regular.liq
   content/liq/replaygain-playlist.liq
@@ -4653,6 +4717,8 @@
   content/liq/prometheus-callback.liq
   content/liq/prometheus-settings.liq
   content/liq/radiopi.liq
+  content/liq/raw-string-delimited.liq
+  content/liq/raw-string.liq
   content/liq/re-encode.liq
   content/liq/regular.liq
   content/liq/replaygain-playlist.liq
@@ -4793,6 +4859,8 @@
   content/liq/prometheus-callback.liq
   content/liq/prometheus-settings.liq
   content/liq/radiopi.liq
+  content/liq/raw-string-delimited.liq
+  content/liq/raw-string.liq
   content/liq/re-encode.liq
   content/liq/regular.liq
   content/liq/replaygain-playlist.liq
@@ -4933,6 +5001,8 @@
   content/liq/prometheus-callback.liq
   content/liq/prometheus-settings.liq
   content/liq/radiopi.liq
+  content/liq/raw-string-delimited.liq
+  content/liq/raw-string.liq
   content/liq/re-encode.liq
   content/liq/regular.liq
   content/liq/replaygain-playlist.liq
@@ -5073,6 +5143,8 @@
   content/liq/prometheus-callback.liq
   content/liq/prometheus-settings.liq
   content/liq/radiopi.liq
+  content/liq/raw-string-delimited.liq
+  content/liq/raw-string.liq
   content/liq/re-encode.liq
   content/liq/regular.liq
   content/liq/replaygain-playlist.liq
@@ -5213,6 +5285,8 @@
   content/liq/prometheus-callback.liq
   content/liq/prometheus-settings.liq
   content/liq/radiopi.liq
+  content/liq/raw-string-delimited.liq
+  content/liq/raw-string.liq
   content/liq/re-encode.liq
   content/liq/regular.liq
   content/liq/replaygain-playlist.liq
@@ -5353,6 +5427,8 @@
   content/liq/prometheus-callback.liq
   content/liq/prometheus-settings.liq
   content/liq/radiopi.liq
+  content/liq/raw-string-delimited.liq
+  content/liq/raw-string.liq
   content/liq/re-encode.liq
   content/liq/regular.liq
   content/liq/replaygain-playlist.liq
@@ -5493,6 +5569,8 @@
   content/liq/prometheus-callback.liq
   content/liq/prometheus-settings.liq
   content/liq/radiopi.liq
+  content/liq/raw-string-delimited.liq
+  content/liq/raw-string.liq
   content/liq/re-encode.liq
   content/liq/regular.liq
   content/liq/replaygain-playlist.liq
@@ -5633,6 +5711,8 @@
   content/liq/prometheus-callback.liq
   content/liq/prometheus-settings.liq
   content/liq/radiopi.liq
+  content/liq/raw-string-delimited.liq
+  content/liq/raw-string.liq
   content/liq/re-encode.liq
   content/liq/regular.liq
   content/liq/replaygain-playlist.liq
@@ -5773,6 +5853,8 @@
   content/liq/prometheus-callback.liq
   content/liq/prometheus-settings.liq
   content/liq/radiopi.liq
+  content/liq/raw-string-delimited.liq
+  content/liq/raw-string.liq
   content/liq/re-encode.liq
   content/liq/regular.liq
   content/liq/replaygain-playlist.liq
@@ -5913,6 +5995,8 @@
   content/liq/prometheus-callback.liq
   content/liq/prometheus-settings.liq
   content/liq/radiopi.liq
+  content/liq/raw-string-delimited.liq
+  content/liq/raw-string.liq
   content/liq/re-encode.liq
   content/liq/regular.liq
   content/liq/replaygain-playlist.liq
@@ -6053,6 +6137,8 @@
   content/liq/prometheus-callback.liq
   content/liq/prometheus-settings.liq
   content/liq/radiopi.liq
+  content/liq/raw-string-delimited.liq
+  content/liq/raw-string.liq
   content/liq/re-encode.liq
   content/liq/regular.liq
   content/liq/replaygain-playlist.liq
@@ -6193,6 +6279,8 @@
   content/liq/prometheus-callback.liq
   content/liq/prometheus-settings.liq
   content/liq/radiopi.liq
+  content/liq/raw-string-delimited.liq
+  content/liq/raw-string.liq
   content/liq/re-encode.liq
   content/liq/regular.liq
   content/liq/replaygain-playlist.liq
@@ -6333,6 +6421,8 @@
   content/liq/prometheus-callback.liq
   content/liq/prometheus-settings.liq
   content/liq/radiopi.liq
+  content/liq/raw-string-delimited.liq
+  content/liq/raw-string.liq
   content/liq/re-encode.liq
   content/liq/regular.liq
   content/liq/replaygain-playlist.liq
@@ -6473,6 +6563,8 @@
   content/liq/prometheus-callback.liq
   content/liq/prometheus-settings.liq
   content/liq/radiopi.liq
+  content/liq/raw-string-delimited.liq
+  content/liq/raw-string.liq
   content/liq/re-encode.liq
   content/liq/regular.liq
   content/liq/replaygain-playlist.liq
@@ -6613,6 +6705,8 @@
   content/liq/prometheus-callback.liq
   content/liq/prometheus-settings.liq
   content/liq/radiopi.liq
+  content/liq/raw-string-delimited.liq
+  content/liq/raw-string.liq
   content/liq/re-encode.liq
   content/liq/regular.liq
   content/liq/replaygain-playlist.liq
@@ -6753,6 +6847,8 @@
   content/liq/prometheus-callback.liq
   content/liq/prometheus-settings.liq
   content/liq/radiopi.liq
+  content/liq/raw-string-delimited.liq
+  content/liq/raw-string.liq
   content/liq/re-encode.liq
   content/liq/regular.liq
   content/liq/replaygain-playlist.liq
@@ -6893,6 +6989,8 @@
   content/liq/prometheus-callback.liq
   content/liq/prometheus-settings.liq
   content/liq/radiopi.liq
+  content/liq/raw-string-delimited.liq
+  content/liq/raw-string.liq
   content/liq/re-encode.liq
   content/liq/regular.liq
   content/liq/replaygain-playlist.liq
@@ -7033,6 +7131,8 @@
   content/liq/prometheus-callback.liq
   content/liq/prometheus-settings.liq
   content/liq/radiopi.liq
+  content/liq/raw-string-delimited.liq
+  content/liq/raw-string.liq
   content/liq/re-encode.liq
   content/liq/regular.liq
   content/liq/replaygain-playlist.liq
@@ -7173,6 +7273,8 @@
   content/liq/prometheus-callback.liq
   content/liq/prometheus-settings.liq
   content/liq/radiopi.liq
+  content/liq/raw-string-delimited.liq
+  content/liq/raw-string.liq
   content/liq/re-encode.liq
   content/liq/regular.liq
   content/liq/replaygain-playlist.liq
@@ -7313,6 +7415,8 @@
   content/liq/prometheus-callback.liq
   content/liq/prometheus-settings.liq
   content/liq/radiopi.liq
+  content/liq/raw-string-delimited.liq
+  content/liq/raw-string.liq
   content/liq/re-encode.liq
   content/liq/regular.liq
   content/liq/replaygain-playlist.liq
@@ -7453,6 +7557,8 @@
   content/liq/prometheus-callback.liq
   content/liq/prometheus-settings.liq
   content/liq/radiopi.liq
+  content/liq/raw-string-delimited.liq
+  content/liq/raw-string.liq
   content/liq/re-encode.liq
   content/liq/regular.liq
   content/liq/replaygain-playlist.liq
@@ -7593,6 +7699,8 @@
   content/liq/prometheus-callback.liq
   content/liq/prometheus-settings.liq
   content/liq/radiopi.liq
+  content/liq/raw-string-delimited.liq
+  content/liq/raw-string.liq
   content/liq/re-encode.liq
   content/liq/regular.liq
   content/liq/replaygain-playlist.liq
@@ -7733,6 +7841,8 @@
   content/liq/prometheus-callback.liq
   content/liq/prometheus-settings.liq
   content/liq/radiopi.liq
+  content/liq/raw-string-delimited.liq
+  content/liq/raw-string.liq
   content/liq/re-encode.liq
   content/liq/regular.liq
   content/liq/replaygain-playlist.liq
@@ -7873,6 +7983,8 @@
   content/liq/prometheus-callback.liq
   content/liq/prometheus-settings.liq
   content/liq/radiopi.liq
+  content/liq/raw-string-delimited.liq
+  content/liq/raw-string.liq
   content/liq/re-encode.liq
   content/liq/regular.liq
   content/liq/replaygain-playlist.liq
@@ -8013,6 +8125,8 @@
   content/liq/prometheus-callback.liq
   content/liq/prometheus-settings.liq
   content/liq/radiopi.liq
+  content/liq/raw-string-delimited.liq
+  content/liq/raw-string.liq
   content/liq/re-encode.liq
   content/liq/regular.liq
   content/liq/replaygain-playlist.liq
@@ -8153,6 +8267,8 @@
   content/liq/prometheus-callback.liq
   content/liq/prometheus-settings.liq
   content/liq/radiopi.liq
+  content/liq/raw-string-delimited.liq
+  content/liq/raw-string.liq
   content/liq/re-encode.liq
   content/liq/regular.liq
   content/liq/replaygain-playlist.liq
@@ -8293,6 +8409,8 @@
   content/liq/prometheus-callback.liq
   content/liq/prometheus-settings.liq
   content/liq/radiopi.liq
+  content/liq/raw-string-delimited.liq
+  content/liq/raw-string.liq
   content/liq/re-encode.liq
   content/liq/regular.liq
   content/liq/replaygain-playlist.liq
@@ -8433,6 +8551,8 @@
   content/liq/prometheus-callback.liq
   content/liq/prometheus-settings.liq
   content/liq/radiopi.liq
+  content/liq/raw-string-delimited.liq
+  content/liq/raw-string.liq
   content/liq/re-encode.liq
   content/liq/regular.liq
   content/liq/replaygain-playlist.liq
@@ -8573,6 +8693,8 @@
   content/liq/prometheus-callback.liq
   content/liq/prometheus-settings.liq
   content/liq/radiopi.liq
+  content/liq/raw-string-delimited.liq
+  content/liq/raw-string.liq
   content/liq/re-encode.liq
   content/liq/regular.liq
   content/liq/replaygain-playlist.liq
@@ -8713,6 +8835,8 @@
   content/liq/prometheus-callback.liq
   content/liq/prometheus-settings.liq
   content/liq/radiopi.liq
+  content/liq/raw-string-delimited.liq
+  content/liq/raw-string.liq
   content/liq/re-encode.liq
   content/liq/regular.liq
   content/liq/replaygain-playlist.liq
@@ -8853,6 +8977,8 @@
   content/liq/prometheus-callback.liq
   content/liq/prometheus-settings.liq
   content/liq/radiopi.liq
+  content/liq/raw-string-delimited.liq
+  content/liq/raw-string.liq
   content/liq/re-encode.liq
   content/liq/regular.liq
   content/liq/replaygain-playlist.liq
@@ -8993,6 +9119,8 @@
   content/liq/prometheus-callback.liq
   content/liq/prometheus-settings.liq
   content/liq/radiopi.liq
+  content/liq/raw-string-delimited.liq
+  content/liq/raw-string.liq
   content/liq/re-encode.liq
   content/liq/regular.liq
   content/liq/replaygain-playlist.liq
@@ -9133,6 +9261,8 @@
   content/liq/prometheus-callback.liq
   content/liq/prometheus-settings.liq
   content/liq/radiopi.liq
+  content/liq/raw-string-delimited.liq
+  content/liq/raw-string.liq
   content/liq/re-encode.liq
   content/liq/regular.liq
   content/liq/replaygain-playlist.liq
@@ -9273,6 +9403,8 @@
   content/liq/prometheus-callback.liq
   content/liq/prometheus-settings.liq
   content/liq/radiopi.liq
+  content/liq/raw-string-delimited.liq
+  content/liq/raw-string.liq
   content/liq/re-encode.liq
   content/liq/regular.liq
   content/liq/replaygain-playlist.liq
@@ -9413,6 +9545,8 @@
   content/liq/prometheus-callback.liq
   content/liq/prometheus-settings.liq
   content/liq/radiopi.liq
+  content/liq/raw-string-delimited.liq
+  content/liq/raw-string.liq
   content/liq/re-encode.liq
   content/liq/regular.liq
   content/liq/replaygain-playlist.liq
@@ -9553,6 +9687,8 @@
   content/liq/prometheus-callback.liq
   content/liq/prometheus-settings.liq
   content/liq/radiopi.liq
+  content/liq/raw-string-delimited.liq
+  content/liq/raw-string.liq
   content/liq/re-encode.liq
   content/liq/regular.liq
   content/liq/replaygain-playlist.liq
@@ -9693,6 +9829,8 @@
   content/liq/prometheus-callback.liq
   content/liq/prometheus-settings.liq
   content/liq/radiopi.liq
+  content/liq/raw-string-delimited.liq
+  content/liq/raw-string.liq
   content/liq/re-encode.liq
   content/liq/regular.liq
   content/liq/replaygain-playlist.liq
@@ -9833,6 +9971,8 @@
   content/liq/prometheus-callback.liq
   content/liq/prometheus-settings.liq
   content/liq/radiopi.liq
+  content/liq/raw-string-delimited.liq
+  content/liq/raw-string.liq
   content/liq/re-encode.liq
   content/liq/regular.liq
   content/liq/replaygain-playlist.liq
@@ -9973,6 +10113,8 @@
   content/liq/prometheus-callback.liq
   content/liq/prometheus-settings.liq
   content/liq/radiopi.liq
+  content/liq/raw-string-delimited.liq
+  content/liq/raw-string.liq
   content/liq/re-encode.liq
   content/liq/regular.liq
   content/liq/replaygain-playlist.liq
@@ -10113,6 +10255,8 @@
   content/liq/prometheus-callback.liq
   content/liq/prometheus-settings.liq
   content/liq/radiopi.liq
+  content/liq/raw-string-delimited.liq
+  content/liq/raw-string.liq
   content/liq/re-encode.liq
   content/liq/regular.liq
   content/liq/replaygain-playlist.liq
@@ -10253,6 +10397,8 @@
   content/liq/prometheus-callback.liq
   content/liq/prometheus-settings.liq
   content/liq/radiopi.liq
+  content/liq/raw-string-delimited.liq
+  content/liq/raw-string.liq
   content/liq/re-encode.liq
   content/liq/regular.liq
   content/liq/replaygain-playlist.liq
@@ -10393,6 +10539,8 @@
   content/liq/prometheus-callback.liq
   content/liq/prometheus-settings.liq
   content/liq/radiopi.liq
+  content/liq/raw-string-delimited.liq
+  content/liq/raw-string.liq
   content/liq/re-encode.liq
   content/liq/regular.liq
   content/liq/replaygain-playlist.liq
@@ -10533,6 +10681,8 @@
   content/liq/prometheus-callback.liq
   content/liq/prometheus-settings.liq
   content/liq/radiopi.liq
+  content/liq/raw-string-delimited.liq
+  content/liq/raw-string.liq
   content/liq/re-encode.liq
   content/liq/regular.liq
   content/liq/replaygain-playlist.liq
@@ -10673,6 +10823,8 @@
   content/liq/prometheus-callback.liq
   content/liq/prometheus-settings.liq
   content/liq/radiopi.liq
+  content/liq/raw-string-delimited.liq
+  content/liq/raw-string.liq
   content/liq/re-encode.liq
   content/liq/regular.liq
   content/liq/replaygain-playlist.liq
@@ -10813,6 +10965,8 @@
   content/liq/prometheus-callback.liq
   content/liq/prometheus-settings.liq
   content/liq/radiopi.liq
+  content/liq/raw-string-delimited.liq
+  content/liq/raw-string.liq
   content/liq/re-encode.liq
   content/liq/regular.liq
   content/liq/replaygain-playlist.liq
@@ -10953,6 +11107,8 @@
   content/liq/prometheus-callback.liq
   content/liq/prometheus-settings.liq
   content/liq/radiopi.liq
+  content/liq/raw-string-delimited.liq
+  content/liq/raw-string.liq
   content/liq/re-encode.liq
   content/liq/regular.liq
   content/liq/replaygain-playlist.liq
@@ -11093,6 +11249,8 @@
   content/liq/prometheus-callback.liq
   content/liq/prometheus-settings.liq
   content/liq/radiopi.liq
+  content/liq/raw-string-delimited.liq
+  content/liq/raw-string.liq
   content/liq/re-encode.liq
   content/liq/regular.liq
   content/liq/replaygain-playlist.liq
@@ -12003,6 +12161,32 @@
   (run %{bin:liquidsoap} --check --no-fallible-check content/liq/radiopi.liq)))
 
 (rule
+ (alias test-doc-raw-string-delimited)
+ (package liquidsoap)
+ (deps
+  (source_tree ../src/libs)
+  (:test_liq content/liq/raw-string-delimited.liq))
+ (action
+  (run
+   %{bin:liquidsoap}
+   --check
+   --no-fallible-check
+   content/liq/raw-string-delimited.liq)))
+
+(rule
+ (alias test-doc-raw-string)
+ (package liquidsoap)
+ (deps
+  (source_tree ../src/libs)
+  (:test_liq content/liq/raw-string.liq))
+ (action
+  (run
+   %{bin:liquidsoap}
+   --check
+   --no-fallible-check
+   content/liq/raw-string.liq)))
+
+(rule
  (alias test-doc-re-encode)
  (package liquidsoap)
  (deps
@@ -12635,6 +12819,8 @@
   (alias test-doc-prometheus-callback)
   (alias test-doc-prometheus-settings)
   (alias test-doc-radiopi)
+  (alias test-doc-raw-string)
+  (alias test-doc-raw-string-delimited)
   (alias test-doc-re-encode)
   (alias test-doc-regular)
   (alias test-doc-replaygain-playlist)

--- a/src/js/.scripts/bundle-playground.sh
+++ b/src/js/.scripts/bundle-playground.sh
@@ -16,7 +16,7 @@ cd "$TMPDIR"
 
 npm init -y > /dev/null 2>&1
 npm install --silent \
-  liquidsoap-playground@1.1.1 \
+  liquidsoap-playground@1.1.2 \
   esbuild@0.24.2 \
   @babel/runtime@7.26.0
 

--- a/src/lang/base/lexer.ml
+++ b/src/lang/base/lexer.ml
@@ -246,6 +246,12 @@ let rec token lexbuf =
     | ']' -> RBRA
     | '(' -> LPAR
     | ')' -> RPAR
+    | '{', Star ('a' .. 'z' | '_'), '|' ->
+        let startp, _ = Sedlexing.lexing_bytes_positions lexbuf in
+        let matched = Sedlexing.Utf8.lexeme lexbuf in
+        let id = String.sub matched 1 (String.length matched - 2) in
+        let s = read_raw_string id startp (Buffer.create 17) lexbuf in
+        RAW_STRING (id, s)
     | '{' -> LCUR
     | '}' -> RCUR
     | ',' -> COMMA
@@ -394,6 +400,25 @@ and read_multiline_comment ?(level = 0) pos buf lexbuf =
         raise
           (Term_base.Parse_error
              (pos, "Illegal character: " ^ Sedlexing.Utf8.lexeme lexbuf))
+
+and read_raw_string id pos buf lexbuf =
+  match%sedlex lexbuf with
+    | '|', Star ('a' .. 'z' | '_'), '}' ->
+        let matched = Sedlexing.Utf8.lexeme lexbuf in
+        let matched_id = String.sub matched 1 (String.length matched - 2) in
+        if matched_id = id then Buffer.contents buf
+        else (
+          Buffer.add_string buf matched;
+          read_raw_string id pos buf lexbuf)
+    | any ->
+        Buffer.add_string buf (Sedlexing.Utf8.lexeme lexbuf);
+        read_raw_string id pos buf lexbuf
+    | eof ->
+        raise
+          (Term_base.Parse_error
+             ( (pos, snd (Sedlexing.lexing_bytes_positions lexbuf)),
+               "Raw string is not terminated" ))
+    | _ -> failwith "Internal error"
 
 and read_string c pos buf lexbuf =
   match%sedlex lexbuf with

--- a/src/lang/base/parser.mly
+++ b/src/lang/base/parser.mly
@@ -33,6 +33,7 @@ open Parser_helper
 %token <char * string * Parsed_term.pos> PP_STRING
 %token <string * char list * Parsed_term.pos> PP_REGEXP
 %token <char * string > STRING
+%token <string * string> RAW_STRING
 %token <string * char list > REGEXP
 %token <string> INT PP_INT_DOT_LCUR
 %token <string> FLOAT
@@ -211,6 +212,7 @@ expr:
   | BOOL                             { mk ~pos:$loc (`Bool $1) }
   | FLOAT                            { mk ~pos:$loc (`Float $1) }
   | STRING                           { mk ~pos:$loc (`String $1) }
+  | RAW_STRING                       { mk ~pos:$loc (`Raw_string $1) }
   | string_interpolation             { mk ~pos:$loc (`String_interpolation $1) }
   | VAR                              { mk ~pos:$loc (`Var $1) }
   | varlist                          { mk ~pos:$loc (`List $1) }

--- a/src/lang/base/term/parsed_term.ml
+++ b/src/lang/base/term/parsed_term.ml
@@ -219,6 +219,7 @@ and parsed_ast =
   | `Bool of bool
   | `Float of string
   | `String of char * string
+  | `Raw_string of string * string
   | `Block of t
   | `Parenthesis of t
   | `Encoder of encoder
@@ -354,6 +355,7 @@ let rec iter_term fn ({ term } as tm) =
     | `Int _ -> ()
     | `Float _ -> ()
     | `String _ -> ()
+    | `Raw_string _ -> ()
     | `Bool _ -> ()
     | `Var _ -> ()
     | `Eof -> ()

--- a/src/lang/base/term/term_preprocessor.ml
+++ b/src/lang/base/term/term_preprocessor.ml
@@ -317,6 +317,7 @@ and expand_term tm =
                 l )
       | `Int _ as ast -> ast
       | `Float _ as ast -> ast
+      | `Raw_string _ as ast -> ast
       | `String _ as ast -> ast
       | `Bool _ as ast -> ast
       | `Eof -> `Eof

--- a/src/lang/base/term/term_reducer.ml
+++ b/src/lang/base/term/term_reducer.ml
@@ -1320,6 +1320,7 @@ let rec to_ast ~throw ~env ~pos ~comments ast =
     | `Encoder e -> `Encoder (to_encoder ~to_term ~env e)
     | `List l -> list_reducer ~pos ~env ~to_term (List.rev l)
     | `Tuple l -> `Tuple (List.map (to_term ~env) l)
+    | `Raw_string (_, s) -> `String s
     | `String (sep, s) -> `String (render_string ~pos ~sep s)
     | `Int i -> `Int (int_of_string i)
     | `Float f -> (

--- a/src/lang/tooling/parsed_json.ml
+++ b/src/lang/tooling/parsed_json.ml
@@ -462,6 +462,8 @@ let rec to_ast_json ~to_json = function
   | `Float v -> ast_node ~typ:"ground" [("value", `String v)]
   | `Parenthesis tm -> ast_node ~typ:"parenthesis" [("value", to_json tm)]
   | `Block tm -> ast_node ~typ:"block" [("value", to_json tm)]
+  | `Raw_string (id, s) ->
+      ast_node ~typ:"raw_string" [("id", `String id); ("value", `String s)]
   | `String (c, s) ->
       ast_node ~typ:"string"
         [("value", `String (Printf.sprintf "%c%s%c" c s c))]

--- a/tests/language/string.liq
+++ b/tests/language/string.liq
@@ -213,6 +213,12 @@ def f() =
   test.equal(string(s), "blablo")
   test.equal(string(print_binary=false, s), "blablo")
 
+  # Raw strings: no interpolation
+  test.equal({|hello #{world}|}, "hello " ^ "#" ^ "{world}")
+  test.equal({foo|contains |} inside|foo}, "contains |} inside")
+  test.equal({_|also works|_}, "also works")
+  test.equal({||}, "")
+
   test.pass()
 end
 


### PR DESCRIPTION
## Summary

Adds a raw string literal syntax that suppresses both escape processing and `#{}` interpolation. Content is taken verbatim from source.

The syntax is inspired by OCaml's quoted string literals (`{id|...|id}`),

This PR implements the changes required to support the feature requested in #4957.

## Syntax

- `{|...|}`  — basic form, terminates at the first `|}`
- `{id|...|id}` — delimited form, where `id` is any sequence of lowercase letters and underscores; terminates only at `|id}` with the matching id

This allows embedding `|}` inside a raw string by choosing a non-empty id:

```liquidsoap
s = {|hello #{world}|}          # => "hello #{world}"
s = {foo|contains |} here|foo}  # => "contains |} here"
s = {||}                        # => ""
```

## Implementation

The lexer matches `{[a-z_]*|` as the opening delimiter, extracts the id, and delegates to `read_raw_string`. That function scans until it finds `|[a-z_]*}` with a matching id, treating any non-matching `|..}` sequences as literal content.

A new `RAW_STRING` token carries the raw content string. The pipeline adds:
- `` `Raw_string of (string * string) `` variant in `parsed_ast`
- passthrough in `term_preprocessor` (no `expand_string` processing)
- reduction `` `Raw_string (_, s) -> `String s `` in `term_reducer`
- JSON serialization in `parsed_json` with both `id` separator and string content.