### PR TITLE
builtins_ssl, builtins_tls: make key optional when cert file contains it

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,7 @@
 
 ## Changed:
 
+- `http.transport.ssl` and `http.transport.tls`: `key` parameter is now optional in server mode when the certificate file also contains the private key.
 - Simplified `cross`/`crossfade` implementation: replaced `start_duration` and `end_duration`
   with a single unified `duration` parameter. Removed autocue-specific code and
   `assume_autocue` setting. Metadata overrides `liq_cross_start_duration` and

--- a/src/core/optionals/ssl/builtins_ssl.ml
+++ b/src/core/optionals/ssl/builtins_ssl.ml
@@ -246,8 +246,8 @@ let _ =
       let find name () =
         match Lang.to_valued_option Lang.to_string (List.assoc name p) with
           | None ->
-              Runtime_error.raise ~pos:(Lang.pos p) "Cannot find "
-              ^ name ^ "file!"
+              Runtime_error.raise ~pos:(Lang.pos p)
+                ("Cannot find " ^ name ^ "file!")
           | Some path -> Utils.check_readable ~pos:(Lang.pos p) path
       in
       let certificate = find "certificate" in

--- a/src/core/optionals/ssl/builtins_ssl.ml
+++ b/src/core/optionals/ssl/builtins_ssl.ml
@@ -91,7 +91,9 @@ let server ~min_protocol ~max_protocol ~read_timeout ~write_timeout ~password
   Option.iter
     (fun password -> Ssl.set_password_callback context (fun _ -> password))
     password;
-  Ssl.use_certificate context (certificate ()) (key ());
+  let cert_path = certificate () in
+  let key_path = Option.value ~default:cert_path (key ()) in
+  Ssl.use_certificate context cert_path key_path;
 
   object
     method transport = transport
@@ -216,7 +218,8 @@ let _ =
         Some Lang.null,
         Some
           "Path to certificate private key. Required in server mode, e.g. \
-           `input.harbor`, etc." );
+           `input.harbor`, etc., unless the certificate file also contains the \
+           private key." );
     ]
     Lang.http_transport_t
     (fun p ->
@@ -243,15 +246,20 @@ let _ =
         Option.map protocol_of_value
           (Lang.to_option (List.assoc "max_protocol" p))
       in
-      let find name () =
-        match Lang.to_valued_option Lang.to_string (List.assoc name p) with
+      let certificate () =
+        match
+          Lang.to_valued_option Lang.to_string (List.assoc "certificate" p)
+        with
           | None ->
               Runtime_error.raise ~pos:(Lang.pos p)
-                ("Cannot find " ^ name ^ "file!")
+                "Cannot find certificate file!"
           | Some path -> Utils.check_readable ~pos:(Lang.pos p) path
       in
-      let certificate = find "certificate" in
-      let key = find "key" in
+      let key () =
+        match Lang.to_valued_option Lang.to_string (List.assoc "key" p) with
+          | None -> None
+          | Some path -> Some (Utils.check_readable ~pos:(Lang.pos p) path)
+      in
       Lang.http_transport
         (transport ~min_protocol ~max_protocol ~read_timeout ~write_timeout
            ~password ~certificate ~key ()))

--- a/src/core/optionals/tls/builtins_tls.ml
+++ b/src/core/optionals/tls/builtins_tls.ml
@@ -366,8 +366,8 @@ let _ =
       let find name () =
         match Lang.to_valued_option Lang.to_string (List.assoc name p) with
           | None ->
-              Runtime_error.raise ~pos:(Lang.pos p) "Cannot find "
-              ^ name ^ "file!"
+              Runtime_error.raise ~pos:(Lang.pos p)
+                ("Cannot find " ^ name ^ "file!")
           | Some path -> Utils.check_readable ~pos:(Lang.pos p) path
       in
       let certificate = find "certificate" in

--- a/src/core/optionals/tls/builtins_tls.ml
+++ b/src/core/optionals/tls/builtins_tls.ml
@@ -207,12 +207,14 @@ let server ~read_timeout ~write_timeout ~certificate ~key ~client_certificate
     transport =
   let server =
     try
-      let certificate = Utils.read_all (certificate ()) in
+      let certificate_path = certificate () in
+      let key_path = Option.value ~default:certificate_path (key ()) in
+      let certificate = Utils.read_all certificate_path in
       let certificates =
         Result.get_ok (X509.Certificate.decode_pem_multiple certificate)
       in
       let key =
-        Result.get_ok (X509.Private_key.decode_pem (Utils.read_all (key ())))
+        Result.get_ok (X509.Private_key.decode_pem (Utils.read_all key_path))
       in
       let authenticator =
         match client_certificate () with
@@ -333,7 +335,8 @@ let _ =
         Some Lang.null,
         Some
           "Path to certificate private key. Required in server mode, e.g. \
-           `input.harbor`, etc. Unused in client mode." );
+           `input.harbor`, etc., unless the certificate file also contains the \
+           private key. Unused in client mode." );
       ( "client_certificate",
         Lang.nullable_t Lang.string_t,
         Some Lang.null,
@@ -370,13 +373,13 @@ let _ =
                 ("Cannot find " ^ name ^ "file!")
           | Some path -> Utils.check_readable ~pos:(Lang.pos p) path
       in
-      let certificate = find "certificate" in
-      let key = find "key" in
       let find_opt name () =
         match Lang.to_valued_option Lang.to_string (List.assoc name p) with
           | None -> None
           | Some path -> Some (Utils.check_readable ~pos:(Lang.pos p) path)
       in
+      let certificate = find "certificate" in
+      let key = find_opt "key" in
       let client_certificate = find_opt "client_certificate" in
       let client_key = find "client_key" in
       Lang.http_transport


### PR DESCRIPTION
The `key` parameter in `http.transport.ssl` and `http.transport.tls` is now optional in server mode. When not provided, both backends fall back to reading the private key from the certificate file itself — a common deployment pattern where the certificate and key are bundled in a single PEM file (e.g. Let's Encrypt combined certs, self-signed certs generated with `openssl req -x509 -nodes -newkey ...`).

Both OpenSSL (`ssl`) and the OCaml `tls`/`X509` stack can parse a combined PEM file, so the fallback is transparent and requires no change to existing configurations that already specify `key`.
