### PR TITLE
icecast.server: add default muxer options for live streaming

### DIFF
--- a/doc/content/icecast_server.md
+++ b/doc/content/icecast_server.md
@@ -28,6 +28,7 @@ This starts a server on port 8000 with the default password "hackme".
 - `serve_html`: Optional callback `(stats) -> string` to replace the built-in HTML renderer
 - `x_forwarded_for_proxy_ips`: List of known reverse-proxy IPs for real-IP extraction (see [below](#reverse-proxy-and-x-forwarded-for))
 - `x_forwarded_for`: Advanced callback to fully override real-IP extraction logic (see [below](#reverse-proxy-and-x-forwarded-for))
+- `format_options`: Optional callback `(string) -> [(string * string)]` that returns muxer options for a given container format name. When `null`, falls back to `settings.icecast.server.default_muxer_options` (see [below](#live-streaming-muxer-options))
 
 ### Return Value
 
@@ -119,6 +120,43 @@ Use `serve_json` to replace the built-in `/status.json` output. The callback rec
 ```
 
 The stats list passed to both `serve_json` and `serve_html` is a list of `(mount, stats)` pairs where each `stats` record contains: `name`, `content_type`, `mime_type`, `started`, `listeners`, `peak_listeners`, and `current_metadata`.
+
+## Live Streaming Muxer Options
+
+Some container formats require specific muxer flags to produce a valid live stream. For example, Matroska and WebM streams need their muxer told that there will be no seekable index at the end.
+
+`icecast.server` automatically applies these options when remuxing an incoming stream via `copy_encoder`. The defaults are controlled by `settings.icecast.server.default_muxer_options`, which maps container format names to lists of FFmpeg muxer options:
+
+| Format     | Default options    | Effect                                                              |
+| ---------- | ------------------ | ------------------------------------------------------------------- |
+| `matroska` | `dash=1`, `live=1` | Disables index/cues, writes streaming-compatible cluster timestamps |
+| `webm`     | `dash=1`, `live=1` | Same as matroska (WebM is a subset)                                 |
+
+To override the defaults globally, set the setting before starting the server:
+
+```liquidsoap
+settings.icecast.server.default_muxer_options :=
+  [("matroska", [("dash", "1"), ("live", "1")]),
+   ("webm",     [("dash", "1"), ("live", "1")])]
+```
+
+To override per-server instance, use the `format_options` parameter. The callback receives the detected container format name and returns the options list to apply:
+
+```liquidsoap
+# Disable all extra muxer options
+icecast.server(format_options=fun (_) -> [], password="hackme")
+
+# Custom options for matroska, defaults for everything else
+icecast.server(
+  format_options=fun (fmt) ->
+    if fmt == "matroska" then [("dash", "1"), ("live", "1"), ("cluster_size_limit", "1000000")]
+    else list.assoc(default=[], fmt, settings.icecast.server.default_muxer_options())
+    end,
+  password="hackme"
+)
+```
+
+When `format_options` is `null` (the default), `settings.icecast.server.default_muxer_options` is used. When provided, it fully replaces the settings lookup — the callback is responsible for returning all options for every format.
 
 ## Key Differences from Icecast
 

--- a/src/core/optionals/ffmpeg/ffmpeg_harbor_input.ml
+++ b/src/core/optionals/ffmpeg/ffmpeg_harbor_input.ml
@@ -85,7 +85,7 @@ let stream_to_record (stream : Ffmpeg_stream_description.stream) =
     | `Subtitle params -> subtitle_stream_to_record params stream.field
     | `Data params -> data_stream_to_record params stream.field
 
-let copy_encoder_of_description ?format ?mime_type
+let copy_encoder_of_description ?format ?mime_type ~opts
     (desc : Ffmpeg_stream_description.container) =
   let streams =
     List.filter_map
@@ -104,7 +104,7 @@ let copy_encoder_of_description ?format ?mime_type
       streams;
       interleaved = `Default;
       metadata = Frame.Metadata.empty;
-      opts = Hashtbl.create 0;
+      opts;
     }
   in
   Encoder.Ffmpeg ffmpeg_format
@@ -243,13 +243,25 @@ class ffmpeg_http_input ~dumpfile ~logfile ~bufferize ~max ~replay_meta
             | _ -> None
         in
         Lang.val_fun
-          [("", "", Some Lang.null)]
+          [
+            ("", "", Some Lang.null); ("options", "options", Some (Lang.list []));
+          ]
           (fun p ->
             let format =
               Lang.to_valued_option Lang.to_string (List.assoc "" p)
             in
+            let opts =
+              List.fold_left
+                (fun opts v ->
+                  let lbl, v = Lang.to_product v in
+                  Hashtbl.replace opts (Lang.to_string lbl)
+                    (`String (Lang.to_string v));
+                  opts)
+                (Hashtbl.create 0)
+                (Lang.to_list (List.assoc "options" p))
+            in
             Lang_encoder.L.format
-              (copy_encoder_of_description ?format ?mime_type desc))
+              (copy_encoder_of_description ?format ?mime_type ~opts desc))
       in
       let callback_record =
         Lang.record
@@ -325,7 +337,12 @@ let on_connect_t =
         ("headers", Lang.metadata_t);
         ( "copy_encoder",
           Lang.fun_t
-            [(true, "", Lang.nullable_t Lang.string_t)]
+            [
+              (true, "", Lang.nullable_t Lang.string_t);
+              ( true,
+                "options",
+                Lang.list_t (Lang.product_t Lang.string_t Lang.string_t) );
+            ]
             (Lang.format_t frame_t) );
       ]
   in

--- a/src/libs/extra/icecast_server.liq
+++ b/src/libs/extra/icecast_server.liq
@@ -61,6 +61,20 @@ end
 settings.icecast.server.tls_transport := ("ssl", icecast.server.ssl_transport)
 %endif
 
+# Default muxer options applied when remuxing incoming streams via `copy_encoder`, keyed by container format name. Used to enable live/streaming-compatible output for formats that require explicit opt-in.
+# @flag extra
+# @category Source / Input / Active
+let settings.icecast.server.default_muxer_options =
+  settings.make(
+    description="Default muxer options applied when remuxing incoming streams, \
+     keyed by container format name. Used to enable live/streaming-compatible \
+     output for formats that require explicit opt-in.",
+    [
+      ("matroska", [("dash", "1"), ("live", "1")]),
+      ("webm", [("dash", "1"), ("live", "1")])
+    ]
+  )
+
 # @flag hidden
 def icecast.server.parse_headers(node) =
   # Defaults mirror icecast 2.5 behaviour. Access-Control-Allow-Origin is
@@ -764,6 +778,7 @@ def icecast.server.default_prepare(
     transport,
     dumpfile,
     dedicated_encoder,
+    muxer_opts,
     streams = _,
     source_headers = _
   }
@@ -808,7 +823,7 @@ def icecast.server.default_prepare(
           dumpfile=dumpfile,
           dedicated_encoder=dedicated_encoder,
           format=mime_type ?? "",
-          copy_encoder(format),
+          copy_encoder(format, options=muxer_opts),
           default_source
         )
 
@@ -872,6 +887,7 @@ def icecast.server.source_manager(
   ~dedicated_encoder=false,
   ~x_forwarded_for_proxy_ips=null,
   ~x_forwarded_for=null,
+  ~format_options=null,
   ~global_headers,
   ~default_mount,
   ~mount_configs
@@ -1095,6 +1111,25 @@ def icecast.server.source_manager(
               list.filter(fun (l) -> l.ip != real_ip, listeners_ref())
           end
 
+          muxer_opts =
+            if
+              null.defined(format)
+            then
+              if
+                null.defined(format_options)
+              then
+                format_options_fn = null.get(format_options)
+                format_options_fn(null.get(format))
+              else
+                list.assoc(
+                  default=[],
+                  null.get(format),
+                  settings.icecast.server.default_muxer_options()
+                )
+              end
+            else
+              []
+            end
           prepare = icecast.server.default_prepare
           connector =
             prepare(
@@ -1110,7 +1145,8 @@ def icecast.server.source_manager(
                 port = port,
                 transport = transport,
                 dumpfile = mount_config.dump_file,
-                dedicated_encoder = dedicated_encoder
+                dedicated_encoder = dedicated_encoder,
+                muxer_opts = muxer_opts
               }
             )
           o =
@@ -1549,6 +1585,7 @@ end
 # @param ~serve_html When provided, called with the stats list and must return an HTML string for the `/` endpoint.
 # @param ~x_forwarded_for_proxy_ips List of known reverse-proxy IPs. When set, the `X-Forwarded-For` header is walked right-to-left and the first non-proxy IP is used as the listener IP in stats. Use only when liquidsoap is behind a trusted reverse proxy.
 # @param ~x_forwarded_for Advanced: custom callback `({ip, headers, proxy_ips, protocol, uri}) -> string` to extract the real listener IP. When set, overrides the default `X-Forwarded-For` logic. `proxy_ips` in the record is populated from `x_forwarded_for_proxy_ips`.
+# @param ~format_options Callback `(string) -> [(string * string)]` that returns muxer options for a given container format name. When `null`, falls back to `settings.icecast.server.default_muxer_options`.
 # @callback on_connect Called when a source connects. Receives a record with mount, source, format, streams, and headers fields.
 # @callback on_disconnect Called when a source disconnects. Receives a record with a mount field.
 # @method stats Returns a list of `(mount, stats)` pairs. Each stats record contains: name, content_type, started, listeners, peak_listeners, and current_metadata.
@@ -1559,6 +1596,7 @@ def icecast.server(
   ~dedicated_encoder=false,
   ~x_forwarded_for_proxy_ips=null,
   ~x_forwarded_for=null,
+  ~format_options=null,
   ~config=null,
   ~serve=true,
   ~serve_auth=null,
@@ -1705,6 +1743,7 @@ def icecast.server(
       dedicated_encoder=dedicated_encoder,
       x_forwarded_for_proxy_ips=x_forwarded_for_proxy_ips,
       x_forwarded_for=x_forwarded_for,
+      format_options=format_options,
       global_headers=global_headers,
       default_mount=default_mount,
       mount_configs=mount_configs


### PR DESCRIPTION
Some container formats require specific muxer flags to produce a valid live stream. Without them, Matroska/WebM muxers write a seekable index at the end (incompatible with streaming), and MP4 muxers write a non-fragmented file (the `moov` atom only lands at the end, so no data can be played until the stream is closed).

This PR adds `settings.icecast.server.default_muxer_options`, a `[(string * [(string * string)])]` setting keyed by container format name, with built-in defaults for the three formats that need them:

- `matroska` / `webm`: `dash=1, live=1` — disables cues/index, enables streaming-compatible cluster timestamps

It also adds a `format_options` parameter to `icecast.server` (type `(string -> [(string * string)])?`) for per-instance overrides. When `null` (the default), the setting is used. When provided, the callback fully replaces the settings lookup for that server instance.

The options are wired through `copy_encoder`'s new `options=` parameter (added to `ffmpeg_harbor_input.ml`) and computed in `source_manager.handle_connection` at source-connect time, then passed into the prepare record so `icecast.server.default_prepare` can forward them to `output.harbor`.

Documentation in `doc/content/icecast_server.md` is updated with a new "Live Streaming Muxer Options" section and the parameter list.
