### PR TITLE
Prevent crashing when getting out-of-bound mark in split_frame

### DIFF
--- a/src/core/base/source.ml
+++ b/src/core/base/source.ml
@@ -504,8 +504,8 @@ class virtual operator ?(stack = []) ?clock ~name sources =
         | 0 :: _ -> (self#empty_frame, Some frame)
         | p :: _ when p > pos ->
             self#log#important
-              "split_frame: ignoring out-of-bounds track mark at %d \
-               (frame position: %d)"
+              "split_frame: ignoring out-of-bounds track mark at %d (frame \
+               position: %d)"
               p pos;
             (frame, None)
         | p :: _ -> (Frame.slice frame p, Some (Frame.after frame p))


### PR DESCRIPTION
Fixes #5044

Adds a bounds check in `split_frame` to prevent `Invalid_argument("Content.sub")` when a track mark position exceeds the content length. Logs a warning when this happens to help to see where the issue is upstream.

The crash occurs when `add()` wraps a `source.dynamic` that switches to `source.fail()`. `Frame.after` receives a track mark position that's beyond the actual content length, and `Content.sub` raises `Invalid_argument`.

Works without crashing: 
```
split_frame: ignoring out-of-bounds track mark at 4608 (frame position: 3840)
```

Note: I'm not an OCaml developer, but since this was blocking my other endeavors, I tried to trace this to the best of my ability.