### PR TITLE
input.jack, output.jack: remove self_sync

### DIFF
--- a/src/core/optionals/bjack/bjack_in.ml
+++ b/src/core/optionals/bjack/bjack_in.ml
@@ -24,15 +24,7 @@ open Mm
 
 let log = Log.make ["input"; "jack"]
 
-module SyncSource = Clock.MkSyncSource (struct
-  type t = unit
-
-  let to_string _ = "jack"
-end)
-
-let sync_source = SyncSource.make ()
-
-class jack_in ~self_sync ~fallible ~autostart ~server =
+class jack_in ~fallible ~autostart ~server =
   let samples_per_frame = AFrame.size () in
   let samples_per_second = Lazy.force Frame.audio_rate in
   let bytes_per_sample = 2 in
@@ -47,11 +39,7 @@ class jack_in ~self_sync ~fallible ~autostart ~server =
     method remaining = -1
     val mutable sample_freq = samples_per_second
     val mutable device = None
-
-    method self_sync =
-      if self_sync then
-        (`Dynamic, if device <> None then Some sync_source else None)
-      else (`Static, None)
+    method self_sync = (`Static, None)
 
     method stop =
       match device with
@@ -114,10 +102,6 @@ let _ =
   Lang.add_operator ~base:Modules.input "jack"
     (Start_stop.active_source_proto ~fallible_opt:(`Yep false)
     @ [
-        ( "self_sync",
-          Lang.bool_t,
-          Some (Lang.bool true),
-          Some "Mark the source as being synchronized by the jack server." );
         ( "server",
           Lang.string_t,
           Some (Lang.string ""),
@@ -127,9 +111,7 @@ let _ =
     ~callbacks:(Start_stop.callbacks ~label:"source")
     ~return_t ~category:`Input ~descr:"Get stream from jack."
     (fun p ->
-      let self_sync = Lang.to_bool (List.assoc "self_sync" p) in
       let fallible = Lang.to_bool (List.assoc "fallible" p) in
       let autostart = Lang.to_bool (List.assoc "start" p) in
       let server = Lang.to_string (List.assoc "server" p) in
-      (new jack_in ~self_sync ~server ~fallible ~autostart
-        :> Start_stop.active_source))
+      (new jack_in ~server ~fallible ~autostart :> Start_stop.active_source))

--- a/src/core/optionals/bjack/bjack_out.ml
+++ b/src/core/optionals/bjack/bjack_out.ml
@@ -24,7 +24,7 @@
 
 let bytes_per_sample = 2
 
-class output ~self_sync ~infallible ~register_telnet ~server source =
+class output ~infallible ~register_telnet ~server source =
   let samples_per_frame = AFrame.size () in
   let seconds_per_frame = Frame.seconds_of_audio samples_per_frame in
   let samples_per_second = Lazy.force Frame.audio_rate in
@@ -35,11 +35,7 @@ class output ~self_sync ~infallible ~register_telnet ~server source =
           ~output_kind:"output.jack" source true
 
     val mutable device = None
-
-    method self_sync =
-      if self_sync then
-        (`Dynamic, if device <> None then Some Bjack_in.sync_source else None)
-      else (`Static, None)
+    method self_sync = (`Static, None)
 
     method get_device =
       match device with
@@ -95,10 +91,6 @@ let _ =
   Lang.add_operator ~base:Modules.output "jack"
     (Output.proto
     @ [
-        ( "self_sync",
-          Lang.bool_t,
-          Some (Lang.bool true),
-          Some "Force the use of the dedicated bjack clock." );
         ( "server",
           Lang.string_t,
           Some (Lang.string ""),
@@ -110,9 +102,7 @@ let _ =
     ~descr:"Output stream to jack."
     (fun p ->
       let source = List.assoc "" p in
-      let self_sync = Lang.to_bool (List.assoc "self_sync" p) in
       let server = Lang.to_string (List.assoc "server" p) in
       let infallible = not (Lang.to_bool (List.assoc "fallible" p)) in
       let register_telnet = Lang.to_bool (List.assoc "register_telnet" p) in
-      (new output ~self_sync ~infallible ~register_telnet ~server source
-        :> Output.output))
+      (new output ~infallible ~register_telnet ~server source :> Output.output))


### PR DESCRIPTION
Fixes #4994.

## Reason

The `self_sync` option on `input.jack` and `output.jack` was causing 100% CPU usage. Investigation revealed that despite being called a "blocking API", `JACK_Read` and `JACK_Write` in ocaml-bjack (bio2jack) are not actually blocking — they return immediately with 0 bytes when the ringbuffer is empty or full. This means the `read_data` loop in `bjack_in.ml` was spinning in a tight busy-wait, consuming a full CPU core.

More fundamentally, the bjack API has no mechanism to drive a clock: it uses a process callback to fill/drain ringbuffers, and the client-side read/write calls just poll those buffers. There is no way to block waiting for a jack period to complete from the client side.

## What changed

Removed `self_sync` parameter and `method self_sync` override from both `input.jack` and `output.jack`. Both now return the default `(\`Static, None)`.