### PR TITLE
[Backport v2.4.x-latest] Fix Strings.Mutable ensure_capacity.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@
 - Fixed crash when external input (`input.process`, `input.ffmpeg`, etc.) encounters an EOF (thanks to @MikaSappi, #5139)
 - Fixed `harbor.remove_http_handler` discarding all registered handlers except the one being removed
 - Fixed crash in `crossfade`/`cross` when `source.skip` is called from outside the clock thread, e.g. from a `harbor.http` handler or `thread.run` (#5194)
+- Fixed memory leak in `Strings.Mutable` (#5231)
 
 ## Optimized:
 

--- a/src/core/base/tools/strings.ml
+++ b/src/core/base/tools/strings.ml
@@ -167,10 +167,17 @@ module Mutable = struct
      Compacts the buffer if needed. Returns new content. *)
   let ensure_capacity c n =
     let required = c.ofs + c.pos + n in
-    if required > Bytes.length c.buffer then begin
+    if required <= Bytes.length c.buffer then c
+    else if c.ofs > 0 && c.pos + n <= Bytes.length c.buffer then begin
+      (* Sliding data to the front avoids reallocation. *)
+      Bytes.blit c.buffer c.ofs c.buffer 0 c.size;
+      { c with ofs = 0 }
+    end
+    else begin
+      let needed = c.pos + n in
       let new_capacity =
         let cap = ref (max (Bytes.length c.buffer) 1) in
-        while !cap < required do
+        while !cap < needed do
           cap := !cap + (!cap / 2) + 1
         done;
         !cap
@@ -179,11 +186,6 @@ module Mutable = struct
       Bytes.blit c.buffer c.ofs new_buffer 0 c.size;
       { c with buffer = new_buffer; ofs = 0 }
     end
-    else if c.ofs > 0 && c.ofs + c.pos + n > Bytes.length c.buffer then begin
-      Bytes.blit c.buffer c.ofs c.buffer 0 c.size;
-      { c with ofs = 0 }
-    end
-    else c
 
   let strings_of_bytes = of_bytes
 
@@ -361,6 +363,7 @@ module Mutable = struct
 
   let is_empty m = get m (fun c -> c.size = 0)
   let length m = get m (fun c -> c.size)
+  let buffer_capacity m = get m (fun c -> Bytes.length c.buffer)
 
   let blit m mo b bo len =
     get m (fun c ->

--- a/src/core/base/tools/strings.mli
+++ b/src/core/base/tools/strings.mli
@@ -208,6 +208,9 @@ module Mutable : sig
   (** Length of the buffer (total bytes written, not capacity). *)
   val length : t -> int
 
+  (** Capacity of the underlying buffer in bytes. *)
+  val buffer_capacity : t -> int
+
   (** Append the content of another buffer at the end. Sets position to end. *)
   val append : t -> t -> unit
 

--- a/tests/core/strings_test.ml
+++ b/tests/core/strings_test.ml
@@ -309,6 +309,26 @@ let () =
   in
   assert (M.to_string m2 = "ABC")
 
+(* Regression test: buffer capacity must stay bounded after repeated
+   append_strings + keep cycles (the pattern used in output.harbor for
+   burst_data). Before the fix, ensure_capacity's compact branch was dead
+   code, so ofs accumulated without bound and the buffer grew unboundedly. *)
+let () =
+  let burst = 65534 in
+  let chunk = Strings.of_string (String.make 4000 'x') in
+  let slen = Strings.length chunk in
+  let m = M.create () in
+  for _ = 1 to 10000 do
+    M.append_strings m chunk;
+    M.keep m burst
+  done;
+  assert (M.length m = burst);
+  assert (M.to_string m = String.make burst 'x');
+  (* Buffer capacity must be bounded: burst + slen is the minimum needed,
+     and must not have grown into the many-MB range from ofs accumulation. *)
+  let cap = M.buffer_capacity m in
+  assert (cap < burst + (10 * slen))
+
 let () =
   let m = M.of_string "initial" in
   let reader () =


### PR DESCRIPTION
Backport e6c4d327c8131fe4202fdada539da8524042c1a6 from #5231.