### PR TITLE
lang: fix is_binary incorrectly skipping charset conversion for non-UTF-8 text

### DIFF
--- a/src/core/base/tools/charset.ml
+++ b/src/core/base/tools/charset.ml
@@ -56,7 +56,7 @@ let recode_string ~fail ~in_enc ~out_enc s =
               s)
 
 let convert ?(fail = false) ?source ?(target = C.utf8) s =
-  if Liquidsoap_lang.Binary_strings_map.is_binary s then (
+  if Liquidsoap_lang.Binary_strings_map.is_binary ~utf8:false s then (
     log#info "Skipping charset conversion for binary string.";
     s)
   else (

--- a/src/lang/base/binary_strings_map.ml
+++ b/src/lang/base/binary_strings_map.ml
@@ -24,6 +24,10 @@
 *)
 let max_printable_length = ref 4096
 
-let is_binary value =
-  String.length value > !max_printable_length
-  || not (String.is_valid_utf_8 value)
+(** Detect binary blobs. When [utf8] is [true] (default), any non-UTF-8 string
+    is considered binary — suitable for internally-managed strings that should
+    always be UTF-8. When [utf8] is [false], only the length is checked —
+    suitable for externally-sourced strings that may be in any text encoding. *)
+let is_binary ?(utf8 = true) value =
+  if String.length value > !max_printable_length then true
+  else utf8 && not (String.is_valid_utf_8 value)

--- a/src/lang/base/binary_strings_map.mli
+++ b/src/lang/base/binary_strings_map.mli
@@ -24,6 +24,7 @@
     Defaults to [4096]. *)
 val max_printable_length : int ref
 
-(** Return [true] if [s] should be treated as binary: either it is longer than
-    [max_printable_length] bytes or contains invalid UTF-8. *)
-val is_binary : string -> bool
+(** Return [true] if [s] should be treated as binary. When [utf8] is [true]
+    (default), any non-UTF-8 string is considered binary. When [utf8] is
+    [false], only the length is checked. *)
+val is_binary : ?utf8:bool -> string -> bool

--- a/tests/core/binary_strings_map_test.ml
+++ b/tests/core/binary_strings_map_test.ml
@@ -7,9 +7,7 @@ let () =
   assert (not (is_binary "résumé"))
 
 (* Invalid UTF-8 is binary. *)
-let () =
-  let invalid_utf8 = "\xFF\xFE" in
-  assert (is_binary invalid_utf8)
+let () = assert (is_binary "\xff\xfe")
 
 (* Strings longer than max_printable_length are binary. *)
 let () =
@@ -17,3 +15,13 @@ let () =
   assert (is_binary long_string);
   let exact_length = String.make !max_printable_length 'a' in
   assert (not (is_binary exact_length))
+
+(* utf8:false — size check only; any encoding passes through. *)
+let () =
+  assert (not (is_binary ~utf8:false "hello"));
+  assert (not (is_binary ~utf8:false ""));
+  assert (not (is_binary ~utf8:false "\xe9\xe0\xfc"));
+  assert (not (is_binary ~utf8:false "\xff\xfeR\x00"));
+  assert (not (is_binary ~utf8:false "\x00\x01\x02"));
+  let long_string = String.make (!max_printable_length + 1) 'a' in
+  assert (is_binary ~utf8:false long_string)


### PR DESCRIPTION
## Summary

Backport of #5107 to v2.4.x-latest.

Fixes a regression where `is_binary` used UTF-8 validity as a proxy for binary detection, causing `charset.convert` to skip recoding for any non-UTF-8 string — including Latin-1, CP1252, or UTF-16 metadata. This broke MP3 metadata with non-ASCII or UTF-16-encoded tags (reported in #5105).

Add an `~utf8` parameter to `is_binary` in `Binary_strings_map`:
- `~utf8:true` (default): binary if too long or not valid UTF-8
- `~utf8:false` (charset.convert only): binary only if too long

Closes #5105