### PR TITLE
stream: optimize content length and timed blit hot paths

### DIFF
--- a/src/core/base/stream/content_base.ml
+++ b/src/core/base/stream/content_base.ml
@@ -277,12 +277,15 @@ module MkContentBase (C : ContentSpecs) :
           if len = max_int then max_int else len - offset
 
   let length { chunks } =
-    List.fold_left
-      (fun cur chunk ->
-        let chunk_length = chunk_length chunk in
-        if cur = max_int || chunk_length = max_int then max_int
-        else cur + chunk_length)
-      0 chunks
+    match chunks with
+    | [] -> 0
+    | [chunk] -> chunk_length chunk
+    | _ ->
+      List.fold_left
+        (fun cur chunk ->
+          let n = chunk_length chunk in
+          if cur = max_int || n = max_int then max_int else cur + n)
+        0 chunks
 
   let is_empty d = length d = 0
 

--- a/src/core/base/stream/content_timed.ml
+++ b/src/core/base/stream/content_timed.ml
@@ -60,19 +60,32 @@ module Specs = struct
 
   let blit : 'a. 'a content -> int -> 'a content -> int -> int -> unit =
    fun src src_pos dst dst_pos len ->
-    let head = (sub dst 0 (Finite dst_pos)).data in
-    let middle =
-      List.map
-        (fun (pos, x) -> (dst_pos + pos, x))
-        (sub src src_pos (Finite len)).data
-    in
-    let tail_length =
-      match dst.length with
-        | Infinite -> Infinite
-        | Finite dst_len -> Finite (dst_len - len - dst_pos)
-    in
-    let tail = (sub dst (dst_pos + len) tail_length).data in
-    dst.data <- sort (head @ middle @ tail)
+    match (src.data, dst.data) with
+    | [], [] -> ()
+    | [], dst_data ->
+        let head = List.filter (fun (pos, _) -> pos < dst_pos) dst_data in
+        let tail =
+          let dst_end = dst_pos + len in
+          List.filter_map
+            (fun (pos, x) ->
+              if pos >= dst_end then Some (pos - len, x) else None)
+            dst_data
+        in
+        dst.data <- sort (head @ tail)
+    | _ ->
+        let head = (sub dst 0 (Finite dst_pos)).data in
+        let middle =
+          List.map
+            (fun (pos, x) -> (dst_pos + pos, x))
+            (sub src src_pos (Finite len)).data
+        in
+        let tail_length =
+          match dst.length with
+            | Infinite -> Infinite
+            | Finite dst_len -> Finite (dst_len - len - dst_pos)
+        in
+        let tail = (sub dst (dst_pos + len) tail_length).data in
+        dst.data <- sort (head @ middle @ tail)
 
   let copy ~copy d =
     { d with data = List.map (fun (pos, x) -> (pos, copy x)) d.data }


### PR DESCRIPTION
Two performance fixes identified via perf profiling of the streaming loop:

Content_base.length: add a fast path for the single-chunk case (the common case after the lift_data pre-computation fix). This avoids List.fold_left and closure dispatch entirely when there is exactly one chunk, eliminating chunk_length_1239 which was showing at ~3% of cycles.

Content_timed.blit: add fast paths for the common cases where src or dst have no timed events (no metadata/track_marks). The dominant case in a normal stream is [] x [] -> no-op, which avoids all list allocations and GC pressure from sub/map/append/sort on every consolidate_chunks call. The [] x dst_data case avoids a sub() call on src. These timed blit calls were showing as a GC trigger (do_some_marking via caml_alloc_small_dispatch) in profiling.