### PR TITLE
hls: fix ID3 timed metadata missing from first mpegts HLS segment

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -30,6 +30,8 @@
 
 ## Fixed:
 
+- Fixed ID3 timed metadata missing from first mpegts HLS segment: metadata is
+  now registered before the segment is opened and before data is encoded (#5084).
 - Make active `stereotool` really be active.. (#4882)
 - Fixed `fMP4` HLS support for audio+video streams (#4841)
 - Fixed crossfade clocks inconsistencies leading to weird caching audio glitches (#4851)

--- a/src/core/base/outputs/hls_output.ml
+++ b/src/core/base/outputs/hls_output.ml
@@ -722,6 +722,21 @@ class hls_output p =
             self#write_main_playlist)
       | _ -> ()
 
+    method private write_metadata ~s ~current_position out_channel =
+      if s.id3_enabled then (
+        let m =
+          match s.metadata with
+            | `Todo m ->
+                s.metadata <- `Sent m;
+                Frame.Metadata.Export.to_list m
+            | `Sent m when s.replay_id3 -> Frame.Metadata.Export.to_list m
+            | `Sent _ | `None -> []
+        in
+        let frame_position, sample_position = current_position in
+        match s.encoder.hls.insert_id3 ~frame_position ~sample_position m with
+          | None -> ()
+          | Some s -> out_channel#output_string s)
+
     method private open_segment s =
       self#log#debug "Opening segment %d for stream %s." s.position s.name;
       let discontinuous, current_discontinuity =
@@ -751,24 +766,12 @@ class hls_output p =
         segment_name ~position ~extname ~duration ~ticks s.name
       in
       let out_channel = self#open_out filename in
+      self#write_metadata ~s ~current_position out_channel;
       Strings.iter out_channel#output_substring (s.encoder.Encoder.header ());
       segment.out_channel <- Some out_channel;
       s.current_segment <- Some segment;
       s.discontinuity_count <- current_discontinuity;
-      s.position <- s.position + 1;
-      if s.id3_enabled then (
-        let m =
-          match s.metadata with
-            | `Todo m ->
-                s.metadata <- `Sent m;
-                Frame.Metadata.Export.to_list m
-            | `Sent m when s.replay_id3 -> Frame.Metadata.Export.to_list m
-            | `Sent _ | `None -> []
-        in
-        let frame_position, sample_position = current_position in
-        match s.encoder.hls.insert_id3 ~frame_position ~sample_position m with
-          | None -> ()
-          | Some s -> out_channel#output_string s)
+      s.position <- s.position + 1
 
     method reopen_segment ~position:(len, offset) =
       function
@@ -910,7 +913,7 @@ class hls_output p =
 
     method start =
       stopped <- false;
-      (match persist_at with
+      match persist_at with
         | Some persist_at when Sys.file_exists persist_at -> (
             try
               self#log#info "Resuming from saved state";
@@ -920,8 +923,7 @@ class hls_output p =
             with exn when not strict_persist ->
               self#log#info "Failed to resume from saved state: %s"
                 (Printexc.to_string exn))
-        | _ -> ());
-      List.iter self#open_segment streams
+        | _ -> ()
 
     method stop =
       stopped <- true;
@@ -1069,7 +1071,10 @@ class hls_output p =
         (frame_pos + (samples_pos / frame_size), samples_pos mod frame_size);
       List.map
         (fun s ->
-          let segment = Option.get s.current_segment in
+          let segment =
+            if s.current_segment = None then self#open_segment s;
+            Option.get s.current_segment
+          in
           let b =
             if s.init_state = `Todo then (
               try

--- a/src/core/base/outputs/icecast2.ml
+++ b/src/core/base/outputs/icecast2.ml
@@ -477,6 +477,11 @@ class output p =
         ~output_kind:"output.icecast" ~infallible ~register_telnet ~autostart
           ~export_cover_metadata:false ~name source_val
 
+    initializer
+      (* When sending ICY metadata, the update requires an active connection,
+         so metadata must come after send (which establishes the connection). *)
+      if send_icy_metadata then self#set_encoding_order `Data_first
+
     (** In this operator, we don't exactly follow the start/stop mechanism of
         Output.encoded because we want to control in a more subtle way the
         connection/disconnection with icecast. So we have specific

--- a/src/core/base/outputs/output.ml
+++ b/src/core/base/outputs/output.ml
@@ -231,17 +231,32 @@ class virtual ['a] encoded ~output_kind ?clock ~name ~infallible
     method virtual private encode : Frame.t -> 'a
     method virtual private send : 'a -> unit
 
+    val mutable encoding_order : [ `Data_first | `Metadata_first ] =
+      `Metadata_first
+
+    method private set_encoding_order v = encoding_order <- v
+
+    method private send_metadata frame start stop =
+      match
+        List.find_map
+          (fun (pos, m) -> if start <= pos && pos < stop then Some m else None)
+          (Frame.get_all_metadata frame)
+      with
+        | None -> ()
+        | Some m ->
+            self#encode_metadata
+              (Frame.Metadata.Export.from_metadata ~cover:export_cover_metadata
+                 m)
+
     method private send_frame frame =
       let rec output_chunks frame =
         let f start stop =
+          if encoding_order = `Metadata_first then
+            self#send_metadata frame start stop;
           let data = self#encode (Frame.sub frame start (stop - start)) in
           self#send data;
-          match Frame.get_metadata frame start with
-            | None -> ()
-            | Some m ->
-                self#encode_metadata
-                  (Frame.Metadata.Export.from_metadata
-                     ~cover:export_cover_metadata m)
+          if encoding_order = `Data_first then
+            self#send_metadata frame start stop
         in
         function
         | [] -> assert false

--- a/src/core/base/outputs/output.mli
+++ b/src/core/base/outputs/output.mli
@@ -74,6 +74,7 @@ object
   method private reset : unit
   method virtual private start : unit
   method virtual private stop : unit
+  method private set_encoding_order : [ `Data_first | `Metadata_first ] -> unit
 end
 
 class dummy :

--- a/tests/core/output_encoded_test.ml
+++ b/tests/core/output_encoded_test.ml
@@ -1,10 +1,12 @@
-let encode_metadata_called = ref false
-let encode_called = ref false
-let send_called = ref false
+let make_flags () =
+  let encode_metadata_called = ref false in
+  let encode_called = ref false in
+  let send_called = ref false in
+  (encode_metadata_called, encode_called, send_called)
 
-(* Make sure send is always called before insert metadata. *)
+(* Default: metadata_first. encode_metadata called before encode, encode before send. *)
 
-class encoded_test =
+class metadata_first_test encode_metadata_called encode_called send_called =
   object (self)
     inherit
       [unit] Output.encoded
@@ -12,6 +14,37 @@ class encoded_test =
           ~register_telnet:false ~autostart:false ~export_cover_metadata:false
         (Lang.source (new Noise.noise None))
 
+    method self_sync = (`Static, None)
+
+    method encode_metadata _ =
+      assert (not !encode_called);
+      encode_metadata_called := true
+
+    method encode _ =
+      assert !encode_metadata_called;
+      encode_called := true;
+      ()
+
+    method send _ =
+      assert !encode_called;
+      send_called := true
+
+    method test_send_frame frame = self#send_frame frame
+    method start = ()
+    method stop = ()
+  end
+
+(* Data_first: encode and send before encode_metadata (e.g. icecast with ICY). *)
+
+class data_first_test encode_metadata_called encode_called send_called =
+  object (self)
+    inherit
+      [unit] Output.encoded
+        ~output_kind:"foo" ~name:"encoded_test" ~infallible:false
+          ~register_telnet:false ~autostart:false ~export_cover_metadata:false
+        (Lang.source (new Noise.noise None))
+
+    initializer self#set_encoding_order `Data_first
     method self_sync = (`Static, None)
 
     method encode_metadata _ =
@@ -31,14 +64,26 @@ class encoded_test =
     method stop = ()
   end
 
-let () =
-  Frame_settings.lazy_config_eval := true;
-  let encoded_test = new encoded_test in
-  encoded_test#content_type_computation_allowed;
+let make_frame encoded_test =
   let frame =
     Frame.create ~length:(Lazy.force Frame.size) encoded_test#content_type
   in
   let m = Frame.Metadata.from_list [("foo", "bla")] in
-  let frame = Frame.add_metadata frame 0 m in
-  encoded_test#test_send_frame frame;
+  Frame.add_metadata frame 0 m
+
+let () =
+  Frame_settings.lazy_config_eval := true;
+  let encode_metadata_called, encode_called, send_called = make_flags () in
+  let t =
+    new metadata_first_test encode_metadata_called encode_called send_called
+  in
+  t#content_type_computation_allowed;
+  t#test_send_frame (make_frame t);
+  assert !encode_metadata_called;
+  let encode_metadata_called, encode_called, send_called = make_flags () in
+  let t =
+    new data_first_test encode_metadata_called encode_called send_called
+  in
+  t#content_type_computation_allowed;
+  t#test_send_frame (make_frame t);
   assert !encode_metadata_called

--- a/tests/regression/GH5084.liq
+++ b/tests/regression/GH5084.liq
@@ -1,0 +1,71 @@
+# Regression test for https://github.com/savonet/liquidsoap/issues/5084
+# HLS ID3 stream should contain metadata, not just the empty 10-byte ID3 header
+
+tmp_dir = file.temp_dir("tmp")
+on_cleanup({file.rmdir(tmp_dir)})
+
+first_segment = ref(null)
+
+def segment_name(meta) =
+  let {position, extname, stream_name} = meta
+  "segment-#{stream_name}_#{position}.#{extname}"
+end
+
+def on_file_change({state, path = fname}) =
+  if
+    state == "created"
+    and string.contains(prefix="segment-ts_with_meta", path.basename(fname))
+    and null.defined(first_segment()) == false
+  then
+    first_segment := fname
+    contents = file.contents(fname)
+    if
+      string.contains(
+        encoding="ascii",
+        substring="test title",
+        contents
+      )
+    then
+      test.pass()
+    else
+      test.fail()
+    end
+  end
+end
+
+s = sine()
+s =
+  metadata.map(
+    insert_missing=true,
+    fun (_) ->
+      [
+        (
+          "title",
+          "test title"
+        ),
+        (
+          "artist",
+          "test artist"
+        )
+      ],
+    s
+  )
+
+o =
+  output.file.hls(
+    fallible=true,
+    segment_duration=2.,
+    segment_name=segment_name,
+    tmp_dir,
+    [
+      (
+        "ts_with_meta",
+        %ffmpeg(format = "mpegts", %audio(codec = "aac")).{id3_version = 4}
+      )
+    ],
+    s
+  )
+
+o.on_file_change(synchronous=true, on_file_change)
+
+thread.run(delay=30., {test.fail()})

--- a/tests/regression/dune.inc
+++ b/tests/regression/dune.inc
@@ -1198,6 +1198,24 @@
   (run %{run_test} GH5019 liquidsoap %{test_liq} GH5019.liq)))
 
 (rule
+ (alias test_GH5084)
+ (package liquidsoap)
+ (deps
+  GH5084.liq
+  (alias ../media/all_media_files)
+  ../liquidsoap-test-assets
+  ../../src/bin/liquidsoap.exe
+  ../streams/file1.png
+  ../streams/file1.mp3
+  ./theora-test.mp4
+  (package liquidsoap)
+  (source_tree ../../src/libs)
+  (:test_liq ../test.liq)
+  (:run_test ../run_test.exe))
+ (action
+  (run %{run_test} GH5084 liquidsoap %{test_liq} GH5084.liq)))
+
+(rule
  (alias test_GH5110)
  (package liquidsoap)
  (deps
@@ -1943,6 +1961,7 @@
   (alias test_GH4922)
   (alias test_GH4995)
   (alias test_GH5019)
+  (alias test_GH5084)
   (alias test_GH5110)
   (alias test_LS268)
   (alias test_LS354-1)

--- a/tests/streams/hls_custom_tags.liq
+++ b/tests/streams/hls_custom_tags.liq
@@ -7,7 +7,7 @@ aac_flags = ref(false)
 mp4_flags = ref(false)
 aac_insert_flags = ref(false)
 
-test.skip()
+#test.skip()
 
 def on_file_change({state, path = p}) =
   fname = path.basename(p)


### PR DESCRIPTION
## Problem

When using `output.file.hls` with a mpegts stream and `id3_version=4`, the first segment's ID3 timed metadata packet was empty — containing only the 10-byte ID3 header with no actual metadata fields.

Two bugs combined to cause this:

1. **Wrong encoding order**: `encode_metadata` was called *after* `encode`+`send` for each frame chunk. This meant metadata was not yet registered when the first HLS segment was opened — the ID3 packet was written before the metadata was available.

2. **Eager segment open at start**: `hls_output` opened all segments eagerly in `start()`, before any source frames (and therefore any metadata) had arrived. Even with the correct encoding order, the first `encode_metadata` call comes after `start()`.

## Changes

**`output.ml`**: Added an `encoding_order` field (defaulting to `` `Metadata_first ``). `send_frame` now calls `send_metadata` before `encode`+`send` (metadata-first) or after (data-first). Also added `set_encoding_order` so subclasses can override. The metadata lookup now scans for any raw metadata in the frame range (not just non-empty exports), preserving the behavior needed for `reopen_on_metadata` in `output.file`.

**`icecast2.ml`**: ICY metadata updates require an active connection, which is established by `send`. So when `send_icy_metadata=true`, icecast sets `Data_first` via an initializer — metadata is updated after `send` establishes the connection.

**`hls_output.ml`**: On a **fresh start**, `open_segment` is now lazy — deferred to the first `encode` call, by which point `encode_metadata` has already run and metadata is available for the ID3 header.

## Tests

- New regression test `tests/regression/GH5084.liq`: verifies that the first mpegts HLS segment produced with `id3_version=4` contains the expected metadata string in its binary content.
- `tests/core/output_encoded_test.ml` rewritten to test both orderings: `Metadata_first` asserts `encode_metadata` → `encode` → `send`; `Data_first` asserts `encode` → `send` → `encode_metadata`.
- Re-enabled `tests/streams/hls_custom_tags.liq` (was marked skip due to a flakiness rooted in the same metadata ordering race).

Fixes: #5084