### PR TITLE
[Backport v2.4.x-latest] clock, source: fix performance regression from PR #5133

### DIFF
--- a/src/core/base/clock.ml
+++ b/src/core/base/clock.ml
@@ -529,10 +529,11 @@ let rec active_params c =
 
 and _register_clock_callback ~clock x s =
   let name = s#id and stack = s#stack in
-  let _ : unit -> unit =
+  let deregister =
     s#on_sync_source_change (fun ~old:_ new_sync_source ->
         _update_clock_sync_source ~clock x ~name ~stack new_sync_source)
   in
+  s#on_sleep deregister;
   _update_clock_sync_source ~clock x ~name ~stack s#source_state
 
 and _activate_pending_sources ~clock x =
@@ -785,7 +786,7 @@ let start_pending () =
               | `True sync ->
                   _start ~sync ~c clock;
                   Queue.push clocks c
-              | `False -> WeakQueue.push pending_clocks c)
+              | `False -> WeakQueue.push_raw pending_clocks c)
         | _ -> ())
     c
 

--- a/src/core/base/clock.mli
+++ b/src/core/base/clock.mli
@@ -70,6 +70,7 @@ type source =
   ; activations : activation list
   ; wake_up : source -> activation
   ; sleep : activation -> unit
+  ; on_sleep : (unit -> unit) -> unit
   ; is_ready : bool
   ; get_frame : Frame.t
   ; source_state : sync_source option

--- a/src/core/base/clock_base.ml
+++ b/src/core/base/clock_base.ml
@@ -41,6 +41,7 @@ end
 module WeakQueue = struct
   include Queues.WeakQueue
 
+  let push_raw = push
   let push q v = if not (exists q (fun v' -> v == v')) then push q v
 end
 
@@ -134,6 +135,7 @@ type source =
   ; activations : activation list
   ; wake_up : source -> activation
   ; sleep : activation -> unit
+  ; on_sleep : (unit -> unit) -> unit
   ; is_ready : bool
   ; get_frame : Frame.t
   ; source_state : sync_source option

--- a/src/core/base/source.ml
+++ b/src/core/base/source.ml
@@ -40,6 +40,9 @@ module SourceSync = Clock.MkSyncSource (struct
   let to_string s = Printf.sprintf "source(id=%s)" s#id
 end)
 
+let sync_source_changed a b =
+  match (a, b) with None, None -> false | Some a, Some b -> a != b | _ -> true
+
 (** {1 Sources} *)
 
 (** Instrumentation. *)
@@ -223,7 +226,7 @@ class virtual operator ?(stack = []) ?clock ~name sources =
       fun () -> Queue.filter_out state_callbacks (fun (i, _) -> i = id)
 
     method private notify_sync_source new_state =
-      if new_state <> source_state then (
+      if sync_source_changed new_state source_state then (
         let old = source_state in
         source_state <- new_state;
         Queue.iter state_callbacks (fun (_, fn) -> fn ~old new_state))
@@ -234,7 +237,7 @@ class virtual operator ?(stack = []) ?clock ~name sources =
     initializer
       self#on_before_streaming_cycle (fun () ->
           let sync_source = snd self#self_sync in
-          if sync_source <> source_state then
+          if sync_source_changed sync_source source_state then
             self#notify_sync_source sync_source)
 
     (* Type describing the contents of the frame: this should be a record

--- a/tests/regression/GH4116.liq
+++ b/tests/regression/GH4116.liq
@@ -1,3 +1,6 @@
+# theora encoder/decoder is deprecated
+test.skip()
+
 s = single("./theora-test.mp4")
 
 enc = %theora


### PR DESCRIPTION
Backport 6906e2a70613004caa55c49272213e9e36512d33 from #5153.