### PR TITLE
unix_utils_stubs: process pending OCaml actions on EINTR in poll

### DIFF
--- a/src/modules/stdlib-utils/unix_utils_stubs.c
+++ b/src/modules/stdlib-utils/unix_utils_stubs.c
@@ -88,9 +88,13 @@ CAMLprim value caml_liquidsoap_poll(value _read, value _write, value _err,
   }
 
   caml_release_runtime_system();
-  do {
+  ret = poll(fds, nfds, timeout);
+  while (ret == -1 && errno == EINTR) {
+    caml_acquire_runtime_system();
+    caml_process_pending_actions();
+    caml_release_runtime_system();
     ret = poll(fds, nfds, timeout);
-  } while (ret == -1 && errno == EINTR);
+  }
   caml_acquire_runtime_system();
 
   if (ret == -1) {


### PR DESCRIPTION
## Problem

Liquidsoap did not respond to Ctrl+C (SIGINT). The main thread sat permanently in `poll` via `caml_liquidsoap_poll` → `camlDtools__code_end` → `Tutils.wait_done`, and the SIGINT was never delivered to OCaml's signal handler.

## Root cause

The C poll stub retried `poll` immediately on EINTR in a tight loop without ever returning to the OCaml runtime:

```c
caml_release_runtime_system();
do {
  ret = poll(fds, nfds, timeout);
} while (ret == -1 && errno == EINTR);
caml_acquire_runtime_system();
```

OCaml dispatches pending signals (including SIGINT → shutdown handler) only at `caml_acquire_runtime_system()` / `caml_process_pending_actions()` boundaries. Because the loop never left C, the signal accumulated but was never processed.

## Fix

On each EINTR, briefly re-acquire the runtime and call `caml_process_pending_actions()` before retrying `poll`. This flushes any pending OCaml signals, allowing the SIGINT handler to run and initiate a clean shutdown.
