### PR TITLE
clock: simplify unification logic and add documentation

### DIFF
--- a/src/core/base/clock.ml
+++ b/src/core/base/clock.ml
@@ -178,17 +178,6 @@ let string_of_controller = function
   | `Clock c -> Printf.sprintf "clock %s" (id c)
   | `Other (c, o) -> Printf.sprintf "%s %s" c o#id
 
-let unifiable_controller ~unify c c' =
-  match (c, c') with
-    | `None, _ | _, `None -> true
-    | `Other (c, o), `Other (c', o') -> c = c' && o == o'
-    | `Clock c, `Clock c' -> (
-        try
-          unify c c';
-          true
-        with _ -> false)
-    | _ -> false
-
 let _set_id _clock new_id =
   if Unifier.deref _clock.id <> Some new_id then
     Unifier.set _clock.id (Some (generate_id new_id))
@@ -305,63 +294,66 @@ let rec check_sub_clocks ~pos _c _c' =
         raise (Liquidsoap_lang.Error.Clock_loop (pos, _descr _c, _descr _c'));
       check_sub_clocks ~pos _x _c')
 
-let unify =
-  let _unify ~pos c c' =
-    let clock = Unifier.deref c in
-    let clock' = Unifier.deref c' in
-    check_sub_clocks ~pos clock clock';
-    check_sub_clocks ~pos clock' clock;
-    (match
-       (Unifier.deref clock.controller, Unifier.deref clock'.controller)
-     with
-      | _, `None -> Unifier.(clock'.controller <-- clock.controller)
-      | _ -> ());
-    Queue.flush_iter clock.pending_activations
-      (Queue.push clock'.pending_activations);
-    Queue.flush_iter clock.sub_clocks (Queue.push clock'.sub_clocks);
-    Queue.flush_iter clock.on_error (Queue.push clock'.on_error);
-    (match (Unifier.deref clock.id, Unifier.deref clock'.id) with
-      | None, None -> Unifier.(clock.id <-- clock'.id)
-      | Some _, None -> Unifier.(clock'.id <-- clock.id)
-      | None, Some _ -> Unifier.(clock.id <-- clock'.id)
-      | Some _, Some id ->
-          log#info "Clocks %s and %s both have id already set. Setting id to %s"
-            (descr c) (descr c') id;
-          Unifier.(clock.id <-- clock'.id));
-    Unifier.(c <-- c');
-    Queue.filter_out clocks (fun el -> el == c);
-    WeakQueue.filter_out pending_clocks (fun el -> el == c)
-  in
-  let rec unify ~pos c c' =
-    let _c = Unifier.deref c in
-    let _c' = Unifier.deref c' in
-    let _controller = Unifier.deref _c.controller in
-    let _controller' = Unifier.deref _c'.controller in
-    if not (unifiable_controller ~unify:(unify ~pos) _controller _controller')
-    then
+let do_merge ~pos ~loser ~winner =
+  let l = Unifier.deref loser and w = Unifier.deref winner in
+  check_sub_clocks ~pos l w;
+  check_sub_clocks ~pos w l;
+  (if Unifier.deref w.controller = `None then
+     Unifier.(w.controller <-- l.controller));
+  Queue.flush_iter l.pending_activations (Queue.push w.pending_activations);
+  Queue.flush_iter l.sub_clocks (Queue.push w.sub_clocks);
+  Queue.flush_iter l.on_error (Queue.push w.on_error);
+  (match (Unifier.deref l.id, Unifier.deref w.id) with
+    | None, _ -> Unifier.(l.id <-- w.id)
+    | Some _, None -> Unifier.(w.id <-- l.id)
+    | Some _, Some id ->
+        log#info "Clocks %s and %s both have id already set. Setting id to %s"
+          (descr loser) (descr winner) id;
+        Unifier.(l.id <-- w.id));
+  Unifier.(loser <-- winner);
+  Queue.filter_out clocks (fun el -> el == loser);
+  WeakQueue.filter_out pending_clocks (fun el -> el == loser)
+
+let rec unify ~pos c c' =
+  let clock = Unifier.deref c and clock' = Unifier.deref c' in
+  if clock == clock' then ()
+  else begin
+    let raise_clock_main () =
       raise
         Liquidsoap_lang.Error.(
           Clock_main
             {
               pos;
-              left_main = string_of_controller _controller;
+              left_main = string_of_controller (Unifier.deref clock.controller);
               left_child = descr c;
-              right_main = string_of_controller _controller';
+              right_main =
+                string_of_controller (Unifier.deref clock'.controller);
               right_child = descr c';
-            });
-    match (_c == _c', Atomic.get _c.state, Atomic.get _c'.state) with
-      | true, _, _ -> ()
-      | _, `Stopped s, `Stopped s' when s = s' -> _unify ~pos c c'
-      | _, `Stopped s, _
-        when s = `Automatic || (s :> sync_mode) = _sync ~pending:true _c' ->
-          _unify ~pos c c'
-      | _, _, `Stopped s'
-        when s' = `Automatic || _sync ~pending:true _c = (s' :> sync_mode) ->
-          _unify ~pos c' c
+            })
+    in
+    (match
+       (Unifier.deref clock.controller, Unifier.deref clock'.controller)
+     with
+      | `None, _ | _, `None -> ()
+      | `Other (k, o), `Other (k', o') when k = k' && o == o' -> ()
+      | `Clock ctl, `Clock ctl' -> (
+          try unify ~pos ctl ctl' with _ -> raise_clock_main ())
+      | _ -> raise_clock_main ());
+    let can_absorb ~winner ~candidate =
+      match Atomic.get candidate.state with
+        | `Stopped `Automatic -> true
+        | `Stopped s -> (s :> sync_mode) = _sync ~pending:true winner
+        | _ -> false
+    in
+    match (Atomic.get clock.state, Atomic.get clock'.state) with
+      | `Stopped s, `Stopped s' when s = s' -> do_merge ~pos ~loser:c ~winner:c'
+      | _ when can_absorb ~winner:clock' ~candidate:clock ->
+          do_merge ~pos ~loser:c ~winner:c'
+      | _ when can_absorb ~winner:clock ~candidate:clock' ->
+          do_merge ~pos ~loser:c' ~winner:c
       | _ ->
           raise (Liquidsoap_lang.Error.Clock_conflict (pos, descr c, descr c'))
-  in
-  unify
+  end
 
 let () =
   Lifecycle.before_core_shutdown ~name:"Clocks stop" (fun () ->

--- a/src/core/base/clock.mli
+++ b/src/core/base/clock.mli
@@ -20,6 +20,51 @@
 
  *****************************************************************************)
 
+(** Clocks drive the streaming loop in Liquidsoap. Each clock owns a set of
+    sources and ticks them forward in lockstep, one frame at a time.
+
+    {1 Clock hierarchy}
+
+    Clocks form a tree. The top-level clocks each run in their own thread and
+    determine the overall timing (CPU-bound, wall-clock, or free-running). Each
+    top-level clock may have passive {e sub-clocks} that it ticks as part of its
+    own tick, after processing its own sources. Sub-clocks are used by operators
+    that need to control a child source at a different rate or in a separate
+    scheduling domain (see [Child_support]).
+
+    Sub-clocks are registered and deregistered dynamically via
+    [register_sub_clock] / [deregister_sub_clock]. Operators that use a
+    sub-clock should register it when they wake up and deregister it when they
+    sleep, so that idle sub-clocks do not accumulate in the parent's tick loop.
+
+    {1 Source activation}
+
+    Sources are not directly added to a clock. Instead they are {e activated}:
+    [source#wake_up activating_source] pushes the source into the clock's
+    [pending_activations] queue and returns an [activation] token. The token
+    must be passed back to [source#sleep] to deactivate the source. A clock
+    drains its [pending_activations] queue at the start of each tick via
+    [_activate_pending_sources].
+
+    {1 Clock unification}
+
+    Every source carries a clock cell (a [Unifier.t]). When an operator is
+    constructed it calls [Clock.unify] on its own clock and each child's clock,
+    merging them into a single cell. This ensures that all sources in a
+    connected graph share the same clock. Unification checks that the clocks'
+    {e controllers} are compatible; incompatible controllers (e.g. two different
+    self-syncing sources) raise [Clock_main].
+
+    {1 Tick sequence}
+
+    On each tick a clock:
+    + drains [pending_activations], waking up newly added sources;
+    + calls [output] on every active and output source;
+    + fires [on_tick] callbacks;
+    + ticks each registered sub-clock that has not yet advanced this cycle;
+    + increments its tick counter;
+    + fires [after_tick] callbacks and handles timing/sleep. *)
+
 exception Invalid_state
 exception Has_stopped
 


### PR DESCRIPTION
## Changes

- `clock.mli`: add documentation block covering clock hierarchy, source activation, clock unification, and tick sequence.
- `clock.ml`: simplify the unification logic:
  - Replace the nested `_unify`/`unify` closure pattern with a flat `do_merge` and a top-level `let rec unify`.
  - Name merge arguments `loser`/`winner` to make the direction of merging explicit.
  - Extract `can_absorb` as a named helper for the sync compatibility check.
  - Inline `unifiable_controller` (called once, with an awkward self-referential callback) directly into `unify` as a controller compatibility match.
  - Remove the now-dead `unifiable_controller`.