### PR TITLE
Do not panic & crash when external input finds an EOF (#5138)

### DIFF
--- a/src/core/base/encoder/encoders/external_encoder.ml
+++ b/src/core/base/encoder/encoders/external_encoder.ml
@@ -38,9 +38,9 @@ let encoder id ext =
     Mutex_utils.mutexify mutex (fun () ->
         let decision =
           match (!is_metadata_restart, !is_stop) with
-            | _, true -> false
-            | true, false -> true
-            | false, false -> ext.restart_on_crash
+            | _, true -> -1.
+            | true, false -> 0.
+            | false, false -> if ext.restart_on_crash then 0. else -1.
         in
         is_metadata_restart := false;
         decision)

--- a/src/core/base/operators/pipe.ml
+++ b/src/core/base/operators/pipe.ml
@@ -225,19 +225,19 @@ class pipe ~replay_delay ~data_len ~process ~bufferize ~max ~restart
               | _ -> true
           in
           match (should_restart, ret) with
-            | false, _ -> false
-            | _, `Sleep -> false
+            | false, _ -> -1.
+            | _, `Sleep -> -1.
             | _, `Break_and_metadata m ->
                 Generator.add_metadata self#buffer m;
                 Generator.add_track_mark self#buffer;
-                true
+                0.
             | _, `Metadata m ->
                 Generator.add_metadata self#buffer m;
-                true
+                0.
             | _, `Break ->
                 Generator.add_track_mark self#buffer;
-                true
-            | _, `Nothing -> restart)
+                0.
+            | _, `Nothing -> if restart then 0. else -1.)
 
     initializer
       let a = ref None in

--- a/src/core/base/sources/external_input_audio.ml
+++ b/src/core/base/sources/external_input_audio.ml
@@ -72,7 +72,7 @@ let proto =
       Some "Restart process when exited with error." );
     ( "restart_delay",
       Lang.float_t,
-      Some (Lang.float 1.),
+      Some (Lang.float 0.1),
       Some
         "Delay (in seconds) before restarting the process. Prevents \
          busy-looping when the command exits immediately." );

--- a/src/core/base/sources/external_input_audio.ml
+++ b/src/core/base/sources/external_input_audio.ml
@@ -27,8 +27,8 @@ open Mm
 
 exception Finished of string * bool
 
-class external_input ~name ~restart ~bufferize ~restart_on_error ~max ~converter
-  ?read_header command =
+class external_input ~name ~restart ~bufferize ~restart_on_error ~restart_delay
+  ~max ~converter ?read_header command =
   let abg_max_len = Frame.audio_of_seconds max in
   let buflen = Utils.buflen in
   let buf = Bytes.create buflen in
@@ -46,7 +46,8 @@ class external_input ~name ~restart ~bufferize ~restart_on_error ~max ~converter
   object
     inherit
       External_input.base
-        ~name ?read_header ~restart ~restart_on_error ~on_data command
+        ~name ?read_header ~restart ~restart_on_error ~restart_delay ~on_data
+          command
 
     inherit! Generated.source ~empty_on_abort:false ~bufferize ()
   end
@@ -69,6 +70,12 @@ let proto =
       Lang.bool_t,
       Some (Lang.bool false),
       Some "Restart process when exited with error." );
+    ( "restart_delay",
+      Lang.float_t,
+      Some (Lang.float 1.),
+      Some
+        "Delay (in seconds) before restarting the process. Prevents \
+         busy-looping when the command exits immediately." );
     ("", Lang.getter_t Lang.string_t, None, Some "Command to execute.");
   ]
 
@@ -104,10 +111,11 @@ let _ =
       in
       let restart = Lang.to_bool (List.assoc "restart" p) in
       let restart_on_error = Lang.to_bool (List.assoc "restart_on_error" p) in
+      let restart_delay = Lang.to_float (List.assoc "restart_delay" p) in
       let max = Lang.to_float (List.assoc "max" p) in
       let s =
         new external_input
-          ~restart ~bufferize ~restart_on_error ~max
+          ~restart ~bufferize ~restart_on_error ~restart_delay ~max
           ~name:"input.external.rawaudio" ~converter command
       in
       let frame_t =
@@ -148,7 +156,8 @@ let _ =
       in
       let restart = Lang.to_bool (List.assoc "restart" p) in
       let restart_on_error = Lang.to_bool (List.assoc "restart_on_error" p) in
+      let restart_delay = Lang.to_float (List.assoc "restart_delay" p) in
       let max = Lang.to_float (List.assoc "max" p) in
       new external_input
-        ~restart ~bufferize ~read_header ~restart_on_error ~max
+        ~restart ~bufferize ~read_header ~restart_on_error ~restart_delay ~max
         ~name:"input.external.wav" ~converter command)

--- a/src/core/base/sources/external_input_audio.ml
+++ b/src/core/base/sources/external_input_audio.ml
@@ -27,8 +27,8 @@ open Mm
 
 exception Finished of string * bool
 
-class external_input ~name ~restart ~bufferize ~restart_on_error ~restart_delay
-  ~max ~converter ?read_header command =
+class external_input ~name ~restart ~bufferize ~restart_on_error
+  ~restart_delay_on_error ~max ~converter ?read_header command =
   let abg_max_len = Frame.audio_of_seconds max in
   let buflen = Utils.buflen in
   let buf = Bytes.create buflen in
@@ -46,8 +46,8 @@ class external_input ~name ~restart ~bufferize ~restart_on_error ~restart_delay
   object
     inherit
       External_input.base
-        ~name ?read_header ~restart ~restart_on_error ~restart_delay ~on_data
-          command
+        ~name ?read_header ~restart ~restart_on_error ~restart_delay_on_error
+          ~on_data command
 
     inherit! Generated.source ~empty_on_abort:false ~bufferize ()
   end
@@ -70,12 +70,13 @@ let proto =
       Lang.bool_t,
       Some (Lang.bool false),
       Some "Restart process when exited with error." );
-    ( "restart_delay",
+    ( "restart_delay_on_error",
       Lang.float_t,
       Some (Lang.float 0.1),
       Some
-        "Delay (in seconds) before restarting the process. Prevents \
-         busy-looping when the command exits immediately." );
+        "Delay (in seconds) before restarting the process if its exit status \
+         is other than 0. Prevents busy-looping when the command exits \
+         immediately." );
     ("", Lang.getter_t Lang.string_t, None, Some "Command to execute.");
   ]
 
@@ -111,11 +112,13 @@ let _ =
       in
       let restart = Lang.to_bool (List.assoc "restart" p) in
       let restart_on_error = Lang.to_bool (List.assoc "restart_on_error" p) in
-      let restart_delay = Lang.to_float (List.assoc "restart_delay" p) in
+      let restart_delay_on_error =
+        Lang.to_float (List.assoc "restart_delay_on_error" p)
+      in
       let max = Lang.to_float (List.assoc "max" p) in
       let s =
         new external_input
-          ~restart ~bufferize ~restart_on_error ~restart_delay ~max
+          ~restart ~bufferize ~restart_on_error ~restart_delay_on_error ~max
           ~name:"input.external.rawaudio" ~converter command
       in
       let frame_t =
@@ -156,8 +159,11 @@ let _ =
       in
       let restart = Lang.to_bool (List.assoc "restart" p) in
       let restart_on_error = Lang.to_bool (List.assoc "restart_on_error" p) in
-      let restart_delay = Lang.to_float (List.assoc "restart_delay" p) in
+      let restart_delay_on_error =
+        Lang.to_float (List.assoc "restart_delay_on_error" p)
+      in
       let max = Lang.to_float (List.assoc "max" p) in
       new external_input
-        ~restart ~bufferize ~read_header ~restart_on_error ~restart_delay ~max
-        ~name:"input.external.wav" ~converter command)
+        ~restart ~bufferize ~read_header ~restart_on_error
+        ~restart_delay_on_error ~max ~name:"input.external.wav" ~converter
+        command)

--- a/src/core/base/tools/external_input.ml
+++ b/src/core/base/tools/external_input.ml
@@ -24,8 +24,8 @@ open Extralib
 
 (* {1 External Input handling} *)
 
-class virtual base ~name ~restart ~restart_on_error ~on_data ?read_header
-  command =
+class virtual base ~name ~restart ~restart_on_error ?(restart_delay = 0.)
+  ~on_data ?read_header command =
   let no_header, read_header =
     match read_header with
       | None -> (true, fun _ -> assert false)
@@ -60,9 +60,14 @@ class virtual base ~name ~restart ~restart_on_error ~on_data ?read_header
           let on_stop status =
             Generator.add_track_mark self#buffer;
             header_read <- false;
-            match status with
-              | `Status (Unix.WEXITED 0) -> restart
-              | _ -> restart_on_error
+            let should_restart =
+              match status with
+                | `Status (Unix.WEXITED 0) -> restart
+                | _ -> restart_on_error
+            in
+            if should_restart && restart_delay > 0. then
+              Thread.delay restart_delay;
+            should_restart
           in
           let log s = self#log#important "%s" s in
           process <-

--- a/src/core/base/tools/external_input.ml
+++ b/src/core/base/tools/external_input.ml
@@ -65,9 +65,7 @@ class virtual base ~name ~restart ~restart_on_error ?(restart_delay = 0.)
                 | `Status (Unix.WEXITED 0) -> restart
                 | _ -> restart_on_error
             in
-            if should_restart && restart_delay > 0. then
-              Thread.delay restart_delay;
-            should_restart
+            if should_restart then restart_delay else -1.
           in
           let log s = self#log#important "%s" s in
           process <-

--- a/src/core/base/tools/external_input.ml
+++ b/src/core/base/tools/external_input.ml
@@ -24,8 +24,8 @@ open Extralib
 
 (* {1 External Input handling} *)
 
-class virtual base ~name ~restart ~restart_on_error ?(restart_delay = 0.)
-  ~on_data ?read_header command =
+class virtual base ~name ~restart ~restart_on_error
+  ?(restart_delay_on_error = 0.) ~on_data ?read_header command =
   let no_header, read_header =
     match read_header with
       | None -> (true, fun _ -> assert false)
@@ -60,12 +60,9 @@ class virtual base ~name ~restart ~restart_on_error ?(restart_delay = 0.)
           let on_stop status =
             Generator.add_track_mark self#buffer;
             header_read <- false;
-            let should_restart =
-              match status with
-                | `Status (Unix.WEXITED 0) -> restart
-                | _ -> restart_on_error
-            in
-            if should_restart then restart_delay else -1.
+            match status with
+              | `Status (Unix.WEXITED 0) -> if restart then 0. else -1.
+              | _ -> if restart_on_error then restart_delay_on_error else -1.
           in
           let log s = self#log#important "%s" s in
           process <-

--- a/src/core/base/tools/process_handler.ml
+++ b/src/core/base/tools/process_handler.ml
@@ -145,7 +145,7 @@ let run ?priority ?env ?on_start ?on_stdin ?on_stdout ?on_stderr ?on_stop ?log
   let env = with_default (Unix.environment ()) env in
   let log = with_default (fun _ -> ()) log in
   let on_start = with_default (fun _ -> `Continue) on_start in
-  let on_stop = with_default (fun _ -> false) on_stop in
+  let on_stop = with_default (fun _ -> -1.) on_stop in
   let mutex = Mutex.create () in
   let create () =
     log "Starting process";
@@ -216,14 +216,25 @@ let run ?priority ?env ?on_start ?on_stdin ?on_stdout ?on_stderr ?on_stop ?log
     in
     { Duppy.Task.priority = Atomic.get process.priority; events; handler }
   in
-  let restart_decision handler = function
-    | true ->
+  let restart_decision handler delay =
+    if delay < 0. then begin
+      cleanup ~log t;
+      []
+    end
+    else begin
+      let spawn _ =
         create ();
         let fd = Unix.descr_of_out_channel (get_process t).p.stdin in
         [get_task handler (on_start (pusher fd))]
-    | false ->
-        cleanup ~log t;
-        []
+      in
+      [
+        {
+          Duppy.Task.priority;
+          events = [`Delay delay];
+          handler = spawn;
+        };
+      ]
+    end
   in
   (* Read any remaining data from stdout/stderr pipes. Called when the process
      exits to ensure we don't miss any output. Reads until EOF on each pipe. *)
@@ -342,9 +353,14 @@ let run ?priority ?env ?on_start ?on_stdin ?on_stdout ?on_stderr ?on_stop ?log
               (Printf.sprintf "Error while running process: %s\n%s"
                  (Printexc.to_string e) bt)
           in
-          let e = match e with Wrapped e -> e | e -> e in
-          f e;
-          restart_decision (on_stop (`Exception e))
+          (match e with
+            | Wrapped e ->
+                f e;
+                cleanup ~log t;
+                []
+            | _ ->
+                f e;
+                restart_decision (on_stop (`Exception e)))
   in
   let fd = Unix.descr_of_out_channel (get_process t).p.stdin in
   Duppy.Task.add Tutils.scheduler (get_task handler (on_start (pusher fd)));

--- a/src/core/base/tools/process_handler.ml
+++ b/src/core/base/tools/process_handler.ml
@@ -242,7 +242,11 @@ let run ?priority ?env ?on_start ?on_stdin ?on_stdout ?on_stderr ?on_stop ?log
         if !last_read = 0 then raise Pipe_flushed;
         loop ()
       in
-      try loop () with Pipe_flushed -> ()
+      try loop () with
+        | Pipe_flushed -> ()
+        | exn ->
+            log
+              (Printf.sprintf "Cannot drain pipe: %s" (Printexc.to_string exn))
     in
     Option.iter (drain_fd stdout) on_stdout;
     Option.iter (drain_fd stderr) on_stderr
@@ -331,7 +335,7 @@ let run ?priority ?env ?on_start ?on_stdin ?on_stdout ?on_stderr ?on_stop ?log
           log descr;
           t.process <- None;
           restart_decision (on_stop status)
-      | e -> (
+      | e ->
           let bt = Printexc.get_backtrace () in
           let f e =
             log
@@ -340,7 +344,7 @@ let run ?priority ?env ?on_start ?on_stdin ?on_stdout ?on_stderr ?on_stop ?log
           in
           let e = match e with Wrapped e -> e | e -> e in
           f e;
-          restart_decision (on_stop (`Exception e)))
+          restart_decision (on_stop (`Exception e))
   in
   let fd = Unix.descr_of_out_channel (get_process t).p.stdin in
   Duppy.Task.add Tutils.scheduler (get_task handler (on_start (pusher fd)));

--- a/src/core/base/tools/process_handler.ml
+++ b/src/core/base/tools/process_handler.ml
@@ -227,13 +227,7 @@ let run ?priority ?env ?on_start ?on_stdin ?on_stdout ?on_stderr ?on_stop ?log
         let fd = Unix.descr_of_out_channel (get_process t).p.stdin in
         [get_task handler (on_start (pusher fd))]
       in
-      [
-        {
-          Duppy.Task.priority;
-          events = [`Delay delay];
-          handler = spawn;
-        };
-      ]
+      [{ Duppy.Task.priority; events = [`Delay delay]; handler = spawn }]
     end
   in
   (* Read any remaining data from stdout/stderr pipes. Called when the process
@@ -346,14 +340,14 @@ let run ?priority ?env ?on_start ?on_stdin ?on_stdout ?on_stderr ?on_stop ?log
           log descr;
           t.process <- None;
           restart_decision (on_stop status)
-      | e ->
+      | e -> (
           let bt = Printexc.get_backtrace () in
           let f e =
             log
               (Printf.sprintf "Error while running process: %s\n%s"
                  (Printexc.to_string e) bt)
           in
-          (match e with
+          match e with
             | Wrapped e ->
                 f e;
                 cleanup ~log t;

--- a/src/core/base/tools/process_handler.ml
+++ b/src/core/base/tools/process_handler.ml
@@ -338,13 +338,9 @@ let run ?priority ?env ?on_start ?on_stdin ?on_stdout ?on_stderr ?on_stop ?log
               (Printf.sprintf "Error while running process: %s\n%s"
                  (Printexc.to_string e) bt)
           in
-          match e with
-            | Wrapped e ->
-                f e;
-                raise e
-            | _ ->
-                f e;
-                restart_decision (on_stop (`Exception e)))
+          let e = match e with Wrapped e -> e | e -> e in
+          f e;
+          restart_decision (on_stop (`Exception e)))
   in
   let fd = Unix.descr_of_out_channel (get_process t).p.stdin in
   Duppy.Task.add Tutils.scheduler (get_task handler (on_start (pusher fd)));

--- a/src/core/base/tools/process_handler.mli
+++ b/src/core/base/tools/process_handler.mli
@@ -72,8 +72,9 @@ exception Finished
 
 (** Create a process handler. Decisions returned by the callbacks are applied
     synchronously, i.e. when returning [`Stop], the process' stdin is closed
-    immediately after the callback has returned. The process is restarted when
-    the function [on_stop] returns [true]. *)
+    immediately after the callback has returned. [on_stop] returns the delay
+    in seconds before restarting the process; negative means do not
+    restart.*)
 val run :
   ?priority:Tutils.priority ->
   ?env:string array ->
@@ -81,7 +82,7 @@ val run :
   ?on_stdin:push callback ->
   ?on_stdout:pull callback ->
   ?on_stderr:pull callback ->
-  ?on_stop:(status -> bool) ->
+  ?on_stop:(status -> float) ->
   ?log:(string -> unit) ->
   string ->
   t

--- a/src/core/base/tools/process_handler.mli
+++ b/src/core/base/tools/process_handler.mli
@@ -72,9 +72,8 @@ exception Finished
 
 (** Create a process handler. Decisions returned by the callbacks are applied
     synchronously, i.e. when returning [`Stop], the process' stdin is closed
-    immediately after the callback has returned. [on_stop] returns the delay
-    in seconds before restarting the process; negative means do not
-    restart.*)
+    immediately after the callback has returned. [on_stop] returns the delay in
+    seconds before restarting the process; negative means do not restart.*)
 val run :
   ?priority:Tutils.priority ->
   ?env:string array ->

--- a/src/core/builtins/builtins_process.ml
+++ b/src/core/builtins/builtins_process.ml
@@ -246,7 +246,7 @@ let _ =
                 ignore (Unix_utils.write in_pipe (Bytes.of_string " ") 0 1)
               with _ -> ()
               end;
-              false
+              -1.
             in
             let on_start _ = `Stop in
             let p =

--- a/tests/core/ffprobe_process_test.ml
+++ b/tests/core/ffprobe_process_test.ml
@@ -39,7 +39,7 @@ let on_stop _ =
   test_finished := true;
   Condition.signal finished;
   Mutex.unlock m;
-  false
+  -1.
 
 let () =
   let media_file =

--- a/tests/core/large_process_stdout_test.ml
+++ b/tests/core/large_process_stdout_test.ml
@@ -61,7 +61,7 @@ let run_test () =
     test_finished := true;
     Condition.signal finished;
     Mutex.unlock m;
-    false
+    -1.
   in
   Tutils.start ();
   let exe = Sys.executable_name in


### PR DESCRIPTION
Exceptions in `process_handler.ml` go through `on_stop` instead of raising them again, and the drain loop logs errors instead of escaping. Added `restart_delay` to `External_input.base` (default `0.`), exposed on `input.external.wav` and `input.external.rawaudio` with a `1.` default. 

Video operator was left untouched because I had no reliable way to test it.

Prevents the crash reported in #5138.