### PR TITLE
clock: prepare time control delegation to sync sources

### DIFF
--- a/src/core/base/clock.ml
+++ b/src/core/base/clock.ml
@@ -66,12 +66,12 @@ let conf_max_latency =
         "The reset is typically only useful to reconnect icecast mounts.";
       ]
 
-let conf_clock_preferred =
+let conf_preferred =
   Dtools.Conf.string ~d:"posix"
     ~p:(conf_clock#plug "preferred")
     "Preferred clock implementation. One if: \"posix\" or \"ocaml\"."
 
-let conf_clock_latency =
+let conf_latency =
   Dtools.Conf.float
     ~p:(conf_clock#plug "latency")
     ~d:0.1
@@ -89,8 +89,17 @@ let conf_leak_warning =
     ~d:50 "Number of sources at which a leak warning should be issued."
 
 let time_implementation () =
-  try Hashtbl.find Liq_time.implementations conf_clock_preferred#get
+  try Hashtbl.find Liq_time.implementations conf_preferred#get
   with Not_found -> Liq_time.unix
+
+let unconstrained_time : Liq_time.implementation =
+  let module U = (val Liq_time.unix : Liq_time.T) in
+  (module struct
+    include U
+
+    let time () = U.of_float 0.
+    let sleep_until _ = ()
+  end)
 
 let () =
   Lifecycle.on_init ~name:"Clock initialization" (fun () ->
@@ -101,18 +110,22 @@ let () =
 module Pos = Liquidsoap_lang.Pos
 module Unifier = Liquidsoap_lang.Unifier
 
+type sync_source_state = {
+  sync_source : sync_source;
+  latency : float;
+  max_latency : float;
+}
+
 type active_params = {
   sync : active_sync_mode;
-  mutable is_self_sync : bool;
+  mutable current_sync_source : sync_source_state option;
   mutable sync_source_entries : sync_source_entry list;
   log : Log.t;
-  time_implementation : Liq_time.implementation;
-  t0 : Liq_time.t;
-  log_delay : Liq_time.t;
-  log_delay_threshold : Liq_time.t;
-  frame_duration : Liq_time.t;
-  max_latency : Liq_time.t;
-  last_catchup_log : Liq_time.t Atomic.t;
+  mutable time_implementation : Liq_time.implementation;
+  log_delay : float;
+  log_delay_threshold : float;
+  frame_duration : float;
+  last_catchup_log : float Atomic.t;
   outputs : (activation * source) Queue.t;
   active_sources : source WeakQueue.t;
   passive_sources : source WeakQueue.t;
@@ -424,7 +437,8 @@ let _update_clock_sync_source ~clock x ~name ~stack new_sync =
   in
   let deduped =
     List.sort_uniq
-      (fun { sync_source = a } { sync_source = b } -> Stdlib.compare a b)
+      (fun ({ sync_source = a } : sync_source_entry) { sync_source = b } ->
+        Stdlib.compare a b)
       entries
   in
   if List.length deduped > 1 then
@@ -435,36 +449,63 @@ let _update_clock_sync_source ~clock x ~name ~stack new_sync =
            stack = Atomic.get clock.stack;
            sync_sources = deduped;
          });
-  let is_self_sync = List.length deduped = 1 in
-  if x.is_self_sync <> is_self_sync && x.sync = `Automatic then (
-    x.log#important "Switching to %sself-sync mode%s"
-      (if is_self_sync then "" else "non ")
-      (if is_self_sync then
-         Printf.sprintf " with sync source: %s"
-           (string_of_sync_source (List.hd deduped).sync_source)
-       else "");
-    x.is_self_sync <- is_self_sync);
+  let new_sync_source =
+    match deduped with [{ sync_source }] -> Some sync_source | _ -> None
+  in
+  let current_sync_source =
+    Option.map (fun s -> s.sync_source) x.current_sync_source
+  in
+  if current_sync_source <> new_sync_source && x.sync = `Automatic then (
+    (match (current_sync_source, new_sync_source) with
+      | None, Some s ->
+          x.log#important "Switching to self-sync mode (%s)"
+            (string_of_sync_source s)
+      | Some _, None -> x.log#important "Switching to non-self-sync mode"
+      | Some _, Some s ->
+          x.log#important "Switching self-sync source to %s"
+            (string_of_sync_source s)
+      | None, None -> ());
+    x.current_sync_source <-
+      Option.map
+        (fun sync_source ->
+          {
+            sync_source;
+            latency =
+              Option.value ~default:conf_latency#get
+                (latency_of_sync_source sync_source);
+            max_latency =
+              Option.value ~default:conf_max_latency#get
+                (max_latency_of_sync_source sync_source);
+          })
+        new_sync_source;
+    let time_implementation =
+      match new_sync_source with
+        | Some s -> time_of_sync_source s
+        | None -> time_implementation ()
+    in
+    let module TimeImplementation = (val time_implementation) in
+    (* Re-anchor the new time implementation so that Time.time () returns time
+       relative to when this clock started ticking, i.e. time () = 0 at tick 0. *)
+    let current_time = x.frame_duration *. float_of_int (Atomic.get x.ticks) in
+    x.time_implementation <-
+      Liq_time.set_offset time_implementation
+        TimeImplementation.(time () |-| of_float current_time));
   x.sync_source_entries <- entries
+
+let _target_time { time_implementation; frame_duration; ticks } =
+  let module Time = (val time_implementation : Liq_time.T) in
+  Time.of_float (frame_duration *. float_of_int (Atomic.get ticks))
 
 let ticks c =
   match Atomic.get (Unifier.deref c).state with
     | `Stopped _ -> 0
     | `Stopping { ticks } | `Started { ticks } -> Atomic.get ticks
 
-let _time { time_implementation; frame_duration; ticks } =
+let _set_time { time_implementation; frame_duration; ticks } t =
   let module Time = (val time_implementation : Liq_time.T) in
-  Time.(frame_duration |*| of_float (float_of_int (Atomic.get ticks)))
+  Atomic.set ticks (int_of_float (Time.to_float t /. frame_duration))
 
-let _target_time ({ time_implementation; t0 } as c) =
-  let module Time = (val time_implementation : Liq_time.T) in
-  Time.(t0 |+| _time c)
-
-let _set_time { time_implementation; t0; frame_duration; ticks } t =
-  let module Time = (val time_implementation : Liq_time.T) in
-  let delta = Time.(to_float (t |-| t0)) in
-  Atomic.set ticks (int_of_float (delta /. Time.to_float frame_duration))
-
-let _after_tick ~self_sync x =
+let _after_tick x =
   Queue.flush_iter x.after_tick (fun fn ->
       check_stopped ();
       fn ());
@@ -472,15 +513,24 @@ let _after_tick ~self_sync x =
   let end_time = Time.time () in
   let target_time = _target_time x in
   check_stopped ();
-  match (x.sync, self_sync, Time.(end_time |<| target_time)) with
-    | `Unsynced, _, _ | `Passive, _, _ | `Automatic, true, _ -> ()
-    | `Automatic, false, true | `CPU, _, true ->
-        if
-          Time.(of_float conf_clock_latency#get |<=| (target_time |-| end_time))
-        then Time.sleep_until target_time
+  match (x.sync, Time.(end_time |<| target_time)) with
+    | `Unsynced, _ | `Passive, _ -> ()
+    | `Automatic, true | `CPU, true ->
+        let latency =
+          match x.current_sync_source with
+            | Some { latency } -> latency
+            | None -> conf_latency#get
+        in
+        if Time.(of_float latency |<=| (target_time |-| end_time)) then
+          Time.sleep_until target_time
     | _ ->
         let latency = Time.(end_time |-| target_time) in
-        if Time.(x.max_latency |<=| latency) then (
+        let max_latency =
+          match x.current_sync_source with
+            | Some { max_latency } -> max_latency
+            | None -> conf_max_latency#get
+        in
+        if Time.(of_float max_latency |<=| latency) then (
           x.log#severe "Too much latency! Resetting active sources...";
           _set_time x end_time;
           List.iter
@@ -492,10 +542,11 @@ let _after_tick ~self_sync x =
             (_animated_sources x))
         else if
           Time.(
-            x.log_delay_threshold |<=| latency
-            && x.log_delay |<=| (end_time |-| Atomic.get x.last_catchup_log))
+            of_float x.log_delay_threshold |<=| latency
+            && of_float x.log_delay
+               |<=| (end_time |-| of_float (Atomic.get x.last_catchup_log)))
         then (
-          Atomic.set x.last_catchup_log end_time;
+          Atomic.set x.last_catchup_log (Time.to_float end_time);
           x.log#severe
             "Latency is too high: we must catchup %.2f seconds! Check if your \
              system can process your stream fast enough (CPU usage, disk \
@@ -618,7 +669,7 @@ and _tick ~clock x =
     sub_clocks;
   Atomic.incr x.ticks;
   check_stopped ();
-  _after_tick ~self_sync:x.is_self_sync x;
+  _after_tick x;
   check_stopped ()
 
 and _clock_thread ~clock ~c x =
@@ -710,24 +761,26 @@ and _start ?force ~sync ~c clock =
   in
   log#important "Starting %s clock %s%s with sources: %s%s" top_level id
     controlled_by sources sync_mode;
-  let time_implementation = time_implementation () in
+  (* Anchor the time implementation so that Time.time () returns time relative
+     to when this clock starts ticking, i.e. time () = 0 at tick 0. *)
+  let time_implementation =
+    let base = time_implementation () in
+    let module Time = (val base : Liq_time.T) in
+    Liq_time.set_offset base (Time.time ())
+  in
   let module Time = (val time_implementation : Liq_time.T) in
-  let frame_duration = Time.of_float (Lazy.force Frame.duration) in
-  let max_latency = Time.of_float conf_max_latency#get in
-  let log_delay = Time.of_float conf_log_delay#get in
-  let log_delay_threshold = Time.of_float conf_log_delay_threshold#get in
-  let t0 = Time.time () in
-  let last_catchup_log = Atomic.make t0 in
+  let frame_duration = Lazy.force Frame.duration in
+  let log_delay = conf_log_delay#get in
+  let log_delay_threshold = conf_log_delay_threshold#get in
+  let last_catchup_log = Atomic.make (Time.to_float (Time.time ())) in
   let x =
     {
       frame_duration;
-      is_self_sync = false;
+      current_sync_source = None;
       sync_source_entries = [];
       log_delay;
       log_delay_threshold;
-      max_latency;
       time_implementation;
-      t0;
       log = Log.make (["clock"] @ String.split_on_char '.' id);
       last_catchup_log;
       sync;
@@ -789,7 +842,7 @@ let time c =
   match active_params c with
     | { time_implementation } as c ->
         let module Time = (val time_implementation : Liq_time.T) in
-        Time.to_float (_time c)
+        Time.to_float (_target_time c)
     | exception Invalid_state -> -1.
 
 let start_pending () =
@@ -830,7 +883,7 @@ let after_eval () = if not (Atomic.get global_stop) then start_pending ()
 let self_sync c =
   let clock = Unifier.deref c in
   match Atomic.get clock.state with
-    | `Started params -> params.is_self_sync
+    | `Started params -> params.current_sync_source <> None
     | _ -> false
 
 let activate_pending_sources clock =

--- a/src/core/base/clock.mli
+++ b/src/core/base/clock.mli
@@ -33,7 +33,11 @@ type sync_source = Clock_base.sync_source
 type self_sync = [ `Static | `Dynamic ] * sync_source option
 type controller = [ `None | `Clock of t | `Other of string * < id : string > ]
 
+val conf_latency : float Dtools.Conf.t
+val conf_max_latency : float Dtools.Conf.t
 val string_of_sync_source : sync_source -> string
+val latency_of_sync_source : sync_source -> float option
+val max_latency_of_sync_source : sync_source -> float option
 
 type sync_source_entry = {
   name : string;
@@ -52,7 +56,10 @@ exception Sync_error of clock_sync_error
 module type SyncSource = sig
   type t
 
+  val time_implementation : t -> Liq_time.implementation
   val to_string : t -> string
+  val latency : t -> float
+  val max_latency : t -> float
 end
 
 module MkSyncSource (S : SyncSource) : sig
@@ -120,6 +127,12 @@ val on_tick : t -> (unit -> unit) -> unit
 val tick : t -> unit
 val after_tick : t -> (unit -> unit) -> unit
 val time_implementation : unit -> Liq_time.implementation
+
+(** A time implementation that always returns [0] for [time] and is a no-op for
+    [sleep_until]. For use by self-sync sources that drive their own clock and
+    do not need liquidsoap's timing. *)
+val unconstrained_time : Liq_time.implementation
+
 val after_eval : unit -> unit
 val dump : unit -> string
 val dump_sources : t -> string

--- a/src/core/base/clock_base.ml
+++ b/src/core/base/clock_base.ml
@@ -45,20 +45,35 @@ module WeakQueue = struct
   let push q v = if not (exists q (fun v' -> v == v')) then push q v
 end
 
-exception Sync_source_name of string
+type sync_source_handler = {
+  to_string : sync_source -> string option;
+  time_implementation : sync_source -> Liq_time.implementation option;
+  latency : sync_source -> float option;
+  max_latency : sync_source -> float option;
+}
 
-let sync_sources_handlers = Queue.create ()
+let sync_source_handlers : sync_source_handler list ref = ref []
+
+let find_sync_source fn s =
+  List.find_map (fun h -> fn h s) !sync_source_handlers
 
 let string_of_sync_source s =
-  try
-    Queue.iter sync_sources_handlers (fun fn -> fn s);
-    assert false
-  with Sync_source_name s -> s
+  Option.value ~default:"unknown" (find_sync_source (fun h -> h.to_string) s)
+
+let time_of_sync_source s =
+  Option.value ~default:Liq_time.unix
+    (find_sync_source (fun h -> h.time_implementation) s)
+
+let latency_of_sync_source s = find_sync_source (fun h -> h.latency) s
+let max_latency_of_sync_source s = find_sync_source (fun h -> h.max_latency) s
 
 module type SyncSource = sig
   type t
 
+  val time_implementation : t -> Liq_time.implementation
   val to_string : t -> string
+  val latency : t -> float
+  val max_latency : t -> float
 end
 
 module MkSyncSource (S : SyncSource) = struct
@@ -67,9 +82,19 @@ module MkSyncSource (S : SyncSource) = struct
   let make v = Sync_source v
 
   let () =
-    Queue.push sync_sources_handlers (function
-      | Sync_source v -> raise (Sync_source_name (S.to_string v))
-      | _ -> ())
+    sync_source_handlers :=
+      {
+        to_string =
+          (function Sync_source v -> Some (S.to_string v) | _ -> None);
+        time_implementation =
+          (function
+          | Sync_source v -> Some (S.time_implementation v)
+          | _ -> None);
+        latency = (function Sync_source v -> Some (S.latency v) | _ -> None);
+        max_latency =
+          (function Sync_source v -> Some (S.max_latency v) | _ -> None);
+      }
+      :: !sync_source_handlers
 end
 
 type sync_source_entry = {

--- a/src/core/base/source.ml
+++ b/src/core/base/source.ml
@@ -37,7 +37,10 @@ type sync = [ `Auto | `CPU | `None ]
 module SourceSync = Clock.MkSyncSource (struct
   type t = < id : string >
 
+  let time_implementation _ = Clock.time_implementation ()
   let to_string s = Printf.sprintf "source(id=%s)" s#id
+  let latency _ = Clock.conf_latency#get
+  let max_latency _ = Clock.conf_max_latency#get
 end)
 
 let sync_source_changed a b =

--- a/src/core/base/tools/liq_time.ml
+++ b/src/core/base/tools/liq_time.ml
@@ -35,6 +35,14 @@ end
 
 type implementation = (module T)
 
+let set_offset (module M : T) off : implementation =
+  (module struct
+    include M
+
+    let time () = M.(time () |-| off)
+    let sleep_until t = M.sleep_until M.(t |+| off)
+  end)
+
 let unix : implementation = (module Unix)
 let implementations : (string, implementation) Hashtbl.t = Hashtbl.create 2
 let () = Hashtbl.replace implementations "ocaml" unix

--- a/src/core/base/tools/liq_time.mli
+++ b/src/core/base/tools/liq_time.mli
@@ -15,5 +15,10 @@ end
 
 type implementation = (module T)
 
+(** [set_offset impl off] returns a new time implementation with [off] as its
+    origin: [time ()] returns [raw_time () - off] and [sleep_until] adds [off]
+    back before delegating. *)
+val set_offset : implementation -> t -> implementation
+
 val unix : implementation
 val implementations : (string, implementation) Hashtbl.t

--- a/src/core/optionals/alsa/alsa_settings.ml
+++ b/src/core/optionals/alsa/alsa_settings.ml
@@ -25,7 +25,10 @@
 module SyncSource = Clock.MkSyncSource (struct
   type t = unit
 
+  let time_implementation () = Clock.unconstrained_time
   let to_string _ = "alsa"
+  let latency () = Clock.conf_latency#get
+  let max_latency () = Clock.conf_max_latency#get
 end)
 
 let sync_source = SyncSource.make ()

--- a/src/core/optionals/ao/ao_out.ml
+++ b/src/core/optionals/ao/ao_out.ml
@@ -27,7 +27,10 @@ open Ao
 module SyncSource = Clock.MkSyncSource (struct
   type t = unit
 
+  let time_implementation () = Clock.unconstrained_time
   let to_string _ = "ao"
+  let latency () = Clock.conf_latency#get
+  let max_latency () = Clock.conf_max_latency#get
 end)
 
 let sync_source = SyncSource.make ()

--- a/src/core/optionals/ndi/ndi_out.ml
+++ b/src/core/optionals/ndi/ndi_out.ml
@@ -28,7 +28,10 @@ open Ndi_format
 module SyncSource = Clock.MkSyncSource (struct
   type t = unit
 
+  let time_implementation () = Clock.unconstrained_time
   let to_string _ = "ndi"
+  let latency () = Clock.conf_latency#get
+  let max_latency () = Clock.conf_max_latency#get
 end)
 
 let sync_source = SyncSource.make ()

--- a/src/core/optionals/oss/oss_io.ml
+++ b/src/core/optionals/oss/oss_io.ml
@@ -29,7 +29,10 @@ external set_rate : Unix.file_descr -> int -> int = "caml_oss_dsp_speed"
 module SyncSource = Clock.MkSyncSource (struct
   type t = unit
 
+  let time_implementation () = Clock.unconstrained_time
   let to_string _ = "oss"
+  let latency () = Clock.conf_latency#get
+  let max_latency () = Clock.conf_max_latency#get
 end)
 
 let sync_source = SyncSource.make ()

--- a/src/core/optionals/portaudio/portaudio_io.ml
+++ b/src/core/optionals/portaudio/portaudio_io.ml
@@ -25,7 +25,10 @@ open Mm
 module SyncSource = Clock.MkSyncSource (struct
   type t = unit
 
+  let time_implementation () = Clock.unconstrained_time
   let to_string _ = "portaudio"
+  let latency () = Clock.conf_latency#get
+  let max_latency () = Clock.conf_max_latency#get
 end)
 
 let sync_source = SyncSource.make ()

--- a/src/core/optionals/pulseaudio/pulseaudio_io.ml
+++ b/src/core/optionals/pulseaudio/pulseaudio_io.ml
@@ -26,7 +26,10 @@ open Pulseaudio
 module SyncSource = Clock.MkSyncSource (struct
   type t = unit
 
+  let time_implementation () = Clock.unconstrained_time
   let to_string _ = "pulseaudio"
+  let latency () = Clock.conf_latency#get
+  let max_latency () = Clock.conf_max_latency#get
 end)
 
 let sync_source = SyncSource.make ()

--- a/src/core/optionals/srt/srt_io.ml
+++ b/src/core/optionals/srt/srt_io.ml
@@ -114,7 +114,10 @@ let getaddrinfo ~(log : Log.t) ~prefer_address address port =
 module SyncSource = Clock.MkSyncSource (struct
   type t = unit
 
+  let time_implementation () = Clock.unconstrained_time
   let to_string _ = "srt"
+  let latency () = Clock.conf_latency#get
+  let max_latency () = Clock.conf_max_latency#get
 end)
 
 let sync_source = SyncSource.make ()


### PR DESCRIPTION
## Summary

This is groundwork to allow APIs with their own notion of time (e.g. JACK, hardware audio devices) to fully take over the clock thread's timing, rather than having liquidsoap's CPU clock fight against the hardware's natural pace.

The key insight is that instead of the clock knowing *about* self-sync as a special boolean flag, each sync source now declares its own timing model — including its time implementation, sleep latency threshold, and max latency before a reset. The clock just follows it.

### Changes

- **`Liq_time.set_offset`**: wraps a time implementation so `time()` returns `raw - offset` and `sleep_until` adds the offset back. Used at clock start to anchor `t=0` to wall time, and on self-sync transitions to re-anchor the new time implementation to the clock's current logical position — so `time()` always returns time relative to when the clock started ticking. `t0` is removed from `active_params`; other time fields (`frame_duration`, `log_delay`, `log_delay_threshold`, `last_catchup_log`) are now plain `float`s rather than `Liq_time.t` values.

- **`Clock.unconstrained_time`**: a time implementation that always returns `0` and is a no-op for `sleep_until`. Self-sync sources (ALSA, PortAudio, OSS, PulseAudio, NDI, SRT, AO) declare this, signalling they drive their own clock and do not need liquidsoap to sleep on their behalf.

- **`time_implementation`, `latency`, and `max_latency` in `SyncSource`**: the `MkSyncSource` functor now requires all three. `_after_tick` reads `latency` (sleep threshold) and `max_latency` (reset threshold) from the current sync source, falling back to `conf_latency#get` / `conf_max_latency#get`. The single `sync_source_handlers` list replaces the old exception-based `sync_sources_handlers` queue, using a `sync_source_handler` record with all four fields (`to_string`, `time_implementation`, `latency`, `max_latency`) and `List.find_map` for early exit.

- **`sync_source_state` cache**: `current_sync_source` stores a `sync_source_state option` (with `sync_source`, `latency`, and `max_latency` fields) instead of a bare `sync_source option`. The `latency` and `max_latency` values are resolved via handler lookup once when the sync source changes, so `_after_tick` — which runs on every streaming tick — reads them with a single record destructure rather than traversing the handler list on each call.

- **`current_sync_source` replaces `is_self_sync`**: the clock stores the active `sync_source option` instead of a boolean. When the sync source changes (gain, loss, or swap), `time_implementation` is updated via `set_offset` to match the new source's timing model while preserving the clock's logical position. All three transitions are logged explicitly.

- **`_check_self_sync` (renamed from `_self_sync`)**: returns `unit`; the `~self_sync` parameter is removed from `_after_tick`. Self-sync behavior emerges naturally from `unconstrained_time` — `sleep_until` is a no-op, so the clock never blocks without special-casing in the tick loop.

- **Config renames**: `conf_clock_preferred` → `conf_preferred` and `conf_clock_latency` → `conf_latency` for consistency; both are now exported in `clock.mli`.

## Test plan

- [ ] Build passes: `dune build`
- [ ] Basic sanity: `./liquidsoap -h output.ao`
- [ ] Verify self-sync log messages appear when connecting a hardware source