### PR TITLE
HLS: recover from transient output errors

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -37,6 +37,8 @@
 
 ## Fixed:
 
+- Fixed `output.file.hls` terminating the process on transient filesystem
+  errors. The output now supports a `reopen_on_error` callback (#5259).
 - Fixed ID3 timed metadata missing from first mpegts HLS segment: metadata is
   now registered before the segment is opened and before data is encoded (#5084).
 - Make active `stereotool` really be active.. (#4882)

--- a/src/core/base/outputs/hls_output.ml
+++ b/src/core/base/outputs/hls_output.ml
@@ -31,6 +31,9 @@ let default_name =
   Lang.eval ~cache:false ~typecheck:false ~stdlib:`Disabled
     {|fun (metadata) -> "#{metadata.stream_name}_#{metadata.position}.#{metadata.extname}"|}
 
+let default_reopen_on_error =
+  Lang.eval ~cache:false ~stdlib:`Disabled ~typecheck:false "fun (_) -> 2."
+
 let hls_proto frame_t =
   let main_playlist_writer_t =
     Lang.fun_t
@@ -98,6 +101,15 @@ let hls_proto frame_t =
   in
   Output.proto
   @ [
+      ( "reopen_on_error",
+        Lang.fun_t
+          [(false, "", Lang.nullable_t Lang.error_t)]
+          (Lang.nullable_t Lang.float_t),
+        Some default_reopen_on_error,
+        Some
+          "Callback called when there is an error. The error is raised when \
+           returning `null`; otherwise, the output is reopened after the \
+           returned delay, in seconds." );
       ( "playlist",
         Lang.string_t,
         Some (Lang.string "stream.m3u8"),
@@ -175,7 +187,8 @@ let hls_proto frame_t =
     ]
 
 type atomic_out_channel =
-  < output_string : string -> unit
+  < abort : unit
+  ; output_string : string -> unit
   ; output_substring : string -> int -> int -> unit
   ; position : int
   ; truncate : int -> unit
@@ -347,6 +360,16 @@ class hls_output p =
   let autostart = Lang.to_bool (List.assoc "start" p) in
   let infallible = not (Lang.to_bool (List.assoc "fallible" p)) in
   let register_telnet = Lang.to_bool (List.assoc "register_telnet" p) in
+  let reopen_on_error = List.assoc "reopen_on_error" p in
+  let reopen_on_error ~bt exn =
+    let error = Lang.runtime_error_of_exception ~bt ~kind:"output" exn in
+    match
+      Lang.to_valued_option Lang.to_float
+        (Lang.apply reopen_on_error [("", Lang.error error)])
+    with
+      | Some delay when 0. <= delay -> delay
+      | _ -> -1.
+  in
   let prefix = Lang.to_string (List.assoc "prefix" p) in
   let main_playlist_writer =
     Option.map
@@ -608,7 +631,7 @@ class hls_output p =
     inherit
       [(int * Strings.t option * Strings.t) list] Output.encoded
         ~infallible ~register_telnet ~autostart ~export_cover_metadata:false
-          ~output_kind:"output.file" ~name:main_playlist_filename source_val
+          ~output_kind:"output.file" ~name:main_playlist_filename source_val as super
 
     (** Available segments *)
     val mutable segments = List.map (fun { name } -> (name, ref [])) streams
@@ -630,7 +653,17 @@ class hls_output p =
           [Unix.O_RDWR; Unix.O_CREAT; Unix.O_TRUNC; Unix.O_CLOEXEC]
           perms
       in
+      let closed = ref false in
+      let close_fd () =
+        if not !closed then (
+          closed := true;
+          try Unix.close fd with _ -> ())
+      in
       object
+        method abort =
+          close_fd ();
+          try Sys.remove tmp_file with _ -> ()
+
         method output_string s = Tutils.write_all fd (Bytes.unsafe_of_string s)
 
         method output_substring s ofs len =
@@ -655,7 +688,7 @@ class hls_output p =
         method saved_filename = saved_filename
 
         method close =
-          (try Unix.close fd with _ -> ());
+          close_fd ();
           Fun.protect
             ~finally:(fun () -> try Sys.remove tmp_file with _ -> ())
             (fun () ->
@@ -881,6 +914,34 @@ class hls_output p =
             segments)
 
     val mutable main_playlist_written = false
+    val mutable reopen_time = 0.
+
+    method private abort_current_segments =
+      List.iter
+        (fun s ->
+          (match s.current_segment with
+            | Some { out_channel = Some oc } -> oc#abort
+            | _ -> ());
+          s.current_segment <- None;
+          s.needs_discontinuity <- true)
+        streams
+
+    method private apply_on_error ~bt exn =
+      self#abort_current_segments;
+      match reopen_on_error ~bt exn with
+        | delay when delay < 0. -> Printexc.raise_with_backtrace exn bt
+        | delay ->
+            reopen_time <- Unix.gettimeofday () +. delay;
+            self#log#important
+              "Error while streaming: %s, will re-open in %.02fs"
+              (Printexc.to_string exn) delay
+
+    method! output =
+      if reopen_time <= Unix.gettimeofday () then (
+        try super#output
+        with exn ->
+          let bt = Printexc.get_raw_backtrace () in
+          self#apply_on_error ~bt exn)
 
     method private write_main_playlist =
       (match (main_playlist_writer, main_playlist_written) with
@@ -913,6 +974,7 @@ class hls_output p =
 
     method start =
       stopped <- false;
+      reopen_time <- 0.;
       match persist_at with
         | Some persist_at when Sys.file_exists persist_at -> (
             try

--- a/src/core/base/outputs/hls_output.ml
+++ b/src/core/base/outputs/hls_output.ml
@@ -101,15 +101,7 @@ let hls_proto frame_t =
   in
   Output.proto
   @ [
-      ( "reopen_on_error",
-        Lang.fun_t
-          [(false, "", Lang.nullable_t Lang.error_t)]
-          (Lang.nullable_t Lang.float_t),
-        Some default_reopen_on_error,
-        Some
-          "Callback called when there is an error. The error is raised when \
-           returning `null`; otherwise, the output is reopened after the \
-           returned delay, in seconds." );
+      Pipe_output.reopen_on_error_proto default_reopen_on_error;
       ( "playlist",
         Lang.string_t,
         Some (Lang.string "stream.m3u8"),
@@ -361,15 +353,6 @@ class hls_output p =
   let infallible = not (Lang.to_bool (List.assoc "fallible" p)) in
   let register_telnet = Lang.to_bool (List.assoc "register_telnet" p) in
   let reopen_on_error = List.assoc "reopen_on_error" p in
-  let reopen_on_error ~bt exn =
-    let error = Lang.runtime_error_of_exception ~bt ~kind:"output" exn in
-    match
-      Lang.to_valued_option Lang.to_float
-        (Lang.apply reopen_on_error [("", Lang.error error)])
-    with
-      | Some delay when 0. <= delay -> delay
-      | _ -> -1.
-  in
   let prefix = Lang.to_string (List.assoc "prefix" p) in
   let main_playlist_writer =
     Option.map
@@ -928,13 +911,8 @@ class hls_output p =
 
     method private apply_on_error ~bt exn =
       self#abort_current_segments;
-      match reopen_on_error ~bt exn with
-        | delay when delay < 0. -> Printexc.raise_with_backtrace exn bt
-        | delay ->
-            reopen_time <- Unix.gettimeofday () +. delay;
-            self#log#important
-              "Error while streaming: %s, will re-open in %.02fs"
-              (Printexc.to_string exn) delay
+      reopen_time <-
+        Pipe_output.reopen_time_on_error ~log:self#log reopen_on_error ~bt exn
 
     method! output =
       if reopen_time <= Unix.gettimeofday () then (

--- a/src/core/base/outputs/pipe_output.ml
+++ b/src/core/base/outputs/pipe_output.ml
@@ -238,6 +238,32 @@ let _ =
 let default_reopen_on_error =
   Lang.eval ~cache:false ~stdlib:`Disabled ~typecheck:false "fun (_) -> null"
 
+let reopen_on_error_proto default =
+  ( "reopen_on_error",
+    Lang.fun_t
+      [(false, "", Lang.nullable_t Lang.error_t)]
+      (Lang.nullable_t Lang.float_t),
+    Some default,
+    Some
+      "Callback called when there is an error. Error is raised when returning \
+       `null`. Otherwise, the output is reopened after the returned delay, in \
+       seconds." )
+
+(** Return the time at which the output should be reopened after an error,
+    according to a `reopen_on_error` callback. The error is re-raised when the
+    callback returns `null` or a negative delay. *)
+let reopen_time_on_error ~(log : Log.t) reopen_on_error ~bt exn =
+  let error = Lang.runtime_error_of_exception ~bt ~kind:"output" exn in
+  match
+    Lang.to_valued_option Lang.to_float
+      (Lang.apply reopen_on_error [("", Lang.error error)])
+  with
+    | Some delay when 0. <= delay ->
+        log#important "Error while streaming: %s, will re-open in %.02fs"
+          (Printexc.to_string exn) delay;
+        Unix.gettimeofday () +. delay
+    | _ -> Printexc.raise_with_backtrace exn bt
+
 let default_reopen_on_metadata =
   Lang.eval ~cache:false ~stdlib:`Disabled ~typecheck:false "fun (_) -> false"
 
@@ -247,15 +273,7 @@ let default_reopen_when =
 let pipe_proto frame_t arg_doc =
   base_proto
   @ [
-      ( "reopen_on_error",
-        Lang.fun_t
-          [(false, "", Lang.nullable_t Lang.error_t)]
-          (Lang.nullable_t Lang.float_t),
-        Some default_reopen_on_error,
-        Some
-          "Callback called when there is an error. Error is raised when \
-           returning `null`. Otherwise, the file is reopened after the \
-           returned value, in seconds." );
+      reopen_on_error_proto default_reopen_on_error;
       ( "reopen_on_metadata",
         Lang.fun_t [(false, "", Lang.metadata_t)] Lang.bool_t,
         Some default_reopen_on_metadata,
@@ -310,15 +328,6 @@ let pipe_meth =
 class virtual piped_output ?clock ~name p =
   let source = Lang.assoc "" 3 p in
   let reopen_on_error = List.assoc "reopen_on_error" p in
-  let reopen_on_error error =
-    let error = Lang.error error in
-    match
-      Lang.to_valued_option Lang.to_float
-        (Lang.apply reopen_on_error [("", error)])
-    with
-      | Some v when 0. <= v -> v
-      | _ -> -1.
-  in
   let reopen_on_metadata = List.assoc "reopen_on_metadata" p in
   let reopen_on_metadata m =
     let m = Lang.metadata m in
@@ -369,15 +378,7 @@ class virtual piped_output ?clock ~name p =
       List.iter (fun fn -> fn ()) on_reopen
 
     method private reopen_on_error ~bt exn =
-      let error = Lang.runtime_error_of_exception ~bt ~kind:"output" exn in
-      match reopen_on_error error with
-        | reopen_delay when reopen_delay < 0. ->
-            Printexc.raise_with_backtrace exn bt
-        | reopen_delay ->
-            open_date <- Unix.gettimeofday () +. reopen_delay;
-            self#log#important
-              "Error while streaming: %s, will re-open in %.02fs"
-              (Printexc.to_string exn) reopen_delay
+      open_date <- reopen_time_on_error ~log:self#log reopen_on_error ~bt exn
 
     method! output =
       try base#output

--- a/tests/regression/GH5259.liq
+++ b/tests/regression/GH5259.liq
@@ -1,0 +1,48 @@
+# Regression test for https://github.com/savonet/liquidsoap/issues/5259
+# A transient HLS filesystem error must not terminate the process.
+
+tmp_dir = file.temp_dir("GH5259")
+on_cleanup({file.rmdir(tmp_dir)})
+
+hls_dir = path.concat(tmp_dir, "hls")
+saved_dir = path.concat(tmp_dir, "hls.saved")
+made_unavailable = ref(false)
+error_seen = ref(false)
+
+def on_file_change({state, path = fname}) =
+  if
+    state == "created"
+    and string.contains(prefix="stream_", path.basename(fname))
+  then
+    if not made_unavailable() then
+      made_unavailable := true
+      file.move(atomic=true, hls_dir, saved_dir)
+      file.write(data="not a directory", hls_dir)
+    elsif error_seen() then
+      test.pass()
+    end
+  end
+end
+
+def on_error(_) =
+  error_seen := true
+  file.remove(hls_dir)
+  file.move(atomic=true, saved_dir, hls_dir)
+  0.1
+end
+
+output.dummy(id="primary", mksafe(buffer(sine())))
+
+o =
+  output.file.hls(
+    fallible=true,
+    reopen_on_error=on_error,
+    segment_duration=0.5,
+    hls_dir,
+    [("stream", %ffmpeg(format = "mpegts", %audio(codec = "aac")))],
+    sine()
+  )
+
+o.on_file_change(synchronous=true, on_file_change)
+
+thread.run(delay=20., {test.fail("HLS output did not recover")})

--- a/tests/regression/GH5259.liq
+++ b/tests/regression/GH5259.liq
@@ -7,8 +7,9 @@ on_cleanup({file.rmdir(tmp_dir)})
 hls_dir = path.concat(tmp_dir, "hls")
 saved_dir = path.concat(tmp_dir, "hls.saved")
 made_unavailable = ref(false)
-error_seen = ref(false)
 
+# A segment can only be created again after `on_error` has restored `hls_dir`,
+# so a second "created" event proves the output recovered from the error.
 def on_file_change({state, path = fname}) =
   if
     state == "created"
@@ -18,20 +19,17 @@ def on_file_change({state, path = fname}) =
       made_unavailable := true
       file.move(atomic=true, hls_dir, saved_dir)
       file.write(data="not a directory", hls_dir)
-    elsif error_seen() then
+    else
       test.pass()
     end
   end
 end
 
 def on_error(_) =
-  error_seen := true
   file.remove(hls_dir)
   file.move(atomic=true, saved_dir, hls_dir)
   0.1
 end
-
-output.dummy(id="primary", mksafe(buffer(sine())))
 
 o =
   output.file.hls(

--- a/tests/regression/dune.inc
+++ b/tests/regression/dune.inc
@@ -1252,6 +1252,24 @@
   (run %{run_test} GH5148 liquidsoap %{test_liq} GH5148.liq)))
 
 (rule
+ (alias test_GH5259)
+ (package liquidsoap)
+ (deps
+  GH5259.liq
+  (glob_files ../media/**)
+  ../liquidsoap-test-assets
+  ../../src/bin/liquidsoap.exe
+  ../streams/file1.png
+  ../streams/file1.mp3
+  ./theora-test.mp4
+  (package liquidsoap)
+  (source_tree ../../src/libs)
+  (:test_liq ../test.liq)
+  (:run_test ../run_test.exe))
+ (action
+  (run %{run_test} GH5259 liquidsoap %{test_liq} GH5259.liq)))
+
+(rule
  (alias test_LS268)
  (package liquidsoap)
  (deps
@@ -2000,6 +2018,7 @@
   (alias test_GH5084)
   (alias test_GH5110)
   (alias test_GH5148)
+  (alias test_GH5259)
   (alias test_LS268)
   (alias test_LS354-1)
   (alias test_LS354-2)


### PR DESCRIPTION
## Summary

- add `reopen_on_error` support to `output.file.hls`, with a default two-second retry delay
- abort incomplete temporary segments after an error while preserving published HLS state and marking the resumed stream as discontinuous
- share `reopen_on_error` parsing and retry scheduling with the existing piped file outputs
- add a regression test that makes the HLS output path unavailable and verifies that segment generation resumes

## Testing

- `GH5259`
- `GH2756`
- `GH2756-2`

Fixes #5259