### PR TITLE
clock: push-based sync_source propagation, O(1) per tick

### DIFF
--- a/src/core/base/clock.ml
+++ b/src/core/base/clock.ml
@@ -104,6 +104,7 @@ module Unifier = Liquidsoap_lang.Unifier
 type active_params = {
   sync : active_sync_mode;
   mutable is_self_sync : bool;
+  mutable sync_source_entries : sync_source_entry list;
   log : Log.t;
   time_implementation : Liq_time.implementation;
   t0 : Liq_time.t;
@@ -398,39 +399,40 @@ let () =
 let _animated_sources { outputs; active_sources } =
   List.map snd (Queue.elements outputs) @ WeakQueue.elements active_sources
 
-let _self_sync ~clock x =
-  let self_sync_sources =
-    List.fold_left
-      (fun self_sync_sources s ->
-        match s#self_sync with
-          | _, None -> self_sync_sources
-          | _, Some sync_source ->
-              { sync_source; name = s#id; stack = s#stack } :: self_sync_sources)
-      [] (_animated_sources x)
+let _update_clock_sync_source ~clock x ~name ~stack new_sync =
+  let entries =
+    List.filter
+      (fun (e : sync_source_entry) -> e.name <> name)
+      x.sync_source_entries
   in
-  let self_sync_sources =
+  let entries =
+    match new_sync with
+      | None -> entries
+      | Some sync_source -> { sync_source; name; stack } :: entries
+  in
+  let deduped =
     List.sort_uniq
-      (fun { sync_source = s } { sync_source = s' } -> Stdlib.compare s s')
-      self_sync_sources
+      (fun { sync_source = a } { sync_source = b } -> Stdlib.compare a b)
+      entries
   in
-  if List.length self_sync_sources > 1 then
+  if List.length deduped > 1 then
     raise
       (Sync_error
          {
            name = Printf.sprintf "clock %s" (_id clock);
            stack = Atomic.get clock.stack;
-           sync_sources = self_sync_sources;
+           sync_sources = deduped;
          });
-  let is_self_sync = List.length self_sync_sources = 1 in
+  let is_self_sync = List.length deduped = 1 in
   if x.is_self_sync <> is_self_sync && x.sync = `Automatic then (
     x.log#important "Switching to %sself-sync mode%s"
       (if is_self_sync then "" else "non ")
       (if is_self_sync then
          Printf.sprintf " with sync source: %s"
-           (string_of_sync_source (List.hd self_sync_sources).sync_source)
+           (string_of_sync_source (List.hd deduped).sync_source)
        else "");
     x.is_self_sync <- is_self_sync);
-  is_self_sync
+  x.sync_source_entries <- entries
 
 let ticks c =
   match Atomic.get (Unifier.deref c).state with
@@ -544,15 +546,26 @@ let rec active_params c =
         log#critical "Clock %s has invalid state: %s" (id c) (string_of_state s);
         raise Invalid_state
 
+and _register_clock_callback ~clock x s =
+  let name = s#id and stack = s#stack in
+  let _ : unit -> unit =
+    s#on_sync_source_change (fun ~old:_ new_sync_source ->
+        _update_clock_sync_source ~clock x ~name ~stack new_sync_source)
+  in
+  _update_clock_sync_source ~clock x ~name ~stack s#source_state
+
 and _activate_pending_sources ~clock x =
   let pending_sources = Queue.length clock.pending_activations in
   Queue.flush_iter clock.pending_activations
     (wrap_errors clock (fun s ->
          match s#source_type with
-           | `Active _ -> WeakQueue.push x.active_sources s
+           | `Active _ ->
+               WeakQueue.push x.active_sources s;
+               _register_clock_callback ~clock x s
            | `Output _ ->
                let a = s#wake_up (s :> source) in
-               Queue.push x.outputs (a, s)
+               Queue.push x.outputs (a, s);
+               _register_clock_callback ~clock x s
            | `Passive -> WeakQueue.push x.passive_sources s));
   if 0 < pending_sources then (
     let total_sources =
@@ -585,7 +598,6 @@ and _tick ~clock x =
   Queue.flush_iter x.on_tick (fun fn ->
       check_stopped ();
       fn ());
-  let self_sync = _self_sync ~clock x in
   check_stopped ();
   List.iter
     (fun (c, old_ticks, clock) ->
@@ -593,7 +605,7 @@ and _tick ~clock x =
     sub_clocks;
   Atomic.incr x.ticks;
   check_stopped ();
-  _after_tick ~self_sync x;
+  _after_tick ~self_sync:x.is_self_sync x;
   check_stopped ()
 
 and _clock_thread ~clock ~c x =
@@ -697,6 +709,7 @@ and _start ?force ~sync ~c clock =
     {
       frame_duration;
       is_self_sync = false;
+      sync_source_entries = [];
       log_delay;
       log_delay_threshold;
       max_latency;
@@ -814,7 +827,7 @@ let after_eval () = if not (Atomic.get global_stop) then start_pending ()
 let self_sync c =
   let clock = Unifier.deref c in
   match Atomic.get clock.state with
-    | `Started params -> _self_sync ~clock params
+    | `Started params -> params.is_self_sync
     | _ -> false
 
 let activate_pending_sources clock =

--- a/src/core/base/clock.mli
+++ b/src/core/base/clock.mli
@@ -71,7 +71,10 @@ type source =
   ; wake_up : source -> activation
   ; sleep : activation -> unit
   ; is_ready : bool
-  ; get_frame : Frame.t >
+  ; get_frame : Frame.t
+  ; source_state : sync_source option
+  ; on_sync_source_change :
+      (old:sync_source option -> sync_source option -> unit) -> unit -> unit >
 
 type active_sync_mode = [ `Automatic | `CPU | `Unsynced | `Passive ]
 type sync_mode = [ active_sync_mode | `Stopping | `Stopped ]

--- a/src/core/base/clock_base.ml
+++ b/src/core/base/clock_base.ml
@@ -135,7 +135,10 @@ type source =
   ; wake_up : source -> activation
   ; sleep : activation -> unit
   ; is_ready : bool
-  ; get_frame : Frame.t >
+  ; get_frame : Frame.t
+  ; source_state : sync_source option
+  ; on_sync_source_change :
+      (old:sync_source option -> sync_source option -> unit) -> unit -> unit >
 
 let self_sync_type sources =
   Lazy.from_fun (fun () ->

--- a/src/core/base/operators/dyn_op.ml
+++ b/src/core/base/operators/dyn_op.ml
@@ -59,6 +59,7 @@ class dyn ~init ~track_sensitive ~infallible ~self_sync ~merge next_fn =
       self#log#info "Switching to source %s" s#id;
       let a = match activation with None -> self#prepare s | Some a -> a in
       Atomic.set current_source (Some (a, s));
+      self#notify_sync_source (snd self#self_sync);
       if s#is_ready then Some s else self#no_source (Some s#id)
 
     method private exchange ~activation s =

--- a/src/core/base/source.ml
+++ b/src/core/base/source.ml
@@ -209,6 +209,37 @@ class virtual operator ?(stack = []) ?clock ~name sources =
     method source_sync self_sync =
       if self_sync then Some self#self_sync_source else None
 
+    val mutable source_state : Clock.sync_source option = None
+    method source_state = source_state
+
+    val state_callbacks
+        : (int
+          * (old:Clock.sync_source option -> Clock.sync_source option -> unit))
+          Queue.t =
+      Queue.create ()
+
+    val callback_id_counter = Atomic.make 0
+
+    method on_sync_source_change fn =
+      let id = Atomic.fetch_and_add callback_id_counter 1 in
+      Queue.push state_callbacks (id, fn);
+      fun () -> Queue.filter_out state_callbacks (fun (i, _) -> i = id)
+
+    method private notify_sync_source new_state =
+      if new_state <> source_state then (
+        let old = source_state in
+        source_state <- new_state;
+        Queue.iter state_callbacks (fun (_, fn) -> fn ~old new_state))
+
+    method private on_child_state_change ~child:_ ~old:_ _ =
+      self#notify_sync_source (snd self#self_sync)
+
+    initializer
+      self#on_before_streaming_cycle (fun () ->
+          let sync_source = snd self#self_sync in
+          if sync_source <> source_state then
+            self#notify_sync_source sync_source)
+
     (* Type describing the contents of the frame: this should be a record
        whose fields (audio, video, etc.) indicate the kind of contents we
        have (e.g. {audio : pcm}). *)
@@ -386,6 +417,22 @@ class virtual operator ?(stack = []) ?clock ~name sources =
                 (None, s))
               sources;
           self#iter_watchers (fun w -> w.sleep ()))
+
+    val mutable child_state_deregisters : (unit -> unit) list = []
+
+    initializer
+      self#on_wake_up (fun () ->
+          self#notify_sync_source (snd self#self_sync);
+          child_state_deregisters <-
+            List.map
+              (fun (_, s) ->
+                s#on_sync_source_change (fun ~old new_state ->
+                    self#on_child_state_change ~child:s ~old new_state))
+              sources);
+      self#on_sleep (fun () ->
+          List.iter (fun d -> d ()) child_state_deregisters;
+          child_state_deregisters <- [];
+          self#notify_sync_source None)
 
     (** Streaming *)
 

--- a/src/core/base/source.mli
+++ b/src/core/base/source.mli
@@ -153,6 +153,19 @@ object
 
   method source_sync : bool -> Clock.sync_source option
 
+  (** Cached sync source of this source, updated at wake_up and on changes. *)
+  method source_state : Clock.sync_source option
+
+  (** Register a callback fired when the source's sync source changes. Returns a
+      deregistration thunk. *)
+  method on_sync_source_change :
+    (old:Clock.sync_source option -> Clock.sync_source option -> unit) ->
+    unit ->
+    unit
+
+  (** Update the cached sync source and notify registered callbacks. *)
+  method private notify_sync_source : Clock.sync_source option -> unit
+
   (** Register a callback when wake_up is called. *)
   method on_wake_up : (unit -> unit) -> unit
 


### PR DESCRIPTION
## Why

`_self_sync` was called on every clock tick to decide whether the clock should sleep (self-sync) or run CPU-led. It walked all animated sources (outputs + active sources) calling `s#self_sync`, which itself recursed down the source graph. For operators like `add`, `muxer`, `merge_metadata`, `Clock_base.self_sync` iterated all children. Net result: O(animated_sources × graph_depth) work on every single tick, even though `sync_source` changes only when sources start/stop or a dynamic operator switches selection.

## What changed

Invert the flow. Sources register callbacks with their children at `wake_up` and propagate `sync_source` changes upward. Active sources and outputs notify the clock when their sync_source changes, letting `is_self_sync` become an O(1) cached read.

**`clock_base.ml` / `clock.mli`**: new `source_state` type `{ sync_source : sync_source option }` and `default_source_state`. The `Clock.source` structural type gains `source_state` and `on_source_state_change` methods.

**`source.ml` / `source.mli`**: the `operator` class gains:
- `source_state` mutable field (cached state) and `source_state` accessor
- `state_callbacks` queue of `(id, fn)` pairs
- `on_source_state_change fn` — registers a callback, returns a deregistration thunk
- `notify_source_state` (private) — fires callbacks only when state actually changes
- `on_child_state_change` (private) — default re-derives from `self#self_sync`; multi-child operators that aggregate differently can override
- A new `initializer` block: at `wake_up`, compute initial state and subscribe to all children; at `sleep`, deregister from children and fire `notify_source_state default_source_state`

**`clock.ml`**: `active_params` gains `sync_source_entries`. `_self_sync` is replaced by `_update_clock_sync_source` (updates entries incrementally, logs mode changes, raises `Sync_error` on conflict). `_activate_pending_sources` registers a clock callback on each Active/Output source via `on_source_state_change`, posting updates to `after_tick` for thread safety. `_tick` reads `x.is_self_sync` directly instead of calling `_self_sync`.

**`dyn_op.ml`**: `dyn` has no children in the base `sources` list (it manages `current_source` dynamically via an Atomic), so the base class subscriptions don't reach its current source. Explicit `notify_source_state` call added after each source switch.

**`srt_io.ml`**: two changes — (1) fix `caller#connect_fn` ordering: `Atomic.set socket` now happens before `apply_on_connect`, so `is_connected = true` when `on_connect` callbacks fire (consistent with the listener path); (2) explicit `notify_source_state` calls added in `input_base` on connect and disconnect.

## Operators that needed no changes

Single-child passthrough operators (`amplify`, `normalize`, etc.) and multi-child operators (`add`, `muxer`) get correct behaviour from the default `on_child_state_change`. `switch` subscribes to all children via the base class; when a non-selected child changes sync, `self#self_sync` is re-evaluated and returns the selected source's value — propagating only what matters. Hardware I/O with static `self_sync` fires the initial `notify_source_state` at `wake_up` and never changes again.

## Thread safety

Updates from non-clock threads (e.g. SRT connect from the Duppy thread) are posted to `x.after_tick`, which is a mutex-protected queue flushed at the start of each `_after_tick` in the clock thread. `sync_source_entries` and `is_self_sync` are only ever written from the clock thread.
