### PR TITLE
tests: make test.fail idempotent with graceful shutdown

### DIFF
--- a/tests/test.liq
+++ b/tests/test.liq
@@ -3,6 +3,7 @@ settings.init.force_start := true
 
 test = ()
 let test.done = ref(false)
+let test.failed = ref(false)
 
 runtime.gc.set(runtime.gc.get().{space_overhead = 20, allocation_policy = 2})
 
@@ -19,21 +20,30 @@ def test.pass() =
   end
 end
 
-# End test with a failure.
+# End test with a failure. Idempotent: subsequent calls are no-ops, and
+# overrides any previous test.pass. Initiates a graceful shutdown with
+# exit code 1, and force-exits after a 10s timeout.
 def test.fail(reason=null) =
-  reason =
-    if
-      null.defined(reason)
-    then
-      ": #{null.get(reason)}"
-    else
-      "!"
-    end
-  print(
-    "Test failed#{reason}"
-  )
-  log.flush()
-  exit(1)
+  if
+    not !test.failed
+  then
+    test.failed := true
+    test.done := true
+    reason =
+      if
+        null.defined(reason)
+      then
+        ": #{null.get(reason)}"
+      else
+        "!"
+      end
+    print(
+      "Test failed#{reason}"
+    )
+    log.flush()
+    shutdown(code=1)
+    thread.run(delay=10., {exit(1)})
+  end
 end
 
 # End test with signal 2


### PR DESCRIPTION
## Summary

`test.fail` previously called `exit(1)` immediately, which could:
- Race with `test.pass` (no idempotency)
- Cut off log output before it was fully flushed
- Hang if called from a context where shutdown never completes

## Changes

- Add `test.failed` ref to track failure state independently of `test.done`
- `test.fail` is now idempotent: subsequent calls are no-ops
- Sets `test.done := true` to block any subsequent `test.pass` from overriding a failure
- Calls `shutdown(code=1)` for graceful teardown with the correct exit code
- Adds a 10s `thread.run` fallback to `exit(1)` in case graceful shutdown hangs