### PR TITLE
fix ICY metadata negotiation

### DIFF
--- a/src/core/base/outputs/harbor_output.ml
+++ b/src/core/base/outputs/harbor_output.ml
@@ -618,7 +618,7 @@ class virtual ['a] base p =
       in
       let metadata_interval, icy_header =
         try
-          assert (List.assoc "Icy-MetaData" headers = "1");
+          assert (List.assoc "icy-metadata" headers = "1");
           (metaint, Printf.sprintf "icy-metaint: %d\r\n" metaint)
         with _ -> (-1, "")
       in


### PR DESCRIPTION
HTTP request headers are normalised before being passed to handlers, which means lookups for non-normalised headers will always fail. In this case, "Icy-MetaData" should be normalised as "icy-metadata".

Tested a built binary before / after with this script:

```test.liq
settings.log.stdout.set(true)
settings.log.level.set(3)

test_source = sine(amplitude=0.1, 440.)

output.harbor(
  %mp3(bitrate=128, samplerate=44100, stereo=true),
  id="test",
  port=8500,
  mount="/stream.mp3",
  metaint=512,
  burst=0,
  test_source
)

thread.run(
  every=1.,
  fun () ->
    test_source.insert_metadata([
      ("artist", "Test artist"),
      ("title", "Test title")
    ])
)
```

```sh
curl --max-time 5 \
    -H 'Icy-MetaData: 1' \
    -D response.headers \
    -o response.body \
    http://127.0.0.1:18500/stream.mp3
```

Without the fix, the `icy-metaint: 512` HTTP response header is missing, and there is no StreamTitle in the response body.