### PR TITLE
[Backport v2.4.x-latest] Prevent crashing when getting out-of-bound mark in split_frame

### DIFF
--- a/src/core/base/source.ml
+++ b/src/core/base/source.ml
@@ -491,8 +491,15 @@ class virtual operator ?(stack = []) ?clock ~name sources =
       fun field lift data -> Frame.set_data self#get_frame field lift data
 
     method private split_frame frame =
+      let pos = Frame.position frame in
       match Frame.track_marks frame with
         | 0 :: _ -> (self#empty_frame, Some frame)
+        | p :: _ when p > pos ->
+            self#log#important
+              "split_frame: ignoring out-of-bounds track mark at %d (frame \
+               position: %d)"
+              p pos;
+            (frame, None)
         | p :: _ -> (Frame.slice frame p, Some (Frame.after frame p))
         | [] -> (frame, None)
 


### PR DESCRIPTION
Backport 6f9f2bcc469045a7aa0a516e08c61121bf36485b from #5054.