### PR TITLE
input.harbor: fix Mount_taken raised outside monad error handler

### DIFF
--- a/.github/scripts/build-apk.sh
+++ b/.github/scripts/build-apk.sh
@@ -8,7 +8,6 @@ APK_VERSION=$(opam show -f version ./opam/liquidsoap.opam | cut -d'-' -f 1)
 COMMIT_SHORT=$(echo "${GITHUB_SHA}" | cut -c-7)
 
 export LIQUIDSOAP_BUILD_TARGET=posix
-export ABUILD_APK_INDEX_OPTS="--allow-untrusted"
 
 if [ -n "${IS_ROLLING_RELEASE}" ]; then
   APK_PACKAGE="liquidsoap-${COMMIT_SHORT}-${ALPINE_TAG}-${ALPINE_ARCH}"
@@ -30,7 +29,6 @@ sed -e "s#@APK_PACKAGE@#${APK_PACKAGE}#" liquidsoap/.github/alpine/APKBUILD.in |
 
 cp "liquidsoap/.github/alpine/liquidsoap.post-install" "${APK_PACKAGE}.post-install"
 
-abuild-keygen -a -n
 abuild
 
 mv /home/opam/packages/tmp/"${ALPINE_ARCH}"/*.apk "${LIQ_TMP_DIR}"
@@ -76,7 +74,6 @@ sed -e "s#@APK_PACKAGE@#${APK_PACKAGE}-minimal#" liquidsoap/.github/alpine/APKBU
 
 cp "liquidsoap/.github/alpine/liquidsoap.post-install" "${APK_PACKAGE}-minimal.post-install"
 
-abuild-keygen -a -n
 abuild
 
 mv /home/opam/packages/tmp/"${ALPINE_ARCH}"/*.apk "${LIQ_TMP_DIR}"

--- a/.github/workflows/build-posix.yml
+++ b/.github/workflows/build-posix.yml
@@ -121,6 +121,8 @@ jobs:
           mkdir -p "${LIQ_TMP_DIR}"
           chown -R opam "${LIQ_TMP_DIR}"
           chown -R opam "${GITHUB_OUTPUT}"
+          sudo -u opam -E abuild-keygen -a -n
+          cp /home/opam/.abuild/*.pub /etc/apk/keys/
           sudo -u opam -E ./.github/scripts/build-apk.sh
       - name: Upload alpine packages artifacts
         if: matrix.os == 'alpine'

--- a/src/core/base/clock.ml
+++ b/src/core/base/clock.ml
@@ -265,8 +265,12 @@ let pending_clocks = WeakQueue.create ()
 let clocks = Queue.create ()
 
 let rec has_stopped ~clear_controller ~clock ~c x =
+  (* Snapshot sub_clocks before sleeping outputs: on_sleep callbacks may
+     deregister sub-clocks (e.g. ffmpeg filter graphs), which would prevent
+     them from being stopped here. *)
+  let sub_clocks = Queue.elements clock.sub_clocks in
   Queue.iter x.outputs (fun (a, o) -> try o#sleep a with _ -> ());
-  Queue.iter clock.sub_clocks stop;
+  List.iter stop sub_clocks;
   Queue.filter_out clocks (fun c -> Unifier.deref c == clock);
   if clear_controller then Unifier.set clock.controller `None;
   Atomic.set clock.state (`Stopped x.sync);

--- a/src/core/base/harbor/harbor.ml
+++ b/src/core/base/harbor/harbor.ml
@@ -157,6 +157,7 @@ module type T = sig
       (string * string) list ->
       ?read:(socket -> bytes -> int -> int -> int) ->
       socket ->
+      unit ->
       unit
 
     method virtual encode_metadata : Frame.metadata -> unit
@@ -217,6 +218,7 @@ module Make (T : Transport_t) : T with type socket = T.socket = struct
             (string * string) list ->
             ?read:(socket -> bytes -> int -> int -> int) ->
             socket ->
+            unit ->
             unit
 
       method virtual encode_metadata : Frame.metadata -> unit
@@ -547,7 +549,7 @@ module Make (T : Transport_t) : T with type socket = T.socket = struct
           Some read)
         else None
       in
-      let f () = s#relay ?read stype headers h.Duppy.Monad.Io.socket in
+      let f = s#relay ?read stype headers h.Duppy.Monad.Io.socket in
       log#info "Adding source on mountpoint %S with type %S." uri stype;
       log#debug "Relaying %s." (string_of_protocol hprotocol);
       let protocol =
@@ -669,7 +671,7 @@ module Make (T : Transport_t) : T with type socket = T.socket = struct
       Utils.buffer_drop binary_data len;
       len
     in
-    let f () = source#relay stype headers ~read h.Duppy.Monad.Io.socket in
+    let f = source#relay stype headers ~read h.Duppy.Monad.Io.socket in
     relayed "" f
 
   exception Handled of (http_verb * (string * string) list * http_handler)

--- a/src/core/base/sources/harbor_input.ml
+++ b/src/core/base/sources/harbor_input.ml
@@ -213,7 +213,8 @@ class http_input_server ~pos ~transport ~dumpfile ~logfile ~bufferize ~max ~icy
                 (Printexc.to_string e))
         | None -> ()
       end;
-      ignore (Tutils.create (fun () -> self#feed) () "harbor source feeding")
+      fun () ->
+        ignore (Tutils.create (fun () -> self#feed) () "harbor source feeding")
 
     method disconnect =
       match Atomic.exchange relay_socket None with

--- a/tests/core/dune.inc
+++ b/tests/core/dune.inc
@@ -336,6 +336,20 @@
 
 
 (executable
+ (name sub_clock_stop_test)
+ (modules sub_clock_stop_test)
+ (libraries liquidsoap_core liquidsoap_optionals))
+
+(rule
+ (alias sub_clock_stop_test)
+ (package liquidsoap)
+ (deps
+  
+  (:sub_clock_stop_test sub_clock_stop_test.exe))
+ (action (run %{sub_clock_stop_test} )))
+
+
+(executable
  (name timezone)
  (modules timezone)
  (libraries liquidsoap_core liquidsoap_optionals))
@@ -445,6 +459,7 @@
     (alias stream_decoder_test)
     (alias string_test)
     (alias strings_test)
+    (alias sub_clock_stop_test)
     (alias timezone)
     (alias types)
     (alias unifier_test)

--- a/tests/core/sub_clock_stop_test.ml
+++ b/tests/core/sub_clock_stop_test.ml
@@ -1,0 +1,47 @@
+(* Regression test: sub-clocks deregistered by on_sleep must still be
+   stopped when the parent clock stops.
+
+   The bug: has_stopped first sleeps outputs (which fires on_sleep callbacks
+   that deregister sub-clocks), then iterates sub_clocks to stop them — but
+   by then the sub-clock is already gone and never gets stopped.
+
+   The fix: snapshot sub_clocks before sleeping outputs. *)
+
+class test_output ~clock source =
+  object
+    inherit
+      Output.dummy
+        ~clock ~autostart:true ~infallible:false ~register_telnet:false
+        (Lang.source (source :> Source.source))
+
+    method! can_generate_frame = false
+  end
+
+class test_source =
+  object (self)
+    inherit Debug_sources.fail "test_source"
+    method! can_generate_frame = false
+    method! generate_frame = self#empty_frame
+  end
+
+let () =
+  Frame_settings.lazy_config_eval := true;
+  let parent_clock = Clock.create ~sync:`Passive () in
+  let sub_clock = Clock.create ~sync:`Passive () in
+  Clock.register_sub_clock parent_clock sub_clock;
+  let source = new test_source in
+  let output = new test_output ~clock:parent_clock source in
+  (* Simulate what ffmpeg filter on_sleep does: deregister the sub-clock
+     when the output source sleeps. *)
+  output#on_sleep (fun () -> Clock.deregister_sub_clock parent_clock sub_clock);
+  output#content_type_computation_allowed;
+  Clock.start ~force:true parent_clock;
+  Clock.start ~force:true sub_clock;
+  (* Activate pending sources so the output is in clock.outputs,
+     without generating frames. *)
+  Clock.activate_pending_sources parent_clock;
+  (* Stopping the parent clock must stop the sub_clock even though
+     on_sleep will deregister it from sub_clocks mid-stop. *)
+  Clock.stop parent_clock;
+  assert (not (Clock.started sub_clock));
+  Printf.printf "sub_clock_stop_test passed!\n%!"


### PR DESCRIPTION
## Reason

When a second source connected to an already-occupied mountpoint, the `Mount_taken` exception was raised too late — inside a `Duppy.Io.write` completion callback, after the `try...with Mount_taken` handler had already returned. This caused it to reach Duppy's generic error handler and log as an "Unknown error" at severity 2, with no 403 response sent to the client.

## What changed

`#relay` previously did all setup and directly spawned the feed thread (returning `unit`). It now does all setup synchronously and **returns the feed thunk** (`unit -> unit`) instead of running it. The two call sites (`handle_source_request` and the WebSocket handler) now call `s#relay` directly — before `relayed` — so any `Mount_taken` raise happens inside the monad context where the existing handler catches it and returns a proper 403.

Fixes #5098