### PR TITLE
source: add has_track_marks tracking

### DIFF
--- a/src/core/base/lang_source.ml
+++ b/src/core/base/lang_source.ml
@@ -569,6 +569,14 @@ let source_methods =
       value = (fun s -> bool s#fallible);
     };
     {
+      name = "has_track_marks";
+      scheme = ([], fun_t [] bool_t);
+      descr =
+        "`true` if the last completed streaming cycle produced a frame \
+         containing at least one track mark.";
+      value = (fun s -> val_fun [] (fun _ -> bool s#has_track_marks));
+    };
+    {
       name = "clock";
       scheme = ([], Lang_clock.ClockValue.base_t);
       descr = "The source's clock";

--- a/src/core/base/source.ml
+++ b/src/core/base/source.ml
@@ -407,6 +407,8 @@ class virtual operator ?(stack = []) ?clock ~name sources =
           | _ -> false)
       else false
 
+    val _has_track_marks = Atomic.make false
+    method has_track_marks = Atomic.get _has_track_marks
     val mutable _cache = None
     val mutable consumed = 0
     val mutable on_before_streaming_cycle = []
@@ -437,6 +439,7 @@ class virtual operator ?(stack = []) ?clock ~name sources =
     method private before_streaming_cycle =
       match Atomic.get streaming_state with
         | `Pending ->
+            Atomic.set _has_track_marks false;
             List.iter (fun fn -> fn ()) on_before_streaming_cycle;
             consumed <- 0;
             let cache_pos = self#cache_pos in
@@ -468,8 +471,10 @@ class virtual operator ?(stack = []) ?clock ~name sources =
 
     method private after_streaming_cycle =
       (match (Atomic.get streaming_state, consumed) with
-        | `Done buf, n when n < Frame.position buf ->
-            _cache <- Some (Frame.append (Frame.after buf n) self#cache)
+        | `Done buf, n ->
+            if Frame.has_track_marks buf then Atomic.set _has_track_marks true;
+            if n < Frame.position buf then
+              _cache <- Some (Frame.append (Frame.after buf n) self#cache)
         | _ -> ());
       List.iter (fun fn -> fn ()) on_after_streaming_cycle;
       Atomic.set streaming_state `Pending

--- a/src/core/base/source.mli
+++ b/src/core/base/source.mli
@@ -129,6 +129,10 @@ object
       use only! *)
   method release_source : source -> unit
 
+  (** [true] if the last completed streaming cycle produced a frame containing
+      at least one track mark. Reset to [false] at the start of each cycle. *)
+  method has_track_marks : bool
+
   (** [true] if the source needs to be animated on each clock tick. *)
   method active : bool
 

--- a/src/core/builtins/builtins_source.ml
+++ b/src/core/builtins/builtins_source.ml
@@ -106,6 +106,16 @@ let _ =
     (fun p -> Lang.bool (Lang.to_source (List.assoc "" p))#is_ready)
 
 let _ =
+  Lang.add_builtin ~base:source "has_track_marks"
+    ~category:(`Source `Liquidsoap)
+    ~descr:
+      "`true` if the last completed streaming cycle produced a frame \
+       containing at least one track mark."
+    [("", Lang.source_t (Lang.univ_t ()), None, None)]
+    Lang.bool_t
+    (fun p -> Lang.bool (Lang.to_source (List.assoc "" p))#has_track_marks)
+
+let _ =
   Lang.add_builtin ~base:source "is_up" ~category:`System
     [("", Lang.source_t (Lang.univ_t ()), None, None)]
     Lang.bool_t ~descr:"Check whether a source is up."


### PR DESCRIPTION
## Summary

Adds an atomic boolean `has_track_marks` to the source class that tracks whether the last completed streaming cycle produced a frame containing at least one track mark. The flag is reset to `false` at the start of each streaming cycle and set to `true` in `after_streaming_cycle` if `Frame.has_track_marks` holds.

Exposed as:
- `s.has_track_marks()` — source method available on all source values
- `source.has_track_marks(s)` — standalone builtin function

## Test plan

- [ ] `dune build` passes
- [ ] `source.has_track_marks(s)` returns `false` mid-track and `true` at track boundaries