### PR TITLE
Backport #5194 to v2.4.x-latest

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
 
 - Fixed crash when external input (`input.process`, `input.ffmpeg`, etc.) encounters an EOF (thanks to @MikaSappi, #5139)
 - Fixed `harbor.remove_http_handler` discarding all registered handlers except the one being removed
+- Fixed crash in `crossfade`/`cross` when `source.skip` is called from outside the clock thread, e.g. from a `harbor.http` handler or `thread.run` (#5194)
 
 ## Optimized:
 

--- a/src/core/base/operators/cross.ml
+++ b/src/core/base/operators/cross.ml
@@ -587,13 +587,18 @@ class cross val_source ~end_duration_getter ~override_end_duration
         | `Idle -> self#source#effective_source
         | `Before (_, s) | `After (_, s) -> s#effective_source
 
+    val pending_abort_track = Atomic.make false
+
+    initializer
+      self#on_before_streaming_cycle (fun () ->
+          if Atomic.exchange pending_abort_track false then (
+            match status with
+              | `Idle -> ()
+              | `Before _ | `After _ -> ignore self#prepare_before))
+
     method abort_track =
-      match status with
-        | `Idle -> self#source#abort_track
-        | `Before s | `After s ->
-            self#source#abort_track;
-            status <- `After s;
-            ignore self#prepare_before
+      self#source#abort_track;
+      Atomic.set pending_abort_track true
   end
 
 let _ =

--- a/tests/regression/GH5148.liq
+++ b/tests/regression/GH5148.liq
@@ -1,0 +1,29 @@
+# Regression for https://github.com/savonet/liquidsoap/discussions/5148
+#
+
+def f() =
+  iterations = ref(0)
+
+  def next() =
+    request.create("../media/@wav[stereo].wav")
+  end
+
+  s = request.dynamic(id="dyn", synchronous=true, next)
+
+  s = cross(duration=0.5, fun (a, b) -> sequence([a.source, b.source]), s)
+
+  clock.assign_new(sync="none", [s])
+  output.dummy(fallible=true, s)
+
+  # Hammer skip from another thread
+  def hammer() =
+    s.skip()
+    ref.incr(iterations)
+    if 1000 < iterations() then test.pass() end
+    0.001
+  end
+
+  thread.run.recurrent(fast=true, delay=0.5, hammer)
+end
+
+test.check(f)

--- a/tests/regression/dune.inc
+++ b/tests/regression/dune.inc
@@ -1128,6 +1128,23 @@
  (action (run %{run_test} GH5110 liquidsoap %{test_liq} GH5110.liq)))
   
 (rule
+ (alias GH5148)
+ (package liquidsoap)
+ 
+ (deps
+  GH5148.liq
+  ../media/all_media_files
+  ../../src/bin/liquidsoap.exe
+  ../streams/file1.png
+  ../streams/file1.mp3
+  ./theora-test.mp4
+  (package liquidsoap)
+  (source_tree ../../src/libs)
+  (:test_liq ../test.liq)
+  (:run_test ../run_test.exe))
+ (action (run %{run_test} GH5148 liquidsoap %{test_liq} GH5148.liq)))
+  
+(rule
  (alias LS268)
  (package liquidsoap)
  
@@ -1756,6 +1773,7 @@
     (alias GH4995)
     (alias GH5019)
     (alias GH5110)
+    (alias GH5148)
     (alias LS268)
     (alias LS354-1)
     (alias LS354-2)


### PR DESCRIPTION
Calling source.skip() from a harbor or thread.run handler on a request.dynamic inside cross/crossfade crashes with Assert_failure at request_dynamic.ml:145.

The cause is cross#abort_track running prepare_before on the caller's thread, racing the clock thread. The fix defers it to the cross's own clock thread via Clock.on_tick.

A regression test (GH5148.liq) reproduces the assertion on current main and passes with the fix.

https://github.com/savonet/liquidsoap/discussions/5148 https://github.com/savonet/liquidsoap/issues/5149