### PR TITLE
Fix delay getting stuck after its first track

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -37,6 +37,8 @@
 
 ## Fixed:
 
+- Fixed `delay` getting stuck after its first track and dropping the following
+  track's metadata (#5282).
 - Fixed `output.file.hls` terminating the process on transient filesystem
   errors. The output now supports a `reopen_on_error` callback (#5259).
 - Fixed `output.file.hls` accepting unwritable output, temporary and

--- a/src/core/base/operators/delay.ml
+++ b/src/core/base/operators/delay.ml
@@ -40,7 +40,7 @@ class delay ~initial (source : source) delay =
   object (self)
     inherit operator ~name:"delay" [source]
     val mutable last_track = initial_last_track
-    val mutable first_track = true
+    val mutable initial_track = true
     method fallible = true
     method remaining = source#remaining
 
@@ -51,19 +51,31 @@ class delay ~initial (source : source) delay =
     method effective_source = source#effective_source
     method self_sync = source#self_sync
     method private delay_ok = delay_ok last_track
-    method private can_generate_frame = self#delay_ok && source#is_ready
+
+    method private can_generate_frame =
+      self#delay_ok && (Generator.length self#buffer > 0 || source#is_ready)
 
     method private generate_frame =
-      let frame = source#get_frame in
-      match self#split_frame frame with
-        | buf, Some _ when first_track && Frame.position buf = 0 ->
-            first_track <- false;
-            frame
-        | buf, Some _ ->
-            first_track <- false;
-            last_track <- time ();
-            buf
-        | buf, None -> buf
+      (* At a track boundary we save the next track's start (which carries its
+         track mark and metadata) and start the delay. Once it has elapsed we
+         serve that start from the buffer, so the next track begins on a clean
+         boundary without losing its metadata. *)
+      if Generator.length self#buffer > 0 then
+        Generator.slice self#buffer (Lazy.force Frame.size)
+      else (
+        let frame = source#get_frame in
+        match self#split_frame frame with
+          | _, Some starting when initial_track ->
+              initial_track <- false;
+              Generator.append self#buffer starting;
+              Generator.slice self#buffer (Lazy.force Frame.size)
+          | buf, Some starting ->
+              last_track <- time ();
+              Generator.append self#buffer starting;
+              buf
+          | buf, None ->
+              initial_track <- false;
+              buf)
   end
 
 let _ =

--- a/tests/regression/delay_gap.liq
+++ b/tests/regression/delay_gap.liq
@@ -1,0 +1,24 @@
+# Regression test: delay(d, s) must keep s unavailable for d seconds between
+# tracks, i.e. the gap must actually be applied. We chop a sine into short
+# tracks and require consecutive track boundaries to be at least half the delay
+# apart (they would only be ~every apart without the delay).
+
+s = sine()
+s = chop(every=0.2, s)
+s = delay(1.0, s)
+
+last = ref(null)
+s.on_track(
+  synchronous=true,
+  fun (_) ->
+    begin
+      t = time()
+      prev = last()
+      last := t
+      if null.defined(prev) and t - null.get(prev) >= 0.5 then test.pass() end
+    end
+)
+
+output.dummy(fallible=true, s)
+
+thread.run(delay=15., {test.fail()})

--- a/tests/regression/delay_track_advance.liq
+++ b/tests/regression/delay_track_advance.liq
@@ -1,0 +1,37 @@
+# Regression test: delay(d, s) must let s advance through successive tracks and
+# preserve each track's metadata.
+#
+# delay used to reset its timer on the leading track mark of every new track,
+# not just the first, so a delayed source got stuck on its first track forever.
+# It also returned the pre-mark content at each boundary and dropped the
+# post-mark content, losing the next track's metadata. Here we chop a sine into
+# tracks with distinct, incrementing titles and check that at least three
+# distinct titles make it through the delay.
+
+count = ref(0)
+def next_metadata() =
+  i = count()
+  ref.incr(count)
+  [("title", "t#{i}")]
+end
+
+s = sine()
+s = chop(every=0.5, metadata=next_metadata, s)
+s = delay(0.3, s)
+
+seen = ref([])
+s.on_metadata(
+  synchronous=true,
+  fun (m) ->
+    begin
+      title = m["title"]
+      if title != "" and not list.mem(title, seen()) then
+        seen := [...seen(), title]
+      end
+      if list.length(seen()) >= 3 then test.pass() end
+    end
+)
+
+output.dummy(fallible=true, s)
+
+thread.run(delay=15., {test.fail()})

--- a/tests/regression/dune.inc
+++ b/tests/regression/dune.inc
@@ -1468,6 +1468,47 @@
   (run %{run_test} default_format liquidsoap %{test_liq} default_format.liq)))
 
 (rule
+ (alias test_delay_gap)
+ (package liquidsoap)
+ (deps
+  delay_gap.liq
+  (glob_files ../media/**)
+  ../liquidsoap-test-assets
+  ../../src/bin/liquidsoap.exe
+  ../streams/file1.png
+  ../streams/file1.mp3
+  ./theora-test.mp4
+  (package liquidsoap)
+  (source_tree ../../src/libs)
+  (:test_liq ../test.liq)
+  (:run_test ../run_test.exe))
+ (action
+  (run %{run_test} delay_gap liquidsoap %{test_liq} delay_gap.liq)))
+
+(rule
+ (alias test_delay_track_advance)
+ (package liquidsoap)
+ (deps
+  delay_track_advance.liq
+  (glob_files ../media/**)
+  ../liquidsoap-test-assets
+  ../../src/bin/liquidsoap.exe
+  ../streams/file1.png
+  ../streams/file1.mp3
+  ./theora-test.mp4
+  (package liquidsoap)
+  (source_tree ../../src/libs)
+  (:test_liq ../test.liq)
+  (:run_test ../run_test.exe))
+ (action
+  (run
+   %{run_test}
+   delay_track_advance
+   liquidsoap
+   %{test_liq}
+   delay_track_advance.liq)))
+
+(rule
  (alias test_double-nullable)
  (package liquidsoap)
  (deps
@@ -2048,6 +2089,8 @@
   (alias test_append-merge2)
   (alias test_cleanup)
   (alias test_default_format)
+  (alias test_delay_gap)
+  (alias test_delay_track_advance)
   (alias test_double-nullable)
   (alias test_eval-check-demeth)
   (alias test_external-encoder)


### PR DESCRIPTION
`delay` reset its timer on every new track's leading mark, not just the first one, so a delayed source (e.g. `delay(d, playlist(...))`) got stuck on its first track forever and dropped the following track's metadata.

This saves the next track's start at each boundary and serves it once the delay has elapsed, so tracks advance on clean boundaries with their metadata intact.

Adds regression tests for track advancement / metadata preservation and for the inter-track gap.
