### PR TITLE
Add documentation for `_vector_kind` enum

### DIFF
--- a/src/modules/synced/ffmpeg/swresample/swresample_stubs.h
+++ b/src/modules/synced/ffmpeg/swresample/swresample_stubs.h
@@ -2,6 +2,18 @@
 
 #include "avutil_stubs.h"
 
+/*
+ * Enum representing different kinds of vectors used in swresample operations.
+ * 
+ * Members:
+ *   Str   - Vector of strings
+ *   P_Str - Vector of pointers to strings
+ *   Fa    - Vector of float arrays (audio samples)
+ *   P_Fa  - Vector of pointers to float arrays
+ *   Ba    - Vector of byte arrays
+ *   P_Ba  - Vector of pointers to byte arrays
+ *   Frm   - Vector of frames
+ */
 typedef enum _vector_kind { Str, P_Str, Fa, P_Fa, Ba, P_Ba, Frm } vector_kind;
 
 typedef struct swr_t swr_t;


### PR DESCRIPTION
## Problem Background
The enum type `_vector_kind` is used in swresample operations to represent different kinds of vectors, but it lacks documentation comments. This makes it unclear what each member means and how it is used, reducing code readability and maintainability for developers.

## Changes Made
Added detailed documentation comments to the `_vector_kind` enum in `src/modules/synced/ffmpeg/swresample/swresample_stubs.h`. The comments explain the enum's purpose and describe each member:
- `Str`: Vector of strings
- `P_Str`: Vector of pointers to strings
- `Fa`: Vector of float arrays (audio samples)
- `P_Fa`: Vector of pointers to float arrays
- `Ba`: Vector of byte arrays
- `P_Ba`: Vector of pointers to byte arrays
- `Frm`: Vector of frames

This change only adds comments and does not modify any functional code or APIs.

## Verification
The added documentation was reviewed for accuracy based on the enum's usage in the codebase. The code compiles without errors, and no changes to external behavior are introduced, ensuring backward compatibility.