### PR TITLE
lang: source.content, track.format, format.description; rename video type to yuv420p

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,8 @@
 ## New:
 
 - Added `getter(t)` type annotation syntax for getter types (#TODO).
+- Added `source.content` operator returning an associative list of frame field names to their content format, `track.format` returning the content format of a single track, and `format.description` returning a typed record description of a content format.
+- Renamed internal video content type from `canvas` to `yuv420p` to better reflect the actual content. The video content remains organized as a canvas (superposition of `yuv420p` layers) internally. Type annotations such as `source(video=canvas)` must be updated to `source(video=yuv420p)`.
 - Added subtitles support as a dedicated content type. Includes native SRT decoding,
   FFmpeg subtitle encoding/decoding (`%subtitle`), passthrough for bitmap subtitles
   (`%subtitle.copy`), callbacks (`on_subtitle`), transformations (`subtitles.map`),

--- a/doc/content/faq.md
+++ b/doc/content/faq.md
@@ -29,7 +29,7 @@ A type error can also indicate that you're trying to use a source of a certain c
 ```
 At ...:
 Error 5: this value has type
-  source(video=canvas(_),...)
+  source(video=yuv420p(_),...)
 but it should be a subtype of
   source(audio=pcm(_),...)
 ```

--- a/doc/content/migrating.md
+++ b/doc/content/migrating.md
@@ -15,6 +15,22 @@ always do a trial run before putting things into production.
 
 ## From 2.4.x to 2.5.x
 
+### Video content type renamed from `canvas` to `yuv420p`
+
+The internal video content type has been renamed from `canvas` to `yuv420p` to
+better reflect what it actually contains: planar YUV420 images. Internally the
+content is still organized as a _canvas_ (a superposition of layers), but the
+type name visible in type annotations and error messages is now `yuv420p`.
+
+If your scripts use type annotations with `canvas`, rename them:
+
+| Old                                       | New                                        |
+| ----------------------------------------- | ------------------------------------------ |
+| `source(video=canvas)`                    | `source(video=yuv420p)`                    |
+| `source(video=canvas(width=W, height=H))` | `source(video=yuv420p(width=W, height=H))` |
+
+The `video.canvas` API (for positioning video elements) is unaffected by this change.
+
 ### Automatic video dimensions detection
 
 Video dimensions (`video.frame.width`/`height`) are now automatically detected from the first decoded video file. This means you no longer need to manually set dimensions in most cases.

--- a/doc/content/multitrack.md
+++ b/doc/content/multitrack.md
@@ -1,71 +1,94 @@
-# 🎚️ Multitrack Support in Liquidsoap
+# Multitrack
 
-Starting in version 2.2.0, Liquidsoap gained support for **multitrack operations** — a powerful addition that lets you work with individual tracks inside your media files. Whether it's audio, video, or metadata, you can now demux, remux, encode, decode, apply filters, and more — all at the track level!
+Liquidsoap supports working with individual tracks inside a source. Audio, video, metadata and track marks can each be extracted,
+manipulated independently, and recombined into a new source. This unlocks
+workflows like keeping multiple language audio tracks, remuxing streams without
+re-encoding, or applying different processing chains to audio and video.
 
-This unlocks advanced media workflows, like keeping multiple language tracks, adding a default video stream to audio-only files, or even mixing and matching content across sources.
+## What is a track?
 
-Let’s walk through what this means, step by step 👇
+A source produces a _frame_ on each streaming cycle. A frame is a collection of
+typed fields — typically `audio`, `video`, `metadata` and `track_marks`, though
+you can have any number of named audio or video fields (e.g. `audio_2`). Each
+field is what Liquidsoap calls a _track_.
 
-## 🧠 What is a Track?
-
-A media file can contain multiple “tracks.” Think of a movie file with:
-
-- 🎧 English and French audio tracks
-- 🎥 One video track
-- 📝 Metadata like title and artist
-
-In Liquidsoap, these tracks are made accessible through operators that let you manipulate them individually. This opens up many possibilities — but also introduces a few new concepts and conventions to learn.
-
-## 🔧 Requirements: When You Need FFmpeg
-
-Some multitrack features rely on FFmpeg, while others don't:
-
-| Feature                                         | Requires FFmpeg?                 |
-| ----------------------------------------------- | -------------------------------- |
-| Track-level encode/decode                       | ✅ Yes                           |
-| Encode or decode multiple audio or video tracks | ✅ Yes                           |
-| Demuxing/remuxing tracks                        | ❌ No                            |
-| Source track manipulation                       | ❌ No (unless decoding/encoding) |
-
-To fully unlock multitrack functionality, make sure your Liquidsoap is compiled with FFmpeg support.
-
-## 🎬 Using Multitrack Media
-
-Let’s say you have a media file with multiple tracks, like:
-
-```sh
-movie.mkv
-├── audio (English)
-├── audio_2 (French)
-└── video
-```
-
-You can create a source with this file like so:
+The type of a source describes its tracks. For example:
 
 ```liquidsoap
-s = single("/path/to/movie.mkv")
+source(audio=pcm(stereo), video=yuv420p)
 ```
 
-By default, only the first audio and video track will be used:
+describes a source with a stereo PCM audio track and a YUV420P video track.
+
+## Content types drive what you get
+
+An important subtlety: **what tracks a source exposes depends on how you use
+it**. Liquidsoap uses type inference to determine the content type of each
+source. The expected content is inferred from the downstream operators and
+propagated back to the source.
+
+For instance, if you write:
 
 ```liquidsoap
+s = single("movie.mkv")
 output.file(%ffmpeg(%audio.copy, %video.copy), "/path/to/copy.mkv", s)
 ```
 
-🪵 **Logs will confirm the detected tracks:**
+then the encoder tells Liquidsoap that it needs `audio` and `video` in FFmpeg
+copy format. That requirement propagates back to `s`, which then instructs the
+decoder to provide exactly those tracks.
 
+If you do not request a track, the decoder will not decode it. A file with three
+audio tracks will only produce `audio` (and discard `audio_2`, `audio_3`) unless
+you explicitly ask for them.
+
+You can force a particular content type with a type annotation:
+
+```liquidsoap
+s = (single("movie.mkv") : source(audio=pcm(stereo), video=yuv420p))
 ```
-[output_file:3] Content type is {audio=ffmpeg.copy,video=ffmpeg.copy}.
-[decoder.ffmpeg:3] Requested content-type for "/path/to/movie.mkv": {audio=ffmpeg.copy,video=ffmpeg.copy}
-[decoder.ffmpeg:3] FFmpeg recognizes "/path/to/movie.mkv" as video: {codec: h264, 1920x1038, yuv420p}, audio: {codec: aac, 48000Hz, 6 channel(s)}, audio_2: {codec: aac, 48000Hz, 6 channel(s)}
-[decoder.ffmpeg:3] Decoded content-type for "/path/to/movie.mkv": {audio=ffmpeg.copy(codec="aac",channel_layout="5.1",sample_format=fltp,sample_rate=48000),video=ffmpeg.copy(codec="h264",width=1920,height=1038,aspect_ratio=1/1,pixel_format=yuv420p)}
+
+## Demuxing and remuxing tracks
+
+Use `source.tracks` to split a source into its individual tracks:
+
+```liquidsoap
+s = single("movie.mkv")
+let {audio, video, metadata, track_marks} = source.tracks(s)
 ```
 
-Here, `audio_2` is present but unused. Let’s fix that 👇
+Each extracted value is a _track_ — a typed handle tied to the underlying
+source. You can then recombine tracks into a new source:
 
-## 🎛️ Custom Track Handling
+```liquidsoap
+s = source({audio = audio, video = video, metadata = metadata, track_marks = track_marks})
+```
 
-What if you want to **keep both audio tracks**, re-encoding the second one to stereo?
+Or replace one track while keeping the others:
+
+```liquidsoap
+image = single("logo.png")
+s = source(source.tracks(s).{video = source.tracks(image).video})
+```
+
+To drop a track entirely, use the `_` pattern or the dedicated `source.drop.*`
+operators:
+
+```liquidsoap
+# Drop track_marks by pattern
+let {track_marks = _, ...tracks} = source.tracks(s)
+s = source(tracks)
+
+# Or equivalently
+s = source.drop.track_marks(s)
+```
+
+## Track naming conventions
+
+When decoding a file with multiple tracks of the same type, the decoder names
+them `audio`, `audio_2`, `audio_3`, ... and `video`, `video_2`, `video_3`, ...
+These names are assigned by the decoder and cannot be changed at the input side.
+You can however give them any name when remuxing:
 
 ```liquidsoap
 output.file(
@@ -79,167 +102,155 @@ output.file(
 )
 ```
 
-🪵 Logs now show `audio_2` being processed:
+Only files containing all requested tracks will be accepted when using a
+playlist. Files missing any of the required tracks will be skipped.
 
-```
-[output_file:3] Content type is {audio=ffmpeg.copy,audio_2=pcm(stereo),video=ffmpeg.copy}.
-[decoder.ffmpeg:3] Requested content-type for "/path/to/movie.mkv": {audio=ffmpeg.copy,audio_2=pcm(stereo),video=ffmpeg.copy}
-[decoder.ffmpeg:3] FFmpeg recognizes "/path/to/movie.mkv" as video: {codec: h264, 1920x1038, yuv420p}, audio: {codec: aac, 48000Hz, 6 channel(s)}, audio_2: {codec: aac, 48000Hz, 6 channel(s)}
-[decoder.ffmpeg:3] Decoded content-type for "/path/to/movie.mkv": {audio=ffmpeg.copy(codec="aac",channel_layout="5.1",sample_format=fltp,sample_rate=48000),audio_2=pcm(5.1),video=ffmpeg.copy(codec="h264",width=1920,height=1038,aspect_ratio=1/1,pixel_format=yuv420p)}
-```
+## Track-level operators
 
-You now have a file with two audio tracks (one copied, one re-encoded) and one video track 🎉
-
-## ⚠️ Playlist Caveats
-
-If your source is a playlist:
+Many processing operators work directly on tracks rather than full sources. This
+lets you apply different processing to each track independently:
 
 ```liquidsoap
-s = playlist("/path/to/playlist")
+let {audio, video} = source.tracks(s)
+
+# Convert to mono
+mono = track.audio.mean(audio)
+
+# Encode audio to AAC via FFmpeg
+encoded = track.ffmpeg.encode.audio(%ffmpeg(%audio(codec="aac")), audio)
 ```
 
-…and you request multiple tracks:
+### Clocks and cross-clock composition
+
+Some track operators — in particular FFmpeg encoders — assign the track to a
+new clock. This becomes relevant when you want to recombine encoded tracks with
+other tracks derived from a different source.
+
+When rebuilding a source from tracks that live on different clocks, you also
+need to re-derive `metadata` and `track_marks` from a track on the same clock.
+`track.metadata` and `track.track_marks` extract those special tracks from any
+content track, making it straightforward to reassemble a full source:
 
 ```liquidsoap
-output.file(
-  fallible=true,
-  %ffmpeg(%audio.copy, %audio_2(...), %video.copy),
-  "/path/to/copy.mkv",
-  s
+let {audio} = source.tracks(s)
+
+encoded = track.ffmpeg.encode.audio(%ffmpeg(%audio(codec="aac")), audio)
+
+# Re-derive metadata and track_marks from the encoded track,
+# which now lives on the encoder's clock
+s = source({
+  audio = encoded,
+  metadata = track.metadata(encoded),
+  track_marks = track.track_marks(encoded)
+})
+```
+
+This pattern is the standard way to rebuild a complete source on the encoder's
+clock. All tracks in a source must share the same clock, so `metadata` and
+`track_marks` must also be derived from the encoded track rather than from the
+original source.
+
+## Inspecting content types at runtime
+
+### source.content
+
+`source.content` returns the content type of a source as an associative list
+mapping field names to their format values:
+
+```liquidsoap
+s = (noise() : source(audio=pcm, video=yuv420p))
+
+list.iter(
+  fun (entry) ->
+    let (field, fmt) = entry
+    print("#{field}: #{format.description(fmt)}"),
+  source.content(s)
 )
 ```
 
-Then **only files with all requested tracks** (audio + audio_2 + video) will be accepted. Others will be skipped.
+The returned list reflects what the type checker has determined the source will
+produce — which, as explained above, depends on how the source is used.
 
-## 🧭 Track Naming Conventions
+### track.format
 
-When decoding, track names follow this pattern:
-
-- `audio`, `audio_2`, `audio_3`, ...
-- `video`, `video_2`, `video_3`, ...
-
-These names are fixed by the decoder — you **can’t** rename them directly when reading media.
-
-For example, this will fail:
+`track.format` returns the content format of a single track:
 
 ```liquidsoap
-output.file(%ffmpeg(%audio_fr.copy, %audio_en(...), "/path/to/file.mkv", playlist("...")))
+let {audio, video} = source.tracks(s)
+
+print("audio format: #{format.description(track.format(audio))}")
+print("video format: #{format.description(track.format(video))}")
 ```
 
-Why? Because the decoder doesn’t know what `audio_fr` or `audio_en` means. Track names must match what the decoder emits: `audio`, `audio_2`, etc.
+### format.description
 
-Once you're remuxing tracks, however, you can assign **any name** you want!
+`format.description` converts a `content_format` value into a record with one
+optional method per content type. Its full type is:
 
-## 🔄 Demuxing and Remuxing Tracks
+```
+(content_format) -> {
+  ffmpeg_copy? : string,
+  ffmpeg_raw_audio? : string,
+  ffmpeg_raw_video? : string,
+  metadata? : string,
+  midi? : {channels : int},
+  pcm? : {channel_layout : string, channels : int},
+  pcm_f32? : {channel_layout : string, channels : int},
+  pcm_s16? : {channel_layout : string, channels : int},
+  subtitle? : string,
+  track_marks? : string,
+  yuv420p? : {height : int, width : int}
+}
+```
 
-To extract and rebuild track sets:
+The main content types and their fields are:
+
+| Format           | Method              | Fields                         |
+| ---------------- | ------------------- | ------------------------------ |
+| `pcm`            | `pcm?`              | `{ channels, channel_layout }` |
+| `pcm_s16`        | `pcm_s16?`          | `{ channels, channel_layout }` |
+| `pcm_f32`        | `pcm_f32?`          | `{ channels, channel_layout }` |
+| `yuv420p`        | `yuv420p?`          | `{ width, height }`            |
+| `midi`           | `midi?`             | `{ channels }`                 |
+| FFmpeg copy      | `ffmpeg_copy?`      | string description             |
+| FFmpeg raw audio | `ffmpeg_raw_audio?` | string description             |
+| FFmpeg raw video | `ffmpeg_raw_video?` | string description             |
+
+Methods are optional (marked `?`) because a given format will only populate one
+of them. Use safe navigation to access them:
 
 ```liquidsoap
-s = playlist(...)
+fmt = track.format(audio)
+desc = format.description(fmt)
 
-let {audio, video, metadata, track_marks} = source.tracks(s)
+if null.defined(desc?.pcm) then
+  pcm = null.get(desc?.pcm)
+  print("PCM: #{pcm.channels} channels, layout: #{pcm.channel_layout}")
+end
 ```
 
-You can then remix these into a new source:
+## Encoder track type hints
 
-```liquidsoap
-s = source({
-  audio = audio,
-  video = video,
-  metadata = metadata,
-  track_marks = track_marks
-})
-```
+When writing an FFmpeg encoder with custom track names, Liquidsoap needs to know
+whether each track is audio or video. It determines this from, in priority order:
 
-Tracks can also be added or replaced:
+1. `%audio.copy` or `%video.copy` — type is inferred from the format
+2. An explicit `audio_content` or `video_content` hint in the encoder spec
+3. The track name containing `"audio"` or `"video"` as a substring
+4. The codec name implying a type
 
-```liquidsoap
-s = source(source.tracks(s).{video = source.tracks(image).video})
-```
-
-One limitation is that it is not currently possible to add default tracks.
-
-The following **won't work**:
-
-```liquidsoap
-video = source.tracks(s).video ?? source.tracks(image).video
-```
-
-## 🧹 Cleaning Up Tracks
-
-Want to remove `track_marks`?
-
-```liquidsoap
-let {track_marks=_, ...tracks} = source.tracks(s)
-s = source(tracks)
-```
-
-This is equivalent to the older `drop_tracks` operator.
-
-## 🔌 Track-Level Operators
-
-Many operators now work directly on tracks. Examples:
-
-```liquidsoap
-mono = track.audio.mean(audio_track)
-encoded = track.ffmpeg.encode.audio(%ffmpeg(%audio(codec="aac")), audio_track)
-```
-
-🚨 But beware: some operators (like inline encoders) put the track on a new **clock**. You’ll need to re-derive metadata and track marks from the new track to avoid clock conflicts:
-
-```liquidsoap
-let encoded_audio = track.ffmpeg.encode.audio(..., audio)
-
-s = source({
-  audio = encoded_audio,
-  metadata = track.metadata(encoded_audio),
-  track_marks = track.track_marks(encoded_audio)
-})
-```
-
-## 🏷️ How Encoders Detect Track Types
-
-Liquidsoap uses **naming conventions** and **hints** to determine what kind of data each track holds:
-
-Priority order:
-
-1. `%audio.copy` or `%video.copy` → auto-detect
-2. Named content type (`audio_content` or `video_content`)
-3. Track name contains “audio” or “video”
-4. Codec implies type
-
-### ✅ Example: Explicit typing
+For full control, use explicit hints:
 
 ```liquidsoap
 output.file(
   %ffmpeg(
     %en(audio_content, codec=audio_codec),
-    %fr(codec="aac"),
     %director_cut(video_content, codec=video_codec)
   ),
-  "/path/to/copy.mkv",
+  "/path/to/output.mkv",
   s
 )
 ```
 
-### ✅ Or by naming convention
-
-```liquidsoap
-%audio_en(codec=...)
-%director_cut_video(codec=...)
-```
-
-Internally, Liquidsoap maps this to content-type info. Once handed off to FFmpeg, **track names are lost** — FFmpeg just sees numbered tracks in order.
-
-## 🚀 Summary
-
-Multitrack support opens up powerful new workflows:
-
-- 🔄 Mix and match audio/video/metadata across sources
-- 🧱 Build custom media containers
-- 🎯 Target different formats per track
-- 🧪 Combine synchronous and asynchronous operations (with care!)
-
-We’ve only scratched the surface — go ahead and explore the code, experiment, and let your creativity flow! 💡
-
-And if there’s an operator you wish worked at the track level, don’t hesitate to [open a feature request](https://github.com/savonet/liquidsoap)!
+Note that once tracks are handed to FFmpeg for muxing, their Liquidsoap names
+are lost — FFmpeg sees them as numbered streams in the order they appear.

--- a/doc/content/stream_content.md
+++ b/doc/content/stream_content.md
@@ -40,7 +40,11 @@ For audio, the default internal content is `pcm` floats
 using OCaml native 64-bits float array representations. This is the format that allows the
 fastest manipulation.
 
-For video, the default is a C in-memory arrays of plannar YUV420 data.
+For video, the default internal content type is `yuv420p`: planar YUV420 images
+stored in C in-memory arrays. Internally, the content is structured as a _canvas_
+— a superposition of layers, each containing a `yuv420p` image placed at a given
+position. This canvas model makes compositing operations (overlaying a logo,
+assembling multi-camera video, etc.) efficient without unnecessary copies.
 
 For users concerned with memory consumption, we also support two additional audio formats,
 `pcm_s16` and `pcm_f32` using, resp., signed 16-bit integers and 32-bit floating point numbers.
@@ -97,7 +101,7 @@ At line 1, char 22-23:
   this value has type
     source(audio=pcm('a))
   but it should be a subtype of
-    source(video=canvas)
+    source(video=yuv420p)
 ```
 
 It means that a source with a video channel was expected

--- a/src/core/base/stream/content.ml
+++ b/src/core/base/stream/content.ml
@@ -137,3 +137,31 @@ module Midi = struct
 
   type midi_params = Content_midi.Specs.params = { channels : int }
 end
+
+(* Custom Liquidsoap value type for Content.format *)
+module Format_val = Liquidsoap_lang.Lang_core.MkCustom (struct
+  type content = Contents.format
+
+  let name = "content_format"
+  let to_string = string_of_format
+
+  let to_json ~pos _ =
+    Liquidsoap_lang.Runtime_error.raise ~pos
+      ~message:"Formats cannot be represented as JSON" "json"
+
+  let compare = Stdlib.compare
+end)
+
+let content_types () =
+  List.fold_right
+    (fun { method_name; content_typ; _ } acc ->
+      Liquidsoap_lang.Type.meth ~optional:true method_name ([], content_typ) acc)
+    !content_lang_specs
+    (Liquidsoap_lang.Type.make Liquidsoap_lang.Type.unit)
+
+let value_of_format fmt =
+  let name = fst fmt in
+  Option.map
+    (fun { method_name; format_to_value; _ } ->
+      (method_name, format_to_value fmt))
+    (List.find_opt (fun s -> s.format_name = name) !content_lang_specs)

--- a/src/core/base/stream/content.ml
+++ b/src/core/base/stream/content.ml
@@ -138,6 +138,13 @@ module Midi = struct
   type midi_params = Content_midi.Specs.params = { channels : int }
 end
 
+let value_of_format fmt =
+  let name = fst fmt in
+  Option.map
+    (fun { method_name; format_to_value; _ } ->
+      (method_name, format_to_value fmt))
+    (List.find_opt (fun s -> s.format_name = name) !content_lang_specs)
+
 (* Custom Liquidsoap value type for Content.format *)
 module Format_val = Liquidsoap_lang.Lang_core.MkCustom (struct
   type content = Contents.format
@@ -145,9 +152,12 @@ module Format_val = Liquidsoap_lang.Lang_core.MkCustom (struct
   let name = "content_format"
   let to_string = string_of_format
 
-  let to_json ~pos _ =
-    Liquidsoap_lang.Runtime_error.raise ~pos
-      ~message:"Formats cannot be represented as JSON" "json"
+  let to_json ~pos fmt =
+    match value_of_format fmt with
+      | Some (method_name, v) ->
+          `Assoc
+            [(method_name, Liquidsoap_lang.Builtins_json.json_of_value ~pos v)]
+      | None -> `Assoc []
 
   let compare = Stdlib.compare
 end)
@@ -158,10 +168,3 @@ let content_types () =
       Liquidsoap_lang.Type.meth ~optional:true method_name ([], content_typ) acc)
     !content_lang_specs
     (Liquidsoap_lang.Type.make Liquidsoap_lang.Type.unit)
-
-let value_of_format fmt =
-  let name = fst fmt in
-  Option.map
-    (fun { method_name; format_to_value; _ } ->
-      (method_name, format_to_value fmt))
-    (List.find_opt (fun s -> s.format_name = name) !content_lang_specs)

--- a/src/core/base/stream/content.mli
+++ b/src/core/base/stream/content.mli
@@ -66,6 +66,11 @@ module type ContentSpecs = sig
   val default_params : kind -> params
   val string_of_kind : kind -> string
   val kind_of_string : string -> kind option
+
+  (** Lang description *)
+
+  val content_lang_typ : Liquidsoap_lang.Type.t
+  val params_to_value : params -> Liquidsoap_lang.Value.t
 end
 
 module type Content = sig
@@ -211,6 +216,27 @@ module Track_marks : sig
   val set_data : Contents.data -> int list -> unit
   val lift_data : int list -> Contents.data
 end
+
+(** Custom Liquidsoap value type for [format]. *)
+module Format_val : sig
+  val t : Liquidsoap_lang.Type.t
+
+  val to_value :
+    ?pos:Liquidsoap_lang.Pos.Option.base ->
+    Contents.format ->
+    Liquidsoap_lang.Value.t
+
+  val of_value : Liquidsoap_lang.Value.t -> Contents.format
+end
+
+(** Record type with one optional method per registered content type. Call after
+    all content modules have been initialized. *)
+val content_types : unit -> Liquidsoap_lang.Type.t
+
+(** Convert a format to [(normalized_name, value)]. Returns [None] for types
+    with no registered Lang spec (metadata, track_marks). *)
+val value_of_format :
+  Contents.format -> (string * Liquidsoap_lang.Value.t) option
 
 (* Some tools *)
 val merge_param :

--- a/src/core/base/stream/content_audio.ml
+++ b/src/core/base/stream/content_audio.ml
@@ -112,6 +112,24 @@ module Specs = struct
         done)
       d;
     Digest.bytes buf |> Digest.to_hex
+
+  let content_lang_typ =
+    let open Liquidsoap_lang in
+    Lang_core.record_t
+      [
+        ("channels", Type.make Type.Int);
+        ("channel_layout", Type.make Type.String);
+      ]
+
+  let params_to_value ({ channel_layout } as p) =
+    let open Liquidsoap_lang in
+    let channels = channels_of_param (Lazy.force channel_layout) in
+    let layout = string_of_params p in
+    Lang_core.record
+      [
+        ("channels", Lang_core.mk (`Int channels));
+        ("channel_layout", Lang_core.mk (`String layout));
+      ]
 end
 
 include MkContentBase (Specs)

--- a/src/core/base/stream/content_base.ml
+++ b/src/core/base/stream/content_base.ml
@@ -75,6 +75,8 @@ module type ContentSpecs = sig
   val default_params : kind -> params
   val string_of_kind : kind -> string
   val kind_of_string : string -> kind option
+  val content_lang_typ : Liquidsoap_lang.Type.t
+  val params_to_value : params -> Liquidsoap_lang.Value.t
 end
 
 module type Content = sig
@@ -225,6 +227,23 @@ let duplicate p = (get_format_handler p).duplicate ()
 let compatible p p' = (get_format_handler p).compatible p'
 let string_of_kind k = (get_kind_handler k).string_of_kind ()
 let content_names = ref []
+
+type content_lang_spec = {
+  format_name : string;
+  method_name : string;
+  content_typ : Liquidsoap_lang.Type.t;
+  format_to_value : Contents.format -> Liquidsoap_lang.Value.t;
+}
+
+let content_lang_specs : content_lang_spec list ref = ref []
+
+let register_content_lang format_name lang_name content_typ format_to_value =
+  let method_name =
+    String.map (fun c -> if c = '.' then '_' else c) lang_name
+  in
+  content_lang_specs :=
+    { format_name; method_name; content_typ; format_to_value }
+    :: !content_lang_specs
 
 module MkContentBase (C : ContentSpecs) :
   Content
@@ -461,4 +480,8 @@ module MkContentBase (C : ContentSpecs) :
       | _ -> raise Invalid
 
   include C
+
+  let () =
+    register_content_lang C.name C.name C.content_lang_typ (fun fmt ->
+        C.params_to_value (get_params fmt))
 end

--- a/src/core/base/stream/content_midi.ml
+++ b/src/core/base/stream/content_midi.ml
@@ -83,6 +83,14 @@ module Specs = struct
       (Printf.sprintf "%d:%d:%s" channels duration
          (String.concat "|" channel_info))
     |> Digest.to_hex
+
+  let content_lang_typ =
+    let open Liquidsoap_lang in
+    Lang_core.record_t [("channels", Type.make Type.Int)]
+
+  let params_to_value { channels } =
+    let open Liquidsoap_lang in
+    Lang_core.record [("channels", Lang_core.mk (`Int channels))]
 end
 
 include MkContentBase (Specs)

--- a/src/core/base/stream/content_pcm_f32.ml
+++ b/src/core/base/stream/content_pcm_f32.ml
@@ -37,6 +37,8 @@ module Specs = struct
   let string_of_kind = function `Pcm_f32 -> "pcm_f32"
   let copy = copy ~fmt:Bigarray.float32
   let make = make ~fmt:Bigarray.float32
+  let content_lang_typ = Content_audio.Specs.content_lang_typ
+  let params_to_value = Content_audio.Specs.params_to_value
 
   let checksum d =
     let len =

--- a/src/core/base/stream/content_pcm_s16.ml
+++ b/src/core/base/stream/content_pcm_s16.ml
@@ -37,6 +37,8 @@ module Specs = struct
   let string_of_kind = function `Pcm_s16 -> "pcm_s16"
   let copy = copy ~fmt:Bigarray.int16_signed
   let make = make ~fmt:Bigarray.int16_signed
+  let content_lang_typ = Content_audio.Specs.content_lang_typ
+  let params_to_value = Content_audio.Specs.params_to_value
 
   let checksum d =
     let len =

--- a/src/core/base/stream/content_timed.ml
+++ b/src/core/base/stream/content_timed.ml
@@ -97,6 +97,8 @@ module Metadata_specs = struct
   let default_params _ = ()
   let parse_param _ _ = Some ()
   let merge _ _ = ()
+  let content_lang_typ = Liquidsoap_lang.Lang_core.string_t
+  let params_to_value () = Liquidsoap_lang.Lang_core.string ""
   let copy = copy ~copy:(fun x -> x)
 
   let checksum d =
@@ -148,6 +150,8 @@ module Track_marks_specs = struct
   let default_params _ = ()
   let parse_param _ _ = Some ()
   let merge _ _ = ()
+  let content_lang_typ = Liquidsoap_lang.Lang_core.string_t
+  let params_to_value () = Liquidsoap_lang.Lang_core.string ""
   let copy = copy ~copy:(fun () -> ())
 
   let checksum d =

--- a/src/core/base/stream/content_video.ml
+++ b/src/core/base/stream/content_video.ml
@@ -83,9 +83,9 @@ module Specs = struct
   type params = { width : int Lazy.t option; height : int Lazy.t option }
   type data = (params, Video.Canvas.image) content
 
-  let name = "canvas"
+  let name = "yuv420p"
   let internal_content_type = Some `Video
-  let string_of_kind = function `Canvas -> "canvas"
+  let string_of_kind = function `Canvas -> "yuv420p"
 
   let string_of_params { width; height } =
     print_optional
@@ -148,7 +148,7 @@ module Specs = struct
 
   let kind = `Canvas
   let default_params _ = { width = None; height = None }
-  let kind_of_string = function "canvas" -> Some `Canvas | _ -> None
+  let kind_of_string = function "yuv420p" -> Some `Canvas | _ -> None
 
   let checksum d =
     (* Hash the video frame positions and render each frame to get pixel data *)
@@ -172,6 +172,22 @@ module Specs = struct
         d.data
     in
     Digest.string (String.concat "|" frames_info) |> Digest.to_hex
+
+  let content_lang_typ =
+    let open Liquidsoap_lang in
+    Lang_core.record_t
+      [("width", Type.make Type.Int); ("height", Type.make Type.Int)]
+
+  let params_to_value { width; height } =
+    let open Liquidsoap_lang in
+    let default_width, default_height = Frame_settings.video_dimensions () in
+    let width = Lazy.force (Option.value ~default:default_width width) in
+    let height = Lazy.force (Option.value ~default:default_height height) in
+    Lang_core.record
+      [
+        ("width", Lang_core.mk (`Int width));
+        ("height", Lang_core.mk (`Int height));
+      ]
 end
 
 include MkContentBase (Specs)

--- a/src/core/base/stream/subtitle_content.ml
+++ b/src/core/base/stream/subtitle_content.ml
@@ -73,6 +73,8 @@ module Specs = struct
 
   let copy d = { d with data = List.map (fun (pos, x) -> (pos, x)) d.data }
   let params _ = ()
+  let content_lang_typ = Liquidsoap_lang.Lang_core.string_t
+  let params_to_value () = Liquidsoap_lang.Lang_core.string ""
 
   let checksum d =
     let entries =

--- a/src/core/builtins/builtins_format.ml
+++ b/src/core/builtins/builtins_format.ml
@@ -20,25 +20,19 @@
 
  *****************************************************************************)
 
-let _ =
-  let track_t = Lang.univ_t ~constraints:[Format_type.track] () in
-  Lang.add_builtin ~base:Modules.track "clock" ~category:`Liquidsoap
-    ~descr:"Return the clock associated with the given track."
-    [("", track_t, None, None)]
-    Lang_clock.ClockValue.base_t
-    (fun p ->
-      let _, s = Lang.to_track (List.assoc "" p) in
-      Lang_clock.ClockValue.to_base_value s#clock)
+let format = Lang.add_module "format"
 
 let _ =
-  let track_t = Lang.univ_t ~constraints:[Format_type.track] () in
-  Lang.add_builtin ~base:Modules.track "format" ~category:`Liquidsoap
+  Lang.add_builtin ~base:format "description" ~category:(`Source `Liquidsoap)
     ~descr:
-      "Return the content format of a track. Use `format.description` to \
-       introspect the returned value."
-    [("", track_t, None, None)]
-    Content.Format_val.t
+      "Return a description of the given format as a record with optional \
+       methods. For PCM audio: `{ channels, channel_layout }`. For YUV420P \
+       video: `{ width, height }`. For MIDI: `{ channels }`. Returns an empty \
+       record for formats without a description (e.g. metadata, track marks)."
+    [("", Content.Format_val.t, None, None)]
+    (Content.content_types ())
     (fun p ->
-      let field, s = Lang.to_track (List.assoc "" p) in
-      let fmt = Frame.Fields.find field s#content_type in
-      Content.Format_val.to_value fmt)
+      let fmt = Content.Format_val.of_value (List.assoc "" p) in
+      match Content.value_of_format fmt with
+        | Some (name, v) -> Lang.meth (Lang.record []) [(name, v)]
+        | None -> Lang.record [])

--- a/src/core/builtins/builtins_source.ml
+++ b/src/core/builtins/builtins_source.ml
@@ -168,3 +168,24 @@ let _ =
       let wrap_f () = ignore (Lang.apply f []) in
       s#on_sleep wrap_f;
       Lang.unit)
+
+let _ =
+  Lang.add_builtin ~base:source "content" ~category:(`Source `Liquidsoap)
+    ~descr:
+      "Return the content type of the source as an associative list mapping \
+       frame field names (e.g. `\"audio\"`, `\"video\"`) to their content \
+       format. Use `format.description` to introspect a format value."
+    [("", Lang.source_t (Lang.univ_t ()), None, None)]
+    (Lang.list_t (Lang.product_t Lang.string_t Content.Format_val.t))
+    (fun p ->
+      let s = Lang.to_source (List.assoc "" p) in
+      let entries =
+        Frame.Fields.fold
+          (fun field fmt acc ->
+            let field_name = Frame.Fields.string_of_field field in
+            Lang.product (Lang.string field_name)
+              (Content.Format_val.to_value fmt)
+            :: acc)
+          s#content_type []
+      in
+      Lang.list (List.rev entries))

--- a/src/core/optionals/ffmpeg/ffmpeg_copy_content.ml
+++ b/src/core/optionals/ffmpeg/ffmpeg_copy_content.ml
@@ -213,6 +213,9 @@ module Specs = struct
         d.chunks
     in
     Digest.string (String.concat "||" chunk_checksums) |> Digest.to_hex
+
+  let content_lang_typ = Liquidsoap_lang.Lang_core.string_t
+  let params_to_value p = Liquidsoap_lang.Lang_core.string (string_of_params p)
 end
 
 include Content.MkContent (Specs)

--- a/src/core/optionals/ffmpeg/ffmpeg_raw_content.ml
+++ b/src/core/optionals/ffmpeg/ffmpeg_raw_content.ml
@@ -165,6 +165,9 @@ module AudioSpecs = struct
       sample_rate =
         Content.merge_param ~name:"sample_rate" (p.sample_rate, p'.sample_rate);
     }
+
+  let content_lang_typ = Liquidsoap_lang.Lang_core.string_t
+  let params_to_value p = Liquidsoap_lang.Lang_core.string (string_of_params p)
 end
 
 module Audio = struct
@@ -313,6 +316,9 @@ module VideoSpecs = struct
         Content.merge_param ~name:"pixel_aspect"
           (p.pixel_aspect, p'.pixel_aspect);
     }
+
+  let content_lang_typ = Liquidsoap_lang.Lang_core.string_t
+  let params_to_value p = Liquidsoap_lang.Lang_core.string (string_of_params p)
 end
 
 module Video = struct

--- a/src/lang/base/lang_core.ml
+++ b/src/lang/base/lang_core.ml
@@ -207,7 +207,7 @@ let add_builtin ~category ~descr ?(flags = []) ?(meth = []) ?(examples = [])
         (fun (m : Type.meth) ->
           let d = m.doc.meth_descr in
           let d = if d = "" then None else Some d in
-          ( m.meth,
+          ( (if m.optional then m.meth ^ "?" else m.meth),
             Doc.Value.
               {
                 meth_type = Repr.string_of_scheme m.scheme;

--- a/src/libs/ffmpeg.liq
+++ b/src/libs/ffmpeg.liq
@@ -203,7 +203,7 @@ end
 # @param ~device V4L2 device to use.
 def input.v4l2(~id=null, ~max_buffer=0.5, ~device="/dev/video0") =
   (input.ffmpeg(id=id, format="v4l2", max_buffer=max_buffer, device) :
-    source(video=canvas)
+    source(video=yuv420p)
   )
 end
 
@@ -223,7 +223,7 @@ def video.testsrc.ffmpeg(
   duration = if null.defined(duration) then ":duration=#{duration}" else "" end
   src = "#{pattern}=#{size}:#{rate}#{duration}"
   (input.ffmpeg(id=id, max_buffer=max_buffer, format="lavfi", src) :
-    source(video=canvas)
+    source(video=yuv420p)
   )
 end
 

--- a/tests/core/ffmpeg_dummy_content_test.ml
+++ b/tests/core/ffmpeg_dummy_content_test.ml
@@ -48,6 +48,8 @@ module DummySpecs = struct
   let parse_param _ _ = None
   let string_of_kind = function `Dummy -> "ffmpeg.dummy"
   let kind_of_string = function "ffmpeg.dummy" -> Some `Dummy | _ -> None
+  let content_lang_typ = Lang.unit_t
+  let params_to_value _ = Lang.unit
 
   let string_of_params = function
     | None -> "none"

--- a/tests/core/types.ml
+++ b/tests/core/types.ml
@@ -218,7 +218,7 @@ let () =
       | _ -> assert false)
 
 let () =
-  (* { audio: pcm('a), video?: canvas } *)
+  (* { audio: pcm('a), video?: yuv420p } *)
   let f =
     Type.meth "audio"
       ([], Format_type.audio ())

--- a/tests/language/dune.inc
+++ b/tests/language/dune.inc
@@ -541,6 +541,25 @@
   (run %{run_test} socket.liq liquidsoap %{test_liq} socket.liq)))
 
 (rule
+ (alias test_source_content)
+ (package liquidsoap)
+ (deps
+  source_content.liq
+  ../../src/bin/liquidsoap.exe
+  (package liquidsoap)
+  (source_tree ../../src/libs)
+  crontab_test_cases.json
+  (:test_liq ../test.liq)
+  (:run_test ../run_test.exe))
+ (action
+  (run
+   %{run_test}
+   source_content.liq
+   liquidsoap
+   %{test_liq}
+   source_content.liq)))
+
+(rule
  (alias test_sqlite)
  (package liquidsoap)
  (deps
@@ -735,6 +754,7 @@
   (alias test_regexp)
   (alias test_replaygain)
   (alias test_socket)
+  (alias test_source_content)
   (alias test_sqlite)
   (alias test_stdlib)
   (alias test_string)

--- a/tests/language/source_content.liq
+++ b/tests/language/source_content.liq
@@ -25,13 +25,34 @@ def f() =
   # Video part should be yuv420p
   video_desc = format.description(video_fmt)
   test.equal(null.defined(video_desc?.yuv420p), true)
-  test.equal((null.get(video_desc?.yuv420p)).width, settings.frame.video.width())
-  test.equal((null.get(video_desc?.yuv420p)).height, settings.frame.video.height())
+  test.equal(
+    (null.get(video_desc?.yuv420p)).width,
+    settings.frame.video.width()
+  )
+  test.equal(
+    (null.get(video_desc?.yuv420p)).height,
+    settings.frame.video.height()
+  )
 
   # Test track.format gives the same result as source.content
   let {audio, video} = source.tracks(s)
   test.equal(null.defined(format.description(track.format(audio))?.pcm), true)
-  test.equal(null.defined(format.description(track.format(video))?.yuv420p), true)
+  test.equal(
+    null.defined(format.description(track.format(video))?.yuv420p),
+    true
+  )
+
+  # Test JSON serialization of content_format via json.stringify
+  test.equal(
+    json.stringify(compact=true, audio_fmt),
+    '{"pcm":{"channel_layout":"stereo","channels":2}}'
+  )
+  test.equal(
+    json.stringify(compact=true, video_fmt),
+    '{"yuv420p":{"height":#{settings.frame.video.height()},"width":#{
+      settings.frame.video.width()
+    }}}'
+  )
 
   test.pass()
 end

--- a/tests/language/source_content.liq
+++ b/tests/language/source_content.liq
@@ -1,0 +1,39 @@
+def f() =
+  # Test source.content on an audio-only source
+  audio_content = source.content(sine())
+  test.equal(list.length(audio_content), 1)
+  let [(field, fmt)] = audio_content
+  test.equal(field, "audio")
+
+  # Check format.description returns a pcm record
+  desc = format.description(fmt)
+  test.equal(null.defined(desc?.pcm), true)
+  test.equal((null.get(desc?.pcm)).channels, 2)
+  test.equal((null.get(desc?.pcm)).channel_layout, "stereo")
+
+  # Test source.content and track.format on a source with both audio and video
+  s = (noise() : source(audio=pcm, video=yuv420p))
+  av_content = source.content(s)
+  audio_fmt = list.assoc("audio", av_content)
+  video_fmt = list.assoc("video", av_content)
+
+  # Audio part should be pcm
+  audio_desc = format.description(audio_fmt)
+  test.equal(null.defined(audio_desc?.pcm), true)
+  test.equal((null.get(audio_desc?.pcm)).channels, 2)
+
+  # Video part should be yuv420p
+  video_desc = format.description(video_fmt)
+  test.equal(null.defined(video_desc?.yuv420p), true)
+  test.equal((null.get(video_desc?.yuv420p)).width, settings.frame.video.width())
+  test.equal((null.get(video_desc?.yuv420p)).height, settings.frame.video.height())
+
+  # Test track.format gives the same result as source.content
+  let {audio, video} = source.tracks(s)
+  test.equal(null.defined(format.description(track.format(audio))?.pcm), true)
+  test.equal(null.defined(format.description(track.format(video))?.yuv420p), true)
+
+  test.pass()
+end
+
+test.check(f)

--- a/tests/language/type_errors.liq
+++ b/tests/language/type_errors.liq
@@ -76,7 +76,7 @@ def f() =
 
   # Next one requires the inference of a subtype (fixed vs. variable arity)
   correct('ignore(stereo(add([])))')
-  correct('ignore((blank():source(audio=pcm,video=canvas)))')
+  correct('ignore((blank():source(audio=pcm,video=yuv420p)))')
   section("CONSTRAINTS")
   incorrect('"bl"+"a"')
   incorrect('(fun(a,b)->a+b)==(fun(a,b)->a+b)')
@@ -146,7 +146,7 @@ def f() =
     "TRACK TYPES"
   )
   correct('(source.tracks(blank()).audio:pcm)')
-  correct('(source.tracks(blank()).audio:canvas)')
+  correct('(source.tracks(blank()).audio:yuv420p)')
   correct('(source.tracks(single("")).midi:midi)')
   correct('(source.tracks(single("")).audio:ffmpeg.copy)')
   section("PATTERNS")

--- a/tests/language/typing.liq
+++ b/tests/language/typing.liq
@@ -161,7 +161,7 @@ def f() =
   end
 
   ignore(sum_eq)
-  (noise() : source(audio=pcm, video=canvas))
+  (noise() : source(audio=pcm, video=yuv420p))
   (noise() : source(audio=pcm(mono)))
   (noise() : source(audio=pcm("5.1")))
   (noise() : source)

--- a/tests/media/test_image_decoder_duration.liq
+++ b/tests/media/test_image_decoder_duration.liq
@@ -11,6 +11,6 @@ s.on_track(
     end
 )
 
-s = (s : source(video=canvas))
+s = (s : source(video=yuv420p))
 
 output.dummy(s)

--- a/tests/media/video_size.liq
+++ b/tests/media/video_size.liq
@@ -11,7 +11,7 @@ fname =
 
 out = {"#{fname}+test_videos_size-#{random.int()}.avi"}
 
-s = (single(fname) : source(video=canvas(width=47, height=52)))
+s = (single(fname) : source(video=yuv420p(width=47, height=52)))
 s = once(s)
 s =
   source({audio = source.tracks(blank()).audio, video = source.tracks(s).video})

--- a/tests/regression/source_dynamic.liq
+++ b/tests/regression/source_dynamic.liq
@@ -12,7 +12,7 @@ end
 
 s =
   (source.dynamic(id="image", track_sensitive=true, next) :
-    source(video=canvas)
+    source(video=yuv420p)
   )
 
 s_ref := s

--- a/tests/streams/image.liq
+++ b/tests/streams/image.liq
@@ -1,4 +1,4 @@
 #!../../liquidsoap ../test.liq
-s = (single("file1.png") : source(video=canvas))
+s = (single("file1.png") : source(video=yuv420p))
 output.dummy(fallible=true, s)
 thread.run(delay=3., test.pass)

--- a/tests/streams/never.liq
+++ b/tests/streams/never.liq
@@ -2,5 +2,5 @@
 
 # Test none/never annotations in sources, see #3222.
 s = (single("file1.png") : source(audio=none, ...))
-output.dummy(fallible=true, (s : source(video=canvas)))
+output.dummy(fallible=true, (s : source(video=yuv420p)))
 thread.run(delay=3., test.pass)


### PR DESCRIPTION
## Summary

Liquidsoap's type system already enforces content consistency at compile time,
but scripts had no way to inspect or react to content types at runtime. This PR
adds a set of operators that give programmers programmatic access to source and
track content formats, enabling scripts to make informed decisions about how to
handle content — for example, adapting processing based on whether a source is
stereo or mono, or whether a video track is present at all.

## New operators

- **`source.content(s)`** — returns the content type of a source as
  `[string * content_format]`, mapping field names (`"audio"`, `"video"`, ...)
  to their format.
- **`track.format(t)`** — returns the `content_format` of a single track.
- **`format.description(fmt)`** — converts a `content_format` to a typed record
  with one optional method per content type (`pcm?`, `yuv420p?`, `midi?`,
  `ffmpeg_copy?`, etc.), suitable for pattern matching and conditional logic.

Together these let you write scripts like:

```liquidsoap
let {audio, video} = source.tracks(s)
print(format.description(track.format(audio)))
# {pcm={channels=2, channel_layout="stereo"}}
```

## Other changes

- Each content `Specs` module now declares `content_lang_typ` and
  `params_to_value`; registration happens automatically inside `MkContentBase`,
  so adding new content types requires no changes to `content.ml`.
- Optional methods now show a trailing `?` in `liquidsoap -h` output.
- `multitrack.md` rewritten: accurate tone, correct clock unification
  explanation, coverage of the new introspection operators.

## ⚠️ Breaking change

The internal video content type has been renamed from **`canvas`** to
**`yuv420p`**. Any script using `canvas` in a type annotation must be updated:

```
# Before
s = (source : source(video=canvas))
s = (source : source(video=canvas(width=1280, height=720)))

# After
s = (source : source(video=yuv420p))
s = (source : source(video=yuv420p(width=1280, height=720)))
```

The rename better reflects the actual content (planar YUV420 images). The
internal canvas model — a superposition of layers — is unchanged. The
`video.canvas` positioning API is unaffected. Migration documentation has been
added to `doc/content/migrating.md`.

## Test plan

- [x] `dune build @test_source_content` passes
- [x] `dune build @citest` passes
- [x] `./liquidsoap -h source.content` / `track.format` / `format.description` show correct types
- [x] Scripts using `source(video=canvas)` type annotations are updated (all in-tree occurrences updated in this PR)