### PR TITLE
source: detach from clock on sleep to prevent WeakQueue accumulation

### DIFF
--- a/src/core/base/source.ml
+++ b/src/core/base/source.ml
@@ -341,6 +341,10 @@ class virtual operator ?(stack = []) ?clock ~name sources =
     method private actual_sleep =
       if Atomic.compare_and_set is_up `True `False then (
         source_log#info "Source %s gets down." self#id;
+        (match self#source_type with
+          | `Passive | `Active _ ->
+              Clock.detach self#clock (self :> Clock.source)
+          | `Output _ -> ());
         List.iter (fun fn -> fn ()) on_sleep)
 
     method sleep (src : Clock.activation) =


### PR DESCRIPTION
## Problem

Over time, CPU usage increases steadily in long-running streams that use `cross` (crossfade). CPU profiles show 49% `caml_weak_get` and 37% `caml_major_collection_slice`.

Each crossfade transition creates several ephemeral sources (`fade_in`, `add`, `track_audio_amplify`, `pre_buffer`, etc.). These sources are registered with the clock and end up in the `active_sources` / `passive_sources` WeakQueues. When a transition ends, `actual_sleep` is called on the compound source tree — but the sources were never removed from the clock's WeakQueues. They stayed as **live** weak entries until GC collected the source objects.

Because every source has `Gc.finalise finalise self` registered, each source object needs **2+ major GC cycles** before its weak reference becomes `None`. Over hundreds of transitions, hundreds of zombie entries accumulate in the WeakQueues. `WeakQueue.elements active_sources` is called twice per tick (in `_tick` and `_self_sync`), scanning the entire array each time — causing the observed CPU profile.

Memory does not grow dramatically because zombies are eventually GC'd; the population just grows proportionally to transition frequency, explaining the slow creep.

## Fix

In `actual_sleep`, call `Clock.detach self#clock` for `Passive` and `Active` sources. `_detach` immediately calls `WeakQueue.filter_out` on `active_sources` and `passive_sources` (or queues it via `after_tick` for started clocks), removing the source after one tick at most.

`Output` sources are excluded: `_detach` finds them in the `outputs` strong-reference Queue and would call `s#sleep a` on them, but `activations` is already empty at that point and would raise an error.

## Changes

- `src/core/base/source.ml`: add `Clock.detach` call in `actual_sleep` for Passive/Active sources

Fixes #4948.