### PR TITLE
cry: drop obsolete bytes findlib dependency

### DIFF
--- a/src/modules/cry/dune
+++ b/src/modules/cry/dune
@@ -1,6 +1,6 @@
 (library
  (name cry)
- (libraries bytes unix stdlib_utils)
+ (libraries unix stdlib_utils)
  (foreign_stubs
   (language c)
   (names cry_stubs))


### PR DESCRIPTION
The `cry` library only uses the `Bytes` module, which has been part of the OCaml standard library since 4.07. The separate `bytes` findlib package is a compatibility shim for older compilers and is no longer needed; listing it breaks builds on toolchains that no longer ship it.

This removes `bytes` from `src/modules/cry/dune`. Verified `dune build src/modules/cry/` passes on OCaml 5.4.1 / dune 3.23.1.

Context: this was being worked around downstream in the Homebrew formula via an `inreplace`; submitting upstream so the workaround can be dropped (Homebrew/homebrew-core#273636).