### PR TITLE
ffmpeg: adapt to new ocaml-ffmpeg configure_stream_decoder API

### DIFF
--- a/src/core/optionals/ffmpeg/ffmpeg_copy_decoder.ml
+++ b/src/core/optionals/ffmpeg/ffmpeg_copy_decoder.ml
@@ -68,7 +68,6 @@ let mk_decoder ~stream_idx ~stream_time_base ~mk_packet ~put_data params =
         with Empty | Corrupt (* Might want to change that later. *) -> ())
 
 let mk_audio_decoder ~stream_idx ~format ~field ~stream params =
-  Ffmpeg_decoder_common.set_audio_stream_decoder stream;
   let params = `Audio params in
   ignore (Content.merge format (Ffmpeg_copy_content.lift_params (Some params)));
   let stream_time_base = Av.get_time_base stream in
@@ -79,7 +78,6 @@ let mk_audio_decoder ~stream_idx ~format ~field ~stream params =
     params
 
 let mk_video_decoder ~stream_idx ~format ~stream ~field params =
-  Ffmpeg_decoder_common.set_video_stream_decoder stream;
   let params =
     `Video
       {
@@ -96,7 +94,6 @@ let mk_video_decoder ~stream_idx ~format ~stream ~field params =
     params
 
 let mk_subtitle_decoder ~stream_idx ~format ~stream ~field params =
-  Ffmpeg_decoder_common.set_subtitle_stream_decoder stream;
   let stream_time_base = Av.get_time_base stream in
   let params =
     `Subtitle

--- a/src/core/optionals/ffmpeg/ffmpeg_decoder.ml
+++ b/src/core/optionals/ffmpeg/ffmpeg_decoder.ml
@@ -1003,8 +1003,7 @@ let mk_streams ~ctype ~decode_first_metadata ~set_remaining container =
                      ( stream,
                        tracked_stream ~track_data:track_frame stream
                          (Ffmpeg_internal_decoder.mk_audio_decoder ~channels
-                            ~stream ~field ~pcm_kind:Content.Audio.kind params)
-                     ))
+                            ~field ~pcm_kind:Content.Audio.kind params) ))
                   streams,
                 pos + 1 )
           | Some format when Content_pcm_s16.is_format format ->
@@ -1014,8 +1013,7 @@ let mk_streams ~ctype ~decode_first_metadata ~set_remaining container =
                      ( stream,
                        tracked_stream ~track_data:track_frame stream
                          (Ffmpeg_internal_decoder.mk_audio_decoder ~channels
-                            ~stream ~field ~pcm_kind:Content_pcm_s16.kind params)
-                     ))
+                            ~field ~pcm_kind:Content_pcm_s16.kind params) ))
                   streams,
                 pos + 1 )
           | Some format when Content_pcm_f32.is_format format ->
@@ -1025,8 +1023,7 @@ let mk_streams ~ctype ~decode_first_metadata ~set_remaining container =
                      ( stream,
                        tracked_stream ~track_data:track_frame stream
                          (Ffmpeg_internal_decoder.mk_audio_decoder ~channels
-                            ~stream ~field ~pcm_kind:Content_pcm_f32.kind params)
-                     ))
+                            ~field ~pcm_kind:Content_pcm_f32.kind params) ))
                   streams,
                 pos + 1 )
           | _ -> (streams, pos + 1))
@@ -1116,7 +1113,7 @@ let mk_streams ~ctype ~decode_first_metadata ~set_remaining container =
         match Frame.Fields.find_opt field ctype with
           | Some format when Subtitle_content.is_format format ->
               let { Ffmpeg_decoder_common.decoder; advance } =
-                Ffmpeg_internal_decoder.mk_text_subtitle_decoder ~stream ~field
+                Ffmpeg_internal_decoder.mk_text_subtitle_decoder ~field
               in
               ( add_stream ~sparse:(`True advance) idx stream
                   (`Subtitle_frame (stream, decoder))
@@ -1125,8 +1122,8 @@ let mk_streams ~ctype ~decode_first_metadata ~set_remaining container =
           | Some format when Content.Video.is_format format ->
               let width, height = Content.Video.dimensions_of_format format in
               let { Ffmpeg_decoder_common.decoder; advance } =
-                Ffmpeg_internal_decoder.mk_bitmap_subtitle_decoder ~stream
-                  ~field ~width ~height
+                Ffmpeg_internal_decoder.mk_bitmap_subtitle_decoder ~field ~width
+                  ~height
               in
               ( add_stream ~sparse:(`True advance) idx stream
                   (`Subtitle_frame (stream, decoder))
@@ -1244,7 +1241,13 @@ let create_decoder ~ctype ~metadata fname =
   if List.exists (fun s -> ext = "." ^ s) image_file_extensions#get then (
     Hashtbl.replace opts "loop" (`Int 1);
     Hashtbl.replace opts "framerate" (`Int (Lazy.force Frame.video_rate)));
-  let container = Av.open_input ?format ~opts fname in
+  let container =
+    Av.open_input ?format ~opts
+      ~configure_audio_stream:Ffmpeg_decoder_common.configure_audio_stream
+      ~configure_video_stream:Ffmpeg_decoder_common.configure_video_stream
+      ~configure_subtitle_stream:Ffmpeg_decoder_common.configure_subtitle_stream
+      fname
+  in
   if Hashtbl.length opts > 0 then
     Runtime_error.raise ~pos:[]
       ~message:
@@ -1300,7 +1303,13 @@ let get_file_type ~metadata ~ctype filename =
         let args, format = parse_file_decoder_args metadata in
         let opts = Hashtbl.create 10 in
         List.iter (fun (k, v) -> Hashtbl.replace opts k v) args;
-        let container = Av.open_input ?format ~opts filename in
+        let container =
+          Av.open_input ?format ~opts
+            ~configure_audio_stream:Ffmpeg_decoder_common.configure_audio_stream
+            ~configure_video_stream:Ffmpeg_decoder_common.configure_video_stream
+            ~configure_subtitle_stream:
+              Ffmpeg_decoder_common.configure_subtitle_stream filename
+        in
         Fun.protect
           ~finally:(fun () -> Av.close container)
           (fun () -> get_type ?format ~ctype ~url:filename container)

--- a/src/core/optionals/ffmpeg/ffmpeg_decoder_common.ml
+++ b/src/core/optionals/ffmpeg/ffmpeg_decoder_common.ml
@@ -87,37 +87,34 @@ let conf_codecs =
       (name, conf) :: l)
     codecs []
 
-let set_stream_decoder ~get_name ~get_codec stream =
-  let params = Av.get_codec_params stream in
+let configure_stream ~get_name ~find_decoder params =
   let name = get_name params in
   match List.assoc_opt name conf_codecs with
     | Some conf -> (
         try
           let preferred = conf#get in
           log#info "Trying preferred decoder %s for codec %s" preferred name;
-          try Av.set_decoder stream (get_codec preferred)
+          try { Av.codec = Some (find_decoder preferred); opts = None }
           with exn ->
             let bt = Printexc.get_backtrace () in
             Utils.log_exception ~log ~bt
               (Printf.sprintf "Failed to set decoder %s for codec %s: %s"
-                 preferred name (Printexc.to_string exn))
-        with _ -> ())
-    | None -> ()
+                 preferred name (Printexc.to_string exn));
+            { Av.codec = None; opts = None }
+        with _ -> { Av.codec = None; opts = None })
+    | None -> { Av.codec = None; opts = None }
 
-let set_audio_stream_decoder (type a)
-    (stream : (Avutil.input, Avutil.audio, a) Av.stream) =
-  set_stream_decoder
+let configure_audio_stream params =
+  configure_stream
     ~get_name:(fun p -> Avcodec.Audio.(string_of_id (get_params_id p)))
-    ~get_codec:Avcodec.Audio.find_decoder_by_name stream
+    ~find_decoder:Avcodec.Audio.find_decoder_by_name params
 
-let set_video_stream_decoder (type a)
-    (stream : (Avutil.input, Avutil.video, a) Av.stream) =
-  set_stream_decoder
+let configure_video_stream params =
+  configure_stream
     ~get_name:(fun p -> Avcodec.Video.(string_of_id (get_params_id p)))
-    ~get_codec:Avcodec.Video.find_decoder_by_name stream
+    ~find_decoder:Avcodec.Video.find_decoder_by_name params
 
-let set_subtitle_stream_decoder (type a)
-    (stream : (Avutil.input, Avutil.subtitle, a) Av.stream) =
-  set_stream_decoder
+let configure_subtitle_stream params =
+  configure_stream
     ~get_name:(fun p -> Avcodec.Subtitle.(string_of_id (get_params_id p)))
-    ~get_codec:Avcodec.Subtitle.find_decoder_by_name stream
+    ~find_decoder:Avcodec.Subtitle.find_decoder_by_name params

--- a/src/core/optionals/ffmpeg/ffmpeg_internal_decoder.ml
+++ b/src/core/optionals/ffmpeg/ffmpeg_internal_decoder.ml
@@ -69,7 +69,7 @@ end
 module Scaler = Swscale.Make (Swscale.Frame) (Swscale.BigArray)
 module SubScaler = Swscale.Make (Swscale.PackedBigArray) (Swscale.BigArray)
 
-let mk_audio_decoder ~channels ~stream ~field ~pcm_kind codec =
+let mk_audio_decoder ~channels ~field ~pcm_kind codec =
   let converter =
     match pcm_kind with
       | _ when Content_audio.is_kind pcm_kind ->
@@ -81,7 +81,6 @@ let mk_audio_decoder ~channels ~stream ~field ~pcm_kind codec =
       | _ -> raise Content_base.Invalid
   in
   let module Converter = (val converter : Converter_type) in
-  Ffmpeg_decoder_common.set_audio_stream_decoder stream;
   let in_sample_rate = ref (Avcodec.Audio.get_sample_rate codec) in
   let in_channel_layout = ref (Avcodec.Audio.get_channel_layout codec) in
   let in_sample_format = ref (Avcodec.Audio.get_sample_format codec) in
@@ -124,7 +123,6 @@ let mk_audio_decoder ~channels ~stream ~field ~pcm_kind codec =
             (Frame.Metadata.from_list metadata)
 
 let mk_video_decoder ~width ~height ~stream ~field codec =
-  Ffmpeg_decoder_common.set_video_stream_decoder stream;
   let pixel_format =
     match Avcodec.Video.get_pixel_format codec with
       | None -> failwith "Pixel format unknown!"
@@ -181,8 +179,7 @@ let mk_video_decoder ~width ~height ~stream ~field codec =
 
 let main_of_subtitle_time time = Frame.main_of_seconds (float time /. 1000.)
 
-let mk_text_subtitle_decoder ~stream ~field =
-  Ffmpeg_decoder_common.set_subtitle_stream_decoder stream;
+let mk_text_subtitle_decoder ~field =
   let avutil_time_base = Avutil.time_base () in
   let liq_main_ticks_time_base = Ffmpeg_utils.liq_main_ticks_time_base () in
   let to_ticks ts =
@@ -228,8 +225,7 @@ let mk_text_subtitle_decoder ~stream ~field =
   in
   Ffmpeg_utils.mk_subtitle_decoder ~output ~process ()
 
-let mk_bitmap_subtitle_decoder ~stream ~field ~width ~height =
-  Ffmpeg_decoder_common.set_subtitle_stream_decoder stream;
+let mk_bitmap_subtitle_decoder ~field ~width ~height =
   let cached_scaler = ref None in
   let get_scaler w h =
     match !cached_scaler with

--- a/src/core/optionals/ffmpeg/ffmpeg_internal_decoder.mli
+++ b/src/core/optionals/ffmpeg/ffmpeg_internal_decoder.mli
@@ -22,7 +22,6 @@
 
 val mk_audio_decoder :
   channels:int ->
-  stream:(Avutil.input, Avutil.audio, [ `Frame ]) Av.stream ->
   field:Frame.field ->
   pcm_kind:Content.kind ->
   Avutil.audio Avcodec.params ->
@@ -41,13 +40,11 @@ val mk_video_decoder :
   unit
 
 val mk_text_subtitle_decoder :
-  stream:(Avutil.input, [ `Subtitle ], [ `Frame ]) Av.stream ->
   field:Frame.field ->
   [ `Subtitle of Avutil.Subtitle.frame | `Flush ]
   Ffmpeg_decoder_common.sparse_decoder
 
 val mk_bitmap_subtitle_decoder :
-  stream:(Avutil.input, [ `Subtitle ], [ `Frame ]) Av.stream ->
   field:Frame.field ->
   width:int ->
   height:int ->

--- a/src/core/optionals/ffmpeg/ffmpeg_io.ml
+++ b/src/core/optionals/ffmpeg/ffmpeg_io.ml
@@ -135,7 +135,11 @@ class input ?(name = "input.ffmpeg") ~autostart ~self_sync ~poll_delay ~debug
         let container =
           Av.open_input
             ~interrupt:(fun () -> Atomic.get shutdown || Atomic.get closed)
-            ?format ~opts url
+            ?format ~opts
+            ~configure_audio_stream:Ffmpeg_decoder_common.configure_audio_stream
+            ~configure_video_stream:Ffmpeg_decoder_common.configure_video_stream
+            ~configure_subtitle_stream:
+              Ffmpeg_decoder_common.configure_subtitle_stream url
         in
         if Hashtbl.length opts > 0 then
           failwith

--- a/src/core/optionals/ffmpeg/ffmpeg_raw_decoder.ml
+++ b/src/core/optionals/ffmpeg/ffmpeg_raw_decoder.ml
@@ -43,7 +43,6 @@ let mk_decoder ~stream_idx ~stream_time_base ~mk_params ~mk_content ~lift_data
           | None -> ())
 
 let mk_audio_decoder ~stream_idx ~format ~stream ~field src_params =
-  Ffmpeg_decoder_common.set_audio_stream_decoder stream;
   let dst_params = Ffmpeg_raw_content.Audio.get_params format in
   let converter =
     let src_channel_layout = Avcodec.Audio.get_channel_layout src_params in
@@ -81,7 +80,6 @@ let mk_audio_decoder ~stream_idx ~format ~stream ~field src_params =
             decoder ~buffer (`Frame frame))
 
 let mk_video_decoder ~stream_idx ~format ~stream ~field params =
-  Ffmpeg_decoder_common.set_video_stream_decoder stream;
   ignore
     (Content.merge format
        Ffmpeg_raw_content.(Video.lift_params (VideoSpecs.mk_params params)));


### PR DESCRIPTION
Adapt the FFmpeg decoder to use the new `configure_*_stream` callbacks added to `Av.open_input` in ocaml-ffmpeg (savonet/ocaml-ffmpeg#93).

Previously, preferred decoders (configured via `settings.decoder.ffmpeg.codecs.*`) were applied after `avformat_find_stream_info` had already run, using `Av.set_decoder`. This meant stream probing always used the default codec, which could produce incorrect codec parameters — for example, VP9 streams with an alpha channel would be reported as `yuv420p` instead of `yuva420p` because the default VP9 decoder doesn't detect the alpha plane.

The new API accepts `configure_audio_stream`, `configure_video_stream`, and `configure_subtitle_stream` callbacks that are called per stream *before* `avformat_find_stream_info`. The returned codec is used both during probing (via a temporary format-level override) and during actual decoding (via a per-stream decoder array). This ensures codec parameters like pixel format are detected correctly.

`Av.set_decoder` has been removed from the ocaml-ffmpeg API; the `stream` parameter has been dropped from the internal decoder functions that previously needed it only to call `set_decoder`.

DEPS=ocaml-ffmpeg#fd049f0f276d94a83804a3052a55de5d1b16b89b
