### PR TITLE
ffmpeg: preserve alpha channel when scaling video frames

### DIFF
--- a/src/core/base/decoder/decoder.ml
+++ b/src/core/base/decoder/decoder.ml
@@ -477,6 +477,7 @@ let mk_buffer ~ctype generator =
             {
               Content.Video.width = Some video_width;
               height = Some video_height;
+              alpha = ref None;
             }
           in
           let interval = Frame.main_of_video 1 in

--- a/src/core/base/decoder/decoder.ml
+++ b/src/core/base/decoder/decoder.ml
@@ -477,7 +477,7 @@ let mk_buffer ~ctype generator =
             {
               Content.Video.width = Some video_width;
               height = Some video_height;
-              alpha = ref None;
+              alpha = Unifier.make None;
             }
           in
           let interval = Frame.main_of_video 1 in

--- a/src/core/base/encoder/encoder.ml
+++ b/src/core/base/encoder/encoder.ml
@@ -111,11 +111,20 @@ let type_of_format f =
                     Type.make
                       (Format_type.descr
                          (`Format (Frame_base.audio_format ~pcm_kind params)))
-                | `Encode { Ffmpeg_format.mode = `Internal; options = `Video _ }
-                  ->
+                | `Encode
+                    {
+                      Ffmpeg_format.mode = `Internal;
+                      options = `Video { Ffmpeg_format.alpha };
+                    } ->
                     Type.make
                       (Format_type.descr
-                         (`Format Content.(default_format Video.kind)))
+                         (`Format
+                            (Content_video.lift_params
+                               {
+                                 Content_video.Specs.width = None;
+                                 height = None;
+                                 alpha = ref alpha;
+                               })))
                 | `Encode { Ffmpeg_format.options = `Subtitle _; _ } ->
                     Type.make
                       (Format_type.descr (`Format Subtitle_content.format)))

--- a/src/core/base/encoder/encoder.ml
+++ b/src/core/base/encoder/encoder.ml
@@ -123,7 +123,7 @@ let type_of_format f =
                                {
                                  Content_video.Specs.width = None;
                                  height = None;
-                                 alpha = ref alpha;
+                                 alpha = Unifier.make alpha;
                                })))
                 | `Encode { Ffmpeg_format.options = `Subtitle _; _ } ->
                     Type.make

--- a/src/core/base/encoder/formats/ffmpeg_format.ml
+++ b/src/core/base/encoder/formats/ffmpeg_format.ml
@@ -47,6 +47,7 @@ type video_options = {
   width : int Lazy.t;
   height : int Lazy.t;
   pixel_format : string option;
+  alpha : bool option;
   hwaccel : hwaccel;
   hwaccel_device : string option;
   hwaccel_pixel_format : string option;

--- a/src/core/base/stream/content.ml
+++ b/src/core/base/stream/content.ml
@@ -56,6 +56,7 @@ module Video = struct
   type video_params = Content_video.Specs.params = {
     width : int Lazy.t option;
     height : int Lazy.t option;
+    alpha : bool option ref;
   }
 
   let lift_image img =
@@ -68,6 +69,7 @@ module Video = struct
           {
             height = Some (Lazy.from_val height);
             width = Some (Lazy.from_val width);
+            alpha = ref (Some (Video.Canvas.Image.has_alpha img));
           };
         data = [(0, img)];
       }
@@ -103,6 +105,7 @@ module Video = struct
         {
           Content_video.Specs.width = Some (Lazy.from_val width);
           height = Some (Lazy.from_val height);
+          alpha = params.Content_video.Specs.alpha;
         };
       width;
       height;

--- a/src/core/base/stream/content.ml
+++ b/src/core/base/stream/content.ml
@@ -56,7 +56,7 @@ module Video = struct
   type video_params = Content_video.Specs.params = {
     width : int Lazy.t option;
     height : int Lazy.t option;
-    alpha : bool option ref;
+    alpha : bool option Unifier.t;
   }
 
   let lift_image img =
@@ -69,7 +69,7 @@ module Video = struct
           {
             height = Some (Lazy.from_val height);
             width = Some (Lazy.from_val width);
-            alpha = ref (Some (Video.Canvas.Image.has_alpha img));
+            alpha = Unifier.make (Some (Video.Canvas.Image.has_alpha img));
           };
         data = [(0, img)];
       }

--- a/src/core/base/stream/content.mli
+++ b/src/core/base/stream/content.mli
@@ -164,7 +164,7 @@ module Video : sig
   type video_params = Content_video.Specs.params = {
     width : int Lazy.t option;
     height : int Lazy.t option;
-    alpha : bool option ref;
+    alpha : bool option Unifier.t;
   }
 
   include

--- a/src/core/base/stream/content.mli
+++ b/src/core/base/stream/content.mli
@@ -164,6 +164,7 @@ module Video : sig
   type video_params = Content_video.Specs.params = {
     width : int Lazy.t option;
     height : int Lazy.t option;
+    alpha : bool option ref;
   }
 
   include
@@ -174,6 +175,7 @@ module Video : sig
 
   val kind : Contents.kind
   val dimensions_of_format : Contents.format -> int * int
+  val alpha_of_format : Contents.format -> bool
   val lift_image : Video.Canvas.image -> Contents.data
 
   type generator

--- a/src/core/base/stream/content_video.ml
+++ b/src/core/base/stream/content_video.ml
@@ -81,10 +81,15 @@ module Specs = struct
 
   type kind = [ `Canvas ]
 
+  (* [alpha] is refined after typechecking: decoders probe the actual codec
+     pixel format and [Unifier.set] the result, which propagates to every
+     format this one has been merged with. A unifier (rather than a plain
+     value) is required so that refinement still propagates across formats
+     unified by [merge]. *)
   type params = {
     width : int Lazy.t option;
     height : int Lazy.t option;
-    alpha : bool option ref;
+    alpha : bool option Unifier.t;
   }
 
   type data = (params, Video.Canvas.image) content
@@ -98,7 +103,7 @@ module Specs = struct
       [
         ("width", Option.map (fun x -> string_of_int !!x) width);
         ("height", Option.map (fun x -> string_of_int !!x) height);
-        ("alpha", Option.map string_of_bool !alpha);
+        ("alpha", Option.map string_of_bool (Unifier.deref alpha));
       ]
 
   let make ?(length = 0) params =
@@ -119,25 +124,30 @@ module Specs = struct
             {
               width = Some (Lazy.from_val (int_of_string value));
               height = None;
-              alpha = ref None;
+              alpha = Unifier.make None;
             }
       | "height" ->
           Some
             {
               width = None;
               height = Some (Lazy.from_val (int_of_string value));
-              alpha = ref None;
+              alpha = Unifier.make None;
             }
       | "alpha" ->
           Some
             {
               width = None;
               height = None;
-              alpha = ref (Some (bool_of_string value));
+              alpha = Unifier.make (Some (bool_of_string value));
             }
       | _ -> None
 
   let merge p p' =
+    let alpha =
+      merge_param ~name:"alpha" (Unifier.deref p.alpha, Unifier.deref p'.alpha)
+    in
+    Unifier.set p'.alpha alpha;
+    Unifier.(p.alpha <-- p'.alpha);
     {
       width =
         Option.map Lazy.from_val
@@ -147,7 +157,7 @@ module Specs = struct
         Option.map Lazy.from_val
           (merge_param ~name:"height"
              (Option.map Lazy.force p.height, Option.map Lazy.force p'.height));
-      alpha = ref (merge_param ~name:"alpha" (!(p.alpha), !(p'.alpha)));
+      alpha = p.alpha;
     }
 
   let compatible p p' =
@@ -163,7 +173,7 @@ module Specs = struct
     in
     compare (p.width, p'.width)
     && compare (p.height, p'.height)
-    && compare_bool (!(p.alpha), !(p'.alpha))
+    && compare_bool (Unifier.deref p.alpha, Unifier.deref p'.alpha)
 
   let blit = fill
 
@@ -171,7 +181,10 @@ module Specs = struct
    fun src -> copy ~copy:(fun x -> x) src
 
   let kind = `Canvas
-  let default_params _ = { width = None; height = None; alpha = ref None }
+
+  let default_params _ =
+    { width = None; height = None; alpha = Unifier.make None }
+
   let kind_of_string = function "yuv420p" -> Some `Canvas | _ -> None
 
   let checksum d =
@@ -216,7 +229,7 @@ module Specs = struct
         ("width", Lang_core.mk (`Int width));
         ("height", Lang_core.mk (`Int height));
         ( "alpha",
-          match !alpha with
+          match Unifier.deref alpha with
             | None -> Lang_core.mk `Null
             | Some b -> Lang_core.mk (`Bool b) );
       ]
@@ -233,19 +246,19 @@ let dimensions_of_format p =
   let height = Lazy.force (Option.value ~default:default_height p.height) in
   (width, height)
 
-let alpha_of_format p = !((get_params p).alpha) = Some true
+let alpha_of_format p = Unifier.deref (get_params p).alpha = Some true
 
 let lift_canvas ?(offset = 0) ?length data =
   let interval = Frame_settings.main_of_video 1 in
   let data = Array.(to_list (mapi (fun pos d -> (pos * interval, d)) data)) in
   let params =
     match data with
-      | [] -> { Specs.width = None; height = None; alpha = ref None }
+      | [] -> { Specs.width = None; height = None; alpha = Unifier.make None }
       | (_, i) :: _ ->
           {
             Specs.width = Some (Lazy.from_val (Video.Canvas.Image.width i));
             height = Some (Lazy.from_val (Video.Canvas.Image.height i));
-            alpha = ref (Some (Video.Canvas.Image.has_alpha i));
+            alpha = Unifier.make (Some (Video.Canvas.Image.has_alpha i));
           }
   in
   let length =

--- a/src/core/base/stream/content_video.ml
+++ b/src/core/base/stream/content_video.ml
@@ -80,18 +80,25 @@ module Specs = struct
   include Base
 
   type kind = [ `Canvas ]
-  type params = { width : int Lazy.t option; height : int Lazy.t option }
+
+  type params = {
+    width : int Lazy.t option;
+    height : int Lazy.t option;
+    alpha : bool option ref;
+  }
+
   type data = (params, Video.Canvas.image) content
 
   let name = "yuv420p"
   let internal_content_type = Some `Video
   let string_of_kind = function `Canvas -> "yuv420p"
 
-  let string_of_params { width; height } =
+  let string_of_params { width; height; alpha } =
     print_optional
       [
         ("width", Option.map (fun x -> string_of_int !!x) width);
         ("height", Option.map (fun x -> string_of_int !!x) height);
+        ("alpha", Option.map string_of_bool !alpha);
       ]
 
   let make ?(length = 0) params =
@@ -112,12 +119,21 @@ module Specs = struct
             {
               width = Some (Lazy.from_val (int_of_string value));
               height = None;
+              alpha = ref None;
             }
       | "height" ->
           Some
             {
               width = None;
               height = Some (Lazy.from_val (int_of_string value));
+              alpha = ref None;
+            }
+      | "alpha" ->
+          Some
+            {
+              width = None;
+              height = None;
+              alpha = ref (Some (bool_of_string value));
             }
       | _ -> None
 
@@ -131,6 +147,7 @@ module Specs = struct
         Option.map Lazy.from_val
           (merge_param ~name:"height"
              (Option.map Lazy.force p.height, Option.map Lazy.force p'.height));
+      alpha = ref (merge_param ~name:"alpha" (!(p.alpha), !(p'.alpha)));
     }
 
   let compatible p p' =
@@ -139,7 +156,14 @@ module Specs = struct
       | Some _, None | None, Some _ -> true
       | Some x, Some y -> !!x = !!y
     in
-    compare (p.width, p'.width) && compare (p.height, p'.height)
+    let compare_bool = function
+      | None, None -> true
+      | Some _, None | None, Some _ -> true
+      | Some x, Some y -> x = y
+    in
+    compare (p.width, p'.width)
+    && compare (p.height, p'.height)
+    && compare_bool (!(p.alpha), !(p'.alpha))
 
   let blit = fill
 
@@ -147,7 +171,7 @@ module Specs = struct
    fun src -> copy ~copy:(fun x -> x) src
 
   let kind = `Canvas
-  let default_params _ = { width = None; height = None }
+  let default_params _ = { width = None; height = None; alpha = ref None }
   let kind_of_string = function "yuv420p" -> Some `Canvas | _ -> None
 
   let checksum d =
@@ -176,9 +200,13 @@ module Specs = struct
   let content_lang_typ =
     let open Liquidsoap_lang in
     Lang_core.record_t
-      [("width", Type.make Type.Int); ("height", Type.make Type.Int)]
+      [
+        ("width", Type.make Type.Int);
+        ("height", Type.make Type.Int);
+        ("alpha", Type.make (Type.Nullable (Type.make Type.Bool)));
+      ]
 
-  let params_to_value { width; height } =
+  let params_to_value { width; height; alpha } =
     let open Liquidsoap_lang in
     let default_width, default_height = Frame_settings.video_dimensions () in
     let width = Lazy.force (Option.value ~default:default_width width) in
@@ -187,6 +215,10 @@ module Specs = struct
       [
         ("width", Lang_core.mk (`Int width));
         ("height", Lang_core.mk (`Int height));
+        ( "alpha",
+          match !alpha with
+            | None -> Lang_core.mk `Null
+            | Some b -> Lang_core.mk (`Bool b) );
       ]
 end
 
@@ -201,16 +233,19 @@ let dimensions_of_format p =
   let height = Lazy.force (Option.value ~default:default_height p.height) in
   (width, height)
 
+let alpha_of_format p = !((get_params p).alpha) = Some true
+
 let lift_canvas ?(offset = 0) ?length data =
   let interval = Frame_settings.main_of_video 1 in
   let data = Array.(to_list (mapi (fun pos d -> (pos * interval, d)) data)) in
   let params =
     match data with
-      | [] -> { Specs.width = None; height = None }
+      | [] -> { Specs.width = None; height = None; alpha = ref None }
       | (_, i) :: _ ->
           {
             Specs.width = Some (Lazy.from_val (Video.Canvas.Image.width i));
             height = Some (Lazy.from_val (Video.Canvas.Image.height i));
+            alpha = ref (Some (Video.Canvas.Image.has_alpha i));
           }
   in
   let length =

--- a/src/core/optionals/ffmpeg/builtins_ffmpeg_decoder.ml
+++ b/src/core/optionals/ffmpeg/builtins_ffmpeg_decoder.ml
@@ -204,27 +204,35 @@ let decode_video_frame ~field ~mode generator =
     let current_format = ref None in
 
     let mk_converter ~width ~height ~pixel_format ~time_base ?pixel_aspect
-        ~stream_idx () =
+        ?color_range ~stream_idx () =
       current_format :=
-        Some (width, height, pixel_format, time_base, pixel_aspect, stream_idx);
+        Some
+          ( width,
+            height,
+            pixel_format,
+            time_base,
+            pixel_aspect,
+            color_range,
+            stream_idx );
       let scaler =
         InternalScaler.create [] width height pixel_format internal_width
-          internal_height Ffmpeg_utils.liq_frame_pixel_format
+          internal_height
+          (Ffmpeg_utils.liq_frame_pixel_format_for pixel_format)
       in
       let fps_converter =
         Ffmpeg_avfilter_utils.Fps.init ~width ~height ~pixel_format ~time_base
-          ?pixel_aspect ~target_fps ()
+          ?pixel_aspect ?color_range ~target_fps ()
       in
       converter := Some (scaler, fps_converter);
       (scaler, fps_converter)
     in
 
-    let get_converter ?pixel_aspect ~pixel_format ~time_base ~width ~height
-        ~stream_idx () =
+    let get_converter ?pixel_aspect ?color_range ~pixel_format ~time_base ~width
+        ~height ~stream_idx () =
       match !converter with
         | None ->
             mk_converter ~width ~height ~pixel_format ~time_base ?pixel_aspect
-              ~stream_idx ()
+              ?color_range ~stream_idx ()
         | Some _
           when !current_format
                <> Some
@@ -233,10 +241,11 @@ let decode_video_frame ~field ~mode generator =
                       pixel_format,
                       time_base,
                       pixel_aspect,
+                      color_range,
                       stream_idx ) ->
             log#info "Video frame format change detected..";
             mk_converter ~width ~height ~pixel_format ~time_base ?pixel_aspect
-              ~stream_idx ()
+              ?color_range ~stream_idx ()
         | Some v -> v
     in
 
@@ -255,9 +264,13 @@ let decode_video_frame ~field ~mode generator =
           let height = Avutil.Video.frame_get_height frame in
           let pixel_format = Avutil.Video.frame_get_pixel_format frame in
           let pixel_aspect = Avutil.Video.frame_get_pixel_aspect frame in
+          let color_range = Avutil.Video.frame_get_color_range frame in
+          let color_range =
+            match color_range with `Unspecified -> None | cr -> Some cr
+          in
           let scaler, fps_converter =
-            get_converter ?pixel_aspect ~pixel_format ~time_base ~width ~height
-              ~stream_idx ()
+            get_converter ?pixel_aspect ?color_range ~pixel_format ~time_base
+              ~width ~height ~stream_idx ()
           in
           Ffmpeg_avfilter_utils.Fps.convert fps_converter frame (put ~scaler)
       | `Flush ->

--- a/src/core/optionals/ffmpeg/builtins_ffmpeg_encoder.ml
+++ b/src/core/optionals/ffmpeg/builtins_ffmpeg_encoder.ml
@@ -194,8 +194,9 @@ let encode_audio_frame ~source_idx ~type_t ~mode ~opts ?codec ~format
       encode_ffmpeg_frame frame
   | `Flush -> encode_frame `Flush
 
-let encode_video_frame ~source_idx ~type_t ~mode ~opts ?codec ~format ~field
-    generator =
+let encode_video_frame ~source_idx ~type_t ~mode ~opts ?codec ~format
+    ~content_type ~field generator =
+  let alpha = ref false in
   let internal_fps = Lazy.force Frame.video_rate in
   let internal_time_base = { Avutil.num = 1; den = internal_fps } in
   let video_width, video_height = Frame.video_dimensions () in
@@ -221,8 +222,8 @@ let encode_video_frame ~source_idx ~type_t ~mode ~opts ?codec ~format ~field
     scaler :=
       Some
         (InternalScaler.create [flag] internal_width internal_height
-           Ffmpeg_utils.liq_frame_pixel_format target_width target_height
-           target_pixel_format)
+           (Ffmpeg_utils.liq_frame_pixel_format_for target_pixel_format)
+           target_width target_height target_pixel_format)
   in
 
   let fps_converter = ref None in
@@ -240,8 +241,19 @@ let encode_video_frame ~source_idx ~type_t ~mode ~opts ?codec ~format ~field
       | `Encoded -> (
           let codec = Option.get codec in
 
+          let computed_alpha =
+            match format.Ffmpeg_format.alpha with
+              | Some b -> b
+              | None -> (
+                  match Frame.Fields.find_opt field (content_type ()) with
+                    | Some fmt when Content.Video.is_format fmt ->
+                        Content.Video.alpha_of_format fmt
+                    | _ -> false)
+          in
+          alpha := computed_alpha;
           let target_pixel_format =
-            Ffmpeg_utils.pixel_format codec format.Ffmpeg_format.pixel_format
+            Ffmpeg_utils.pixel_format ~alpha:computed_alpha codec
+              format.Ffmpeg_format.pixel_format
           in
 
           mk_scaler ~target_pixel_format;
@@ -320,7 +332,11 @@ let encode_video_frame ~source_idx ~type_t ~mode ~opts ?codec ~format ~field
           | `Frame frame -> Avcodec.encode encoder write_packet frame
           | `Flush -> Avcodec.flush_encoder encoder write_packet)
       | `Raw -> (
-          let target_pixel_format = Ffmpeg_utils.liq_frame_pixel_format in
+          let target_pixel_format =
+            match format.Ffmpeg_format.pixel_format with
+              | Some p -> Avutil.Pixel_format.of_string p
+              | None -> Ffmpeg_utils.liq_frame_pixel_format
+          in
 
           mk_scaler ~target_pixel_format;
           mk_fps_converter ~target_pixel_format;
@@ -385,7 +401,7 @@ let encode_video_frame ~source_idx ~type_t ~mode ~opts ?codec ~format ~field
       let vbuf = VFrame.data frame in
       List.iter
         (fun (_, img) ->
-          let f = Video.Canvas.Image.render img in
+          let f = Video.Canvas.Image.render ~transparent:!alpha img in
           let vdata = Ffmpeg_utils.pack_image f in
           let frame = InternalScaler.convert (Option.get !scaler) vdata in
           Avutil.Frame.set_pts frame (Some !nb_frames);
@@ -501,7 +517,7 @@ let mk_encoder mode =
                      generator
                | `Encode { mode = `Raw; options = `Video format } ->
                    encode_video_frame ~source_idx ~type_t:output_frame_t
-                     ~mode:`Raw ~opts ~format ~field generator
+                     ~mode:`Raw ~opts ~format ~content_type ~field generator
                | `Encode
                    {
                      mode = `Internal;
@@ -510,7 +526,8 @@ let mk_encoder mode =
                    } ->
                    let codec = Avcodec.Video.find_encoder_by_name codec in
                    encode_video_frame ~source_idx ~type_t:output_frame_t
-                     ~mode:`Encoded ~opts ~codec ~format ~field generator
+                     ~mode:`Encoded ~opts ~codec ~format ~content_type ~field
+                     generator
                | _ -> assert false
            in
            let size = Lazy.force Frame.size in

--- a/src/core/optionals/ffmpeg/builtins_ffmpeg_encoder.ml
+++ b/src/core/optionals/ffmpeg/builtins_ffmpeg_encoder.ml
@@ -196,7 +196,7 @@ let encode_audio_frame ~source_idx ~type_t ~mode ~opts ?codec ~format
 
 let encode_video_frame ~source_idx ~type_t ~mode ~opts ?codec ~format
     ~content_type ~field generator =
-  let alpha = ref false in
+  let chosen_pixel_format = ref Ffmpeg_utils.liq_frame_pixel_format in
   let internal_fps = Lazy.force Frame.video_rate in
   let internal_time_base = { Avutil.num = 1; den = internal_fps } in
   let video_width, video_height = Frame.video_dimensions () in
@@ -219,6 +219,7 @@ let encode_video_frame ~source_idx ~type_t ~mode ~opts ?codec ~format
 
   let scaler = ref None in
   let mk_scaler ~target_pixel_format =
+    chosen_pixel_format := target_pixel_format;
     scaler :=
       Some
         (InternalScaler.create [flag] internal_width internal_height
@@ -241,18 +242,17 @@ let encode_video_frame ~source_idx ~type_t ~mode ~opts ?codec ~format
       | `Encoded -> (
           let codec = Option.get codec in
 
-          let computed_alpha =
-            match format.Ffmpeg_format.alpha with
-              | Some b -> b
-              | None -> (
-                  match Frame.Fields.find_opt field (content_type ()) with
-                    | Some fmt when Content.Video.is_format fmt ->
-                        Content.Video.alpha_of_format fmt
-                    | _ -> false)
+          let frame_alpha =
+            match Frame.Fields.find_opt field (content_type ()) with
+              | Some fmt when Content.Video.is_format fmt ->
+                  Content.Video.alpha_of_format fmt
+              | _ -> false
           in
-          alpha := computed_alpha;
+          let alpha =
+            Option.value ~default:frame_alpha format.Ffmpeg_format.alpha
+          in
           let target_pixel_format =
-            Ffmpeg_utils.pixel_format ~alpha:computed_alpha codec
+            Ffmpeg_utils.pixel_format ~alpha codec
               format.Ffmpeg_format.pixel_format
           in
 
@@ -401,7 +401,10 @@ let encode_video_frame ~source_idx ~type_t ~mode ~opts ?codec ~format
       let vbuf = VFrame.data frame in
       List.iter
         (fun (_, img) ->
-          let f = Video.Canvas.Image.render ~transparent:!alpha img in
+          let transparent =
+            Ffmpeg_utils.pixel_format_has_alpha !chosen_pixel_format
+          in
+          let f = Video.Canvas.Image.render ~transparent img in
           let vdata = Ffmpeg_utils.pack_image f in
           let frame = InternalScaler.convert (Option.get !scaler) vdata in
           Avutil.Frame.set_pts frame (Some !nb_frames);

--- a/src/core/optionals/ffmpeg/ffmpeg_avfilter_utils.ml
+++ b/src/core/optionals/ffmpeg/ffmpeg_avfilter_utils.ml
@@ -34,7 +34,7 @@ module Fps = struct
     | `Pass_through time_base -> time_base
 
   let init ?start_pts ~width ~height ~pixel_format ~time_base ?pixel_aspect
-      ?source_fps ~target_fps () =
+      ?source_fps ?color_range ~target_fps () =
     let config = Avfilter.init () in
     let _buffer =
       let args =
@@ -47,6 +47,12 @@ module Fps = struct
           match pixel_aspect with
           | None -> []
           | Some p -> [`Pair ("pixel_aspect", `Rational p)]
+      in
+      let args =
+        match color_range with
+          | None -> args
+          | Some cr ->
+              `Pair ("range", `String (Avutil.Color_range.name cr)) :: args
       in
       let args =
         match source_fps with
@@ -120,13 +126,13 @@ module Fps = struct
 
   (* Source fps is not always known so it is optional here. *)
   let init ?start_pts ~width ~height ~pixel_format ~time_base ?pixel_aspect
-      ?source_fps ~target_fps () =
+      ?source_fps ?color_range ~target_fps () =
     match source_fps with
       | Some f when f = target_fps -> `Pass_through time_base
       | _ ->
           `Filter
             (init ?start_pts ~width ~height ~pixel_format ~time_base
-               ?pixel_aspect ?source_fps ~target_fps ())
+               ?pixel_aspect ?source_fps ?color_range ~target_fps ())
 
   let rec flush cb output =
     try

--- a/src/core/optionals/ffmpeg/ffmpeg_avfilter_utils.mli
+++ b/src/core/optionals/ffmpeg/ffmpeg_avfilter_utils.mli
@@ -33,6 +33,7 @@ module Fps : sig
     time_base:Avutil.rational ->
     ?pixel_aspect:Avutil.rational ->
     ?source_fps:int ->
+    ?color_range:Avutil.Color_range.t ->
     target_fps:int ->
     unit ->
     t

--- a/src/core/optionals/ffmpeg/ffmpeg_decoder.ml
+++ b/src/core/optionals/ffmpeg/ffmpeg_decoder.ml
@@ -1076,20 +1076,7 @@ let mk_streams ~ctype ~decode_first_metadata ~set_remaining container =
               in
               ignore (Frame.video_dimensions ~ideal_size ());
               let width, height = Content.Video.dimensions_of_format format in
-              let format_params = Content.Video.get_params format in
-              let () =
-                if !(format_params.Content.Video.alpha) = None then (
-                  let has_alpha =
-                    match Avcodec.Video.get_pixel_format params with
-                      | None -> false
-                      | Some pf ->
-                          let { Avutil.Pixel_format.flags } =
-                            Avutil.Pixel_format.descriptor pf
-                          in
-                          List.mem `Alpha flags
-                  in
-                  format_params.Content.Video.alpha := Some has_alpha)
-              in
+              Ffmpeg_utils.set_format_alpha ~codec_params:params format;
               let alpha = Content.Video.alpha_of_format format in
               ( add_stream ~sparse:`False idx stream
                   (`Video_frame

--- a/src/core/optionals/ffmpeg/ffmpeg_decoder.ml
+++ b/src/core/optionals/ffmpeg/ffmpeg_decoder.ml
@@ -1076,12 +1076,27 @@ let mk_streams ~ctype ~decode_first_metadata ~set_remaining container =
               in
               ignore (Frame.video_dimensions ~ideal_size ());
               let width, height = Content.Video.dimensions_of_format format in
+              let format_params = Content.Video.get_params format in
+              let () =
+                if !(format_params.Content.Video.alpha) = None then (
+                  let has_alpha =
+                    match Avcodec.Video.get_pixel_format params with
+                      | None -> false
+                      | Some pf ->
+                          let { Avutil.Pixel_format.flags } =
+                            Avutil.Pixel_format.descriptor pf
+                          in
+                          List.mem `Alpha flags
+                  in
+                  format_params.Content.Video.alpha := Some has_alpha)
+              in
+              let alpha = Content.Video.alpha_of_format format in
               ( add_stream ~sparse:`False idx stream
                   (`Video_frame
                      ( stream,
                        tracked_stream ~track_data:track_frame stream
                          (Ffmpeg_internal_decoder.mk_video_decoder ~width
-                            ~height ~stream ~field params) ))
+                            ~height ~alpha ~stream ~field params) ))
                   streams,
                 pos + 1 )
           | _ -> (streams, pos + 1))

--- a/src/core/optionals/ffmpeg/ffmpeg_internal_decoder.ml
+++ b/src/core/optionals/ffmpeg/ffmpeg_internal_decoder.ml
@@ -279,7 +279,7 @@ let mk_bitmap_subtitle_decoder ~field ~width ~height =
       {
         Content.Video.width = Some (lazy width);
         height = Some (lazy height);
-        alpha = ref (Some true);
+        alpha = Unifier.make (Some true);
       }
   in
   let pos = ref 0 in

--- a/src/core/optionals/ffmpeg/ffmpeg_internal_decoder.ml
+++ b/src/core/optionals/ffmpeg/ffmpeg_internal_decoder.ml
@@ -122,7 +122,7 @@ let mk_audio_decoder ~channels ~field ~pcm_kind codec =
           Generator.add_metadata buffer.Decoder.generator
             (Frame.Metadata.from_list metadata)
 
-let mk_video_decoder ~width ~height ~stream ~field codec =
+let mk_video_decoder ~width ~height ~alpha ~stream ~field codec =
   let pixel_format =
     match Avcodec.Video.get_pixel_format codec with
       | None -> failwith "Pixel format unknown!"
@@ -133,6 +133,10 @@ let mk_video_decoder ~width ~height ~stream ~field codec =
   let width = Avcodec.Video.get_width codec in
   let height = Avcodec.Video.get_height codec in
   let target_fps = Lazy.force Frame.video_rate in
+  let target_pixel_format =
+    if alpha then Ffmpeg_utils.liq_frame_pixel_format_with_alpha
+    else Ffmpeg_utils.liq_frame_pixel_format
+  in
   let scale =
     let scale_proportional (sw, sh) (tw, th) =
       if th * sw < tw * sh then (sw * th / sh, th) else (tw, sh * tw / sw)
@@ -142,8 +146,7 @@ let mk_video_decoder ~width ~height ~stream ~field codec =
       scale_proportional (width, height) (target_width, target_height)
     in
     let scaler =
-      Scaler.create [] width height pixel_format aw ah
-        Ffmpeg_utils.liq_frame_pixel_format
+      Scaler.create [] width height pixel_format aw ah target_pixel_format
     in
     fun frame : Video.Canvas.Image.t ->
       let img =
@@ -168,14 +171,31 @@ let mk_video_decoder ~width ~height ~stream ~field codec =
       Generator.add_metadata buffer.Decoder.generator
         (Frame.Metadata.from_list metadata)
   in
-  let converter =
-    Ffmpeg_avfilter_utils.Fps.init ~width ~height ~pixel_format ~time_base
-      ?pixel_aspect ~target_fps ()
+  let converter = ref None in
+  let get_converter color_range =
+    match !converter with
+      | Some (cr, c) when cr = color_range -> c
+      | _ ->
+          let c =
+            Ffmpeg_avfilter_utils.Fps.init ~width ~height ~pixel_format
+              ~time_base ?pixel_aspect ?color_range ~target_fps ()
+          in
+          converter := Some (color_range, c);
+          c
   in
   fun ~buffer -> function
     | `Frame frame ->
-        Ffmpeg_avfilter_utils.Fps.convert converter frame (cb ~buffer)
-    | `Flush -> Ffmpeg_avfilter_utils.Fps.eof converter (cb ~buffer)
+        let color_range = Avutil.Video.frame_get_color_range frame in
+        let color_range =
+          match color_range with `Unspecified -> None | cr -> Some cr
+        in
+        Ffmpeg_avfilter_utils.Fps.convert
+          (get_converter color_range)
+          frame (cb ~buffer)
+    | `Flush ->
+        Option.iter
+          (fun (_, c) -> Ffmpeg_avfilter_utils.Fps.eof c (cb ~buffer))
+          !converter
 
 let main_of_subtitle_time time = Frame.main_of_seconds (float time /. 1000.)
 
@@ -256,7 +276,11 @@ let mk_bitmap_subtitle_decoder ~field ~width ~height =
   let active_canvas = ref [] in
   let generator =
     Content.Video.make_generator
-      { Content.Video.width = Some (lazy width); height = Some (lazy height) }
+      {
+        Content.Video.width = Some (lazy width);
+        height = Some (lazy height);
+        alpha = ref (Some true);
+      }
   in
   let pos = ref 0 in
   let generate =

--- a/src/core/optionals/ffmpeg/ffmpeg_internal_decoder.mli
+++ b/src/core/optionals/ffmpeg/ffmpeg_internal_decoder.mli
@@ -32,6 +32,7 @@ val mk_audio_decoder :
 val mk_video_decoder :
   width:int ->
   height:int ->
+  alpha:bool ->
   stream:(Avutil.input, Avutil.video, [ `Frame ]) Av.stream ->
   field:Frame.field ->
   Avutil.video Avcodec.params ->

--- a/src/core/optionals/ffmpeg/ffmpeg_internal_encoder.ml
+++ b/src/core/optionals/ffmpeg/ffmpeg_internal_encoder.ml
@@ -419,13 +419,24 @@ let mk_video ~pos ~on_keyframe ~mode ~codec ~params ~options ~field output =
         }
   in
 
-  let codec_attr () = Av.codec_attr (get_state ()).stream in
+  let codec_attr () =
+    match !video_stream_state with
+      | None -> None
+      | Some s -> Av.codec_attr s.stream
+  in
 
-  let bitrate () = Av.bitrate (get_state ()).stream in
+  let bitrate () =
+    match !video_stream_state with
+      | None -> None
+      | Some s -> Av.bitrate s.stream
+  in
 
   let video_size () =
-    let p = Av.get_codec_params (get_state ()).stream in
-    Some (Avcodec.Video.get_width p, Avcodec.Video.get_height p)
+    match !video_stream_state with
+      | None -> None
+      | Some s ->
+          let p = Av.get_codec_params s.stream in
+          Some (Avcodec.Video.get_width p, Avcodec.Video.get_height p)
   in
 
   let converter = ref None in

--- a/src/core/optionals/ffmpeg/ffmpeg_internal_encoder.ml
+++ b/src/core/optionals/ffmpeg/ffmpeg_internal_encoder.ml
@@ -324,6 +324,14 @@ let mk_audio ~pos ~on_keyframe ~mode ~codec ~params ~options ~field output =
     video_size;
   }
 
+type video_stream_state = {
+  alpha : bool;
+  target_pixel_format : Avutil.Pixel_format.t;
+  stream : (Avutil.output, Avutil.video, [ `Frame ]) Av.stream;
+  stream_time_base : Avutil.rational;
+  on_keyframe : (unit -> unit) option;
+}
+
 let mk_video ~pos ~on_keyframe ~mode ~codec ~params ~options ~field output =
   let codec =
     try Avcodec.Video.find_encoder_by_name codec
@@ -337,10 +345,6 @@ let mk_video ~pos ~on_keyframe ~mode ~codec ~params ~options ~field output =
   let target_video_frame_time_base = { Avutil.num = 1; den = target_fps } in
   let target_width = Lazy.force params.Ffmpeg_format.width in
   let target_height = Lazy.force params.Ffmpeg_format.height in
-  let target_pixel_format =
-    Ffmpeg_utils.pixel_format codec params.Ffmpeg_format.pixel_format
-  in
-
   let flag =
     match Ffmpeg_utils.conf_scaling_algorithm#get with
       | "fast_bilinear" -> Swscale.Fast_bilinear
@@ -351,8 +355,6 @@ let mk_video ~pos ~on_keyframe ~mode ~codec ~params ~options ~field output =
             "Invalid value set for ffmpeg scaling algorithm!"
   in
 
-  let opts = Hashtbl.copy options in
-
   let hwaccel = params.Ffmpeg_format.hwaccel in
   let hwaccel_device = params.Ffmpeg_format.hwaccel_device in
   let hwaccel_pixel_format =
@@ -360,50 +362,69 @@ let mk_video ~pos ~on_keyframe ~mode ~codec ~params ~options ~field output =
       params.Ffmpeg_format.hwaccel_pixel_format
   in
 
-  let hardware_context, stream_pixel_format =
-    Ffmpeg_utils.mk_hardware_context ~hwaccel ~hwaccel_pixel_format
-      ~hwaccel_device ~opts ~target_pixel_format ~target_width ~target_height
-      codec
+  let video_stream_state = ref None in
+  let get_state () = Option.get !video_stream_state in
+
+  let mk_stream frame =
+    let frame_alpha =
+      match Frame.Fields.find_opt field (Frame.content_type frame) with
+        | Some fmt when Content.Video.is_format fmt ->
+            Content.Video.alpha_of_format fmt
+        | _ -> false
+    in
+    let alpha = Option.value ~default:frame_alpha params.Ffmpeg_format.alpha in
+    let target_pixel_format =
+      Ffmpeg_utils.pixel_format ~alpha codec params.Ffmpeg_format.pixel_format
+    in
+    let opts = Hashtbl.copy options in
+    let hardware_context, stream_pixel_format =
+      Ffmpeg_utils.mk_hardware_context ~hwaccel ~hwaccel_pixel_format
+        ~hwaccel_device ~opts ~target_pixel_format ~target_width ~target_height
+        codec
+    in
+    let stream =
+      Av.new_video_stream ~time_base:target_video_frame_time_base
+        ~pixel_format:stream_pixel_format ?hardware_context
+        ~frame_rate:{ Avutil.num = target_fps; den = 1 }
+        ~width:target_width ~height:target_height ~opts ~codec output
+    in
+    let remaining_options = Hashtbl.copy options in
+    Hashtbl.filter_map_inplace
+      (fun l v -> if Hashtbl.mem opts l then Some v else None)
+      remaining_options;
+    if Hashtbl.length remaining_options > 0 then
+      Lang_encoder.raise_error ~pos
+        (Printf.sprintf "Unrecognized options: %s"
+           (Ffmpeg_format.string_of_options remaining_options));
+    let intra_only =
+      match Avcodec.descriptor (Av.get_codec_params stream) with
+        | None -> true
+        | Some { Avcodec.properties } -> List.mem `Intra_only properties
+    in
+    let stream_on_keyframe =
+      Option.map
+        (fun ok () ->
+          if not intra_only then Av.flush output;
+          ok ())
+        on_keyframe
+    in
+    video_stream_state :=
+      Some
+        {
+          alpha;
+          target_pixel_format;
+          stream;
+          stream_time_base = Av.get_time_base stream;
+          on_keyframe = stream_on_keyframe;
+        }
   in
 
-  let stream =
-    Av.new_video_stream ~time_base:target_video_frame_time_base
-      ~pixel_format:stream_pixel_format ?hardware_context
-      ~frame_rate:{ Avutil.num = target_fps; den = 1 }
-      ~width:target_width ~height:target_height ~opts ~codec output
-  in
+  let codec_attr () = Av.codec_attr (get_state ()).stream in
 
-  let options = Hashtbl.copy options in
-  Hashtbl.filter_map_inplace
-    (fun l v -> if Hashtbl.mem opts l then Some v else None)
-    options;
-
-  if Hashtbl.length options > 0 then
-    Lang_encoder.raise_error ~pos
-      (Printf.sprintf "Unrecognized options: %s"
-         (Ffmpeg_format.string_of_options options));
-
-  let intra_only =
-    let params = Av.get_codec_params stream in
-    match Avcodec.descriptor params with
-      | None -> true
-      | Some { Avcodec.properties } -> List.mem `Intra_only properties
-  in
-
-  let on_keyframe =
-    Option.map
-      (fun on_keyframe () ->
-        if not intra_only then Av.flush output;
-        on_keyframe ())
-      on_keyframe
-  in
-
-  let codec_attr () = Av.codec_attr stream in
-
-  let bitrate () = Av.bitrate stream in
+  let bitrate () = Av.bitrate (get_state ()).stream in
 
   let video_size () =
-    let p = Av.get_codec_params stream in
+    let p = Av.get_codec_params (get_state ()).stream in
     Some (Avcodec.Video.get_width p, Avcodec.Video.get_height p)
   in
 
@@ -430,9 +451,8 @@ let mk_video ~pos ~on_keyframe ~mode ~codec ~params ~options ~field output =
       | Some (_, _, _, c) -> c
   in
 
-  let stream_time_base = Av.get_time_base stream in
-
   let write_frame ~time_base frame =
+    let { stream; stream_time_base; on_keyframe; _ } = get_state () in
     let frame_pts =
       Option.map
         (fun pts ->
@@ -467,16 +487,25 @@ let mk_video ~pos ~on_keyframe ~mode ~codec ~params ~options ~field output =
     let video_width, video_height = Frame.video_dimensions () in
     let src_width = Lazy.force video_width in
     let src_height = Lazy.force video_height in
-    let scaler =
-      InternalScaler.create [flag] src_width src_height
-        Ffmpeg_utils.liq_frame_pixel_format target_width target_height
-        target_pixel_format
-    in
+    let scaler = ref None in
     let nb_frames = ref 0L in
     let time_base = Ffmpeg_utils.liq_video_sample_time_base () in
     let stream_idx = 1L in
 
     fun frame ->
+      let { alpha; target_pixel_format; _ } = get_state () in
+      let scaler =
+        match !scaler with
+          | Some s -> s
+          | None ->
+              let s =
+                InternalScaler.create [flag] src_width src_height
+                  (Ffmpeg_utils.liq_frame_pixel_format_for target_pixel_format)
+                  target_width target_height target_pixel_format
+              in
+              scaler := Some s;
+              s
+      in
       let content = Frame.get frame field in
       let buf = Content.Video.get_data content in
       List.iter
@@ -485,7 +514,7 @@ let mk_video ~pos ~on_keyframe ~mode ~codec ~params ~options ~field output =
             img
             (* TODO: we could scale instead of aggressively changing the viewport *)
             |> Video.Canvas.Image.viewport src_width src_height
-            |> Video.Canvas.Image.render ~transparent:false
+            |> Video.Canvas.Image.render ~transparent:alpha
           in
           let vdata = Ffmpeg_utils.pack_image f in
           let frame = InternalScaler.convert scaler vdata in

--- a/src/core/optionals/ffmpeg/ffmpeg_stream_description.ml
+++ b/src/core/optionals/ffmpeg/ffmpeg_stream_description.ml
@@ -288,20 +288,7 @@ let build_video_content_type ~ctype content_type video_streams =
                  Ffmpeg_raw_content.(Video.lift_params (VideoSpecs.mk_params p)));
             Frame.Fields.add field format content_type
         | codec_params, Some format ->
-            let format_params = Content.Video.get_params format in
-            let () =
-              if !(format_params.Content.Video.alpha) = None then (
-                let has_alpha =
-                  match Avcodec.Video.get_pixel_format codec_params with
-                    | None -> false
-                    | Some pf ->
-                        let { Avutil.Pixel_format.flags } =
-                          Avutil.Pixel_format.descriptor pf
-                        in
-                        List.mem `Alpha flags
-                in
-                format_params.Content.Video.alpha := Some has_alpha)
-            in
+            Ffmpeg_utils.set_format_alpha ~codec_params format;
             Frame.Fields.add field format content_type
         | _ -> content_type)
     content_type video_streams

--- a/src/core/optionals/ffmpeg/ffmpeg_stream_description.ml
+++ b/src/core/optionals/ffmpeg/ffmpeg_stream_description.ml
@@ -287,10 +287,22 @@ let build_video_content_type ~ctype content_type video_streams =
               (Content.merge format
                  Ffmpeg_raw_content.(Video.lift_params (VideoSpecs.mk_params p)));
             Frame.Fields.add field format content_type
-        | _, Some _ ->
-            Frame.Fields.add field
-              Content.(default_format Video.kind)
-              content_type
+        | codec_params, Some format ->
+            let format_params = Content.Video.get_params format in
+            let () =
+              if !(format_params.Content.Video.alpha) = None then (
+                let has_alpha =
+                  match Avcodec.Video.get_pixel_format codec_params with
+                    | None -> false
+                    | Some pf ->
+                        let { Avutil.Pixel_format.flags } =
+                          Avutil.Pixel_format.descriptor pf
+                        in
+                        List.mem `Alpha flags
+                in
+                format_params.Content.Video.alpha := Some has_alpha)
+            in
+            Frame.Fields.add field format content_type
         | _ -> content_type)
     content_type video_streams
 

--- a/src/core/optionals/ffmpeg/ffmpeg_utils.ml
+++ b/src/core/optionals/ffmpeg/ffmpeg_utils.ml
@@ -111,11 +111,20 @@ let liq_frame_time_base () =
 let liq_frame_pixel_format = `Yuv420p
 let liq_frame_pixel_format_with_alpha = `Yuva420p
 
+let liq_frame_pixel_format_for pixel_format =
+  let { Avutil.Pixel_format.flags } =
+    Avutil.Pixel_format.descriptor pixel_format
+  in
+  if List.mem `Alpha flags then liq_frame_pixel_format_with_alpha
+  else liq_frame_pixel_format
+
 let pack_image f =
   let y, u, v = Image.YUV420.data f in
   let sy = Image.YUV420.y_stride f in
   let s = Image.YUV420.uv_stride f in
-  [| (y, sy); (u, s); (v, s) |]
+  match Image.YUV420.alpha f with
+    | None -> [| (y, sy); (u, s); (v, s) |]
+    | Some a -> [| (y, sy); (u, s); (v, s); (a, sy) |]
 
 let unpack_image ~width ~height = function
   | [| (y, sy); (u, su); (v, sv) |] ->
@@ -362,15 +371,25 @@ module Duration = struct
     (max_duration, packets)
 end
 
-let find_pixel_format codec =
+let find_pixel_format ?(alpha = false) codec =
   let formats = Avcodec.Video.get_supported_pixel_formats codec in
-  if List.mem liq_frame_pixel_format formats then liq_frame_pixel_format
+  let preferred =
+    if alpha then liq_frame_pixel_format_with_alpha else liq_frame_pixel_format
+  in
+  if List.mem preferred formats then preferred
   else (
-    match
+    let non_hwaccel =
       List.filter
         (fun f ->
           not (List.mem `Hwaccel Avutil.Pixel_format.((descriptor f).flags)))
         formats
+    in
+    match
+      if alpha then
+        List.filter
+          (fun f -> List.mem `Alpha Avutil.Pixel_format.((descriptor f).flags))
+          non_hwaccel
+      else non_hwaccel
     with
       | p :: _ -> p
       (* Hardware accelerated codecs list hardware-specific pixel_formats
@@ -378,9 +397,9 @@ let find_pixel_format codec =
          we use the internal pixel_format. *)
       | [] -> liq_frame_pixel_format)
 
-let pixel_format codec = function
+let pixel_format ?(alpha = false) codec = function
   | Some p -> Avutil.Pixel_format.of_string p
-  | None -> find_pixel_format codec
+  | None -> find_pixel_format ~alpha codec
 
 let mk_subtitle_decoder ~output ~process () =
   let current_position = ref None in

--- a/src/core/optionals/ffmpeg/ffmpeg_utils.ml
+++ b/src/core/optionals/ffmpeg/ffmpeg_utils.ml
@@ -111,12 +111,28 @@ let liq_frame_time_base () =
 let liq_frame_pixel_format = `Yuv420p
 let liq_frame_pixel_format_with_alpha = `Yuva420p
 
-let liq_frame_pixel_format_for pixel_format =
+let pixel_format_has_alpha pixel_format =
   let { Avutil.Pixel_format.flags } =
     Avutil.Pixel_format.descriptor pixel_format
   in
-  if List.mem `Alpha flags then liq_frame_pixel_format_with_alpha
+  List.mem `Alpha flags
+
+let liq_frame_pixel_format_for pixel_format =
+  if pixel_format_has_alpha pixel_format then liq_frame_pixel_format_with_alpha
   else liq_frame_pixel_format
+
+let set_format_alpha ~codec_params format =
+  let format_params = Content_video.get_params format in
+  if Unifier.deref format_params.Content_video.Specs.alpha = None then (
+    let has_alpha =
+      match
+        Avcodec.Video.get_pixel_format
+          (codec_params : Avutil.video Avcodec.params)
+      with
+        | None -> false
+        | Some pf -> pixel_format_has_alpha pf
+    in
+    Unifier.set format_params.Content_video.Specs.alpha (Some has_alpha))
 
 let pack_image f =
   let y, u, v = Image.YUV420.data f in

--- a/src/core/optionals/ffmpeg/ffmpeg_utils.mli
+++ b/src/core/optionals/ffmpeg/ffmpeg_utils.mli
@@ -34,7 +34,11 @@ val liq_video_sample_time_base : unit -> Avutil.rational
 val liq_frame_time_base : unit -> Avutil.rational
 val liq_frame_pixel_format : Avutil.Pixel_format.t
 val liq_frame_pixel_format_with_alpha : Avutil.Pixel_format.t
-val pixel_format : 'a Avcodec.Video.t -> string option -> Avutil.Pixel_format.t
+val liq_frame_pixel_format_for : Avutil.Pixel_format.t -> Avutil.Pixel_format.t
+
+val pixel_format :
+  ?alpha:bool -> 'a Avcodec.Video.t -> string option -> Avutil.Pixel_format.t
+
 val pack_image : Image.YUV420.t -> (Image.Data.t * int) array
 
 val unpack_image :

--- a/src/core/optionals/ffmpeg/ffmpeg_utils.mli
+++ b/src/core/optionals/ffmpeg/ffmpeg_utils.mli
@@ -34,10 +34,16 @@ val liq_video_sample_time_base : unit -> Avutil.rational
 val liq_frame_time_base : unit -> Avutil.rational
 val liq_frame_pixel_format : Avutil.Pixel_format.t
 val liq_frame_pixel_format_with_alpha : Avutil.Pixel_format.t
+val pixel_format_has_alpha : Avutil.Pixel_format.t -> bool
 val liq_frame_pixel_format_for : Avutil.Pixel_format.t -> Avutil.Pixel_format.t
 
 val pixel_format :
   ?alpha:bool -> 'a Avcodec.Video.t -> string option -> Avutil.Pixel_format.t
+
+val set_format_alpha :
+  codec_params:Avutil.video Avcodec.params ->
+  Content_base.Contents.format ->
+  unit
 
 val pack_image : Image.YUV420.t -> (Image.Data.t * int) array
 

--- a/src/core/optionals/ffmpeg/lang_ffmpeg.ml
+++ b/src/core/optionals/ffmpeg/lang_ffmpeg.ml
@@ -425,11 +425,7 @@ let ffmpeg_gen params =
         let pixel_format = to_string t in
         let alpha =
           match Avutil.Pixel_format.of_string pixel_format with
-            | pixel_format ->
-                let { Avutil.Pixel_format.flags } =
-                  Avutil.Pixel_format.descriptor pixel_format
-                in
-                Some (List.mem `Alpha flags)
+            | pf -> Some (Ffmpeg_utils.pixel_format_has_alpha pf)
             | exception _ -> None
         in
         parse_video_args ~opts

--- a/src/core/optionals/ffmpeg/lang_ffmpeg.ml
+++ b/src/core/optionals/ffmpeg/lang_ffmpeg.ml
@@ -325,6 +325,7 @@ let ffmpeg_gen params =
       width = video_width;
       height = video_height;
       pixel_format = None;
+      alpha = None;
       hwaccel = `Auto;
       hwaccel_device = None;
       hwaccel_pixel_format = None;
@@ -418,11 +419,21 @@ let ffmpeg_gen params =
           args
     | ("pixel_format", String { value = "guess" }) :: args ->
         parse_video_args ~opts
-          { options with Ffmpeg_format.pixel_format = None }
+          { options with Ffmpeg_format.pixel_format = None; alpha = None }
           args
     | ("pixel_format", t) :: args ->
+        let pixel_format = to_string t in
+        let alpha =
+          match Avutil.Pixel_format.of_string pixel_format with
+            | pixel_format ->
+                let { Avutil.Pixel_format.flags } =
+                  Avutil.Pixel_format.descriptor pixel_format
+                in
+                Some (List.mem `Alpha flags)
+            | exception _ -> None
+        in
         parse_video_args ~opts
-          { options with Ffmpeg_format.pixel_format = Some (to_string t) }
+          { options with Ffmpeg_format.pixel_format = Some pixel_format; alpha }
           args
     | ("hwaccel", String { value = "auto" }) :: args ->
         parse_video_args ~opts

--- a/tests/language/source_content.liq
+++ b/tests/language/source_content.liq
@@ -49,9 +49,9 @@ def f() =
   )
   test.equal(
     json.stringify(compact=true, video_fmt),
-    '{"yuv420p":{"height":#{settings.frame.video.height()},"width":#{
-      settings.frame.video.width()
-    }}}'
+    '{"yuv420p":{"alpha":null,"height":#{
+      settings.frame.video.height()
+    },"width":#{settings.frame.video.width()}}}'
   )
 
   test.pass()

--- a/tests/media/dune
+++ b/tests/media/dune
@@ -566,6 +566,38 @@
    %{test_liq}
    test_subtitle_text_to_ass.liq)))
 
+(rule
+ (alias test_ffmpeg_vp9_alpha)
+ (target alarm-clock-alpha.webm)
+ (action
+  (run
+   curl
+   -L
+   -o
+   %{target}
+   "https://upload.wikimedia.org/wikipedia/commons/a/a7/Alarm_Clock_Animation_High_Res_alpha_transparency.webm")))
+
+(rule
+ (alias test_ffmpeg_vp9_alpha)
+ (package liquidsoap)
+ (deps
+  alarm-clock-alpha.webm
+  test_ffmpeg_vp9_alpha.liq
+  ../../src/bin/liquidsoap.exe
+  (package liquidsoap)
+  (source_tree ../../src/libs)
+  (:test_liq ../test.liq)
+  (:run_test ../run_test.exe))
+ (action
+  (run
+   %{run_test}
+   "FFmpeg VP9 alpha transparency encoding"
+   liquidsoap
+   %{test_liq}
+   test_ffmpeg_vp9_alpha.liq
+   --
+   alarm-clock-alpha.webm)))
+
 (alias
  (name mediatest)
  (deps
@@ -581,4 +613,5 @@
   (alias test_lufs_integrated)
   (alias test_image_decoder_duration)
   (alias test_bitmap_subtitle_to_video)
-  (alias test_subtitle_text_to_ass)))
+  (alias test_subtitle_text_to_ass)
+  (alias test_ffmpeg_vp9_alpha)))

--- a/tests/media/test_ffmpeg_vp9_alpha.liq
+++ b/tests/media/test_ffmpeg_vp9_alpha.liq
@@ -1,0 +1,57 @@
+log.level.set(4)
+
+settings.decoder.ffmpeg.codecs.vp9.set("libvpx-vp9")
+
+fname = argv(default="", 1)
+out = file.temp(cleanup=true, "vp9-alpha", ".webm")
+
+s = max_duration(1., single(fname))
+
+clock.assign_new(id='test_clock', sync='none', [s])
+
+done = ref(false)
+
+def on_close(filename) =
+  if
+    not done()
+  then
+    done := true
+
+    json =
+      process.read(
+        "ffprobe -c:v libvpx-vp9 -v error -select_streams v:0 -show_entries \
+         stream=pix_fmt:format=duration -of json #{process.quote(filename)}"
+      )
+
+    let json.parse (parsed :
+      {streams: [{pix_fmt: string?}], format: {duration: string}}
+    ) = json
+
+    pix_fmt = null.get(default="", (list.hd(parsed.streams)).pix_fmt)
+    duration = float_of_string(default=0., parsed.format.duration)
+
+    if
+      pix_fmt == "yuva420p" and duration > 0.
+    then
+      test.pass()
+    else
+      test.fail()
+    end
+  end
+end
+
+output.file(
+  fallible=true,
+  on_close=on_close,
+  %ffmpeg(
+    %video(
+      codec = "libvpx-vp9",
+      deadline = "realtime",
+      "cpu-used" = 8,
+      threads = 4,
+      "row-mt" = 1
+    )
+  ),
+  out,
+  s
+)


### PR DESCRIPTION
This PR adds end-to-end alpha channel support for video in Liquidsoap. Prior to this change, transparent video (e.g. VP9 with alpha in a WebM container) could not be round-tripped through Liquidsoap at all — the alpha channel was silently discarded at every stage of the pipeline.

**Changes**:

`ffmpeg: preserve alpha channel when scaling video frames` — adds `liq_frame_pixel_format_for` which selects `yuva420p` as the internal pixel format when the source has alpha, and `yuv420p` otherwise. Uses it in decoder and encoder scalers instead of always targeting `yuv420p`.

`ffmpeg: pass alpha planes and select alpha pixel format in internal encoder` — when encoding, select the correct output pixel format (e.g. `yuva420p`) based on whether alpha is present, and pass alpha planes through.

`ffmpeg: defer video stream init to first frame for alpha detection` — the FFmpeg internal encoder previously created the output stream eagerly at construction time, before the first frame arrived. At that point `params.alpha` is `None` (not yet known), so the stream was created with `yuv420p`. The fix defers stream creation to `mk_stream`, which receives the first frame and can detect alpha from its content type. The scaler is also deferred so it picks up the correct pixel format. The same alpha detection is applied in `builtins_ffmpeg_encoder` to ensure the canvas render call preserves transparency.

`ffmpeg: pass color_range to fps filter buffer to suppress property mismatch warning` — when the fps filter's buffer was initialized without a `color_range` arg, FFmpeg logged a spurious warning on the first frame if that frame carried a non-unspecified color range (common with libvpx-vp9 content). The fix extracts color range from each decoded frame and passes it as the `range` arg to the buffer filter. In `ffmpeg_internal_decoder` the fps filter creation is deferred to the first frame for the same reason.

`tests: add VP9 alpha transparency encoding test` — downloads a real WebM with VP9 alpha transparency from Wikimedia, transcodes it with libvpx-vp9, and verifies the output stream has `pix_fmt=yuva420p` and non-zero duration using `ffprobe -c:v libvpx-vp9`.

Note: alpha detection in the decoder requires `libvpx-vp9` as the preferred VP9 decoder (see #5166) since the default FFmpeg VP9 decoder does not expose the alpha plane.
