### PR TITLE
mutex_utils: fix busy-loop in mutable_wait when lock is Mutating

### DIFF
--- a/src/core/base/tools/mutex_utils.ml
+++ b/src/core/base/tools/mutex_utils.ml
@@ -52,7 +52,12 @@ let[@inline always] on_mutex_done state =
 
 let rec mutable_wait state =
   if not (Atomic.compare_and_set state.lock `None `Mutating) then (
-    Domain.cpu_relax ();
+    (match Atomic.get state.lock with
+      | `Mutating ->
+          mutexify state.mutex
+            (fun () -> Condition.wait state.condition state.mutex)
+            ()
+      | _ -> Domain.cpu_relax ());
     mutable_wait state)
 
 let mutable_lock ~state fn v =


### PR DESCRIPTION
`mutable_wait` was a pure spin-loop: it called `Domain.cpu_relax()` unconditionally, regardless of the current lock state. When another `mutable_lock` holder is running (state = `` `Mutating ``), waiters burned CPU for the entire duration of the critical section, even though `on_mutex_done` broadcasts on `state.condition` on release — so there was a condition variable sitting unused.

The fix mirrors the strategy already used by `atomic_wait`: when the observed state is `` `Mutating ``, sleep on `state.condition` (protected by `state.mutex`) rather than spinning. When the state is `` `Locked `` (held by `atomic_lock`), we still fall back to `Domain.cpu_relax()` because `atomic_lock` releases with a bare `Atomic.set state.lock `None`` and no broadcast, so sleeping on the condition there would deadlock.
