### PR TITLE
Defer cross abort_track transition to its own clock thread

### DIFF
--- a/src/core/base/operators/cross.ml
+++ b/src/core/base/operators/cross.ml
@@ -475,13 +475,16 @@ class cross val_source ~override_duration ~duration_getter ~persist_override
         | `Idle -> self#source#effective_source
         | `Before (_, s) | `After (_, s) -> s#effective_source
 
+    val pending_abort_track = Atomic.make false
+
     method abort_track =
-      match status with
-        | `Idle -> self#source#abort_track
-        | `Before s | `After s ->
-            self#source#abort_track;
-            status <- `After s;
-            ignore self#prepare_before
+      self#source#abort_track;
+      if not (Atomic.exchange pending_abort_track true) then
+        Clock.on_tick self#clock (fun () ->
+            Atomic.set pending_abort_track false;
+            match status with
+              | `Idle -> ()
+              | `Before _ | `After _ -> ignore self#prepare_before)
   end
 
 let _ =

--- a/src/core/base/operators/cross.ml
+++ b/src/core/base/operators/cross.ml
@@ -477,14 +477,16 @@ class cross val_source ~override_duration ~duration_getter ~persist_override
 
     val pending_abort_track = Atomic.make false
 
-    method abort_track =
-      self#source#abort_track;
-      if not (Atomic.exchange pending_abort_track true) then
-        Clock.on_tick self#clock (fun () ->
-            Atomic.set pending_abort_track false;
+    initializer
+      self#on_before_streaming_cycle (fun () ->
+          if Atomic.exchange pending_abort_track false then (
             match status with
               | `Idle -> ()
-              | `Before _ | `After _ -> ignore self#prepare_before)
+              | `Before _ | `After _ -> ignore self#prepare_before))
+
+    method abort_track =
+      self#source#abort_track;
+      Atomic.set pending_abort_track true
   end
 
 let _ =

--- a/tests/regression/GH5148.liq
+++ b/tests/regression/GH5148.liq
@@ -1,0 +1,29 @@
+# Regression for https://github.com/savonet/liquidsoap/discussions/5148
+#
+
+def f() =
+  iterations = ref(0)
+
+  def next() =
+    request.create("../media/@wav[stereo].wav")
+  end
+
+  s = request.dynamic(id="dyn", synchronous=true, next)
+
+  s = cross(duration=0.5, fun (a, b) -> sequence([a.source, b.source]), s)
+
+  clock.assign_new(sync="none", [s])
+  output.dummy(fallible=true, s)
+
+  # Hammer skip from another thread
+  def hammer() =
+    s.skip()
+    ref.incr(iterations)
+    if 1000 < iterations() then test.pass() end
+    0.001
+  end
+
+  thread.run.recurrent(fast=true, delay=0.5, hammer)
+end
+
+test.check(f)

--- a/tests/regression/dune.inc
+++ b/tests/regression/dune.inc
@@ -1234,6 +1234,24 @@
   (run %{run_test} GH5110 liquidsoap %{test_liq} GH5110.liq)))
 
 (rule
+ (alias test_GH5148)
+ (package liquidsoap)
+ (deps
+  GH5148.liq
+  (glob_files ../media/**)
+  ../liquidsoap-test-assets
+  ../../src/bin/liquidsoap.exe
+  ../streams/file1.png
+  ../streams/file1.mp3
+  ./theora-test.mp4
+  (package liquidsoap)
+  (source_tree ../../src/libs)
+  (:test_liq ../test.liq)
+  (:run_test ../run_test.exe))
+ (action
+  (run %{run_test} GH5148 liquidsoap %{test_liq} GH5148.liq)))
+
+(rule
  (alias test_LS268)
  (package liquidsoap)
  (deps
@@ -1963,6 +1981,7 @@
   (alias test_GH5019)
   (alias test_GH5084)
   (alias test_GH5110)
+  (alias test_GH5148)
   (alias test_LS268)
   (alias test_LS354-1)
   (alias test_LS354-2)


### PR DESCRIPTION
Calling `source.skip()` from a harbor or `thread.run` handler on a `request.dynamic` inside `cross`/`crossfade` crashes with `Assert_failure` at `request_dynamic.ml:145`. 

The cause is `cross#abort_track` running `prepare_before` on the caller's thread, racing the clock thread. The fix defers it to the cross's own clock thread via `Clock.on_tick`. 

A regression test (`GH5148.liq`) reproduces the assertion on current `main` and passes with the fix.

#5148 #5149 