### PR TITLE
ffmpeg: delay mpegts ID3 writes until after avformat_write_header

### DIFF
--- a/src/core/optionals/ffmpeg/ffmpeg_encoder_common.ml
+++ b/src/core/optionals/ffmpeg/ffmpeg_encoder_common.ml
@@ -101,16 +101,19 @@ let mk_format ffmpeg =
     | _ -> None
 
 let flush_pending_on_start ~encoder =
-  while not (Queue.is_empty encoder.pending_on_start) do
-    (Queue.pop encoder.pending_on_start) ()
-  done
+  if
+    (not (Queue.is_empty encoder.pending_on_start))
+    && Av.output_started encoder.output
+  then
+    while not (Queue.is_empty encoder.pending_on_start) do
+      (Queue.pop encoder.pending_on_start) ()
+    done
 
 let encode ~encoder frame =
-  let first_encode = not (Atomic.exchange encoder.started true) in
-  if first_encode then
+  if not (Atomic.exchange encoder.started true) then
     Frame.Fields.iter (fun _ { mk_stream } -> mk_stream frame) encoder.streams;
   Frame.Fields.iter (fun _ { encode } -> encode frame) encoder.streams;
-  if first_encode then flush_pending_on_start ~encoder
+  flush_pending_on_start ~encoder
 
 (* Convert ffmpeg-specific options. *)
 let convert_options opts =
@@ -265,7 +268,7 @@ let encoder ~pos ~hls_utils ~mk_streams ffmpeg meta =
                   Avcodec.Packet.set_dts packet (Some position);
                   write_id3 packet
                 in
-                if Atomic.get encoder.started then write ()
+                if Av.output_started encoder.output then write ()
                 else Queue.push write encoder.pending_on_start;
                 None);
             true)
@@ -361,7 +364,7 @@ let encoder ~pos ~hls_utils ~mk_streams ffmpeg meta =
     let m = Frame.Metadata.append ffmpeg.metadata m in
     let m = Frame.Metadata.to_list m in
     match (ffmpeg.Ffmpeg_format.output, ffmpeg.Ffmpeg_format.format) with
-      | _ when not (Atomic.get (Atomic.get encoder).started) ->
+      | _ when not (Av.output_started (Atomic.get encoder).output) ->
           Av.set_output_metadata (Atomic.get encoder).output m
       | `Stream, Some "ogg" ->
           flush ();

--- a/src/core/optionals/ffmpeg/ffmpeg_encoder_common.ml
+++ b/src/core/optionals/ffmpeg/ffmpeg_encoder_common.ml
@@ -100,16 +100,17 @@ let mk_format ffmpeg =
     | Some short_name, _ -> Av.Format.guess_output_format ~short_name ()
     | _ -> None
 
-let delayed_start ~encoder frame =
-  if not (Atomic.exchange encoder.started true) then (
-    Frame.Fields.iter (fun _ { mk_stream } -> mk_stream frame) encoder.streams;
-    while not (Queue.is_empty encoder.pending_on_start) do
-      (Queue.pop encoder.pending_on_start) ()
-    done)
+let flush_pending_on_start ~encoder =
+  while not (Queue.is_empty encoder.pending_on_start) do
+    (Queue.pop encoder.pending_on_start) ()
+  done
 
 let encode ~encoder frame =
-  delayed_start ~encoder frame;
-  Frame.Fields.iter (fun _ { encode } -> encode frame) encoder.streams
+  let first_encode = not (Atomic.exchange encoder.started true) in
+  if first_encode then
+    Frame.Fields.iter (fun _ { mk_stream } -> mk_stream frame) encoder.streams;
+  Frame.Fields.iter (fun _ { encode } -> encode frame) encoder.streams;
+  if first_encode then flush_pending_on_start ~encoder
 
 (* Convert ffmpeg-specific options. *)
 let convert_options opts =


### PR DESCRIPTION
## Problem

`hls_id3v2.liq` crashes with SIGSEGV when using mpegts with internal AAC encoding. The root cause is `avformat_write_header` being triggered by an ID3 timed-metadata packet before the AAC stream has audio codec parameters (`extradata`, `frame_size`) set up, leaving `ts_st->amux = NULL` in the mpegts muxer, which causes a NULL dereference on the first audio packet.

## What changed

`pending_on_start` is a queue of callbacks that must run after `avformat_write_header` has fired (e.g. mpegts ID3 packet writes).

The previous fix flushed the queue after the first `encode` call, assuming that encode would always produce at least one output packet. This assumption is wrong: an internal AAC encoder buffers frames and may emit no packet on the first call. In that case `avformat_write_header` has not fired yet, and the queued ID3 write becomes the trigger — before AAC parameters are ready.

The fix gates the flush on `Av.output_started` (`av->header_written`) instead of on "first encode was called". The flush is attempted after every encode call and runs as soon as the first packet has actually been written to the container. The same predicate replaces `encoder.started` checks in `insert_id3` and `encode_metadata`.

## Tests

- `tests/streams/hls_id3v2.liq` — covers mpegts ID3 with internal AAC encoder
- `tests/media/test_ffmpeg_distributed_hls_setup.liq` — covers mpegts with copy streams (original SIGFPE regression from #5117)
