### PR TITLE
HLS: validate writable directories at startup

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -37,6 +37,8 @@
 
 ## Fixed:
 
+- Fixed `output.file.hls` accepting unwritable output and temporary directories
+  during initialization (#5261).
 - Fixed ID3 timed metadata missing from first mpegts HLS segment: metadata is
   now registered before the segment is opened and before data is encoded (#5084).
 - Make active `stereotool` really be active.. (#4882)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -37,8 +37,8 @@
 
 ## Fixed:
 
-- Fixed `output.file.hls` accepting unwritable output and temporary directories
-  during initialization (#5261).
+- Fixed `output.file.hls` accepting unwritable output, temporary and
+  `persist_at` directories during initialization (#5261).
 - Fixed ID3 timed metadata missing from first mpegts HLS segment: metadata is
   now registered before the segment is opened and before data is encoded (#5084).
 - Make active `stereotool` really be active.. (#4882)

--- a/src/core/base/outputs/hls_output.ml
+++ b/src/core/base/outputs/hls_output.ml
@@ -343,6 +343,19 @@ let string_of_file_state = function
   | `Updated -> "updated"
   | `Deleted -> "deleted"
 
+let validate_writable_directory ~descr value directory =
+  try
+    let probe = Filename.temp_file ~temp_dir:directory "liq" "tmp" in
+    Sys.remove probe
+  with exn ->
+    raise
+      (Error.Invalid_value
+         ( value,
+           Printf.sprintf "Could not write to %s %s: %s" descr
+             (Lang_string.quote_string directory)
+             (Printexc.to_string exn),
+           [] ))
+
 class hls_output p =
   let autostart = Lang.to_bool (List.assoc "start" p) in
   let infallible = not (Lang.to_bool (List.assoc "fallible" p)) in
@@ -386,9 +399,8 @@ class hls_output p =
   in
   let perms = Lang.to_int (List.assoc "perm" p) in
   let dir_perm = Lang.to_int (List.assoc "dir_perm" p) in
-  let temp_dir =
-    Lang.to_valued_option Lang.to_string (List.assoc "temp_dir" p)
-  in
+  let temp_dir_val = List.assoc "temp_dir" p in
+  let temp_dir = Lang.to_valued_option Lang.to_string temp_dir_val in
   let () =
     if
       (not (Sys.file_exists hls_directory))
@@ -399,6 +411,13 @@ class hls_output p =
         raise
           (Error.Invalid_value
              (directory_val, "Could not create or open output directory!", [])))
+  in
+  let () =
+    validate_writable_directory ~descr:"output directory" directory_val
+      hls_directory;
+    Option.iter
+      (validate_writable_directory ~descr:"temporary directory" temp_dir_val)
+      temp_dir
   in
   let persist_at =
     Option.map

--- a/src/core/base/outputs/hls_output.ml
+++ b/src/core/base/outputs/hls_output.ml
@@ -419,6 +419,7 @@ class hls_output p =
       (validate_writable_directory ~descr:"temporary directory" temp_dir_val)
       temp_dir
   in
+  let persist_at_val = List.assoc "persist_at" p in
   let persist_at =
     Option.map
       (fun filename ->
@@ -432,15 +433,18 @@ class hls_output p =
          with exn ->
            raise
              (Error.Invalid_value
-                ( List.assoc "persist_at" p,
+                ( persist_at_val,
                   Printf.sprintf
                     "Error while creating directory for persisting state at \
                      %s: %s"
                     (Lang_string.quote_string filename)
                     (Printexc.to_string exn),
                   [] )));
+        validate_writable_directory ~descr:"persistence directory"
+          persist_at_val
+          (Filename.dirname filename);
         filename)
-      (Lang.to_option (List.assoc "persist_at" p))
+      (Lang.to_option persist_at_val)
   in
   let strict_persist = Lang.to_bool (List.assoc "strict_persist" p) in
   (* better choice? *)

--- a/tests/regression/GH5261.liq
+++ b/tests/regression/GH5261.liq
@@ -1,0 +1,51 @@
+# Regression test for https://github.com/savonet/liquidsoap/issues/5261
+# HLS output and temporary directories must be writable during initialization.
+
+tmp_dir = file.temp_dir("GH5261")
+on_cleanup({file.rmdir(tmp_dir)})
+
+def make_unwritable(name) =
+  dir = path.concat(tmp_dir, name)
+  file.mkdir(dir)
+  if not process.test("chmod 0555 #{process.quote(dir)}") then
+    test.fail("Could not make test directory unwritable")
+  end
+  on_cleanup({ignore(process.run("chmod 0755 #{process.quote(dir)}"))})
+  dir
+end
+
+def expect_invalid(~temp_dir="null", ~message, output_dir) =
+  script = file.temp("GH5261", ".liq")
+  on_cleanup({file.remove(script)})
+  file.write(
+    data="output.file.hls(start=false,temp_dir=#{temp_dir},#{
+      string.quote(output_dir)
+    },[(\"stream\",%ffmpeg(format=\"mpegts\",%audio(codec=\"aac\")))],sine())",
+    script
+  )
+  result =
+    process.run(
+      "#{process.quote(liquidsoap.executable)} -q --no-stdlib #{
+        process.quote(script)
+      }"
+    )
+  child_output = result.stdout ^ result.stderr
+  if
+    result.status != "exit"
+    or result.status.code == 0
+    or not string.contains(substring=message, child_output)
+  then
+    test.fail("HLS did not reject an unwritable directory: #{child_output}")
+  end
+end
+
+expect_invalid(
+  message="Could not write to output directory",
+  make_unwritable("output")
+)
+expect_invalid(
+  temp_dir=string.quote(make_unwritable("temporary")),
+  message="Could not write to temporary directory",
+  path.concat(tmp_dir, "writable")
+)
+test.pass()

--- a/tests/regression/GH5261.liq
+++ b/tests/regression/GH5261.liq
@@ -1,32 +1,43 @@
 # Regression test for https://github.com/savonet/liquidsoap/issues/5261
-# HLS output and temporary directories must be writable during initialization.
+# HLS output, temporary and persistence directories must be writable during
+# initialization.
 
-tmp_dir = file.temp_dir("GH5261")
-on_cleanup({file.rmdir(tmp_dir)})
+tmp_dir = file.temp_dir(cleanup=true, "GH5261")
 
 def make_unwritable(name) =
   dir = path.concat(tmp_dir, name)
   file.mkdir(dir)
-  if not process.test("chmod 0555 #{process.quote(dir)}") then
-    test.fail("Could not make test directory unwritable")
+  if
+    not process.test(
+      "chmod 0555 #{process.quote(dir)}"
+    )
+  then
+    test.fail(
+      "Could not make test directory unwritable"
+    )
   end
-  on_cleanup({ignore(process.run("chmod 0755 #{process.quote(dir)}"))})
+  on_cleanup(
+    {
+      ignore(
+        process.run(
+          "chmod 0755 #{process.quote(dir)}"
+        )
+      )
+    }
+  )
   dir
 end
 
-def expect_invalid(~temp_dir="null", ~message, output_dir) =
-  script = file.temp("GH5261", ".liq")
-  on_cleanup({file.remove(script)})
-  file.write(
-    data="output.file.hls(start=false,temp_dir=#{temp_dir},#{
+def expect_invalid(~args="", ~message, output_dir) =
+  code =
+    "output.file.hls(start=false,#{args}#{
       string.quote(output_dir)
-    },[(\"stream\",%ffmpeg(format=\"mpegts\",%audio(codec=\"aac\")))],sine())",
-    script
-  )
+    },[(\"stream\",%ffmpeg(format=\"mpegts\",%audio(codec=\"aac\")))],sine())"
   result =
     process.run(
+      timeout=30.,
       "#{process.quote(liquidsoap.executable)} -q --no-stdlib #{
-        process.quote(script)
+        process.quote(code)
       }"
     )
   child_output = result.stdout ^ result.stderr
@@ -35,17 +46,31 @@ def expect_invalid(~temp_dir="null", ~message, output_dir) =
     or result.status.code == 0
     or not string.contains(substring=message, child_output)
   then
-    test.fail("HLS did not reject an unwritable directory: #{child_output}")
+    test.fail(
+      "HLS did not reject an unwritable directory: #{child_output}"
+    )
   end
 end
+
+writable_dir = path.concat(tmp_dir, "writable")
 
 expect_invalid(
   message="Could not write to output directory",
   make_unwritable("output")
 )
+
+temporary_dir = make_unwritable("temporary")
 expect_invalid(
-  temp_dir=string.quote(make_unwritable("temporary")),
+  args="temp_dir=#{string.quote(temporary_dir)},",
   message="Could not write to temporary directory",
-  path.concat(tmp_dir, "writable")
+  writable_dir
 )
+
+persist_file = path.concat(make_unwritable("persist"), "state.json")
+expect_invalid(
+  args="persist_at=#{string.quote(persist_file)},",
+  message="Could not write to persistence directory",
+  writable_dir
+)
+
 test.pass()

--- a/tests/regression/dune.inc
+++ b/tests/regression/dune.inc
@@ -1252,6 +1252,24 @@
   (run %{run_test} GH5148 liquidsoap %{test_liq} GH5148.liq)))
 
 (rule
+ (alias test_GH5261)
+ (package liquidsoap)
+ (deps
+  GH5261.liq
+  (glob_files ../media/**)
+  ../liquidsoap-test-assets
+  ../../src/bin/liquidsoap.exe
+  ../streams/file1.png
+  ../streams/file1.mp3
+  ./theora-test.mp4
+  (package liquidsoap)
+  (source_tree ../../src/libs)
+  (:test_liq ../test.liq)
+  (:run_test ../run_test.exe))
+ (action
+  (run %{run_test} GH5261 liquidsoap %{test_liq} GH5261.liq)))
+
+(rule
  (alias test_LS268)
  (package liquidsoap)
  (deps
@@ -2000,6 +2018,7 @@
   (alias test_GH5084)
   (alias test_GH5110)
   (alias test_GH5148)
+  (alias test_GH5261)
   (alias test_LS268)
   (alias test_LS354-1)
   (alias test_LS354-2)


### PR DESCRIPTION
## Summary

- probe the HLS output directory during operator initialization to verify that files can be created and removed
- apply the same validation to an explicitly configured `temp_dir`
- report failures as `Error.Invalid_value` against the relevant operator argument before clocks start
- add regression coverage for unwritable output and temporary directories

## Testing

- `GH5261`
- `GH2926`
- release build of `src/bin/liquidsoap.exe`

Fixes #5261