### PR TITLE
Require delay to be applied to a leaf source

### DIFF
--- a/src/core/base/operators/delay.ml
+++ b/src/core/base/operators/delay.ml
@@ -44,6 +44,20 @@ class delay ~initial (source : source) delay =
     method fallible = true
     method remaining = source#remaining
 
+    (* delay controls when [source] advances by leaving it unavailable between
+       tracks. This only works if [source] is animated solely by us, so refuse
+       any other consumer as soon as it activates the source. *)
+    initializer
+      source#on_activation (fun () ->
+          if List.length source#activations > 1 then
+            Lang.raise_error ~pos:[]
+              ~message:
+                (Printf.sprintf
+                   "delay must be applied to a leaf source such as a dedicated \
+                    playlist or single, but %s is shared with another consumer"
+                   source#id)
+              "invalid")
+
     method abort_track =
       last_track <- time ();
       source#abort_track
@@ -95,11 +109,23 @@ let _ =
       ("", Lang.source_t return_t, None, None);
     ]
     ~category:`Track
-    ~descr:"Make the source unavailable for a given time between tracks."
+    ~descr:
+      "Make the source unavailable for a given time between tracks. Because \
+       delay controls when its source advances by leaving it unavailable \
+       between tracks, it must be applied to a leaf source that it animates on \
+       its own, such as a dedicated `playlist` or `single`: an active source \
+       or a source shared with another operator would make it inconsistent."
     ~return_t
     (fun p ->
       let f n = Lang.assoc "" n p in
       let d = Lang.to_float_getter (f 1) in
       let s = Lang.to_source (f 2) in
+      if s#active then
+        raise
+          (Error.Invalid_value
+             ( f 2,
+               "delay must be applied to a leaf source such as a dedicated \
+                playlist or single, but the given source is active",
+               [] ));
       let initial = Lang.to_bool (List.assoc "initial" p) in
       new delay ~initial s d)

--- a/src/core/base/source.ml
+++ b/src/core/base/source.ml
@@ -331,6 +331,8 @@ class virtual operator ?(stack = []) ?clock ~name sources =
 
     val mutable on_wake_up = []
     method on_wake_up fn = on_wake_up <- on_wake_up @ [fn]
+    val mutable on_activation = []
+    method on_activation fn = on_activation <- on_activation @ [fn]
 
     initializer
       self#on_wake_up (fun () ->
@@ -382,6 +384,7 @@ class virtual operator ?(stack = []) ?clock ~name sources =
             (Printf.sprintf "Error while starting source %s: %s!" self#id
                (Printexc.to_string exn));
           Printexc.raise_with_backtrace exn bt);
+      List.iter (fun fn -> fn ()) on_activation;
       activation
 
     val mutable on_sleep = []

--- a/src/core/base/source.mli
+++ b/src/core/base/source.mli
@@ -172,6 +172,10 @@ object
   (** Register a callback when wake_up is called. *)
   method on_wake_up : (unit -> unit) -> unit
 
+  (** Register a callback called on every activation, i.e. each time [wake_up]
+      is called, not just the first one. *)
+  method on_activation : (unit -> unit) -> unit
+
   (** Called when the source must be ready. Each call to [wake_up] must be
       matched by a corresponding call to [sleep] with the returned activation to
       allow the source to sleep and be collected. Can be called multiple times


### PR DESCRIPTION
`delay` controls when its source advances by leaving it unavailable between tracks, which only works when it animates that source on its own. Applying it to an active source, or to a source that is also consumed by another operator, makes it inconsistent.

This rejects active sources at instantiation and adds a `on_activation` source hook, called on every activation rather than just the first, so `delay` errors out as soon as any other consumer activates its source. The operator doc now states it must be applied to a leaf source such as a dedicated `playlist` or `single`.
