### PR TITLE
[Backport v2.4.x-latest] Allow sequence to do early release of the sources it does not use.

### DIFF
--- a/src/core/base/operators/sequence.ml
+++ b/src/core/base/operators/sequence.ml
@@ -82,6 +82,7 @@ class sequence ?(name = "sequence") ?(merge = false) ?(single_track = true)
             else (
               self#log#info "Finished with %s" s#id;
               Atomic.set seq_sources rest;
+              self#release_source s;
               self#get_stateful_source ~source_skipped:true
                 ~reselect:(match reselect with `Force -> `Ok | v -> v)
                 ())

--- a/src/core/base/source.ml
+++ b/src/core/base/source.ml
@@ -106,6 +106,16 @@ class virtual operator ?(stack = []) ?clock ~name sources =
     val mutable sources : (Clock.activation option * operator) list =
       List.map (fun s -> (None, s)) sources
 
+    method release_source s =
+      let rec filter_source = function
+        | (a, s') :: ret when s == s' ->
+            Option.iter s'#sleep a;
+            ret
+        | v :: ret -> v :: filter_source ret
+        | [] -> []
+      in
+      sources <- filter_source sources
+
     method add_watcher w = watchers <- w :: watchers
     method private iter_watchers fn = List.iter fn watchers
     method clock = clock

--- a/src/core/base/source.mli
+++ b/src/core/base/source.mli
@@ -124,6 +124,10 @@ object
   (** The source type. Defaults to [`Passive] *)
   method source_type : source_type
 
+  (** Remove the given source from the list of controlled sources. For advanced
+      use only! *)
+  method release_source : source -> unit
+
   (** [true] if the source needs to be animated on each clock tick. *)
   method active : bool
 


### PR DESCRIPTION
Backport b0227a7d73d78539bf318bfedab75dc2498dd2b0 from #5079.