### PR TITLE
Fix content type propagation through free type variables

### DIFF
--- a/src/core/base/lang_source.ml
+++ b/src/core/base/lang_source.ml
@@ -624,7 +624,6 @@ let check_content v t =
     if not (has_value_flag v Flags.checked_value) then (
       add_value_flag v Flags.checked_value;
       match (v, (Type.deref t).Type.descr) with
-        | _, Type.Var _ -> ()
         | _ when Source_val.is_value v ->
             let source_t = source_t (Source_val.of_value v)#frame_type in
             check source_t t
@@ -717,6 +716,7 @@ let check_content v t =
                 let v = ffi_fn env in
                 check_value v ret_t;
                 v)
+        | _, Type.Var _ -> ()
         | _ ->
             failwith
               (Printf.sprintf "Unhandled value in check_content: %s, type: %s."

--- a/src/core/base/operators/amplify.ml
+++ b/src/core/base/operators/amplify.ml
@@ -89,8 +89,7 @@ class amplify ~field ~override_field (source : source) coeff =
   end
 
 let _ =
-  (* let frame_t = Lang.pcm_audio_t () in *)
-  let frame_t = Format_type.audio () in
+  let frame_t = Lang.pcm_audio_t () in
   Lang.add_track_operator ~base:Modules.track_audio "amplify"
     [
       ( "override",


### PR DESCRIPTION
## Reason

When `track.audio.amplify` uses `pcm_audio_t()` as its argument and return type, both resolve to the same fresh constrained type variable `'rt : pcm_audio` at runtime. The `check_content` function is responsible for linking actual source frame types to these type variables — but it wasn't doing so.

## What was wrong

`check_content` had `| _, Type.Var _ -> ()` as its **first** match case, so any call where the expected type was a free variable bailed out immediately — including calls for source and track values that have real propagation work to do.

Concretely: with `track.audio.amplify(1., a)` feeding into `output.file(%mp3(mono), ...)`:
1. `check_content a_val 'rt` is called with `'rt` a free variable
2. `Var _` fires first → bail out
3. `sine`'s frame type is never linked to `'rt`
4. `%mp3(mono)` forces `'rt = mono`, but `sine` is disconnected → stays stereo → runtime content type mismatch

## Fix

Move `| _, Type.Var _ -> ()` to just before the final `failwith` catch-all, so it serves purely as a safety valve for genuinely unhandled value/type combinations, rather than pre-empting source, track, encoder, and other cases that have meaningful work to do.

Also restores `Lang.pcm_audio_t ()` in `track.audio.amplify`, reverting a `Format_type.audio ()` workaround that had masked the underlying bug.

## Tests

`tests/regression/GH3239-bis.liq` — the pattern that was broken:

```liquidsoap
def f() =
  s = once(sine(duration=2.))
  let {audio = a} = source.tracks(s)
  track.audio.amplify(1., a)
end
s = source({audio=f()})
o = output.file(fallible=true, %mp3(mono), tmp, s)
```

Fixes #3239.