### PR TITLE
input.harbor.dynamic: rename on_connection to on_connect, curry source argument

### DIFF
--- a/doc/content/harbor.md
+++ b/doc/content/harbor.md
@@ -107,13 +107,19 @@ metadata before any audio or video is processed.
 Supported container formats include MP3, OGG, FLAC, AAC, MKV, WebM, MP4, FLV,
 MPEG-TS, and anything else FFmpeg can demux.
 
-### The `on_connection` callback
+### The `on_connect` callback
 
-The callback receives a single record argument with the following fields:
+The callback has the signature `(connection_record) -> source -> unit`. It is
+first called with a connection record describing the incoming stream, and must
+return a function that will be called with the live source. This two-step design
+lets you inspect the stream before deciding how to handle it, and allows you to
+select a pre-determined handler function for each content type based on
+`streams` without having to dispatch inside a single catch-all function.
+
+The connection record contains:
 
 | Field          | Type                  | Description                                           |
 | -------------- | --------------------- | ----------------------------------------------------- |
-| `source`       | `source`              | The live source, with all standard harbor methods     |
 | `uri`          | `string`              | The request URI                                       |
 | `query`        | `[(string * string)]` | Named capture groups from a regexp mountpoint         |
 | `format`       | `string?`             | Detected container format, e.g. `"ogg"`, `"matroska"` |
@@ -127,7 +133,8 @@ Each entry in `streams` is a record with:
 - `samplerate`, `channels`, `channel_layout` — present for audio streams
 - `width`, `height`, `pixel_format`, `frame_rate` — present for video streams
 
-To refuse a connection, raise an error in the callback.
+To refuse a connection, raise an error in the callback (in either the first or
+second call).
 
 ### `copy_encoder`
 

--- a/doc/content/liq/harbor-dynamic-basic.liq
+++ b/doc/content/liq/harbor-dynamic-basic.liq
@@ -1,11 +1,12 @@
 input.harbor.dynamic(
   port=8005,
   "/example",
-  on_connection=fun (c) ->
+  on_connect=fun (c) ->
     begin
       log(
         "Client connected on #{c.uri}, format: #{c.format}"
       )
-      output.file(c.copy_encoder(), "/tmp/record-#{time()}.%(ext)", c.source)
+      fun (source) ->
+        output.file(c.copy_encoder(), "/tmp/record-#{time()}.%(ext)", source)
     end
 )

--- a/doc/content/liq/harbor-dynamic-filter.liq
+++ b/doc/content/liq/harbor-dynamic-filter.liq
@@ -1,16 +1,24 @@
 input.harbor.dynamic(
   port=8005,
   "/example",
-  on_connection=fun(c) ->
+  on_connect=fun (c) ->
     begin
       list.iter(
-        fun(s) -> log("Stream: #{s.field} type=#{s.type} codec=#{s.codec}"),
+        fun (s) ->
+          log(
+            "Stream: #{s.field} type=#{s.type} codec=#{s.codec}"
+          ),
         c.streams
       )
-      if list.exists(fun(s) -> s.type == "audio", c.streams) then
-        output.file(c.copy_encoder(), "/tmp/audio.ogg", c.source)
+      if
+        list.exists(fun (s) -> s.type == "audio", c.streams)
+      then
+        fun (source) -> output.file(c.copy_encoder(), "/tmp/audio.ogg", source)
       else
-        error.raise(error.not_found, "No audio stream, rejecting connection")
+        error.raise(
+          error.not_found,
+          "No audio stream, rejecting connection"
+        )
       end
     end
 )

--- a/doc/content/liq/harbor-dynamic-regexp.liq
+++ b/doc/content/liq/harbor-dynamic-regexp.liq
@@ -3,13 +3,14 @@
 input.harbor.dynamic.regexp(
   port=8005,
   r/^\/live\/foo-(?<id>\d+)$/,
-  on_connection=fun (c) ->
+  on_connect=fun (c) ->
     begin
       let id = list.assoc(default="0", "id", c.query)
       in
       log(
         "Stream foo-#{id} connected, format: #{c.format}"
       )
-      output.harbor(c.copy_encoder(), mount="/relay/foo-#{id}", c.source)
+      fun (source) ->
+        output.harbor(c.copy_encoder(), mount="/relay/foo-#{id}", source)
     end
 )

--- a/doc/content/liq/harbor-dynamic-routing.liq
+++ b/doc/content/liq/harbor-dynamic-routing.liq
@@ -3,10 +3,11 @@
 input.harbor.dynamic(
   port=8005,
   "/live/:name",
-  on_connection=fun (c) ->
+  on_connect=fun (c) ->
     begin
       let name = list.assoc(default="unknown", "name", c.query)
       log("Stream '#{name}' connected, format: #{c.format}")
-      output.harbor(c.copy_encoder(), mount="/relay/#{name}", c.source)
+      fun (source) ->
+        output.harbor(c.copy_encoder(), mount="/relay/#{name}", source)
     end
 )

--- a/src/core/optionals/ffmpeg/ffmpeg_harbor_input.ml
+++ b/src/core/optionals/ffmpeg/ffmpeg_harbor_input.ml
@@ -120,7 +120,8 @@ let mime_to_format = function
   | _ -> None
 
 class ffmpeg_http_input ~dumpfile ~logfile ~bufferize ~max ~replay_meta
-  ~mountpoint ~login ~debug ~timeout ~on_connection () =
+  ~mountpoint ~login ~debug ~timeout ~on_connect () =
+  let on_connect_callback = on_connect in
   object (self)
     inherit
       Harbor_input.http_input_base
@@ -152,7 +153,7 @@ class ffmpeg_http_input ~dumpfile ~logfile ~bufferize ~max ~replay_meta
       Duppy.Task.add Tutils.scheduler task
 
     method private do_open_container =
-      (* Open FFmpeg container and call on_connection *)
+      (* Open FFmpeg container and call on_connect *)
       let socket = Option.get (Atomic.get relay_socket) in
       let mime = Option.get self#get_mime_type in
       let format = mime_to_format (String.lowercase_ascii mime) in
@@ -226,7 +227,6 @@ class ffmpeg_http_input ~dumpfile ~logfile ~bufferize ~max ~replay_meta
       let callback_record =
         Lang.record
           [
-            ("source", source_value);
             ("uri", Lang.string self#uri);
             ( "query",
               Lang.list
@@ -240,7 +240,8 @@ class ffmpeg_http_input ~dumpfile ~logfile ~bufferize ~max ~replay_meta
             ("copy_encoder", copy_encoder);
           ]
       in
-      ignore (Lang.apply on_connection [("", callback_record)])
+      let handler = Lang.apply on_connect_callback [("", callback_record)] in
+      ignore (Lang.apply handler [("", source_value)])
 
     method private register_decoder _ =
       match Atomic.get ffmpeg_container with
@@ -276,7 +277,7 @@ let stream_info_t =
       ("codec", ([], Lang.string_t), "Stream codec.");
     ]
 
-let callback_record_t =
+let on_connect_t =
   let frame_t = Lang.univ_t () in
   let meth_t =
     List.map (fun m -> (m, `Method)) (Harbor_input.meth ())
@@ -285,28 +286,33 @@ let callback_record_t =
         (Harbor_input.callbacks ())
   in
   let source_t = Lang_source._method_t (Lang.source_t frame_t) meth_t in
-  Lang.record_t
-    [
-      ("source", source_t);
-      ("uri", Lang.string_t);
-      ("query", Lang.metadata_t);
-      ("format", Lang.nullable_t Lang.string_t);
-      ("streams", Lang.list_t stream_info_t);
-      ("headers", Lang.metadata_t);
-      ( "copy_encoder",
-        Lang.fun_t
-          [(true, "", Lang.nullable_t Lang.string_t)]
-          (Lang.format_t frame_t) );
-    ]
+  let connection_record_t =
+    Lang.record_t
+      [
+        ("uri", Lang.string_t);
+        ("query", Lang.metadata_t);
+        ("format", Lang.nullable_t Lang.string_t);
+        ("streams", Lang.list_t stream_info_t);
+        ("headers", Lang.metadata_t);
+        ( "copy_encoder",
+          Lang.fun_t
+            [(true, "", Lang.nullable_t Lang.string_t)]
+            (Lang.format_t frame_t) );
+      ]
+  in
+  Lang.fun_t
+    [(false, "", connection_record_t)]
+    (Lang.fun_t [(false, "", source_t)] Lang.unit_t)
 
 let extra_proto =
   [
-    ( "on_connection",
-      Lang.fun_t [(false, "", callback_record_t)] Lang.unit_t,
+    ( "on_connect",
+      on_connect_t,
       None,
       Some
-        "Callback when a source connects. Receives a record with: `source`, \
-         `uri`, `query`, `format`, `streams`, `headers` and `copy_encoder`." );
+        "Callback when a source connects. Called with a connection record \
+         containing `uri`, `query`, `format`, `streams`, `headers` and \
+         `copy_encoder`; returns a function that receives the source." );
   ]
 
 let input_harbor_dynamic =
@@ -316,9 +322,10 @@ let _ =
   Lang.add_builtin ~base:input_harbor_dynamic "regexp"
     ~descr:
       "Start a http/icecast receiver server. When a source connects, a new \
-       source is created and passed to the `on_connection` callback along with \
-       a description of its content (URI, format, streams, headers) and a \
-       `copy_encoder` that can be used to re-encode the stream as a copy."
+       source is created and its description (URI, format, streams, headers) \
+       passed to the `on_connect` callback, which returns a function that \
+       receives the source. A `copy_encoder` is provided for passthrough \
+       remuxing."
     ~category:(`Source `Input)
     (Harbor_input.proto ~buffer_default:0.2 Lang.regexp_t @ extra_proto)
     Lang.unit_t
@@ -344,7 +351,7 @@ let _ =
         Harbor_input.parse_args ~parse_mountpoint:Lang.to_regexp p
       in
       let mountpoint_s = Lang.descr_of_regexp mountpoint in
-      let on_connection = List.assoc "on_connection" p in
+      let on_connect = List.assoc "on_connect" p in
       let current_source = Atomic.make None in
       let handler =
         {
@@ -353,8 +360,7 @@ let _ =
               let s =
                 new ffmpeg_http_input
                   ~dumpfile ~logfile ~bufferize ~max ~replay_meta
-                  ~mountpoint:mountpoint_s ~login ~debug ~timeout ~on_connection
-                  ()
+                  ~mountpoint:mountpoint_s ~login ~debug ~timeout ~on_connect ()
               in
               s#set_id
                 (if String.length relay.uri > 1 && relay.uri.[0] = '/' then


### PR DESCRIPTION
## Summary

- Renames the `on_connection` parameter to `on_connect` for consistency with the rest of the codebase.
- Changes the callback signature from `{ source, <args> } -> unit` to `{ <args> } -> source -> unit` (curried two-step call).

## Motivation

The previous single-record design forced the programmer to handle all stream types inside one catch-all function, which made it awkward to dispatch based on detected stream content (e.g. audio-only vs. video streams). With the new curried signature, `on_connect` receives the connection record first — containing `uri`, `query`, `format`, `streams`, `headers`, and `copy_encoder` — and returns a handler function that is then called with the live source. This allows the programmer to inspect the stream and return a pre-typed, pre-determined handler for each content type without fighting the type system.

## Changes

- `src/core/optionals/ffmpeg/ffmpeg_harbor_input.ml`: updated type, renamed parameter, split the callback invocation into two `Lang.apply` calls.
- `doc/content/harbor.md`: updated the `on_connect` section to reflect the new signature and document the design rationale.
- `doc/content/liq/harbor-dynamic-*.liq`: updated all examples to use the new `fun (c) -> fun (source) -> ...` pattern.