### PR TITLE
clock: make sub_clocks always unique modulo deref

### DIFF
--- a/src/core/base/clock.ml
+++ b/src/core/base/clock.ml
@@ -264,10 +264,17 @@ let sync c = _sync (Unifier.deref c)
 let pending_clocks = WeakQueue.create ()
 let clocks = Queue.create ()
 
+let compare_clock_identity c c' =
+  Int.compare (Obj.magic c : int) (Obj.magic c' : int)
+
 let _sub_clocks c =
-  List.sort_uniq
-    (fun (_, c) (_, c') -> if c == c' then 0 else Stdlib.compare c c')
-    (List.map (fun c -> (c, Unifier.deref c)) (Queue.elements c.sub_clocks))
+  let all = ref [] in
+  Queue.flush_iter c.sub_clocks (fun x -> all := (x, Unifier.deref x) :: !all);
+  let deduped =
+    List.sort_uniq (fun (_, c) (_, c') -> compare_clock_identity c c') !all
+  in
+  List.iter (fun (ref, _) -> Queue.push c.sub_clocks ref) deduped;
+  deduped
 
 let sub_clocks c = List.map fst (_sub_clocks (Unifier.deref c))
 
@@ -767,7 +774,9 @@ let time c =
 let start_pending () =
   let c = WeakQueue.flush_elements pending_clocks in
   let c = List.map (fun c -> (c, Unifier.deref c)) c in
-  let c = List.sort_uniq (fun (_, c) (_, c') -> Stdlib.compare c c') c in
+  let c =
+    List.sort_uniq (fun (_, c) (_, c') -> compare_clock_identity c c') c
+  in
   List.iter
     (fun (c, clock) ->
       match Atomic.get clock.state with
@@ -811,10 +820,7 @@ let set_stack c stack =
   ignore (Atomic.compare_and_set (Unifier.deref c).stack [] stack)
 
 let register_sub_clock parent sub =
-  let _sub = Unifier.deref sub in
-  let sub_clocks = (Unifier.deref parent).sub_clocks in
-  if not (Queue.exists sub_clocks (fun c -> Unifier.deref c == _sub)) then
-    Queue.push sub_clocks sub
+  Queue.push (Unifier.deref parent).sub_clocks sub
 
 let deregister_sub_clock parent sub =
   let _sub = Unifier.deref sub in
@@ -826,7 +832,7 @@ let create ?stack ?controller ?on_error ?id ?sync () =
 
 let clocks () =
   List.sort_uniq
-    (fun c c' -> Stdlib.compare (Unifier.deref c) (Unifier.deref c'))
+    (fun c c' -> compare_clock_identity (Unifier.deref c) (Unifier.deref c'))
     (WeakQueue.elements pending_clocks @ Queue.elements clocks)
 
 let dump () =

--- a/src/core/base/clock.ml
+++ b/src/core/base/clock.ml
@@ -267,14 +267,16 @@ let clocks = Queue.create ()
 let compare_clock_identity c c' =
   Int.compare (Obj.magic c : int) (Obj.magic c' : int)
 
-let _sub_clocks c =
+let _compact_sub_clocks c =
   let all = ref [] in
   Queue.flush_iter c.sub_clocks (fun x -> all := (x, Unifier.deref x) :: !all);
   let deduped =
     List.sort_uniq (fun (_, c) (_, c') -> compare_clock_identity c c') !all
   in
-  List.iter (fun (ref, _) -> Queue.push c.sub_clocks ref) deduped;
-  deduped
+  List.iter (fun (ref, _) -> Queue.push c.sub_clocks ref) deduped
+
+let _sub_clocks c =
+  List.map (fun x -> (x, Unifier.deref x)) (Queue.elements c.sub_clocks)
 
 let sub_clocks c = List.map fst (_sub_clocks (Unifier.deref c))
 
@@ -340,6 +342,10 @@ let unify =
     Queue.flush_iter clock.pending_activations
       (Queue.push clock'.pending_activations);
     Queue.flush_iter clock.sub_clocks (Queue.push clock'.sub_clocks);
+    _compact_sub_clocks clock';
+    List.iter
+      (fun c -> _compact_sub_clocks (Unifier.deref c))
+      (Queue.elements clocks @ WeakQueue.elements pending_clocks);
     Queue.flush_iter clock.on_error (Queue.push clock'.on_error);
     (match (Unifier.deref clock.id, Unifier.deref clock'.id) with
       | None, None -> Unifier.(clock.id <-- clock'.id)
@@ -820,7 +826,10 @@ let set_stack c stack =
   ignore (Atomic.compare_and_set (Unifier.deref c).stack [] stack)
 
 let register_sub_clock parent sub =
-  Queue.push (Unifier.deref parent).sub_clocks sub
+  let _parent = Unifier.deref parent in
+  let _sub = Unifier.deref sub in
+  if not (Queue.exists _parent.sub_clocks (fun c -> Unifier.deref c == _sub))
+  then Queue.push _parent.sub_clocks sub
 
 let deregister_sub_clock parent sub =
   let _sub = Unifier.deref sub in

--- a/src/core/base/clock.ml
+++ b/src/core/base/clock.ml
@@ -264,11 +264,18 @@ let sync c = _sync (Unifier.deref c)
 let pending_clocks = WeakQueue.create ()
 let clocks = Queue.create ()
 
+let _sub_clocks c =
+  List.sort_uniq
+    (fun (_, c) (_, c') -> if c == c' then 0 else Stdlib.compare c c')
+    (List.map (fun c -> (c, Unifier.deref c)) (Queue.elements c.sub_clocks))
+
+let sub_clocks c = List.map fst (_sub_clocks (Unifier.deref c))
+
 let rec has_stopped ~clear_controller ~clock ~c x =
   (* Snapshot sub_clocks before sleeping outputs: on_sleep callbacks may
      deregister sub-clocks (e.g. ffmpeg filter graphs), which would prevent
      them from being stopped here. *)
-  let sub_clocks = Queue.elements clock.sub_clocks in
+  let sub_clocks = List.map fst (_sub_clocks clock) in
   Queue.iter x.outputs (fun (a, o) -> try o#sleep a with _ -> ());
   List.iter stop sub_clocks;
   Queue.filter_out clocks (fun c -> Unifier.deref c == clock);
@@ -494,13 +501,12 @@ let pretty_sources ~clock x =
   let rec build_entry clock x =
     let sub_clocks =
       List.filter_map
-        (fun sub ->
-          let sub_clock = Unifier.deref sub in
+        (fun (_, sub_clock) ->
           match Atomic.get sub_clock.state with
             | `Started sub_x | `Stopping sub_x ->
                 Some (build_entry sub_clock sub_x)
             | _ -> None)
-        (Queue.elements clock.sub_clocks)
+        (_sub_clocks clock)
     in
     let src s =
       Clock_utils.
@@ -553,7 +559,7 @@ and _activate_pending_sources ~clock x =
 
 and _tick ~clock x =
   let sub_clocks =
-    List.map (fun c -> (c, ticks c)) (Queue.elements clock.sub_clocks)
+    List.map (fun (c, clock) -> (c, ticks c, clock)) (_sub_clocks clock)
   in
   _activate_pending_sources ~clock x;
   let sources = _animated_sources x in
@@ -569,9 +575,8 @@ and _tick ~clock x =
   let self_sync = _self_sync ~clock x in
   check_stopped ();
   List.iter
-    (fun (c, old_ticks) ->
-      if ticks c = old_ticks then
-        _tick ~clock:(Unifier.deref c) (active_params c))
+    (fun (c, old_ticks, clock) ->
+      if ticks c = old_ticks then _tick ~clock (active_params c))
     sub_clocks;
   Atomic.incr x.ticks;
   check_stopped ();
@@ -812,7 +817,9 @@ let register_sub_clock parent sub =
     Queue.push sub_clocks sub
 
 let deregister_sub_clock parent sub =
-  Queue.filter_out (Unifier.deref parent).sub_clocks (fun c -> c == sub)
+  let _sub = Unifier.deref sub in
+  Queue.filter_out (Unifier.deref parent).sub_clocks (fun c ->
+      Unifier.deref c == _sub)
 
 let create ?stack ?controller ?on_error ?id ?sync () =
   create ?stack ?controller ?on_error ?id ?sync ()
@@ -821,10 +828,6 @@ let clocks () =
   List.sort_uniq
     (fun c c' -> Stdlib.compare (Unifier.deref c) (Unifier.deref c'))
     (WeakQueue.elements pending_clocks @ Queue.elements clocks)
-
-let sub_clocks c =
-  let clock = Unifier.deref c in
-  Queue.elements clock.sub_clocks
 
 let dump () =
   let rec build_entry c =


### PR DESCRIPTION
## Summary

`clock` values contain function fields (`on_error`), so using `Stdlib.compare` on them raises `Invalid_argument "compare: functional value"` whenever two genuinely distinct clocks are compared. This was latent in `start_pending`, `clocks()`, and the old `sub_clocks` implementation.

Changes vs `main`:

- **`compare_clock_identity`**: address-based comparison via `Obj.magic` used wherever two `clock` values need to be ordered/deduplicated — replaces all `Stdlib.compare` calls on clock values.

- **`deregister_sub_clock`**: fix to compare by dereferenced identity (`Unifier.deref c == _sub`) rather than raw ref equality, so deregistration works correctly after clock unification.

- **`_sub_clocks` / `_compact_sub_clocks`**: split into two functions. `_compact_sub_clocks` does the drain → sort_uniq → refill compaction (write-time operation). `_sub_clocks` is now a plain read with no queue mutation, keeping it cheap in the hot path of `_tick`.

- **`_tick`**: avoid calling `Unifier.deref` again on each sub-clock tick by storing the already-dereferenced clock in the snapshot tuple.

- **`register_sub_clock`**: check-before-push prevents trivial duplicates at insertion time.

- **`_unify`**: after merging one clock's sub_clocks into another, compact the merged queue and also compact all other known clocks. Unification can turn two distinct refs in a third clock's sub_clocks list into duplicates pointing to the same canonical clock; those need to be collapsed too.

## Test plan

- `dune build` passes cleanly
- Existing regression and streaming tests cover clock unification and sub-clock lifecycle