### PR TITLE
[Backport v2.4.x-latest] mutex_utils: fix busy-loop in mutable_wait when lock is Mutating

### DIFF
--- a/src/core/base/tools/mutex_utils.ml
+++ b/src/core/base/tools/mutex_utils.ml
@@ -52,7 +52,12 @@ let[@inline always] on_mutex_done state =
 
 let rec mutable_wait state =
   if not (Atomic.compare_and_set state.lock `None `Mutating) then (
-    Domain.cpu_relax ();
+    (match Atomic.get state.lock with
+      | `Mutating ->
+          mutexify state.mutex
+            (fun () -> Condition.wait state.condition state.mutex)
+            ()
+      | _ -> Domain.cpu_relax ());
     mutable_wait state)
 
 let mutable_lock ~state fn v =


### PR DESCRIPTION
Backport 684e5de56dd8ced946893b6029d876821ccc957f from #5144.