### PR TITLE
ffmpeg: delay mpegts ID3 packet writes until streams are initialized

### DIFF
--- a/src/core/optionals/ffmpeg/ffmpeg_encoder_common.ml
+++ b/src/core/optionals/ffmpeg/ffmpeg_encoder_common.ml
@@ -43,6 +43,7 @@ type handler = {
     (string * string) list ->
     string option;
   started : bool Atomic.t;
+  pending_on_start : (unit -> unit) Queue.t;
 }
 
 type stream_data = {
@@ -99,9 +100,15 @@ let mk_format ffmpeg =
     | Some short_name, _ -> Av.Format.guess_output_format ~short_name ()
     | _ -> None
 
-let encode ~encoder frame =
-  if not (Atomic.exchange encoder.started true) then
+let delayed_start ~encoder frame =
+  if not (Atomic.exchange encoder.started true) then (
     Frame.Fields.iter (fun _ { mk_stream } -> mk_stream frame) encoder.streams;
+    while not (Queue.is_empty encoder.pending_on_start) do
+      (Queue.pop encoder.pending_on_start) ()
+    done)
+
+let encode ~encoder frame =
+  delayed_start ~encoder frame;
   Frame.Fields.iter (fun _ { encode } -> encode frame) encoder.streams
 
 (* Convert ffmpeg-specific options. *)
@@ -193,6 +200,7 @@ let encoder ~pos ~hls_utils ~mk_streams ffmpeg meta =
       streams;
       insert_id3 = (fun ~frame_position:_ ~sample_position:_ _ -> None);
       started = Atomic.make false;
+      pending_on_start = Queue.create ();
     }
   in
   let encoder = Atomic.make (make ()) in
@@ -240,10 +248,11 @@ let encoder ~pos ~hls_utils ~mk_streams ffmpeg meta =
             let stream =
               Av.new_data_stream ~time_base ~codec:`Timed_id3 encoder.output
             in
+            let write_id3 packet = Av.write_packet stream time_base packet in
             encoder.insert_id3 <-
               (fun ~frame_position ~sample_position m ->
-                if Atomic.get encoder.started then (
-                  let tag = Utils.id3v2_of_metadata ~version:id3_version m in
+                let tag = Utils.id3v2_of_metadata ~version:id3_version m in
+                let write () =
                   let packet = Avcodec.Packet.create tag in
                   let position =
                     Int64.of_int
@@ -253,7 +262,10 @@ let encoder ~pos ~hls_utils ~mk_streams ffmpeg meta =
                   in
                   Avcodec.Packet.set_pts packet (Some position);
                   Avcodec.Packet.set_dts packet (Some position);
-                  Av.write_packet stream time_base packet);
+                  write_id3 packet
+                in
+                if Atomic.get encoder.started then write ()
+                else Queue.push write encoder.pending_on_start;
                 None);
             true)
           else false


### PR DESCRIPTION
The mpegts `insert_id3` closure previously dropped the packet when `started` was false. This meant ID3 metadata written before the first encode (e.g. from `write_metadata` at segment open) was silently lost.

This PR queues those writes instead, using the existing `pending_on_start` mechanism. The queue is flushed by `delayed_start` on the first encode, after `mk_stream` has initialized copy stream parameters.