### PR TITLE
[Backport v2.4.x-latest] unix_utils_stubs: process pending OCaml actions on EINTR in poll

### DIFF
--- a/src/modules/stdlib-utils/unix_utils_stubs.c
+++ b/src/modules/stdlib-utils/unix_utils_stubs.c
@@ -85,9 +85,13 @@ CAMLprim value caml_liquidsoap_poll(value _read, value _write, value _err,
   }
 
   caml_release_runtime_system();
-  do {
+  ret = poll(fds, nfds, timeout);
+  while (ret == -1 && errno == EINTR) {
+    caml_acquire_runtime_system();
+    caml_process_pending_actions();
+    caml_release_runtime_system();
     ret = poll(fds, nfds, timeout);
-  } while (ret == -1 && errno == EINTR);
+  }
   caml_acquire_runtime_system();
 
   if (ret == -1) {


### PR DESCRIPTION
Backport 861effbd866ab43984f4be2842ca65973404bfdc from #5130.