### PR TITLE
xiph: install ffmpeg before running citest

### DIFF
--- a/src/modules/synced/xiph/.github/workflows/ci.yml
+++ b/src/modules/synced/xiph/.github/workflows/ci.yml
@@ -21,6 +21,14 @@ jobs:
         uses: savonet/build-and-test-ocaml-module@main
         with:
           ocaml-compiler: ${{ matrix.compiler }}
+      - name: Install ffmpeg
+        run: |
+          if [ "$RUNNER_OS" = "macOS" ]; then
+            brew install ffmpeg
+          else
+            sudo apt-get install -y ffmpeg
+          fi
+        shell: bash
       - name: Run CI tests
         run: |
           opam exec dune build @xiph_citest

--- a/src/modules/synced/xiph/.github/workflows/ci.yml
+++ b/src/modules/synced/xiph/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
           if [ "$RUNNER_OS" = "macOS" ]; then
             brew install ffmpeg flac
           else
-            sudo apt-get update && sudo apt-get install -y ffmpeg flac
+            sudo apt-get update && sudo apt-get install -y ffmpeg libflac-dev
           fi
         shell: bash
       - name: Run CI tests

--- a/src/modules/synced/xiph/.github/workflows/ci.yml
+++ b/src/modules/synced/xiph/.github/workflows/ci.yml
@@ -17,12 +17,12 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-      - name: Install ffmpeg, flac and ogg
+      - name: Install deps
         run: |
           if [ "$RUNNER_OS" = "macOS" ]; then
-            brew install ffmpeg flac libogg
+            brew install ffmpeg flac libogg libvorbis speex theora opus
           else
-            sudo apt-get update && sudo apt-get install -y ffmpeg libflac-dev libogg-dev
+            sudo apt-get update && sudo apt-get install -y ffmpeg libflac-dev libogg-dev libvorbis-dev libspeex-dev libtheora-dev libopus-dev
           fi
         shell: bash
       - name: Build and test module

--- a/src/modules/synced/xiph/.github/workflows/ci.yml
+++ b/src/modules/synced/xiph/.github/workflows/ci.yml
@@ -17,18 +17,16 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+      - name: Install ffmpeg, flac and ogg
+        run: |
+          if [ "$RUNNER_OS" = "macOS" ]; then
+            brew install ffmpeg flac libogg
+          else
+            sudo apt-get update && sudo apt-get install -y ffmpeg libflac-dev libogg-dev
+          fi
+        shell: bash
       - name: Build and test module
         uses: savonet/build-and-test-ocaml-module@main
         with:
           ocaml-compiler: ${{ matrix.compiler }}
-      - name: Install ffmpeg
-        run: |
-          if [ "$RUNNER_OS" = "macOS" ]; then
-            brew install ffmpeg flac
-          else
-            sudo apt-get update && sudo apt-get install -y ffmpeg libflac-dev
-          fi
-        shell: bash
-      - name: Run CI tests
-        run: |
-          opam exec dune build @xiph_citest
+          test-target: xiph_citest

--- a/src/modules/synced/xiph/.github/workflows/ci.yml
+++ b/src/modules/synced/xiph/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
           if [ "$RUNNER_OS" = "macOS" ]; then
             brew install ffmpeg
           else
-            sudo apt-get install -y ffmpeg
+            sudo apt-get update && sudo apt-get install -y ffmpeg
           fi
         shell: bash
       - name: Run CI tests

--- a/src/modules/synced/xiph/.github/workflows/ci.yml
+++ b/src/modules/synced/xiph/.github/workflows/ci.yml
@@ -24,9 +24,9 @@ jobs:
       - name: Install ffmpeg
         run: |
           if [ "$RUNNER_OS" = "macOS" ]; then
-            brew install ffmpeg
+            brew install ffmpeg flac
           else
-            sudo apt-get update && sudo apt-get install -y ffmpeg
+            sudo apt-get update && sudo apt-get install -y ffmpeg flac
           fi
         shell: bash
       - name: Run CI tests

--- a/src/modules/synced/xiph/speex/examples/gen/gen.ml
+++ b/src/modules/synced/xiph/speex/examples/gen/gen.ml
@@ -9,7 +9,7 @@ let () =
     executable "wav2speex" "wav2speex" ["speex"];
     print_string
       {|(rule
- (alias runtest)
+ (alias xiph_citest)
  (package speex)
  (deps
   (:speex test.ogg)


### PR DESCRIPTION
The `@xiph_citest` dune alias is only emitted by `gen.ml` when `ffmpeg` is found on `PATH`. Without it the alias is empty and `dune build @xiph_citest` fails with "Alias is empty / not defined".

Install ffmpeg via brew (macOS) or apt (Linux) before the CI test step so the alias is always defined.
