### PR TITLE
Implement a better skip for file-base sources

### DIFF
--- a/src/core/base/source.mli
+++ b/src/core/base/source.mli
@@ -282,6 +282,8 @@ object
 
   method on_before_streaming_cycle : (unit -> unit) -> unit
   method on_after_streaming_cycle : (unit -> unit) -> unit
+  method private before_streaming_cycle : unit
+  method private after_streaming_cycle : unit
 
   (** Sources must implement this method. It should return the data produced
       during the current streaming cycle. Sources are responsible for producing

--- a/src/core/base/sources/request_dynamic.ml
+++ b/src/core/base/sources/request_dynamic.ml
@@ -72,12 +72,24 @@ class dynamic ?(name = "request.dynamic") ~retry_delay ~available ~prefetch
     method current = Atomic.get current
     method self_sync = (`Static, None)
     val should_skip = Atomic.make false
+
+    initializer
+      self#on_before_streaming_cycle (fun () ->
+          if Atomic.exchange should_skip false then (
+            self#after_streaming_cycle;
+            self#end_request;
+            if self#is_ready then (
+              let f = self#peek_frame in
+              (match Frame.track_marks f with
+                | p :: _ -> self#consumed p
+                | _ -> self#consumed (Frame.position f));
+              self#after_streaming_cycle)))
+
     method is_synchronous = synchronous
     method prefetch = prefetch
 
     (** How to unload a request. *)
     method private end_request =
-      Atomic.set should_skip false;
       remaining <- 0;
       match Atomic.exchange current None with
         | None -> ()
@@ -161,7 +173,7 @@ class dynamic ?(name = "request.dynamic") ~retry_delay ~available ~prefetch
           let buf =
             Frame.append buf (self#generate_from_current_request (size - pos))
           in
-          if Atomic.get should_skip || Frame.is_partial buf then (
+          if Frame.is_partial buf then (
             self#end_request;
             let buf = Frame.add_track_mark buf (Frame.position buf) in
             if self#fetch_request then fill buf else buf)


### PR DESCRIPTION
Skip operations have always been tricky for our users. Part of the issue is that everything needs to be driven by clock ticks so skips are never really synchronous: a skip indicates to the underlying source that it should abot its current track, which is only effective during the next streaming cycle.

This is also made more complicated due to the fact that we cache data in-between streaming cycles. So, when the next cycle happens, we do not remember that we were supposed to skip a track and might pass the remaining data from the cache, which may contain up-to a frame of data from the old track, leading to audio and video artifacts.

This PR improves file-base sources `skip`. After skip is called, and before the next streaming cycle, a whole cycle of data generation is generated and all generated data up-to the first track mark is discarded.

This makes it possible to have a clean skip with no side-effect that should be what most users expect when skipping tracks.