### PR TITLE
[Backport v2.4.x-latest] lang: add call stack to Invalid_value errors

### DIFF
--- a/src/core/base/converters/audio/native_audio_converter.ml
+++ b/src/core/base/converters/audio/native_audio_converter.ml
@@ -44,7 +44,8 @@ let quality_of_string = function
         (Error.Invalid_value
            ( Lang.string s,
              "Native resampling quality must either be \"nearest\" or \
-              \"linear\"." ))
+              \"linear\".",
+             [] ))
 
 let samplerate_converter _ =
   let mode = quality_of_string quality_conf#get in

--- a/src/core/base/io/udp_io.ml
+++ b/src/core/base/io/udp_io.ml
@@ -224,7 +224,7 @@ let _ =
         with Not_found ->
           raise
             (Error.Invalid_value
-               (fmt, "Cannot get a stream encoder for that format"))
+               (fmt, "Cannot get a stream encoder for that format", []))
       in
       let source = Lang.assoc "" 2 p in
       (new output
@@ -260,7 +260,8 @@ let _ =
               raise
                 (Error.Invalid_value
                    ( Lang.assoc "" 1 p,
-                     "Cannot get a stream decoder for this MIME" ))
+                     "Cannot get a stream decoder for this MIME",
+                     [] ))
           | Some decoder_factory -> decoder_factory
       in
       (new input ~hostname ~port ~bufferize ~get_stream_decoder

--- a/src/core/base/operators/add.ml
+++ b/src/core/base/operators/add.ml
@@ -415,7 +415,8 @@ let _ =
                 || Content_timed.Track_marks.is_format format
               then (audio_tracks, video_tracks)
               else
-                raise (Error.Invalid_value (sources_val, "Invalid source type")))
+                raise
+                  (Error.Invalid_value (sources_val, "Invalid source type", [])))
             ([], []) content_type
         in
         let audio_tracks =

--- a/src/core/base/operators/echo.ml
+++ b/src/core/base/operators/echo.ml
@@ -90,7 +90,8 @@ let _ =
         (* Check the initial value, wrap the getter with a converter. *)
         if feedback () > 0. then
           raise
-            (Error.Invalid_value (f "feedback", "feedback should be negative"));
+            (Error.Invalid_value
+               (f "feedback", "feedback should be negative", []));
         fun () -> Audio.lin_of_dB (feedback ())
       in
       new echo src duration feedback pp)

--- a/src/core/base/operators/filter.ml
+++ b/src/core/base/operators/filter.ml
@@ -135,6 +135,6 @@ let filter =
           | _ ->
               raise
                 (Error.Invalid_value
-                   (mode, "valid values are low|high|band|notch"))
+                   (mode, "valid values are low|high|band|notch", []))
       in
       (new filter src freq q wet mode :> Source.source))

--- a/src/core/base/operators/filter_rc.ml
+++ b/src/core/base/operators/filter_rc.ml
@@ -115,6 +115,8 @@ let _ =
         match Lang.to_string mode with
           | "low" -> Low_pass
           | "high" -> High_pass
-          | _ -> raise (Error.Invalid_value (mode, "valid values are low|high"))
+          | _ ->
+              raise
+                (Error.Invalid_value (mode, "valid values are low|high", []))
       in
       (new filter src freq wet mode :> Source.source))

--- a/src/core/base/operators/noblank.ml
+++ b/src/core/base/operators/noblank.ml
@@ -238,7 +238,7 @@ let extract p =
     fun () ->
       let t = t () in
       if t > 0. then
-        raise (Error.Invalid_value (v, "threshold should be negative"));
+        raise (Error.Invalid_value (v, "threshold should be negative", []));
       Audio.lin_of_dB t
   in
   let ts = Lang.to_bool_getter (f "track_sensitive") in

--- a/src/core/base/operators/switch.ml
+++ b/src/core/base/operators/switch.ml
@@ -343,7 +343,7 @@ let _ =
         if ltr > l then
           raise
             (Error.Invalid_value
-               (List.assoc "transitions" p, "Too many transitions"));
+               (List.assoc "transitions" p, "Too many transitions", []));
         if ltr < l then tr @ List.init (l - ltr) (fun _ -> default_transition)
         else tr
       in
@@ -371,7 +371,8 @@ let _ =
           raise
             (Error.Invalid_value
                ( List.assoc "single" p,
-                 "there should be exactly one flag per children" ))
+                 "there should be exactly one flag per children",
+                 [] ))
       in
       new switch
         ~replay_meta ~override_meta ~all_predicates ~transition_length:tl

--- a/src/core/base/operators/video_fade.ml
+++ b/src/core/base/operators/video_fade.ml
@@ -241,7 +241,7 @@ let rec transition_of_string p transition =
     | _ ->
         raise
           (Error.Invalid_value
-             (List.assoc "transition" p, "Invalid transition kind"))
+             (List.assoc "transition" p, "Invalid transition kind", []))
 
 let extract p =
   ( Lang.to_float (List.assoc "duration" p),
@@ -267,7 +267,7 @@ let extract p =
              let msg =
                "The 'type' parameter should be 'lin','sin','log' or 'exp'!"
              in
-             raise (Error.Invalid_value (mode, msg))
+             raise (Error.Invalid_value (mode, msg, []))
      in
      fun l ->
        let l = float l in

--- a/src/core/base/outputs/harbor_output.ml
+++ b/src/core/base/outputs/harbor_output.ml
@@ -303,12 +303,16 @@ class output p =
     if chunk > buflen then
       raise
         (Error.Invalid_value
-           (List.assoc "buffer" p, "Maximum buffering inferior to chunk length"))
+           ( List.assoc "buffer" p,
+             "Maximum buffering inferior to chunk length",
+             [] ))
     else ();
     if burst > buflen then
       raise
         (Error.Invalid_value
-           (List.assoc "buffer" p, "Maximum buffering inferior to burst length"))
+           ( List.assoc "buffer" p,
+             "Maximum buffering inferior to burst length",
+             [] ))
     else ()
   in
   let source_val = Lang.assoc "" 2 p in

--- a/src/core/base/outputs/hls_output.ml
+++ b/src/core/base/outputs/hls_output.ml
@@ -399,7 +399,7 @@ class hls_output p =
       with _ ->
         raise
           (Error.Invalid_value
-             (directory_val, "Could not create or open output directory!")))
+             (directory_val, "Could not create or open output directory!", [])))
   in
   let persist_at =
     Option.map
@@ -419,7 +419,8 @@ class hls_output p =
                     "Error while creating directory for persisting state at \
                      %s: %s"
                     (Lang_string.quote_string filename)
-                    (Printexc.to_string exn) )));
+                    (Printexc.to_string exn),
+                  [] )));
         filename)
       (Lang.to_option (List.assoc "persist_at" p))
   in
@@ -452,7 +453,7 @@ class hls_output p =
     let l = Lang.to_list streams in
     if l = [] then
       raise
-        (Error.Invalid_value (streams, "The list of streams cannot be empty"));
+        (Error.Invalid_value (streams, "The list of streams cannot be empty", []));
     l
   in
   let mk_streams, streams =
@@ -464,7 +465,7 @@ class hls_output p =
       let encoder_factory =
         try Encoder.get_factory format
         with Not_found ->
-          raise (Error.Invalid_value (fmt_val, "Unsupported format"))
+          raise (Error.Invalid_value (fmt_val, "Unsupported format", []))
       in
       let encoder =
         encoder_factory ~hls:true ~pos:(Value.pos fmt_val) name
@@ -486,7 +487,8 @@ class hls_output p =
                                "Bandwidth for stream %S cannot be inferred \
                                 from codec, please specify it with: \
                                 `%%encoder(...).{bandwidth = <number>, ...}`"
-                               name )))))
+                               name,
+                             [] )))))
       in
       let codecs =
         Lazy.from_fun (fun () ->
@@ -504,7 +506,8 @@ class hls_output p =
                                "Stream info for stream %S cannot be inferred \
                                 from codec, please specify it with: \
                                 `%%encoder(...).{codecs = \"...\", ...}`"
-                               name )))))
+                               name,
+                             [] )))))
       in
       let extname =
         try Lang.to_string (List.assoc "extname" stream_info)
@@ -518,7 +521,8 @@ class hls_output p =
                      "File extension for stream %S cannot be inferred from \
                       codec, please specify it with: `%%encoder(...).{extname \
                       = \"...\", ...}`"
-                     name )))
+                     name,
+                   [] )))
       in
       let extname = if extname = "mp4" then "m4s" else extname in
       let video_size =

--- a/src/core/base/outputs/icecast2.ml
+++ b/src/core/base/outputs/icecast2.ml
@@ -348,7 +348,7 @@ class output p =
         | _ ->
             raise
               (Error.Invalid_value
-                 (m, "Valid values are: 'source' 'put' or 'post'."))
+                 (m, "Valid values are: 'source' 'put' or 'post'.", []))
     in
     let v = List.assoc "protocol" p in
     match Lang.to_string v with
@@ -357,7 +357,7 @@ class output p =
       | _ ->
           raise
             (Error.Invalid_value
-               (v, "Valid values are 'http' (icecast) and 'icy' (shoutcast)"))
+               (v, "Valid values are 'http' (icecast) and 'icy' (shoutcast)", []))
   in
   let send_icy_metadata =
     match
@@ -377,7 +377,8 @@ class output p =
             (Error.Invalid_value
                ( List.assoc "send_icy_metadata" p,
                  "Could not guess send_icy_metadata for this format, please \
-                  specify either true or false." ))
+                  specify either true or false.",
+                 [] ))
   in
   let icy_metadata =
     List.map Lang.to_string (Lang.to_list (List.assoc "icy_metadata" p))
@@ -424,7 +425,9 @@ class output p =
       | _ ->
           raise
             (Error.Invalid_value
-               (v, "Valid values are: `\"system\"`, `\"ipv4\"` or `\"ipv6\"`."))
+               ( v,
+                 "Valid values are: `\"system\"`, `\"ipv4\"` or `\"ipv6\"`.",
+                 [] ))
   in
   let transport = (transport :> Cry.transport) in
   let transport =

--- a/src/core/base/outputs/output.ml
+++ b/src/core/base/outputs/output.ml
@@ -55,7 +55,7 @@ class virtual output ~output_kind ?clock ?(name = "") ~infallible
       (* This should be done before the active_operator initializer attaches us
          to a clock. *)
       if !fallibility_check && infallible && source#fallible then
-        raise (Error.Invalid_value (val_source, "That source is fallible."))
+        raise (Error.Invalid_value (val_source, "That source is fallible.", []))
 
     initializer Typing.(source#frame_type <: self#frame_type)
     inherit active_operator ?clock ~name:output_kind [source]

--- a/src/core/base/outputs/pipe_output.ml
+++ b/src/core/base/outputs/pipe_output.ml
@@ -30,7 +30,7 @@ let encoder_factory ?format format_val =
   in
   try (Encoder.get_factory format) ~hls:false ~pos:(Value.pos format_val)
   with Not_found ->
-    raise (Error.Invalid_value (format_val, "Unsupported encoding format"))
+    raise (Error.Invalid_value (format_val, "Unsupported encoding format", []))
 
 let base_proto =
   ( "export_cover_metadata",
@@ -158,7 +158,7 @@ class url_output p =
     if not (Encoder.url_output format) then
       raise
         (Error.Invalid_value
-           (format_val, "Encoding format does not support output url!"))
+           (format_val, "Encoding format does not support output url!", []))
   in
   let format = Encoder.with_url_output format url in
   let source = Lang.assoc "" 2 p in

--- a/src/core/base/sources/harbor_input.ml
+++ b/src/core/base/sources/harbor_input.ml
@@ -472,7 +472,8 @@ let _ =
         raise
           (Error.Invalid_value
              ( List.assoc "max" p,
-               "Maximum buffering inferior to pre-buffered data" ));
+               "Maximum buffering inferior to pre-buffered data",
+               [] ));
       let pos = Lang.pos p in
       new http_input_server
         ~pos ~transport ~timeout ~bufferize ~max ~login ~mountpoint ~dumpfile

--- a/src/core/base/tools/child_support.ml
+++ b/src/core/base/tools/child_support.ml
@@ -34,7 +34,8 @@ class virtual base ~check_self_sync children_val =
                 (Error.Invalid_value
                    ( c,
                      "This source may control its own latency and cannot be \
-                      used with this operator." )))
+                      used with this operator.",
+                     [] )))
           children_val
 
     method virtual id : string

--- a/src/core/base/tools/icecast_utils.ml
+++ b/src/core/base/tools/icecast_utils.ml
@@ -193,7 +193,7 @@ module Icecast_v (M : Icecast_t) = struct
     let encoder_factory =
       try Encoder.get_factory enc
       with Not_found ->
-        raise (Error.Invalid_value (v, "No encoder found for that format"))
+        raise (Error.Invalid_value (v, "No encoder found for that format", []))
     in
     let format =
       let f = Lang.to_string (List.assoc "format" p) in
@@ -205,7 +205,8 @@ module Icecast_v (M : Icecast_t) = struct
               raise
                 (Error.Invalid_value
                    ( Lang.assoc "" 1 p,
-                     "No format (mime) found, please specify one." )))
+                     "No format (mime) found, please specify one.",
+                     [] )))
     in
     { factory = encoder_factory ~pos:(Value.pos v); format; info }
 end

--- a/src/core/builtins/builtins_clock.ml
+++ b/src/core/builtins/builtins_clock.ml
@@ -89,7 +89,8 @@ let _ =
             (Error.Invalid_value
                ( sync,
                  "Invalid sync mode! Should be one of: `\"auto\"`, `\"CPU\"`, \
-                  `\"unsynced\"` or `\"passive\"`" ))
+                  `\"unsynced\"` or `\"passive\"`",
+                 [] ))
       in
       Lang_clock.ClockValue.to_value
         (Clock.create ~stack:(Lang.pos p) ?on_error ?id ~sync ()))

--- a/src/core/builtins/builtins_cry.ml
+++ b/src/core/builtins/builtins_cry.ml
@@ -107,7 +107,9 @@ let _ =
           | _ ->
               raise
                 (Error.Invalid_value
-                   (v, "protocol should be one of: 'icy', 'http' or 'https'."))
+                   ( v,
+                     "protocol should be one of: 'icy', 'http' or 'https'.",
+                     [] ))
       in
       let mount =
         match protocol with

--- a/src/core/builtins/builtins_time.ml
+++ b/src/core/builtins/builtins_time.ml
@@ -255,8 +255,9 @@ let _ =
       let entry = Lang.to_string entry_val in
       let ({ Cron.week_day; month; month_day; hour; minute } as entry) =
         try Cron.parse entry with
-          | Cron.Parse_error s -> raise (Error.Invalid_value (entry_val, s))
-          | _ -> raise (Error.Invalid_value (entry_val, "Invalid CRON entry!"))
+          | Cron.Parse_error s -> raise (Error.Invalid_value (entry_val, s, []))
+          | _ ->
+              raise (Error.Invalid_value (entry_val, "Invalid CRON entry!", []))
       in
       let test =
         Lang.val_fun

--- a/src/core/optionals/ffmpeg/builtins_ffmpeg_encoder.ml
+++ b/src/core/optionals/ffmpeg/builtins_ffmpeg_encoder.ml
@@ -451,13 +451,15 @@ let mk_encoder mode =
                 ( format_val,
                   Printf.sprintf
                     "Muxer options are not supported for inline encoders: %s"
-                    (Ffmpeg_format.string_of_options format.Ffmpeg_format.opts)
-                ));
+                    (Ffmpeg_format.string_of_options format.Ffmpeg_format.opts),
+                  [] ));
 
          if format.Ffmpeg_format.format <> None then
            raise
              (Error.Invalid_value
-                (format_val, "Format option is not supported inline encoders"));
+                ( format_val,
+                  "Format option is not supported inline encoders",
+                  [] ));
 
          let mk_encode_frame generator =
            let output_frame_t = Type.fresh output_frame_t in
@@ -531,7 +533,8 @@ let mk_encoder mode =
                (Error.Invalid_value
                   ( format_val,
                     Printf.sprintf "Unrecognized options: %s"
-                      (Ffmpeg_format.string_of_options original_opts) ));
+                      (Ffmpeg_format.string_of_options original_opts),
+                    [] ));
 
            encode_frame
          in

--- a/src/core/optionals/ffmpeg/builtins_ffmpeg_filters.ml
+++ b/src/core/optionals/ffmpeg/builtins_ffmpeg_filters.ml
@@ -329,7 +329,7 @@ let mk_options options =
           in
           let x =
             try from_value v
-            with _ -> raise (Error.Invalid_value (v, "Invalid value"))
+            with _ -> raise (Error.Invalid_value (v, "Invalid value", []))
           in
           (match min with
             | Some m when x < m ->
@@ -337,7 +337,8 @@ let mk_options options =
                   (Error.Invalid_value
                      ( v,
                        Printf.sprintf "%s must be more than %s" name
-                         (to_string m) ))
+                         (to_string m),
+                       [] ))
             | _ -> ());
           (match max with
             | Some m when m < x ->
@@ -345,7 +346,8 @@ let mk_options options =
                   (Error.Invalid_value
                      ( v,
                        Printf.sprintf "%s must be less than %s" name
-                         (to_string m) ))
+                         (to_string m),
+                       [] ))
             | _ -> ());
           (match values with
             | _ :: _ when List.find_opt (fun (_, v) -> v = x) values = None ->
@@ -354,7 +356,8 @@ let mk_options options =
                      ( v,
                        Printf.sprintf "%s should be one of: %s" name
                          (String.concat ", "
-                            (List.map (fun (_, v) -> to_string v) values)) ))
+                            (List.map (fun (_, v) -> to_string v) values)),
+                       [] ))
             | _ -> ());
           let x =
             match default with
@@ -419,7 +422,8 @@ let mk_options options =
                 in
                 let values =
                   try array_from_value v
-                  with _ -> raise (Error.Invalid_value (v, "Invalid value"))
+                  with _ ->
+                    raise (Error.Invalid_value (v, "Invalid value", []))
                 in
                 let array_args =
                   List.map
@@ -441,8 +445,8 @@ let get_config graph =
         raise
           (Error.Invalid_value
              ( graph,
-               "Graph variables cannot be used outside of ffmpeg.filter.create!"
-             ))
+               "Graph variables cannot be used outside of ffmpeg.filter.create!",
+               [] ))
 
 let apply_filter ~args_parser ~filter ~sources_t p =
   Avfilter.(
@@ -510,8 +514,8 @@ let apply_filter ~args_parser ~filter ~sources_t p =
                       (Error.Invalid_value
                          ( v,
                            Printf.sprintf
-                             "Invalid number of input for filter %s" filter.name
-                         ));
+                             "Invalid number of input for filter %s" filter.name,
+                           [] ));
                   List.nth inputs idx)
                 else Lang.assoc "" (idx + ofs + 1) p
               in

--- a/src/core/optionals/ffmpeg/ffmpeg_io.ml
+++ b/src/core/optionals/ffmpeg/ffmpeg_io.ml
@@ -569,8 +569,8 @@ let register_input is_http =
                      raise
                        (Error.Invalid_value
                           ( Lang.string format,
-                            "Could not find ffmpeg input format with that name"
-                          )))
+                            "Could not find ffmpeg input format with that name",
+                            [] )))
              format
          in
          let opts = Hashtbl.create 10 in

--- a/src/core/optionals/portaudio/portaudio_io.ml
+++ b/src/core/optionals/portaudio/portaudio_io.ml
@@ -119,7 +119,8 @@ class virtual base =
                            Printf.sprintf
                              "Could not find portaudio device named %s, \
                               available devices are %s."
-                             name names )))
+                             name names,
+                           [] )))
       in
       match device_id with
         | None ->

--- a/src/core/optionals/prometheus/builtins_prometheus.ml
+++ b/src/core/optionals/prometheus/builtins_prometheus.ml
@@ -72,7 +72,8 @@ let add_metric metric_name create register set =
              let labels = List.map Lang.to_string (Lang.to_list labels_v) in
              if List.length labels <> List.length label_names then
                raise
-                 (Error.Invalid_value (labels_v, "Not enough labels provided!"));
+                 (Error.Invalid_value
+                    (labels_v, "Not enough labels provided!", []));
              let m = register m labels in
              Lang.val_fun
                [("", "", None)]
@@ -229,6 +230,6 @@ let _ =
           let labels = List.map Lang.to_string (Lang.to_list labels_v) in
           if List.length labels <> List.length label_names then
             raise
-              (Error.Invalid_value (labels_v, "Not enough labels provided!"));
+              (Error.Invalid_value (labels_v, "Not enough labels provided!", []));
           source_monitor ~label_names ~labels ~window ~prefix s;
           Lang.unit))

--- a/src/core/optionals/samplerate/libsamplerate_converter.ml
+++ b/src/core/optionals/samplerate/libsamplerate_converter.ml
@@ -55,7 +55,8 @@ let quality_of_string v =
           (Error.Invalid_value
              ( Lang.string v,
                "libsamplerate quality must be one of: \"best\", \"medium\", \
-                \"fast\", \"zero_order\", \"linear\"." ))
+                \"fast\", \"zero_order\", \"linear\".",
+               [] ))
 
 let samplerate_converter channels =
   let quality = quality_of_string quality_conf#get in

--- a/src/core/optionals/sdl/video_text_sdl.ml
+++ b/src/core/optionals/sdl/video_text_sdl.ml
@@ -34,7 +34,7 @@ let get_font font size =
   with e ->
     raise
       (Error.Invalid_value
-         (Lang.string font, Printexc.to_string e ^ "(font: " ^ font ^ ")"))
+         (Lang.string font, Printexc.to_string e ^ "(font: " ^ font ^ ")", []))
 
 let render_text ~font ~size text =
   let text = if text = "" then " " else text in

--- a/src/core/optionals/srt/srt_io.ml
+++ b/src/core/optionals/srt/srt_io.ml
@@ -127,8 +127,8 @@ let mode_of_value v =
         raise
           (Error.Invalid_value
              ( v,
-               "Invalid mode! Should be one of: `\"listener\"` or `\"caller\"`."
-             ))
+               "Invalid mode! Should be one of: `\"listener\"` or `\"caller\"`.",
+               [] ))
 
 let string_of_mode = function `Listener -> "listener" | `Caller -> "caller"
 
@@ -372,7 +372,9 @@ let parse_common_options p =
       | _ ->
           raise
             (Error.Invalid_value
-               (v, "Valid values are: `\"system\"`, `\"ipv4\"` or `\"ipv6\"`."))
+               ( v,
+                 "Valid values are: `\"system\"`, `\"ipv4\"` or `\"ipv6\"`.",
+                 [] ))
   in
   let ipv6only = Lang.to_valued_option Lang.to_bool (List.assoc "ipv6only" p) in
   let passphrase_v = List.assoc "passphrase" p in
@@ -381,11 +383,13 @@ let parse_common_options p =
     | Some s when String.length s < 10 ->
         raise
           (Error.Invalid_value
-             (passphrase_v, "Passphrase must be at least 10 characters long!"))
+             ( passphrase_v,
+               "Passphrase must be at least 10 characters long!",
+               [] ))
     | Some s when String.length s > 79 ->
         raise
           (Error.Invalid_value
-             (passphrase_v, "Passphrase must be at most 79 characters long!"))
+             (passphrase_v, "Passphrase must be at most 79 characters long!", []))
     | _ -> ());
   let streamid =
     Lang.to_valued_option Lang.to_string (List.assoc "streamid" p)
@@ -1318,7 +1322,7 @@ let _ =
         with Not_found ->
           raise
             (Error.Invalid_value
-               (format_val, "Cannot get a stream encoder for that format"))
+               (format_val, "Cannot get a stream encoder for that format", []))
       in
       match mode with
         | `Caller ->

--- a/src/core/optionals/ssl/builtins_ssl.ml
+++ b/src/core/optionals/ssl/builtins_ssl.ml
@@ -32,7 +32,8 @@ let protocol_of_value protocol_val =
     | "tls.1.1" -> Ssl.TLSv1_1 [@alert "-deprecated"]
     | "tls.1.2" -> Ssl.TLSv1_2
     | "tls.1.3" -> Ssl.TLSv1_3
-    | _ -> raise (Error.Invalid_value (protocol_val, "Invalid SSL protocol"))
+    | _ ->
+        raise (Error.Invalid_value (protocol_val, "Invalid SSL protocol", []))
 
 let ssl_socket ~pos transport ssl =
   let closed = Atomic.make false in

--- a/src/lang/base/builtins_lang.ml
+++ b/src/lang/base/builtins_lang.ml
@@ -163,7 +163,8 @@ let liquidsoap_cache =
               raise
                 (Error.Invalid_value
                    ( mode,
-                     "Invalid mode. Should be one of: \"user\" or \"system\"" ))
+                     "Invalid mode. Should be one of: \"user\" or \"system\"",
+                     [] ))
       in
       match Cache.dir dirtype with
         | None -> Lang.null
@@ -190,7 +191,8 @@ let _ =
               raise
                 (Error.Invalid_value
                    ( mode,
-                     "Invalid mode. Should be one of: \"user\" or \"system\"" ))
+                     "Invalid mode. Should be one of: \"user\" or \"system\"",
+                     [] ))
       in
       let fn = !Hooks.cache_maintenance in
       fn dirtype;

--- a/src/lang/base/builtins_regexp.ml
+++ b/src/lang/base/builtins_regexp.ml
@@ -249,7 +249,8 @@ let _ =
         List.map
           (fun v ->
             try regexp_flag_of_string (Lang_core.to_string v)
-            with _ -> raise (Error.Invalid_value (v, "Invalid regexp flag")))
+            with _ ->
+              raise (Error.Invalid_value (v, "Invalid regexp flag", [])))
           (Lang_core.to_list (List.assoc "flags" p))
       in
       let descr = Lang_core.to_string (List.assoc "" p) in

--- a/src/lang/base/builtins_string.ml
+++ b/src/lang/base/builtins_string.ml
@@ -208,7 +208,8 @@ let string_escape =
               raise
                 (Error.Invalid_value
                    ( encoding,
-                     "Encoding should be one of: \"ascii\" or \"utf8\"." ))
+                     "Encoding should be one of: \"ascii\" or \"utf8\".",
+                     [] ))
       in
       let exec encoding =
         let encoding_string =
@@ -293,7 +294,8 @@ let _ =
                 (Error.Invalid_value
                    ( format,
                      "Format should be one of: `\"octal\"`, `\"hex\"` or \
-                      `\"utf8\"`." ))
+                      `\"utf8\"`.",
+                     [] ))
       in
       let s = Lang.to_string (List.assoc "" p) in
       Lang.string
@@ -327,7 +329,9 @@ let _ =
         | _ ->
             raise
               (Error.Invalid_value
-                 (encoding, "Encoding should be one of: \"ascii\" or \"utf8\".")))
+                 ( encoding,
+                   "Encoding should be one of: \"ascii\" or \"utf8\".",
+                   [] )))
 
 let _ =
   Lang.add_builtin ~base:string "unescape"

--- a/src/lang/base/error.ml
+++ b/src/lang/base/error.ml
@@ -21,7 +21,7 @@
  *****************************************************************************)
 
 (** Runtime error, should eventually disappear. *)
-exception Invalid_value of Value.t * string
+exception Invalid_value of Value.t * string * Pos.t list
 
 exception Clock_conflict of (Pos.Option.t * string * string)
 exception Clock_loop of (Pos.Option.t * string * string)

--- a/src/lang/base/error.mli
+++ b/src/lang/base/error.mli
@@ -21,7 +21,7 @@
  *****************************************************************************)
 
 (** Runtime error, should eventually disappear. *)
-exception Invalid_value of Value.t * string
+exception Invalid_value of Value.t * string * Pos.t list
 
 exception Clock_conflict of (Pos.Option.t * string * string)
 exception Clock_loop of (Pos.Option.t * string * string)

--- a/src/lang/base/evaluation.ml
+++ b/src/lang/base/evaluation.ml
@@ -121,6 +121,11 @@ and apply ?(pos = []) ~eval_check f l =
           Printexc.raise_with_backtrace
             (Internal_error (Option.to_list apply_pos @ poss, e))
             bt
+      | Error.Invalid_value (v, msg, stack) ->
+          let bt = Printexc.get_raw_backtrace () in
+          Printexc.raise_with_backtrace
+            (Error.Invalid_value (v, msg, Option.to_list apply_pos @ stack))
+            bt
   in
   (* Provide given arguments. *)
   let pe, p =

--- a/src/lang/base/runtime.ml
+++ b/src/lang/base/runtime.ml
@@ -188,9 +188,14 @@ let rec throw ?(formatter = Format.std_formatter) ~lexbuf ~bt () =
       Format.fprintf formatter
         "Function has multiple arguments with the same label: %s@]@." lbl;
       Printexc.raise_with_backtrace Error bt
-  | Error.Invalid_value (v, msg) ->
+  | Error.Invalid_value (v, msg, stack) ->
       error_header ~formatter 7 (Value.pos v);
-      Format.fprintf formatter "Invalid value:@ %s@]@." msg;
+      Format.fprintf formatter "Invalid value:@ %s" msg;
+      if stack <> [] then
+        Format.fprintf formatter
+          "@\nThis value was passed through the following call stack:@\n%s"
+          (Pos.List.to_string ~newlines:true stack);
+      Format.fprintf formatter "@]@.";
       Printexc.raise_with_backtrace Error bt
   | Lang_error.Encoder_error (pos, s) ->
       error_header ~formatter 8 pos;


### PR DESCRIPTION
Backport of #5089 to v2.4.x-latest.

## Summary

`Error.Invalid_value` (error 7) previously reported only the position stored in the value itself — which is where the value was *created*. When that value was a variable assigned far from the failing call site, the error location was confusing: it pointed to the definition, with no trace of how the value ended up being used.

With this change, `Invalid_value` carries a `Pos.t list` call stack that is accumulated as the exception propagates through `apply` frames, exactly mirroring the existing treatment of `Internal_error`. The error output now shows both:

- the variable's **definition location** (unchanged — from `Value.pos`)
- the **call stack** leading to the error, under "This value was passed through the following call stack:"

For example, passing a fallible source to an infallible output through several helper functions will now show exactly which functions the source was threaded through before hitting the check.

## Changes

- `Error.Invalid_value` gains a `Pos.t list` third field (all existing raise sites initialised with `[]`)
- `evaluation.ml`: `apply`'s error wrapper catches `Invalid_value` and prepends `apply_pos` to the stack, same as for `Internal_error`
- `runtime.ml`: prints the stack when non-empty

Closes #5073