### PR TITLE
avutil/avutil_stubs: fix subtitle rect buffer size handling

### DIFF
--- a/src/modules/synced/ffmpeg/avutil/avutil_stubs.c
+++ b/src/modules/synced/ffmpeg/avutil/avutil_stubs.c
@@ -1300,7 +1300,9 @@ static value value_of_pict(AVSubtitleRect *rect) {
     intnat dims[1];
     size_t buf_size = rect->type == SUBTITLE_BITMAP && i == 1
                           ? AVPALETTE_SIZE
-                          : rect->h * rect->linesize[i];
+                          : (rect->h > 0 && rect->linesize[i] > 0
+                             ? (size_t)rect->h * (size_t)rect->linesize[i]
+                             : 0);
     if (rect->data[i] && buf_size > 0) {
       dims[0] = buf_size;
     } else {
@@ -1453,7 +1455,7 @@ CAMLprim value ocaml_avutil_subtitle_create_frame(value _content) {
         for (int p = 0; p < 4; p++) {
           value ba = Field(data_arr, p);
           int linesize = Int_val(Field(linesize_arr, p));
-          int size = caml_ba_byte_size(Caml_ba_array_val(ba));
+          size_t size = caml_ba_byte_size(Caml_ba_array_val(ba));
 
           if (size > 0) {
             rect->data[p] = av_malloc(size);


### PR DESCRIPTION
Fix two issues in subtitle rect buffer size handling in `avutil/avutil_stubs.c`, originally reported in https://github.com/savonet/ocaml-ffmpeg/pull/95.

In `value_of_pict`, `buf_size` was computed as `rect->h * rect->linesize[i]` — an `int * int` product assigned to `size_t`. A negative value from either field (possible with malformed subtitle data) wraps to a huge `size_t`, which flows into `caml_ba_alloc` and then `memcpy`, causing an out-of-bounds read. The fix guards against non-positive values and adds explicit `size_t` casts before multiplication to avoid signed integer overflow UB.

In `ocaml_avutil_subtitle_create_frame`, the return value of `caml_ba_byte_size` (which is `mlsize_t` / `uintnat`) was stored in `int`, which is a type mismatch. Changed to `size_t`.
