### PR TITLE
Fix sequence dropping the first chunk of the source it moves to.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -43,6 +43,11 @@
 
 - Fixed `delay` getting stuck after its first track and dropping the following
   track's metadata (#5282).
+- Fixed `sequence` dropping the first chunk of a source, along with its
+  metadata, when the source it follows leaves no room in the current frame.
+  This showed up as the track after a `cross`/`crossfade` transition built with
+  `sequence` keeping the previous track's metadata until the next track
+  boundary (#TODO).
 - Fixed `output.file.hls` terminating the process on transient filesystem
   errors. The output now supports a `reopen_on_error` callback (#5259).
 - Fixed `output.file.hls` accepting unwritable output, temporary and

--- a/src/core/base/operators/sequence.ml
+++ b/src/core/base/operators/sequence.ml
@@ -84,9 +84,13 @@ class sequence ?(name = "sequence") ?(merge = false) ?(single_track = true)
               Atomic.set seq_sources rest;
               self#release_source s;
               self#notify_sync_source (snd self#self_sync);
-              self#get_stateful_source ~source_skipped:true
-                ~reselect:(match reselect with `Force -> `Ok | v -> v)
-                ())
+              (* The source we just moved to has not been read yet during this
+                 streaming cycle, so a position constraint computed against the
+                 source we are done with does not apply to it. Carrying
+                 `After_position` over rejects a source that has no more samples
+                 available than the one it follows, silently dropping its first
+                 chunk along with the metadata it carries. *)
+              self#get_stateful_source ~source_skipped:true ~reselect:`Ok ())
         | _ -> None
 
     method private get_source ~reselect () =

--- a/tests/streams/cross-sequence-transition.liq
+++ b/tests/streams/cross-sequence-transition.liq
@@ -1,0 +1,73 @@
+# A transition returning `sequence([before, after])` only pulls the incoming
+# source once the outgoing one is done. `b` sets a cross duration of a single
+# frame and its duration leaves a partial frame, so both sources end up in the
+# same frame with exactly as many samples available. The incoming source used to
+# be rejected there, dropping its first chunk along with `c`'s metadata, which
+# left the stream advertising `b` until the next track boundary.
+
+success = ref(false)
+
+a = sine(duration=4., 440.)
+a =
+  metadata.map(
+    insert_missing=true,
+    id="a",
+    update=false,
+    (fun (_) -> [("source", "a"), ("liq_cross_duration", "2.")]),
+    a
+  )
+
+b = sine(duration=4.02, 880.)
+b =
+  metadata.map(
+    insert_missing=true,
+    id="b",
+    update=false,
+    (fun (_) -> [("source", "b"), ("liq_cross_duration", "0.")]),
+    b
+  )
+
+c = sine(duration=4., 440.)
+c =
+  metadata.map(
+    insert_missing=true,
+    id="c",
+    update=false,
+    (fun (_) -> [("source", "c"), ("liq_cross_duration", "2.")]),
+    c
+  )
+
+s = sequence([a, b, c])
+
+def transition(before, after) =
+  sequence([before.source, after.source])
+end
+
+s = cross(duration=2., transition, s)
+
+track_count = ref(0)
+
+def on_metadata(m) =
+  ref.incr(track_count)
+
+  if track_count() == 1 then if m["source"] != "a" then test.fail() end end
+
+  if track_count() == 2 then if m["source"] != "b" then test.fail() end end
+
+  if
+    track_count() == 3
+  then
+    if m["source"] != "c" then test.fail() end
+    success := true
+  end
+end
+
+s.on_metadata(synchronous=true, on_metadata)
+clock.assign_new(sync="none", [s])
+
+def on_stop() =
+  if success() then test.pass() else test.fail() end
+end
+
+o = output.dummy(fallible=true, s)
+o.on_stop(synchronous=true, on_stop)

--- a/tests/streams/dune.inc
+++ b/tests/streams/dune.inc
@@ -169,6 +169,42 @@
    cross-persist-override.liq)))
 
 (rule
+ (alias test_cross-sequence-transition)
+ (package liquidsoap)
+ (deps
+  cross-sequence-transition.liq
+  ./file1.mp3
+  ./file2.mp3
+  ./file3.mp3
+  ./jingle1.mp3
+  ./jingle2.mp3
+  ./jingle3.mp3
+  ./file1.png
+  ./file2.png
+  ./jingles
+  ./playlist
+  ./huge_playlist
+  ./replaygain_track_gain.mp3
+  ./r128_track_gain.mp3
+  ./replaygain_r128_track_gain.mp3
+  ./replaygain_track_gain.opus
+  ./r128_track_gain.opus
+  ./replaygain_r128_track_gain.opus
+  ./without_replaygain_track_gain.mp3
+  ../media/test-subtitle.srt
+  ../../src/bin/liquidsoap.exe
+  (package liquidsoap)
+  (:test_liq ../test.liq)
+  (:run_test ../run_test.exe))
+ (action
+  (run
+   %{run_test}
+   cross-sequence-transition.liq
+   liquidsoap
+   %{test_liq}
+   cross-sequence-transition.liq)))
+
+(rule
  (alias test_cross)
  (package liquidsoap)
  (deps
@@ -2403,6 +2439,7 @@
   (alias test_cross)
   (alias test_cross-override)
   (alias test_cross-persist-override)
+  (alias test_cross-sequence-transition)
   (alias test_crossfade)
   (alias test_crossfade2)
   (alias test_ctype1)


### PR DESCRIPTION
When `sequence` is done with a source mid-frame it advances to the next one but carries the `After_position` reselect constraint over. That position was computed against the source we just finished with and does not apply to a source that has not been read yet during this streaming cycle, so a source with no more samples available than the one it follows gets rejected and its first chunk is silently dropped, along with the metadata it carries.

This shows up with `cross`/`crossfade` transitions built with `sequence([before, after])`: when the outgoing track sets a cross duration of a single frame, `create_after` hands both sides buffers of the same length, the incoming side is rejected and the stream keeps advertising the outgoing track's metadata until the next track boundary.