### PR TITLE
synced-push: factor out rsync; xiph: revamp README

### DIFF
--- a/.github/workflows/synced-push.yml
+++ b/.github/workflows/synced-push.yml
@@ -38,32 +38,24 @@ jobs:
             git config user.name "github-actions[bot]"
             git config user.email "github-actions[bot]@users.noreply.github.com"
 
+            rsync -a --delete --exclude='.git' "$GITHUB_WORKSPACE/src/modules/synced/$name/" .
+            git add -A
+            if ! git diff --cached --quiet; then
+              git commit -m "Synced from savonet/liquidsoap@${{ github.sha }}"
+            fi
+
             if [ -n "$pr_number" ]; then
               mirror_branch="mirror/pr-${pr_number}"
               if gh pr list --repo "savonet/ocaml-$name" --head "$mirror_branch" --json number --jq 'length > 0' | grep -q true; then
-                git fetch origin "$mirror_branch"
-                git checkout -b "$mirror_branch" "origin/$mirror_branch"
-                rsync -a --delete --exclude='.git' "$GITHUB_WORKSPACE/src/modules/synced/$name/" .
-                git add -A
-                if ! git diff --cached --quiet; then
-                  git commit -m "Synced from savonet/liquidsoap@${{ github.sha }}"
-                fi
-                git push origin "$mirror_branch"
-                git checkout main
-                git merge --no-ff "$mirror_branch" \
-                  -m "Merged via savonet/liquidsoap#${pr_number}."
+                git push origin HEAD:refs/heads/$mirror_branch
                 git push origin main
+                git push origin --delete "$mirror_branch"
                 cd -
                 continue
               fi
             fi
 
-            rsync -a --delete --exclude='.git' "$GITHUB_WORKSPACE/src/modules/synced/$name/" .
-            git add -A
-            if ! git diff --cached --quiet; then
-              git commit -m "Synced from savonet/liquidsoap@${{ github.sha }}"
-              git push origin main
-            fi
+            git push origin main
 
             cd -
           done

--- a/src/modules/synced/xiph/README.md
+++ b/src/modules/synced/xiph/README.md
@@ -5,48 +5,49 @@
 > [savonet/liquidsoap](https://github.com/savonet/liquidsoap) under
 > `src/modules/synced/xiph/` and will be mirrored here automatically.
 
-![GitHub](https://img.shields.io/github/license/savonet/ocaml-xiph)
-![CI](https://github.com/savonet/ocaml-xiph/workflows/CI/badge.svg)
-![GitHub release (latest by date)](https://img.shields.io/github/v/release/savonet/ocaml-xiph)
+[![GitHub license](https://img.shields.io/github/license/savonet/ocaml-xiph)](https://github.com/savonet/ocaml-xiph/blob/main/LICENSE)
+[![CI](https://github.com/savonet/ocaml-xiph/workflows/CI/badge.svg)](https://github.com/savonet/ocaml-xiph/actions)
+[![GitHub release](https://img.shields.io/github/v/release/savonet/ocaml-xiph)](https://github.com/savonet/ocaml-xiph/releases)
 
-This repository provides various OCaml bindings to the [xiph](https://xiph.org/) libraries.
+OCaml bindings to the [Xiph.Org](https://xiph.org/) codec libraries, providing
+support for **Ogg**, **Vorbis**, **Opus**, **Speex**, **Theora**, and **FLAC**
+in OCaml projects.
 
-# Documentation:
+## Packages
 
-The [API documentation is available here](http://www.liquidsoap.info/ocaml-xiph/).
+| Package  | Wraps                            | opam                                                                                              |
+| -------- | -------------------------------- | ------------------------------------------------------------------------------------------------- |
+| `ogg`    | libogg — Ogg bitstream container | [![opam](https://img.shields.io/badge/opam-ogg-blue)](https://opam.ocaml.org/packages/ogg/)       |
+| `vorbis` | libvorbis — Vorbis audio codec   | [![opam](https://img.shields.io/badge/opam-vorbis-blue)](https://opam.ocaml.org/packages/vorbis/) |
+| `opus`   | libopus — Opus audio codec       | [![opam](https://img.shields.io/badge/opam-opus-blue)](https://opam.ocaml.org/packages/opus/)     |
+| `speex`  | libspeex — Speex audio codec     | [![opam](https://img.shields.io/badge/opam-speex-blue)](https://opam.ocaml.org/packages/speex/)   |
+| `theora` | libtheora — Theora video codec   | [![opam](https://img.shields.io/badge/opam-theora-blue)](https://opam.ocaml.org/packages/theora/) |
+| `flac`   | libflac — FLAC lossless audio    | [![opam](https://img.shields.io/badge/opam-flac-blue)](https://opam.ocaml.org/packages/flac/)     |
 
-# Prerequisites:
+## Installation
 
-- ocaml
-- dune
-- findlib
-- libogg
-- libvorbis
-- libspeex
-- libflac
-- libtheora
-- libopus
+The recommended way is via [opam](https://opam.ocaml.org/):
 
-See [dune-project](dune-project) file for versions.
-
-# Installation:
-
-The preferred installation method is via [opam](http://opam.ocaml.org/):
-
-```
-opam install ogg vorbis ...
+```sh
+opam install ogg vorbis opus speex theora flac
 ```
 
-If you wish to install the latest code from this repository, you can do:
+To install the latest development version directly from this repository:
 
-```
+```sh
 opam install .
 ```
 
-From within this repository.
+## Building from source
 
-# Compilation:
-
-```
+```sh
 dune build
 ```
+
+## Documentation
+
+[API documentation](http://www.liquidsoap.info/ocaml-xiph/)
+
+## License
+
+LGPL-2.1-only — see [LICENSE](LICENSE).


### PR DESCRIPTION
Refactor `synced-push.yml` to avoid duplicating the rsync logic. The new flow is: rsync + commit on main to create the new tip, then if a mirror PR branch exists push that tip to the PR branch (GitHub closes the PR automatically when it sees the branch tip is in main), push main, and delete the mirror branch.

Also revamps the `ocaml-xiph` README with a package table, proper linked badges, and cleaner sections.
