### PR TITLE
clock: fix sub_clock leak when on_sleep deregisters during has_stopped

### DIFF
--- a/src/core/base/clock.ml
+++ b/src/core/base/clock.ml
@@ -265,8 +265,12 @@ let pending_clocks = WeakQueue.create ()
 let clocks = Queue.create ()
 
 let rec has_stopped ~clear_controller ~clock ~c x =
+  (* Snapshot sub_clocks before sleeping outputs: on_sleep callbacks may
+     deregister sub-clocks (e.g. ffmpeg filter graphs), which would prevent
+     them from being stopped here. *)
+  let sub_clocks = Queue.elements clock.sub_clocks in
   Queue.iter x.outputs (fun (a, o) -> try o#sleep a with _ -> ());
-  Queue.iter clock.sub_clocks stop;
+  List.iter stop sub_clocks;
   Queue.filter_out clocks (fun c -> Unifier.deref c == clock);
   if clear_controller then Unifier.set clock.controller `None;
   Atomic.set clock.state (`Stopped x.sync);

--- a/tests/core/dune.inc
+++ b/tests/core/dune.inc
@@ -345,6 +345,19 @@
   (run %{strings_test})))
 
 (executable
+ (name sub_clock_stop_test)
+ (modules sub_clock_stop_test)
+ (libraries liquidsoap_core liquidsoap_optionals))
+
+(rule
+ (alias sub_clock_stop_test)
+ (package liquidsoap)
+ (deps
+  (:sub_clock_stop_test sub_clock_stop_test.exe))
+ (action
+  (run %{sub_clock_stop_test})))
+
+(executable
  (name timezone)
  (modules timezone)
  (libraries liquidsoap_core liquidsoap_optionals))
@@ -451,6 +464,7 @@
   (alias stream_decoder_test)
   (alias string_test)
   (alias strings_test)
+  (alias sub_clock_stop_test)
   (alias timezone)
   (alias types)
   (alias unifier_test)

--- a/tests/core/sub_clock_stop_test.ml
+++ b/tests/core/sub_clock_stop_test.ml
@@ -1,0 +1,47 @@
+(* Regression test: sub-clocks deregistered by on_sleep must still be
+   stopped when the parent clock stops.
+
+   The bug: has_stopped first sleeps outputs (which fires on_sleep callbacks
+   that deregister sub-clocks), then iterates sub_clocks to stop them — but
+   by then the sub-clock is already gone and never gets stopped.
+
+   The fix: snapshot sub_clocks before sleeping outputs. *)
+
+class test_output ~clock source =
+  object
+    inherit
+      Output.dummy
+        ~clock ~autostart:true ~infallible:false ~register_telnet:false
+        (Lang.source (source :> Source.source))
+
+    method! can_generate_frame = false
+  end
+
+class test_source =
+  object (self)
+    inherit Debug_sources.fail "test_source"
+    method! can_generate_frame = false
+    method! generate_frame = self#empty_frame
+  end
+
+let () =
+  Frame_settings.lazy_config_eval := true;
+  let parent_clock = Clock.create ~sync:`Passive () in
+  let sub_clock = Clock.create ~sync:`Passive () in
+  Clock.register_sub_clock parent_clock sub_clock;
+  let source = new test_source in
+  let output = new test_output ~clock:parent_clock source in
+  (* Simulate what ffmpeg filter on_sleep does: deregister the sub-clock
+     when the output source sleeps. *)
+  output#on_sleep (fun () -> Clock.deregister_sub_clock parent_clock sub_clock);
+  output#content_type_computation_allowed;
+  Clock.start ~force:true parent_clock;
+  Clock.start ~force:true sub_clock;
+  (* Activate pending sources so the output is in clock.outputs,
+     without generating frames. *)
+  Clock.activate_pending_sources parent_clock;
+  (* Stopping the parent clock must stop the sub_clock even though
+     on_sleep will deregister it from sub_clocks mid-stop. *)
+  Clock.stop parent_clock;
+  assert (not (Clock.started sub_clock));
+  Printf.printf "sub_clock_stop_test passed!\n%!"


### PR DESCRIPTION
Fixes #5097.

## Problem

`has_stopped` stopped sub-clocks by iterating `clock.sub_clocks` *after* sleeping all outputs. The output sleep cascade fires `on_sleep` callbacks — and ffmpeg filter graphs use `on_sleep` to deregister their input sub-clock (`deregister_sub_clock`) when the last filter output goes down. This means by the time `has_stopped` iterated `sub_clocks`, the queue was already empty: the sub-clock was never stopped, and its associated resources (the Avfilter C context, `ffmpeg_filter_audio_input` output source) were never freed. With `request.process`-style per-track filter graphs, this leaked memory on every track.

## Fix

Snapshot `sub_clocks` at the top of `has_stopped`, before sleeping outputs. The stop iteration then uses the snapshot and stops the sub-clock regardless of what `on_sleep` callbacks do to the live queue.

## Test

New regression test in `tests/core/sub_clock_stop_test.ml`: creates a parent clock with a registered sub-clock, attaches an `on_sleep` callback to an output that deregisters the sub-clock (replicating the ffmpeg filter pattern), stops the parent clock, and asserts the sub-clock was stopped.