### PR TITLE
clock: defer detach to after_tick when clock is running

### DIFF
--- a/src/core/base/clock.ml
+++ b/src/core/base/clock.ml
@@ -201,17 +201,20 @@ let attach c s =
 
 let _detach x s =
   Queue.filter_out x.pending_activations (fun s' -> s == s');
+  let do_detach { outputs; active_sources; passive_sources } =
+    Queue.filter_out outputs (fun (a, s') ->
+        if s == s' then (
+          s#sleep a;
+          true)
+        else false);
+    WeakQueue.filter_out active_sources (fun s' -> s == s');
+    WeakQueue.filter_out passive_sources (fun s' -> s == s')
+  in
   match Atomic.get x.state with
     | `Stopped _ -> ()
-    | `Stopping { outputs; active_sources; passive_sources }
-    | `Started { outputs; active_sources; passive_sources } ->
-        Queue.filter_out outputs (fun (a, s') ->
-            if s == s' then (
-              s#sleep a;
-              true)
-            else false);
-        WeakQueue.filter_out active_sources (fun s' -> s == s');
-        WeakQueue.filter_out passive_sources (fun s' -> s == s')
+    | `Stopping params -> do_detach params
+    | `Started params ->
+        Queue.push params.after_tick (fun () -> do_detach params)
 
 let detach c s = _detach (Unifier.deref c) s
 


### PR DESCRIPTION
## Summary

When `detach` is called on a running clock, the source removal was previously done inline, which means it could mutate `outputs`, `active_sources`, or `passive_sources` mid-tick from another thread.

This change defers the actual removal to an `after_tick` callback when the clock is in `Started` state, so the mutation happens at a safe boundary between ticks. When the clock is `Stopping`, the removal is still immediate (the tick loop may not run again).

The refactor also extracts the removal logic into a local `do_detach` helper to avoid duplication.