### PR TITLE
unifier: add path compression to avoid unbounded deref cost growth

### DIFF
--- a/src/lang/base/unifier.ml
+++ b/src/lang/base/unifier.ml
@@ -25,24 +25,45 @@
 type 'a t = [ `Value of 'a | `Link of 'a t Atomic.t ]
 
 let make v = `Link (Atomic.make (`Value v))
-let rec deref x = match x with `Value v -> v | `Link x -> deref (Atomic.get x)
+
+(* Return the terminal atom of a chain (the one holding `Value), compressing
+   the path behind it: every link visited is re-pointed directly at the
+   terminal atom, so subsequent walks are O(1) instead of O(chain length).
+   Without this, chains only ever grow (each [<--] appends one), and code
+   that derefs in a hot loop pays for the full history of unifications. *)
+let find_root a =
+  let rec find a =
+    match Atomic.get a with `Value _ -> a | `Link a' -> find a'
+  in
+  let root = find a in
+  let rec compress a =
+    match Atomic.get a with
+      | `Value _ -> ()
+      | `Link a' ->
+          if a' != root then Atomic.set a (`Link root);
+          compress a'
+  in
+  compress a;
+  root
+
+let rec deref x =
+  match x with
+    | `Value v -> v
+    | `Link a -> (
+        match Atomic.get (find_root a) with
+          | `Value v -> v
+          (* A concurrent [<--] may have linked our root onward; retry. *)
+          | `Link _ as l -> deref l)
 
 let set x v =
-  let rec f x =
-    match Atomic.get x with
-      | `Value _ -> Atomic.set x (`Value v)
-      | `Link x -> f x
-  in
-  match x with `Value _ -> assert false | `Link x -> f x
+  match x with
+    | `Value _ -> assert false
+    | `Link a -> Atomic.set (find_root a) (`Value v)
 
 let ( <-- ) x x' =
-  let rec f x x' =
-    match (Atomic.get x, Atomic.get x') with
-      | `Link x, _ -> f x x'
-      | _, `Link x' -> f x x'
-      | _ when x != x' -> Atomic.set x (`Link x')
-      | _ -> ()
-  in
   match (x, x') with
     | `Value _, _ | _, `Value _ -> assert false
-    | `Link x, `Link x' -> f x x'
+    | `Link a, `Link a' ->
+        let r = find_root a in
+        let r' = find_root a' in
+        if r != r' then Atomic.set r (`Link r')


### PR DESCRIPTION
## Problem

`Unifier.t` is a union-find with no path compression: every `(<--)` appends a link, and `deref` walks the full chain on every call without shortening it. Chains only ever grow over a process lifetime, so code that derefs unifiers in a hot path pays a cost proportional to the total number of unifications performed so far.

In a long-running script that creates sources dynamically per track (playlist + crossfade via `source.dynamic`), we measured chains growing ~12 links per track transition. The per-frame hot path that walks them (from a DWARF call-graph `perf` profile of an aged process):

```
Cross → source.dynamic get_next → Lang.apply → check_content
      → Typing.(<:) / unify_meth → Content_base.merge → Unifier.deref
```

The result is CPU that grows linearly with uptime while memory stays flat, until the stream can no longer sustain realtime ("Latency is too high: we must catchup…"). A stock 2.4.5 process left running for 4.5 days on a high-transition-rate config ended up pegged at 100% of a core, ~60 s behind realtime, with 84–91% of all perf samples inside `Unifier.deref` and the `set`/`(<--)` walk loops.

`unifier.ml` is identical on `main`, and 2.4.5 already contains the recent clock optimisations (#5114, #5133, #5153) — this is a separate issue.

## Fix

Route `deref`/`set`/`(<--)` through a `find_root` that re-points every visited link directly at the terminal atom (path compression). Two tail-recursive passes, no stack growth on long chains. Semantics unchanged: `deref` returns the same value (with a retry if a concurrent `(<--)` moves the root mid-read), `set` writes the same terminal atom, `(<--)` still links root to root.

## Measurements

Two stations with identical configuration (10 s tracks, 6 s crossfades ≈ 600 transitions/hour) on the same host, restarted together and run side by side for 20.4 h — one stock 2.4.5, one with this patch. Both builds had temporary counters compiled into `deref` (call count, total walk steps, max chain length, reported every 16.7M derefs):

| identical 20.4 h workload | stock 2.4.5 | patched |
|---|---|---|
| longest chain | 145,763 — growing linearly | 13 — constant |
| walk steps per deref (final interval) | 2,568 — accelerating | 0.904 — constant |
| total walk steps | 959.7 billion | 668 million |
| process CPU (lifetime avg) | 26% → 48%, climbing | ~22%, flat |
| "catchup" latency warnings | 4,375 (lag up to 3.3 s) | 0 |
| RSS | ~157 MB, flat | ~155 MB, flat |

Deref *demand* was identical (both emitted counter reports at the same cadence throughout); only the per-walk cost diverges. Flat RSS on both is why this presents as a "CPU leak" that memory monitoring never catches. A patched process aged 23 h shows no Unifier frames ≥2% in perf — its profile is indistinguishable from a freshly started process.

## How this was diagnosed

- `perf record` on aged vs young processes (symbol-level first, then `--call-graph dwarf` to resolve the per-frame call path above)
- temporary counters in `unifier.ml` to distinguish "more derefs" from "longer walks" — that split is what pointed at chain growth rather than a growing caller-side structure
- side-by-side A/B of stock vs patched builds running identical production-like scripts, watching systemd CPU accounting, RSS, and the log latency warnings

Happy to share the full perf profiles or counter series, re-run any measurement, or adjust the implementation (e.g. halving-style compression instead of the two-pass) if preferred.

## Note

I should be upfront: I'm not an experienced liquidsoap or OCaml developer — I maintain a deployment that runs it. The diagnosis and this fix were done with heavy help from AI (Claude), with every step validated against production-like liquidsoap scripts as described above. Please review the concurrency reasoning in particular with that in mind.
