### PR TITLE
ci: update and upgrade alpine packages before build

### DIFF
--- a/.github/workflows/build-posix.yml
+++ b/.github/workflows/build-posix.yml
@@ -114,6 +114,8 @@ jobs:
           APK_RELEASE: 0
         run: |
           cd /tmp/liquidsoap-full/liquidsoap
+          apk update
+          apk upgrade
           apk add alpine-sdk
           adduser opam abuild
           mkdir -p "${LIQ_TMP_DIR}"


### PR DESCRIPTION
## Summary

Run `apk update` and `apk upgrade` before installing `alpine-sdk` in the `build_posix` Alpine CI job to ensure the package index is current and all packages are up-to-date before building.