### PR TITLE
lang: statement-based blocks, unified bindings, lexed interpolation

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,7 +26,7 @@ repos:
         exclude: (dune.inc|fixtures/)
 
   - repo: https://github.com/savonet/pre-commit-liquidsoap
-    rev: 404acb1cec01cbd327d1e73702950ebf00714204
+    rev: 6c5b79e26d81a71f38f1f32a39e2cb71db6e3e77
     hooks:
       - id: liquidsoap-prettier
       - id: prettier

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -27,6 +27,12 @@
 
 ## Changed:
 
+- Bindings written without `let` accept the same targets as `let`: destructuring patterns, field paths and type
+  annotations. `(x, y) = (1, 2)`, `r.field = 1` and `(n : int) = 2` are all valid. A leading binding inside the
+  `{ … }` function shorthand still requires `let`, since `{ x = 1 }` is a record literal. An invalid left-hand side
+  reports what is allowed instead of a bare syntax error.
+- String interpolation accepts any expression: `"#{m["key"]}"`, `"#{ {a = 1}.a }"` and nested interpolated strings
+  now work. Error positions inside `#{ … }` point at the offending code rather than at the start of the string.
 - `http.transport.ssl` and `http.transport.tls`: `key` parameter is now optional in server mode when the certificate file also contains the private key.
 - `switch`, `fallback`, `rotate`, `random`: replaced the parallel list parameters
   (`transitions`, `transition_length`, `override`, `track_sensitive`,

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -120,6 +120,10 @@
   of the segment grid. The drift rate depends on the encoder's frame size, so
   variants using different codecs, e.g. HE-AAC and AAC-LC, diverged from each
   other without bound (#5319).
+- The names liquidsoap's syntactic sugar expands to are no longer writable in a script: they now start with an
+  underscore followed by a digit, which the lexer does not accept as an identifier, so user code cannot shadow what
+  `let eval`, `let json.parse`, `let xml.parse`, `let yaml.parse`, `let sqlite.row`/`sqlite.query` or `%argsof` expand
+  to. `_null` is unchanged, being a real callable builtin.
 - Record fields are evaluated when the record is built, whether or not they are ever invoked. Previously a field of a
   record that was invoked directly, as in `{a = 1, b = f()}.a`, was dropped along with its effects when running a
   script normally, but not under `--interactive` or in the standard library, and not if the record was bound to a name

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -120,6 +120,10 @@
   of the segment grid. The drift rate depends on the encoder's frame size, so
   variants using different codecs, e.g. HE-AAC and AAC-LC, diverged from each
   other without bound (#5319).
+- Record fields are evaluated when the record is built, whether or not they are ever invoked. Previously a field of a
+  record that was invoked directly, as in `{a = 1, b = f()}.a`, was dropped along with its effects when running a
+  script normally, but not under `--interactive` or in the standard library, and not if the record was bound to a name
+  first.
 - Inline `ffmpeg.encode.*` operators report unrecognized codec options, as the
   container encoder does.
 - Fixed `%ffmpeg` copy encoder initializing the video stream twice and setting the

--- a/doc/content/language.md
+++ b/doc/content/language.md
@@ -144,6 +144,15 @@ print("The number #{random.float()} is random.")
 will print `The number 0.663455738438 is random.` (at least it did last time I
 tried).
 
+The interpolated expression is ordinary Liquidsoap code, so it can contain
+strings, records and further interpolations:
+
+```liquidsoap
+m = [("key", "value")]
+print("got #{m["key"]}")
+print("a #{ {a = 1}.a } b")
+```
+
 #### Raw strings
 
 When a string should be taken verbatim — without any interpolation or escape
@@ -1083,6 +1092,26 @@ reading the code.
 
 Patterns are constructed using _variable placeholders_, which are either a variable name such as: `x`, `foo`, etc. or
 the special symbol `_` for any ignored value.
+
+The `let` keyword is optional: a pattern, a field path or a type annotation can all appear on the left of a plain `=`.
+
+```liquidsoap
+(x, y) = (1, 2)
+[a, b] = [3, 4]
+(n : int) = 5
+
+r = {}
+r.field = 6
+```
+
+There is one exception. Inside the `{ … }` function shorthand a _leading_ binding must use `let`, because `{ x = 1 }`
+is a record literal:
+
+```liquidsoap
+f = { let x = 1; x + 1 }
+```
+
+Only the first statement is affected; the ones after it can be written either way.
 
 ### Tuple patterns
 

--- a/doc/content/liq/enc-ffmpeg.liq
+++ b/doc/content/liq/enc-ffmpeg.liq
@@ -2,5 +2,9 @@ source = sine()
 
 # BEGIN
 # AAC audio in an MPEG-TS container
-output.file(%ffmpeg(format="mpegts", %audio(codec="aac", b="128k")), "/tmp/out.ts", source)
+output.file(
+  %ffmpeg(format = "mpegts", %audio(codec = "aac", b = "128k")),
+  "/tmp/out.ts",
+  source
+)
 # END

--- a/doc/content/liq/enc-flac.liq
+++ b/doc/content/liq/enc-flac.liq
@@ -2,7 +2,11 @@ source = sine()
 
 # BEGIN
 # Lossless archive
-output.file(%flac(compression=8, bits_per_sample=24), "/tmp/archive.flac", source)
+output.file(
+  %flac(compression = 8, bits_per_sample = 24),
+  "/tmp/archive.flac",
+  source
+)
 
 # Streamable Ogg/FLAC
 output.icecast(%ogg(%flac), host="myserver", mount="stream.flac", source)

--- a/doc/content/liq/enc-mp3.liq
+++ b/doc/content/liq/enc-mp3.liq
@@ -2,14 +2,18 @@ source = sine()
 
 # BEGIN
 # Standard 128 kbps stereo stream
-output.icecast(%mp3(bitrate=128), host="myserver", mount="stream.mp3", source)
+output.icecast(%mp3(bitrate = 128), host="myserver", mount="stream.mp3", source)
 
 # High-quality VBR archive
-output.file(%mp3.vbr(quality=0), "/tmp/archive.mp3", source)
+output.file(%mp3.vbr(quality = 0), "/tmp/archive.mp3", source)
 
 # Average bitrate with bounds
-output.file(%mp3.abr(bitrate=192, min_bitrate=128, max_bitrate=320), "/tmp/out.mp3", source)
+output.file(
+  %mp3.abr(bitrate = 192, min_bitrate = 128, max_bitrate = 320),
+  "/tmp/out.mp3",
+  source
+)
 
 # Low-bitrate mono speech (use mean() to downmix stereo to mono)
-output.file(%mp3(bitrate=32, mono=true), "/tmp/speech.mp3", mean(source))
+output.file(%mp3(bitrate = 32, mono = true), "/tmp/speech.mp3", mean(source))
 # END

--- a/doc/content/liq/enc-opus.liq
+++ b/doc/content/liq/enc-opus.liq
@@ -2,11 +2,26 @@ source = sine()
 
 # BEGIN
 # General-purpose music stream
-output.icecast(%opus(bitrate=128), host="myserver", mount="stream.opus", source)
+output.icecast(
+  %opus(bitrate = 128),
+  host="myserver",
+  mount="stream.opus",
+  source
+)
 
 # Low-bitrate voice stream (use mean() to downmix stereo to mono)
-output.icecast(%opus(bitrate=24, application="voip", signal="voice", channels=1), host="myserver", mount="stream-voice.opus", mean(source))
+output.icecast(
+  %opus(bitrate = 24, application = "voip", signal = "voice", channels = 1),
+  host="myserver",
+  mount="stream-voice.opus",
+  mean(source)
+)
 
 # Low-latency real-time audio
-output.icecast(%opus(frame_size=10., application="restricted_lowdelay"), host="myserver", mount="stream-ll.opus", source)
+output.icecast(
+  %opus(frame_size = 10., application = "restricted_lowdelay"),
+  host="myserver",
+  mount="stream-ll.opus",
+  source
+)
 # END

--- a/doc/content/liq/enc-vorbis.liq
+++ b/doc/content/liq/enc-vorbis.liq
@@ -2,8 +2,13 @@ source = sine()
 
 # BEGIN
 # Standard Ogg/Vorbis stream
-output.icecast(%vorbis(quality=0.5), host="myserver", mount="stream.ogg", source)
+output.icecast(
+  %vorbis(quality = 0.5),
+  host="myserver",
+  mount="stream.ogg",
+  source
+)
 
 # High-quality archive
-output.file(%vorbis(quality=0.9), "/tmp/archive.ogg", source)
+output.file(%vorbis(quality = 0.9), "/tmp/archive.ogg", source)
 # END

--- a/doc/content/liq/icecast-server-serve-json.liq
+++ b/doc/content/liq/icecast-server-serve-json.liq
@@ -1,5 +1,6 @@
 icecast.server(
-  serve_html=fun (_) -> "<!DOCTYPE html><html><body>Not found.</body></html>",
+  serve_html=fun (_) ->
+    "<!DOCTYPE html><html><body>Not found.</body></html>",
   serve_json=fun (stats) ->
     begin
       mounts =

--- a/doc/content/liq/jack-buffer.liq
+++ b/doc/content/liq/jack-buffer.liq
@@ -4,6 +4,7 @@ let input.jack = blank
 %ifndef output.jack
 let output.jack = output.dummy
 %endif
+
 # BEGIN
 # Cross from the JACK clock to another output using buffer():
 output.ao(buffer(input.jack(id="input")))

--- a/doc/content/liq/jack-passthrough.liq
+++ b/doc/content/liq/jack-passthrough.liq
@@ -4,12 +4,9 @@ let input.jack = blank
 %ifndef output.jack
 let output.jack = output.dummy
 %endif
+
 # BEGIN
 output.jack(id="output", input.jack(id="input"))
 
-output.jack(
-  id="playlist",
-  fallible=true,
-  playlist("~/music")
-)
+output.jack(id="playlist", fallible=true, playlist("~/music"))
 # END

--- a/doc/content/liq/jack-record.liq
+++ b/doc/content/liq/jack-record.liq
@@ -1,10 +1,7 @@
 %ifndef input.jack
 let input.jack = blank
 %endif
+
 # BEGIN
-output.file(
-  %wav,
-  "/tmp/jack-recording.wav",
-  input.jack(id="input")
-)
+output.file(%wav, "/tmp/jack-recording.wav", input.jack(id="input"))
 # END

--- a/doc/content/liq/server-interactive-float.liq
+++ b/doc/content/liq/server-interactive-float.liq
@@ -1,5 +1,6 @@
 #!./liquidsoap
 source = sine()
+
 # Register a telnet variable named volume with 1 as initial value
 v = interactive.float("volume", 1.)
 

--- a/src/bin/runtime/main.ml
+++ b/src/bin/runtime/main.ml
@@ -122,11 +122,11 @@ let eval_script expr =
     | (`Eval as v) | (`Eval_toplevel as v) ->
         let toplevel = v = `Eval_toplevel in
         let stdlib = !stdlib in
-        ignore
-          (Lang.eval ~toplevel ~cache:!cache ~stdlib ~deprecated:!deprecated
-             ~name:"main script" expr);
-        if not (Lang_eval.effective_toplevel ~stdlib toplevel) then
-          Environment.clear_toplevel_environments ()
+        let _, retained_toplevel =
+          Lang_eval.eval_with_toplevel ~toplevel ~cache:!cache ~stdlib
+            ~deprecated:!deprecated ~name:"main script" expr
+        in
+        if not retained_toplevel then Environment.clear_toplevel_environments ()
 
 (** Evaluate the user script. *)
 let eval () =

--- a/src/core/optionals/sqlite/builtins_sqlite.ml
+++ b/src/core/optionals/sqlite/builtins_sqlite.ml
@@ -193,7 +193,7 @@ let query_parser ~db query =
 
 let _ =
   let return_t = Type.var ~constraints:[insert_record_constr] () in
-  Lang.add_builtin "_sqlite_row_parser_" ~category:`String ~flags:[`Hidden]
+  Lang.add_builtin "_0_sqlite_row_parser" ~category:`String ~flags:[`Hidden]
     ~descr:"Internal sql row parser"
     [
       ("type", Value.RuntimeType.t, None, Some "Runtime type");

--- a/src/core/runtime/hooks_implementations.ml
+++ b/src/core/runtime/hooks_implementations.ml
@@ -69,7 +69,7 @@ let eval_check ~env:_ ~tm v =
 
 let render_string = function
   | `Verbatim s -> s
-  | `String (pos, (sep, s)) -> Lexer.render_string ~pos ~sep s
+  | `String (pos, (sep, s)) -> String_literal.render ~pos ~sep s
 
 let mk_field_t ?pos kind params =
   let err_pos =

--- a/src/lang/ast/parsed_term.ml
+++ b/src/lang/ast/parsed_term.ml
@@ -67,7 +67,32 @@ type _if = {
   if_end_pos : pos; [@hash.ignore]
 }
 
-and block = { block_body : t; block_pos : pos [@hash.ignore] }
+(* A binding scopes over the statements that follow it in its own block.
+   Constructs that stand for several statements -- `%include`, the static
+   conditionals -- splice into the list. *)
+and block = { block_body : statement list; block_pos : pos [@hash.ignore] }
+
+and statement = {
+  stmt : statement_ast;
+  stmt_pos : pos; [@hash.ignore]
+  mutable stmt_comments : (pos * comment) list; [@hash.ignore]
+}
+
+and statement_ast =
+  [ `Expr of t | `Binding of _let | `Open of t | `Include of inc ]
+
+(* %ifdef / %ifversion / %ifencoder: resolved before typechecking, against the
+   builtin environment, the build version and the available encoders. *)
+and static_cond =
+  [ `Defined of bool * string
+  | `Version of [ `Eq | `Geq | `Leq | `Gt | `Lt ] * Lang_string.Version.t
+  | `Encoder of bool * string ]
+
+and static_if = {
+  static_cond : static_cond;
+  static_then : block;
+  static_else : block option;
+}
 
 and if_elsif = {
   elsif_condition : t;
@@ -114,7 +139,12 @@ and let_decoration =
   | `Xml_parse
   | `Json_parse of (string * t) list ]
 
+(* Which surface syntax produced the binding. Semantically irrelevant -- all
+   three reduce to the same `Let` -- but the formatter round-trips it. *)
+and binding_kind = [ `Bare | `Let | `Def ]
+
 and _let = {
+  kind : binding_kind;
   decoration : let_decoration;
   pat : pattern;
   arglist : fun_arg list option;
@@ -137,27 +167,6 @@ and parsed_func_argument = {
 
 and fun_arg = [ `Term of parsed_func_argument | `Argsof of _of ]
 and list_el = [ `Term of t | `Ellipsis of t ]
-
-and if_def = {
-  if_def_negative : bool;
-  if_def_condition : string;
-  if_def_then_block : block;
-  if_def_else_block : block option;
-}
-
-and if_version = {
-  if_version_op : [ `Eq | `Geq | `Leq | `Gt | `Lt ];
-  if_version_version : Lang_string.Version.t;
-  if_version_then_block : block;
-  if_version_else_block : block option;
-}
-
-and if_encoder = {
-  if_encoder_negative : bool;
-  if_encoder_condition : string;
-  if_encoder_then_block : block;
-  if_encoder_else_block : block option;
-}
 
 and time_el = {
   week : int option;
@@ -204,9 +213,7 @@ and type_annotation =
 and parsed_ast =
   [ `If of _if
   | `Inline_if of _if
-  | `If_def of if_def
-  | `If_version of if_version
-  | `If_encoder of if_encoder
+  | `Static_if of static_if
   | `While of _while
   | `For of _for
   | `Iterable_for of iterable_for
@@ -215,9 +222,6 @@ and parsed_ast =
   | `Regexp of string * char list
   | `Time_interval of time_el * time_el
   | `Time of time_el
-  | `Def of _let * t
-  | `Let of _let * t
-  | `Binding of _let * t
   | `App of t * app_arg list
   | `Invoke of invoke
   | `Fun of fun_arg list * t
@@ -233,18 +237,16 @@ and parsed_ast =
   | `BoolOp of string * t list
   | `Coalesce of t * t
   | `At of t * t
-  | `Simple_fun of t
+  | `Simple_fun of block
   | `String_interpolation of char * string_interpolation list
-  | `Include of inc
   | `Int of string
   | `Bool of bool
   | `Float of string
   | `String of char * string
   | `Raw_string of string * string
-  | `Block of t
+  | `Block of block
   | `Parenthesis of t
   | `Encoder of encoder
-  | `Eof
   | (t, type_annotation) common_ast ]
 
 and t = {
@@ -271,140 +273,220 @@ let unit = `Tuple []
 let make ?(comments = []) ?(annotations = []) ~pos term =
   { pos; term; comments; annotations }
 
-let rec iter_term fn ({ term } as tm) =
-  if term <> `Eof then fn tm;
-  match term with
-    | `If p | `Inline_if p -> (
-        iter_term fn p.if_condition;
-        iter_term fn p.if_then_block.block_body;
-        List.iter
-          (fun { elsif_condition; elsif_then_block; _ } ->
-            iter_term fn elsif_condition;
-            iter_term fn elsif_then_block.block_body)
-          p.if_elsif;
-        match p.if_else_block with
-          | None -> ()
-          | Some b -> iter_term fn b.block_body)
-    | `If_def { if_def_then_block; if_def_else_block } -> (
-        iter_term fn if_def_then_block.block_body;
-        match if_def_else_block with
-          | None -> ()
-          | Some b -> iter_term fn b.block_body)
-    | `If_version { if_version_then_block; if_version_else_block } -> (
-        iter_term fn if_version_then_block.block_body;
-        match if_version_else_block with
-          | None -> ()
-          | Some b -> iter_term fn b.block_body)
-    | `If_encoder { if_encoder_then_block; if_encoder_else_block } -> (
-        iter_term fn if_encoder_then_block.block_body;
-        match if_encoder_else_block with
-          | None -> ()
-          | Some b -> iter_term fn b.block_body)
-    | `While { while_condition; while_do_block } ->
-        iter_term fn while_condition;
-        iter_term fn while_do_block.block_body
-    | `For { for_from; for_to; for_do_block } ->
-        iter_term fn for_from;
-        iter_term fn for_to;
-        iter_term fn for_do_block.block_body
-    | `Iterable_for { iterable_for_iterator; iterable_for_do_block } ->
-        iter_term fn iterable_for_iterator;
-        iter_term fn iterable_for_do_block.block_body
-    | `List l ->
-        List.iter (function `Term tm | `Ellipsis tm -> iter_term fn tm) l
-    | `Try { try_body_block; try_handler; try_finally_block } -> (
-        iter_term fn try_body_block.block_body;
-        (match try_handler with
-          | None -> ()
-          | Some { try_handler_errors_list; try_handler_block; _ } ->
-              (match try_handler_errors_list with
-                | None -> ()
-                | Some tm -> iter_term fn tm);
-              iter_term fn try_handler_block.block_body);
-        match try_finally_block with
-          | None -> ()
-          | Some b -> iter_term fn b.block_body)
-    | `Regexp _ -> ()
-    | `Time_interval _ -> ()
-    | `Time _ -> ()
-    | `Def (_let, tm) | `Let (_let, tm) | `Binding (_let, tm) ->
-        (match _let.arglist with
-          | Some args -> iter_fun_args fn args
-          | None -> ());
-        iter_term fn _let.def;
-        iter_term fn tm
-    | `Cast { cast } -> iter_term fn cast
-    | `App (tm, args) ->
-        iter_term fn tm;
-        List.iter
-          (function `Term (_, tm) -> iter_term fn tm | `Argsof _ -> ())
-          args
-    | `Invoke { invoked; meth } -> (
-        iter_term fn invoked;
-        match meth with
-          | `String _ -> ()
-          | `App (_, args) ->
-              List.iter
-                (function `Argsof _ -> () | `Term (_, tm) -> iter_term fn tm)
-                args)
-    | `Fun (args, tm) | `RFun (_, args, tm) ->
-        iter_fun_args fn args;
-        iter_term fn tm
-    | `Not tm -> iter_term fn tm
-    | `Get tm -> iter_term fn tm
-    | `Set (tm, tm') ->
-        iter_term fn tm;
-        iter_term fn tm'
-    | `Negative tm -> iter_term fn tm
-    | `Append (tm, tm') ->
-        iter_term fn tm;
-        iter_term fn tm'
-    | `Assoc (tm, tm') ->
-        iter_term fn tm;
-        iter_term fn tm'
-    | `Infix (tm, _, tm') ->
-        iter_term fn tm;
-        iter_term fn tm'
-    | `BoolOp (_, l) -> List.iter (iter_term fn) l
-    | `Coalesce (tm, tm') ->
-        iter_term fn tm;
-        iter_term fn tm'
-    | `At (tm, tm') ->
-        iter_term fn tm;
-        iter_term fn tm'
-    | `Simple_fun tm -> iter_term fn tm
-    | `Include _ -> ()
-    | `Custom _ -> ()
-    | `Encoder _ -> ()
-    | `Tuple l -> List.iter (iter_term fn) l
-    | `Null -> ()
-    | `Open (tm, tm') ->
-        iter_term fn tm;
-        iter_term fn tm'
-    | `Parenthesis tm -> iter_term fn tm
-    | `Block tm -> iter_term fn tm
-    | `Methods (base, methods) ->
-        (match base with None -> () | Some tm -> iter_term fn tm);
-        List.iter
-          (function `Method (_, tm) | `Ellipsis tm -> iter_term fn tm)
-          methods
-    | `Int _ -> ()
-    | `Float _ -> ()
-    | `String _ -> ()
-    | `Raw_string _ -> ()
-    | `Bool _ -> ()
-    | `Var _ -> ()
-    | `Eof -> ()
-    | `String_interpolation (_, l) ->
-        List.iter (function `String _ -> () | `Term tm -> iter_term fn tm) l
-    | `Seq (tm, tm') ->
-        iter_term fn tm;
-        iter_term fn tm'
+(** [map_children fn ast] applies [fn] to every direct child term of [ast], and
+    [map_block] / [map_statement] do the same for blocks and statements.
 
-and iter_fun_args fn args =
-  List.iter
-    (function
-      | `Term tm -> (
-          match tm.default with Some tm -> iter_term fn tm | None -> ())
-      | `Argsof _ -> ())
-    args
+    Children are visited in source order, using explicit [let] bindings rather
+    than record literals: OCaml leaves record field evaluation order
+    unspecified, and [iter_term] below relies on the order to break ties when
+    attaching a comment to the closest of two equally distant terms.
+
+    These are the one place that knows the shape of [parsed_ast]; [iter_term]
+    and [Term_preprocessor.expand_term] are both written on top of them.
+
+    [?block] overrides how blocks are rebuilt. `%include` expansion needs it:
+    splicing turns one statement into several, which [map_statement] alone
+    cannot express. *)
+let rec map_children ?block:on_block fn ast =
+  let block b =
+    match on_block with Some f -> f b | None -> map_block ?block:on_block fn b
+  in
+  let opt_block = Option.map block in
+  let opt = Option.map fn in
+  let _if ({ if_condition; if_then_block; if_elsif; if_else_block; _ } as p) =
+    let if_condition = fn if_condition in
+    let if_then_block = block if_then_block in
+    let if_elsif =
+      List.map
+        (fun ({ elsif_condition; elsif_then_block; _ } as e) ->
+          let elsif_condition = fn elsif_condition in
+          let elsif_then_block = block elsif_then_block in
+          { e with elsif_condition; elsif_then_block })
+        if_elsif
+    in
+    let if_else_block = opt_block if_else_block in
+    { p with if_condition; if_then_block; if_elsif; if_else_block }
+  in
+  let fun_args =
+    List.map (function
+      | `Term arg -> `Term { arg with default = opt arg.default }
+      | `Argsof _ as v -> v)
+  in
+  let app_args =
+    List.map (function
+      | `Term (lbl, tm) -> `Term (lbl, fn tm)
+      | `Argsof _ as v -> v)
+  in
+  let rec encoder (lbl, params) =
+    ( lbl,
+      List.map
+        (function
+          | `Anonymous _ as v -> v
+          | `Labelled (s, tm) -> `Labelled (s, fn tm)
+          | `Encoder e -> `Encoder (encoder e))
+        params )
+  in
+  match ast with
+    | `If p -> `If (_if p)
+    | `Inline_if p -> `Inline_if (_if p)
+    | `Static_if p -> `Static_if (map_static_if ?block:on_block fn p)
+    | `While { while_condition; while_do_block } ->
+        let while_condition = fn while_condition in
+        let while_do_block = block while_do_block in
+        `While { while_condition; while_do_block }
+    | `For ({ for_from; for_to; for_do_block; _ } as p) ->
+        let for_from = fn for_from in
+        let for_to = fn for_to in
+        let for_do_block = block for_do_block in
+        `For { p with for_from; for_to; for_do_block }
+    | `Iterable_for ({ iterable_for_iterator; iterable_for_do_block; _ } as p)
+      ->
+        let iterable_for_iterator = fn iterable_for_iterator in
+        let iterable_for_do_block = block iterable_for_do_block in
+        `Iterable_for { p with iterable_for_iterator; iterable_for_do_block }
+    | `List l ->
+        `List
+          (List.map
+             (function
+               | `Term tm -> `Term (fn tm) | `Ellipsis tm -> `Ellipsis (fn tm))
+             l)
+    | `Try { try_body_block; try_handler; try_finally_block } ->
+        let try_body_block = block try_body_block in
+        let try_handler =
+          Option.map
+            (fun ({ try_handler_errors_list; try_handler_block; _ } as h) ->
+              let try_handler_errors_list = opt try_handler_errors_list in
+              let try_handler_block = block try_handler_block in
+              { h with try_handler_errors_list; try_handler_block })
+            try_handler
+        in
+        let try_finally_block = opt_block try_finally_block in
+        `Try { try_body_block; try_handler; try_finally_block }
+    | `Cast { cast; typ } -> `Cast { cast = fn cast; typ }
+    | `App (tm, args) ->
+        let tm = fn tm in
+        `App (tm, app_args args)
+    | `Invoke ({ invoked; meth; _ } as p) ->
+        let invoked = fn invoked in
+        let meth =
+          match meth with
+            | `String _ as s -> s
+            | `App (n, args) -> `App (n, app_args args)
+        in
+        `Invoke { p with invoked; meth }
+    | `Fun (args, tm) ->
+        let args = fun_args args in
+        `Fun (args, fn tm)
+    | `RFun (name, args, tm) ->
+        let args = fun_args args in
+        `RFun (name, args, fn tm)
+    | `Not tm -> `Not (fn tm)
+    | `Get tm -> `Get (fn tm)
+    | `Set (tm, tm') ->
+        let tm = fn tm in
+        `Set (tm, fn tm')
+    | `Negative tm -> `Negative (fn tm)
+    | `Append (tm, tm') ->
+        let tm = fn tm in
+        `Append (tm, fn tm')
+    | `Assoc (tm, tm') ->
+        let tm = fn tm in
+        `Assoc (tm, fn tm')
+    | `Infix (tm, op, tm') ->
+        let tm = fn tm in
+        `Infix (tm, op, fn tm')
+    | `BoolOp (op, l) -> `BoolOp (op, List.map fn l)
+    | `Coalesce (tm, tm') ->
+        let tm = fn tm in
+        `Coalesce (tm, fn tm')
+    | `At (tm, tm') ->
+        let tm = fn tm in
+        `At (tm, fn tm')
+    | `Simple_fun b -> `Simple_fun (block b)
+    | `Tuple l -> `Tuple (List.map fn l)
+    | `Open (tm, tm') ->
+        let tm = fn tm in
+        `Open (tm, fn tm')
+    | `Seq (tm, tm') ->
+        let tm = fn tm in
+        `Seq (tm, fn tm')
+    | `Parenthesis tm -> `Parenthesis (fn tm)
+    | `Block b -> `Block (block b)
+    | `Methods (base, methods) ->
+        let base = opt base in
+        `Methods
+          ( base,
+            List.map
+              (function
+                | `Method (name, tm) -> `Method (name, fn tm)
+                | `Ellipsis tm -> `Ellipsis (fn tm))
+              methods )
+    | `String_interpolation (sep, l) ->
+        `String_interpolation
+          ( sep,
+            List.map
+              (function `String _ as s -> s | `Term tm -> `Term (fn tm))
+              l )
+    | `Encoder e -> `Encoder (encoder e)
+    (* Leaves: no child terms. *)
+    | ( `Regexp _ | `Time_interval _ | `Time _ | `Int _ | `Float _ | `String _
+      | `Raw_string _ | `Bool _ | `Var _ | `Null | `Custom _ ) as ast ->
+        ast
+
+and map_block ?block fn b =
+  { b with block_body = List.map (map_statement ?block fn) b.block_body }
+
+and map_static_if ?block:on_block fn ({ static_then; static_else; _ } as p) =
+  let block b =
+    match on_block with Some f -> f b | None -> map_block ?block:on_block fn b
+  in
+  let static_then = block static_then in
+  let static_else = Option.map block static_else in
+  { p with static_then; static_else }
+
+and map_let fn ({ decoration; arglist; def; _ } as l) =
+  let decoration =
+    match decoration with
+      | `Json_parse args ->
+          `Json_parse (List.map (fun (lbl, tm) -> (lbl, fn tm)) args)
+      | ( `None | `Recursive | `Replaces | `Eval | `Sqlite_query | `Sqlite_row
+        | `Yaml_parse | `Xml_parse ) as d ->
+          d
+  in
+  let arglist =
+    Option.map
+      (List.map (function
+        | `Term arg -> `Term { arg with default = Option.map fn arg.default }
+        | `Argsof _ as v -> v))
+      arglist
+  in
+  let def = fn def in
+  { l with decoration; arglist; def }
+
+and map_statement ?block:_ fn stmt =
+  let stmt_ast =
+    match stmt.stmt with
+      | `Expr tm -> `Expr (fn tm)
+      | `Binding l -> `Binding (map_let fn l)
+      | `Open tm -> `Open (fn tm)
+      | `Include _ as v -> v
+  in
+  { stmt with stmt = stmt_ast }
+
+let rec iter_term fn tm =
+  fn tm;
+  ignore
+    (map_children
+       (fun tm ->
+         iter_term fn tm;
+         tm)
+       tm.term)
+
+(** Visit every term in [b], including those inside its statements. *)
+let iter_block fn b =
+  ignore
+    (map_block
+       (fun tm ->
+         iter_term fn tm;
+         tm)
+       b)

--- a/src/lang/ast/parsed_term.ml
+++ b/src/lang/ast/parsed_term.ml
@@ -473,6 +473,35 @@ and map_statement ?block:_ fn stmt =
   in
   { stmt with stmt = stmt_ast }
 
+(** Visit every node a comment can be attached to: terms and statements. [fn]
+    receives the node's position, whether it is a statement, and a function that
+    updates its comment list. A binding is a statement, so its doc comment has
+    no term to land on. Nodes are visited outermost first. *)
+let iter_anchors fn tm =
+  let rec go_term (tm : t) =
+    fn tm.pos `Term (fun update -> tm.comments <- update tm.comments);
+    ignore
+      (map_children ~block:go_block
+         (fun tm ->
+           go_term tm;
+           tm)
+         tm.term)
+  and go_block (b : block) =
+    List.iter
+      (fun stmt ->
+        fn stmt.stmt_pos `Statement (fun update ->
+            stmt.stmt_comments <- update stmt.stmt_comments);
+        ignore
+          (map_statement
+             (fun tm ->
+               go_term tm;
+               tm)
+             stmt))
+      b.block_body;
+    b
+  in
+  go_term tm
+
 let rec iter_term fn tm =
   fn tm;
   ignore

--- a/src/lang/ast/runtime_term.ml
+++ b/src/lang/ast/runtime_term.ml
@@ -83,6 +83,24 @@ type 'a let_t = {
 
 type cached_env = { var_name : int; var_id : int; env : Typing.env }
 
+(* [`Cache_env] is a sentinel appended to the end of the standard library's
+   let-chain, filled by the typechecker with the environment in scope at that
+   point -- that is, every stdlib binding -- along with the global type-variable
+   counters.
+
+   It lives in the term rather than beside it for two reasons. The typing
+   environment is an immutable object threaded *down* the recursion, so once
+   [Typechecking.check] returns, the extensions made by the top-level lets are
+   out of scope; the innermost body is the only place the full environment can
+   be observed. And the environment has to be marshalled in the same call as the
+   term, so that they share one [Type.t] graph: serialised apart, every type
+   variable in the environment would be a distinct copy from the term's, and
+   unifying the user script against it would silently do the wrong thing.
+
+   Reconstructing the environment from the checked term instead would mean
+   replaying the [`Let] case of the typechecker -- [type_of_pat], the [replace]
+   remeth, and the nested-path [Type.meths] case -- in a second place. *)
+
 type 'a runtime_ast =
   [ `Int of int
   | `Cache_env of cached_env ref

--- a/src/lang/ast/term.ml
+++ b/src/lang/ast/term.ml
@@ -206,36 +206,9 @@ let rec to_string (v : t) =
         (List.map (fun (l, meth_term) -> l ^ "=" ^ to_string meth_term) methods)
     ^ "}")
 
-(** Create a new value. *)
-let id =
-  let counter = Atomic.make 0 in
-  fun () -> Atomic.fetch_and_add counter 1
-
 let make ?pos ?t ?(flags = Flags.empty) ?(methods = Methods.empty) e =
   let t = match t with Some t -> t | None -> Type.var ?pos () in
   { t; term = e; methods; flags }
-
-let rec free_vars_pat = function
-  | `PVar [] -> assert false
-  | `PVar [_] -> Vars.empty
-  | `PVar (x :: _) -> Vars.singleton x
-  | `PTuple l -> List.fold_left Vars.union Vars.empty (List.map free_vars_pat l)
-  | `PList (l, spread, l') ->
-      List.fold_left Vars.union Vars.empty
-        (List.map free_vars_pat
-           (l @ (match spread with None -> [] | Some v -> [`PVar [v]]) @ l'))
-  | `PMeth (pat, l) ->
-      List.fold_left Vars.union
-        (match pat with None -> Vars.empty | Some pat -> free_vars_pat pat)
-        (List.map free_vars_pat
-           (List.fold_left
-              (fun cur (lbl, pat) ->
-                [`PVar [lbl]]
-                @ (match pat with
-                  | `None | `Nullable -> []
-                  | `Pattern pat -> [pat])
-                @ cur)
-              [] l))
 
 let bound_vars_pat = function
   | `PVar [] -> assert false

--- a/src/lang/ast/term_trim.ml
+++ b/src/lang/ast/term_trim.ml
@@ -54,19 +54,11 @@ and trim_ast tm =
     | `List l -> `List (List.map trim_term l)
     | `Cast c -> `Cast { c with cast = trim_term c.cast }
     | `App (t, l) ->
-        `App
-          ( { (trim_term t) with methods = Methods.empty },
-            List.map (fun (lbl, t) -> (lbl, trim_term t)) l )
+        `App (trim_term t, List.map (fun (lbl, t) -> (lbl, trim_term t)) l)
     | `Invoke { invoked; invoke_default; meth } ->
-        let invoked = trim_term invoked in
         `Invoke
           {
-            invoked =
-              {
-                invoked with
-                methods =
-                  Methods.filter (fun lbl _ -> lbl = meth) invoked.methods;
-              };
+            invoked = trim_term invoked;
             invoke_default = Option.map trim_term invoke_default;
             meth;
           }
@@ -92,6 +84,10 @@ and trim_ast tm =
                 arguments;
           }
 
+(* Trimming only hollows out types: they are what a checked term mostly weighs,
+   and past typechecking only their positions are read. It must not touch terms
+   themselves -- method bodies are ordinary terms and are evaluated eagerly, so
+   dropping one would decide whether its effects happen. *)
 and trim_term ({ t; term; methods } as tm) =
   {
     tm with

--- a/src/lang/data/flags.ml
+++ b/src/lang/data/flags.ml
@@ -5,7 +5,6 @@ let empty = 0
 let octal_int = 1
 let hex_int = 1 lsl 1
 let checked_value = 1 lsl 2
-let itered_value = 1 lsl 3
 let has flags flag = flags land flag <> 0
 let add flags flag = flags lor flag
 let merge f f' = f lor f'

--- a/src/lang/data/flags.mli
+++ b/src/lang/data/flags.mli
@@ -5,7 +5,6 @@ val empty : flags
 val octal_int : flag
 val hex_int : flag
 val checked_value : flag
-val itered_value : flag
 val has : flags -> flag -> bool
 val add : flags -> flag -> flags
 val merge : flags -> flags -> flags

--- a/src/lang/parser/dune
+++ b/src/lang/parser/dune
@@ -1,39 +1,33 @@
 ; The front end: lexer, grammar and the token-level preprocessor that handles
 ; string interpolation and %include / %ifdef.
 
+; The --unused-token list is exactly the tokens Lexer emits and preprocessor.ml
+; consumes before menhir ever sees them; the grammar therefore has no rule for
+; them.
+;
+; --strict promotes menhir's warnings to errors, which is what keeps the grammar
+; conflict-free: it has no shift/reduce or reduce/reduce conflict today, and a
+; refactor that introduces one fails the build instead of getting silently
+; resolved by menhir's defaults. (--explain is useless here: dune does not
+; declare parser.conflicts as a target, so the file is written in the sandbox
+; and discarded.)
+
 (menhir
  (modules parser)
  (flags
+  --strict
   --unused-token
   NULLDOT
   --unused-token
   DOTVAR
   --unused-token
-  PP_ELSE
-  --unused-token
-  PP_ENDIF
-  --unused-token
   PP_ENDL
-  --unused-token
-  PP_IFDEF
-  --unused-token
-  PP_IFENCODER
-  --unused-token
-  PP_IFNDEF
-  --unused-token
-  PP_IFNENCODER
-  --unused-token
-  PP_IFVERSION
   --unused-token
   PP_INT_DOT_LCUR
   --unused-token
   PP_REGEXP
   --unused-token
-  PP_STRING
-  --unused-token
-  REPLACES
-  --unused-token
-  SLASH))
+  PP_STRING_START))
 
 (library
  (name liquidsoap_lang_parser)

--- a/src/lang/parser/lexer.ml
+++ b/src/lang/parser/lexer.ml
@@ -171,7 +171,7 @@ let rec token lexbuf =
           {
             inc_type = `Extra;
             inc_name = file;
-            inc_pos = Sedlexing.lexing_positions lexbuf;
+            inc_pos = Sedlexing.lexing_bytes_positions lexbuf;
           }
     | "%include", Star (white_space | '\t'), '"', Star (Compl '"'), '"' ->
         let matched = Sedlexing.Utf8.lexeme lexbuf in
@@ -182,7 +182,7 @@ let rec token lexbuf =
           {
             inc_type = `Default;
             inc_name = file;
-            inc_pos = Sedlexing.lexing_positions lexbuf;
+            inc_pos = Sedlexing.lexing_bytes_positions lexbuf;
           }
     | "%include", Star (white_space | '\t'), '<', Star (Compl '>'), '>' ->
         let matched = Sedlexing.Utf8.lexeme lexbuf in
@@ -193,7 +193,7 @@ let rec token lexbuf =
           {
             inc_type = `Lib;
             inc_name = file;
-            inc_pos = Sedlexing.lexing_positions lexbuf;
+            inc_pos = Sedlexing.lexing_bytes_positions lexbuf;
           }
     | "%argsof" -> ARGS_OF
     | '#', Star (Compl '\n'), eof -> EOF
@@ -267,7 +267,6 @@ let rec token lexbuf =
     | "while" -> WHILE
     | "for" -> FOR
     | "to" -> TO
-    | "do" -> DO
     | "not" -> NOT
     | "open" -> OPEN
     | "and" -> AND
@@ -316,16 +315,8 @@ let rec token lexbuf =
         let t2 = String.trim t2 in
         INTERVAL (parse_time t1, parse_time t2)
     | var -> VAR (Sedlexing.Utf8.lexeme lexbuf)
-    | '"' ->
-        let startp, _ = Sedlexing.lexing_bytes_positions lexbuf in
-        let s = read_string '"' startp (Buffer.create 17) lexbuf in
-        let _, endp = Sedlexing.lexing_bytes_positions lexbuf in
-        PP_STRING ('"', s, (startp, endp))
-    | '\'' ->
-        let startp, _ = Sedlexing.lexing_bytes_positions lexbuf in
-        let s = read_string '\'' startp (Buffer.create 17) lexbuf in
-        let _, endp = Sedlexing.lexing_bytes_positions lexbuf in
-        PP_STRING ('\'', s, (startp, endp))
+    | '"' -> PP_STRING_START '"'
+    | '\'' -> PP_STRING_START '\''
     | "r/" ->
         let startp, _ = Sedlexing.lexing_bytes_positions lexbuf in
         let regexp = read_string '/' startp (Buffer.create 17) lexbuf in
@@ -419,6 +410,39 @@ and read_raw_string id pos buf lexbuf =
                "Raw string is not terminated" ))
     | _ -> failwith "Internal error"
 
+(* Read one chunk of a string literal: up to the closing delimiter, or up to
+   `#{`, whichever comes first. Leaving the lexbuf positioned right after `#{`
+   is what lets the interpolated expression be read as ordinary tokens. *)
+and read_string_chunk c pos buf lexbuf =
+  match%sedlex lexbuf with
+    | "#{" -> `Interpolation (Buffer.contents buf)
+    | '\\', Opt any ->
+        Buffer.add_string buf (Sedlexing.Utf8.lexeme lexbuf);
+        read_string_chunk c pos buf lexbuf
+    | Plus (Compl ('"' | '\'' | '\\' | '/' | '#')) ->
+        Buffer.add_string buf (Sedlexing.Utf8.lexeme lexbuf);
+        read_string_chunk c pos buf lexbuf
+    | '#' ->
+        Buffer.add_char buf '#';
+        read_string_chunk c pos buf lexbuf
+    | '"' | '\'' | '/' ->
+        let matched = Sedlexing.Utf8.lexeme lexbuf in
+        let c' = matched.[0] in
+        if c = c' then `Done (Buffer.contents buf)
+        else (
+          Buffer.add_char buf c';
+          read_string_chunk c pos buf lexbuf)
+    | eof ->
+        raise
+          (Term.Parse_error
+             ( (pos, snd (Sedlexing.lexing_bytes_positions lexbuf)),
+               "String is not terminated" ))
+    | _ ->
+        raise
+          (Term.Parse_error
+             ( (pos, snd (Sedlexing.lexing_bytes_positions lexbuf)),
+               "Illegal string character: " ^ Sedlexing.Utf8.lexeme lexbuf ))
+
 and read_string c pos buf lexbuf =
   match%sedlex lexbuf with
     | '\\', Opt any ->
@@ -451,114 +475,3 @@ and read_string c pos buf lexbuf =
           (Term.Parse_error
              ( (pos, snd (Sedlexing.lexing_bytes_positions lexbuf)),
                msg ^ Sedlexing.Utf8.lexeme lexbuf ))
-
-let render_string ~pos ~sep s =
-  let buf = Buffer.create (String.length s) in
-  let lexbuf = Sedlexing.Utf8.from_string (Printf.sprintf "%s%c" s sep) in
-  let rec render_string () =
-    (* See: https://en.wikipedia.org/wiki/Escape_sequences_in_C *)
-      match%sedlex lexbuf with
-      | '\\', 'a' ->
-          Buffer.add_char buf '\x07';
-          render_string ()
-      | '\\', 'b' ->
-          Buffer.add_char buf '\b';
-          render_string ()
-      | '\\', 'e' ->
-          Buffer.add_char buf '\x1b';
-          render_string ()
-      | '\\', 'f' ->
-          Buffer.add_char buf '\x0c';
-          render_string ()
-      | '\\', 'n' ->
-          Buffer.add_char buf '\n';
-          render_string ()
-      | '\\', 'r' ->
-          Buffer.add_char buf '\r';
-          render_string ()
-      | '\\', 't' ->
-          Buffer.add_char buf '\t';
-          render_string ()
-      | '\\', 'v' ->
-          Buffer.add_char buf '\x0b';
-          render_string ()
-      | '\\', ('"' | '\'' | '/' | '\\') ->
-          let matched = Sedlexing.Utf8.lexeme lexbuf in
-          (* For regexp, we want to make sure these are kept as-is
-             and does not need any further escaping. *)
-          if sep = '/' && matched.[1] <> '/' then
-            Buffer.add_char buf matched.[0];
-          Buffer.add_char buf matched.[1];
-          render_string ()
-      | '\\', '?' ->
-          (* For regexp, we want to make sure \? is kept as-is
-             and does not need any further escaping. *)
-          if sep = '/' then (
-            Buffer.add_char buf '\\';
-            Buffer.add_char buf '?';
-            render_string ())
-          else (
-            Buffer.add_char buf '\x3f';
-            render_string ())
-      | '\\', 'x', ascii_hex_digit, ascii_hex_digit ->
-          let matched = Sedlexing.Utf8.lexeme lexbuf in
-          let idx = String.index matched 'x' in
-          let code = String.sub matched (idx + 1) 2 in
-          let code = int_of_string (Printf.sprintf "0x%s" code) in
-          Buffer.add_char buf (Char.chr code);
-          render_string ()
-      | '\\', oct_digit, oct_digit, oct_digit ->
-          let matched = Sedlexing.Utf8.lexeme lexbuf in
-          let idx = String.index matched '\\' in
-          let code = String.sub matched (idx + 1) 3 in
-          let code = min 255 (int_of_string (Printf.sprintf "0o%s" code)) in
-          Buffer.add_char buf (Char.chr code);
-          render_string ()
-      | ( '\\',
-          'u',
-          ascii_hex_digit,
-          ascii_hex_digit,
-          ascii_hex_digit,
-          ascii_hex_digit ) ->
-          let matched = Sedlexing.Utf8.lexeme lexbuf in
-          Buffer.add_string buf (Lang_string.unescape_utf8_char matched);
-          render_string ()
-      (* Multiline string support: some text \
-         Some more text *)
-      | '\\', '\n', Star skipped -> render_string ()
-      | '\\', any ->
-          if sep <> '/' then (
-            let pos = Pos.(to_string (of_lexing_pos pos)) in
-            Printf.printf
-              "Warning at position %s: illegal backslash escape in string.\n"
-              pos);
-          Buffer.add_string buf (Sedlexing.Utf8.lexeme lexbuf);
-          render_string ()
-      | Plus (Compl ('"' | '\'' | '\\' | '/')) ->
-          Buffer.add_string buf (Sedlexing.Utf8.lexeme lexbuf);
-          render_string ()
-      | '"' | '\'' | '/' ->
-          let matched = Sedlexing.Utf8.lexeme lexbuf in
-          let c' = matched.[0] in
-          if sep = c' then Buffer.contents buf
-          else (
-            Buffer.add_char buf c';
-            render_string ())
-      | eof ->
-          let msg =
-            if sep = '/' then "Regexp not terminated"
-            else "String is not terminated"
-          in
-          raise (Term.Parse_error (pos, msg))
-      | _ ->
-          let msg =
-            if sep = '/' then "Illegal regexp character: "
-            else "Illegal string character: "
-          in
-          raise (Term.Parse_error (pos, msg ^ Sedlexing.Utf8.lexeme lexbuf))
-  in
-  render_string ()
-
-let () =
-  Parser_helper.render_string_ref :=
-    fun ~pos (sep, s) -> render_string ~pos ~sep s

--- a/src/lang/parser/liquidsoap_lang_parser.ml
+++ b/src/lang/parser/liquidsoap_lang_parser.ml
@@ -1,5 +1,6 @@
 module Parser = Parser
 module Parser_helper = Parser_helper
 module Lexer = Lexer
+module String_literal = String_literal
 module Preprocessor = Preprocessor
 module Term_preprocessor = Term_preprocessor

--- a/src/lang/parser/liquidsoap_lang_parser.mli
+++ b/src/lang/parser/liquidsoap_lang_parser.mli
@@ -10,6 +10,9 @@ module Parser_helper = Parser_helper
 (** The tokenizer. *)
 module Lexer = Lexer
 
+(** Escape decoding for string and regexp literal bodies. *)
+module String_literal = String_literal
+
 (** Token-level preprocessing: string interpolation and conditionals. *)
 module Preprocessor = Preprocessor
 

--- a/src/lang/parser/parser.mly
+++ b/src/lang/parser/parser.mly
@@ -30,7 +30,7 @@ open Parser_helper
 %token <string> VARLPAR
 %token <string> VARLBRA
 %token <Lang_string.Version.t> VERSION
-%token <char * string * Parsed_term.pos> PP_STRING
+%token <char> PP_STRING_START
 %token <string * char list * Parsed_term.pos> PP_REGEXP
 %token <char * string > STRING
 %token <string * string> RAW_STRING
@@ -50,11 +50,9 @@ open Parser_helper
 %token QUESTION_DOT
 (* name, arguments, methods *)
 %token <Parser_helper.lexer_let_decoration> DEF
-%token REPLACES
 %token COALESCE
 %token TRY CATCH FINALLY DO
 %token IF THEN ELSE ELSIF
-%token SLASH
 %token OPEN
 %token LPAR RPAR COMMA SEQ SEQSEQ COLON COLONCOLON DOT
 %token <string> DOTVAR
@@ -133,14 +131,14 @@ open Parser_helper
 %type <string list * string list> args_of_params
 %type <Parsed_term.type_annotation Type.argument list> argsty
 %type <Parsed_term.type_annotation Type.argument> argty
-%type <Parser_helper.explicit_binding> explicit_binding
-%type <Parser_helper.binding> binding
+%type <Parsed_term._let> explicit_binding
+%type <Parsed_term._let> binding
 %type <Parsed_term.encoder_params> encoder_params
 %type <Parsed_term.t> expr
-%type <Parsed_term.t> exprs
-%type <Parsed_term.t> simple_fun_body
+%type <Parsed_term.statement list> exprs
+%type <Parsed_term.statement list> simple_fun_body
 %type <unit> g
-%type <Parsed_term.if_elsif list * (Parsed_term.pos * Parsed_term.t) option> if_elsif
+%type <Parsed_term.if_elsif list * (Parsed_term.pos * Parsed_term.statement list) option> if_elsif
 %type <string list> in_subfield
 %type <string list> in_subfield_lbra
 %type <Parsed_term.list_el list> inner_list
@@ -171,39 +169,50 @@ open Parser_helper
 
 program:
   | error { raise (Term.Parse_error ($loc, "Syntax error!")) }
-  | EOF { mk ~pos:$loc `Eof }
-  | exprs EOF { $1 }
+  | EOF { mk ~pos:$loc (`Block (mk_block ~pos:$loc [])) }
+  | exprs EOF { mk ~pos:$loc (`Block (mk_block ~pos:$loc $1)) }
 
 interactive:
   | error { raise (Term.Parse_error ($loc, "Syntax error!")) }
-  | exprs SEQSEQ { $1 }
+  | exprs SEQSEQ { mk ~pos:$loc (`Block (mk_block ~pos:$loc $1)) }
   | EOF { raise End_of_file }
 
 s: | {} | SEQ  {}
 g: | {} | GETS {}
 
-exprs:
-  | OPEN expr s exprs        { mk ~pos:$loc (`Open ($2,$4)) }
-  | expr s                   { $1 }
-  | expr s exprs             { mk ~pos:$loc (`Seq ($1,$3)) }
-  | binding s                { mk_let ~pos:$loc($1) $1 (mk ~pos:$loc `Eof) }
-  | binding s exprs          { mk_let ~pos:$loc($1) $1 $3 }
+(* A block is a flat list of statements. A binding scopes over the statements
+   that follow it in the same block; that is the only scoping rule, and the
+   reducer implements it in exactly one place. *)
+block_body(STMT):
+  | STMT s                   { [$1] }
+  | STMT s block_body(STMT)  { $1::$3 }
 
-(* Simple fun body, syntax: { ... }. Same as expressions except initial x = 1
-   which conflicts with record declaration: { x = 1 } *)
+exprs: block_body(stmt) { $1 }
+
+(* Inside `{ ... }` only the *first* statement is restricted: a leading
+   `x = 1` is the record literal `{ x = 1 }`, so it must be written
+   `let x = 1`. Once past that, `{ ... }` is an ordinary block. *)
 simple_fun_body:
-  | OPEN expr s exprs        { mk ~pos:$loc (`Open ($2,$4)) }
-  | expr s                   { $1 }
-  | expr s exprs             { mk ~pos:$loc (`Seq ($1,$3)) }
-  | explicit_binding s       { mk_let ~pos:$loc($1) $1 (mk ~pos:$loc unit) }
-  | explicit_binding s exprs { mk_let ~pos:$loc($1) $1 $3 }
+  | fun_stmt s        { [$1] }
+  | fun_stmt s exprs  { $1::$3 }
+
+stmt:
+  | expr             { mk_stmt ~pos:$loc (`Expr $1) }
+  | binding          { mk_stmt ~pos:$loc (`Binding $1) }
+  | common_stmt      { mk_stmt ~pos:$loc $1 }
+
+fun_stmt:
+  | expr             { mk_stmt ~pos:$loc (`Expr $1) }
+  | explicit_binding { mk_stmt ~pos:$loc (`Binding $1) }
+  | common_stmt      { mk_stmt ~pos:$loc $1 }
+
+common_stmt:
+  | OPEN expr        { `Open $2 }
+  | INCLUDE          { `Include $1 }
 
 (* General expressions. *)
 expr:
-  | INCLUDE                          { mk ~pos:$loc (`Include $1) }
-  | if_def                           { mk ~pos:$loc (`If_def $1) }
-  | if_encoder                       { mk ~pos:$loc (`If_encoder $1) }
-  | if_version                       { mk ~pos:$loc (`If_version $1) }
+  | static_if                        { mk ~pos:$loc (`Static_if $1) }
   | LPAR expr COLON ty RPAR          { mk ~pos:$loc (`Cast {cast = $2; typ = $4}) }
   | UMINUS expr                      { mk ~pos:$loc (`Negative $2) }
   | LPAR expr RPAR                   { mk ~pos:$loc (`Parenthesis $2) }
@@ -235,9 +244,9 @@ expr:
   | VARLBRA expr RBRA                { mk ~pos:$loc (`Assoc (mk ~pos:$loc($1) (`Var $1), $2)) }
   | expr DOT VARLBRA expr RBRA       { let src = mk ~pos:($startpos($1),$endpos($3)) (`Invoke ({invoked = $1; optional = false; meth = `String $3})) in
                                        mk ~pos:$loc (`Assoc (src, $4)) }
-  | BEGIN exprs END                  { mk ~pos:$loc (`Block $2) }
+  | BEGIN exprs END                  { mk ~pos:$loc (`Block (mk_block ~pos:($startpos($1),$endpos($3)) $2)) }
   | FUN LPAR arglist RPAR YIELDS expr{ mk_fun ~pos:$loc $3 $6 }
-  | LCUR simple_fun_body RCUR        { mk ~pos:$loc (`Simple_fun $2) }
+  | LCUR simple_fun_body RCUR        { mk ~pos:$loc (`Simple_fun (mk_block ~pos:($startpos($1),$endpos($3)) $2)) }
   | WHILE expr DO exprs END
       { mk ~pos:$loc (`While {
           while_condition = $2;
@@ -310,7 +319,7 @@ expr:
               | None -> $startpos($6))
         in
         mk ~pos:$loc (`If {
-          if_condition = $2;
+          if_condition = expr_of_block ~pos:$loc($2) (mk_block ~pos:$loc($2) $2);
           if_then_block = { block_body = $4; block_pos = ($startpos($3), if_then_end) };
           if_elsif;
           if_else_block;
@@ -319,10 +328,10 @@ expr:
   | expr QUESTION expr COLON expr
       { mk ~pos:$loc (`Inline_if {
           if_condition = $1;
-          if_then_block = { block_body = $3;
+          if_then_block = { block_body = [mk_stmt ~pos:$loc($3) (`Expr $3)];
                             block_pos = ($startpos($2), $startpos($4)) };
           if_elsif = [];
-          if_else_block = Some { block_body = $5;
+          if_else_block = Some { block_body = [mk_stmt ~pos:$loc($5) (`Expr $5)];
                                  block_pos = ($startpos($4), $endpos($5)) };
           if_end_pos = ($startpos($5), $endpos($5)) }) }
   | expr AND expr                  { match $1.term, $3.term with
@@ -558,20 +567,22 @@ def:
   | DEF { Parser_helper.let_decoration_of_lexer_let_decoration $1 }
 
 explicit_binding:
-  | _let pattern GETS expr   { `Let Parser_helper.(let_args ~decoration:$1 ~pat:$2 ~def:$4 ()) }
+  | _let pattern GETS expr   { Parser_helper.(let_args ~kind:`Let ~decoration:$1 ~pat:$2 ~def:$4 ()) }
   | _let LPAR pattern COLON ty RPAR GETS expr
-                             { `Let Parser_helper.(let_args ~decoration:$1 ~pat:$3 ~def:$8 ~cast:$5 ()) }
-  | _let subfield GETS expr  { `Let Parser_helper.(let_args ~decoration:$1 ~pat:({ pat_pos = $loc($2); pat_entry = `PVar $2 }) ~def:$4 ()) }
-  | def optvar g exprs END   { `Def Parser_helper.(let_args ~decoration:$1 ~pat:({ pat_pos = $loc($2); pat_entry = `PVar [$2] }) ~def:$4 ()) }
+                             { Parser_helper.(let_args ~kind:`Let ~decoration:$1 ~pat:$3 ~def:$8 ~cast:$5 ()) }
+  | _let subfield GETS expr  { Parser_helper.(let_args ~kind:`Let ~decoration:$1 ~pat:({ pat_pos = $loc($2); pat_entry = `PVar $2 }) ~def:$4 ()) }
+  | def optvar g exprs END   { Parser_helper.(let_args ~kind:`Def ~decoration:$1 ~pat:({ pat_pos = $loc($2); pat_entry = `PVar [$2] }) ~def:(block_expr ~pos:$loc($4) $4) ()) }
   | def LPAR optvar COLON ty RPAR g exprs END
-                             { `Def Parser_helper.(let_args ~decoration:$1 ~pat:({ pat_pos = $loc($3); pat_entry =`PVar [$3] }) ~def:$8 ~cast:$5 ()) }
-  | def subfield g exprs END { `Def Parser_helper.(let_args ~decoration:$1 ~pat:({ pat_pos = $loc($2); pat_entry = `PVar $2 }) ~def:$4 ()) }
+                             { Parser_helper.(let_args ~kind:`Def ~decoration:$1 ~pat:({ pat_pos = $loc($3); pat_entry =`PVar [$3] }) ~def:(block_expr ~pos:$loc($8) $8) ~cast:$5 ()) }
+  | def subfield g exprs END { Parser_helper.(let_args ~kind:`Def ~decoration:$1 ~pat:({ pat_pos = $loc($2); pat_entry = `PVar $2 }) ~def:(block_expr ~pos:$loc($4) $4) ()) }
   | def subfield_lpar arglist RPAR g exprs END
-                             { `Def Parser_helper.(let_args ~decoration:$1 ~pat:({ pat_pos = $loc($2); pat_entry = `PVar $2 }) ~arglist:$3 ~def:$6 ()) }
+                             { Parser_helper.(let_args ~kind:`Def ~decoration:$1 ~pat:({ pat_pos = $loc($2); pat_entry = `PVar $2 }) ~arglist:$3 ~def:(block_expr ~pos:$loc($6) $6) ()) }
 
 binding:
-  | optvar GETS expr         { `Binding Parser_helper.(let_args ~decoration:`None ~pat:({ pat_pos = $loc($1); pat_entry = `PVar [$1] }) ~def:$3 ()) }
-  | explicit_binding         { ($1 :> binding) }
+  | expr GETS expr           { let pat, cast = Parser_helper.binding_target $1 in
+                               Parser_helper.(let_args ~kind:`Bare ~decoration:`None ~pat ?cast ~def:$3 ()) }
+  | UNDERSCORE GETS expr     { Parser_helper.(let_args ~kind:`Bare ~decoration:`None ~pat:({ pat_pos = $loc($1); pat_entry = `PVar ["_"] }) ~def:$3 ()) }
+  | explicit_binding         { $1 }
 
 subfield_lpar:
   | VARLPAR               { [$1] }
@@ -633,7 +644,7 @@ if_elsif:
   | ELSIF exprs THEN exprs if_elsif
       { let (rest, else_opt) = $5 in
         let e : Parsed_term.if_elsif = {
-            elsif_condition = $2;
+            elsif_condition = expr_of_block ~pos:$loc($2) (mk_block ~pos:$loc($2) $2);
             elsif_then_block = { block_body = $4; block_pos = ($startpos($3), $endpos($4)) };
             elsif_pos = ($startpos($1), $endpos($1)) }
         in (e :: rest, else_opt) }
@@ -684,33 +695,36 @@ if_def_var:
   | VAR                { [$1] }
   | VAR DOT if_def_var { $1::$3 }
 
-if_def:
-  | PP_IFDEF if_def_var exprs PP_ENDIF { {
-      if_def_negative = $1;
-      if_def_condition = String.concat "." $2;
-      if_def_then_block = { block_body = $3; block_pos = ($startpos($3), $startpos($4)) };
-      if_def_else_block = None
-   } }
-  | PP_IFDEF if_def_var exprs PP_ELSE exprs PP_ENDIF { {
-      if_def_negative = $1;
-      if_def_condition = String.concat "." $2;
-      if_def_then_block = { block_body = $3; block_pos = ($startpos($3), $startpos($4)) };
-      if_def_else_block = Some { block_body = $5; block_pos = ($startpos($4), $startpos($6)) };
-  } }
+(* %ifdef / %ifversion / %ifencoder. These are statements, not expressions:
+   the selected branch splices its statements into the enclosing block, so a
+   binding made under a `%ifdef` scopes over the code that follows it. *)
+static_if:
+  | PP_IFDEF if_def_var static_body PP_ENDIF
+      { { static_cond = `Defined ($1, String.concat "." $2);
+          static_then = mk_block ~pos:($startpos($3), $startpos($4)) $3;
+          static_else = None } }
+  | PP_IFDEF if_def_var static_body PP_ELSE static_body PP_ENDIF
+      { { static_cond = `Defined ($1, String.concat "." $2);
+          static_then = mk_block ~pos:($startpos($3), $startpos($4)) $3;
+          static_else = Some (mk_block ~pos:($startpos($4), $startpos($6)) $5) } }
+  | PP_IFENCODER ENCODER static_body PP_ENDIF
+      { { static_cond = `Encoder ($1, $2);
+          static_then = mk_block ~pos:($startpos($3), $startpos($4)) $3;
+          static_else = None } }
+  | PP_IFENCODER ENCODER static_body PP_ELSE static_body PP_ENDIF
+      { { static_cond = `Encoder ($1, $2);
+          static_then = mk_block ~pos:($startpos($3), $startpos($4)) $3;
+          static_else = Some (mk_block ~pos:($startpos($4), $startpos($6)) $5) } }
+  | PP_IFVERSION if_version_op if_version_version static_body PP_ENDIF
+      { { static_cond = `Version ($2, $3);
+          static_then = mk_block ~pos:($startpos($4), $startpos($5)) $4;
+          static_else = None } }
+  | PP_IFVERSION if_version_op if_version_version static_body PP_ELSE static_body PP_ENDIF
+      { { static_cond = `Version ($2, $3);
+          static_then = mk_block ~pos:($startpos($4), $startpos($5)) $4;
+          static_else = Some (mk_block ~pos:($startpos($5), $startpos($7)) $6) } }
 
-if_encoder:
-  | PP_IFENCODER ENCODER exprs PP_ENDIF { {
-      if_encoder_negative = $1;
-      if_encoder_condition = $2;
-      if_encoder_then_block = { block_body = $3; block_pos = ($startpos($3), $startpos($4)) };
-      if_encoder_else_block = None
-   } }
-  | PP_IFENCODER ENCODER exprs PP_ELSE exprs PP_ENDIF { {
-      if_encoder_negative = $1;
-      if_encoder_condition = $2;
-      if_encoder_then_block = { block_body = $3; block_pos = ($startpos($3), $startpos($4)) };
-      if_encoder_else_block = Some { block_body = $5; block_pos = ($startpos($4), $startpos($6)) };
-  } }
+static_body: exprs { $1 }
 
 if_version_op:
   | BIN1 {
@@ -727,20 +741,6 @@ if_version_version:
   | VERSION  { $1 }
   | INT      { Lang_string.Version.of_string $1 }
   | FLOAT    { Lang_string.Version.of_string $1 }
-
-if_version:
-  | PP_IFVERSION if_version_op if_version_version exprs PP_ENDIF { {
-      if_version_op = $2;
-      if_version_version = $3;
-      if_version_then_block = { block_body = $4; block_pos = ($startpos($4), $startpos($5)) };
-      if_version_else_block = None
-   } }
-  | PP_IFVERSION if_version_op if_version_version exprs PP_ELSE exprs PP_ENDIF { {
-      if_version_op = $2;
-      if_version_version = $3;
-      if_version_then_block = { block_body = $4; block_pos = ($startpos($4), $startpos($5)) };
-      if_version_else_block = Some { block_body = $6; block_pos = ($startpos($5), $startpos($7)) };
-  } }
 
 annotate:
   | annotate_metadata COLON { $1 }

--- a/src/lang/parser/parser.mly
+++ b/src/lang/parser/parser.mly
@@ -360,12 +360,23 @@ time_predicate:
   | INTERVAL { mk ~pos:$loc (`Time_interval $1) }
   | TIME     { mk ~pos:$loc (`Time $1) }
 
+(* Contextual keywords. These are ordinary identifiers elsewhere, so they are
+   matched as variables and their spelling is checked in the action. %inline
+   means the generated automaton is the same as writing the tokens out. *)
+%inline as_kw:
+  | VAR { Parser_helper.expect_keyword ~pos:$loc "as" $1 }
+
+%inline json_object_kw:
+  | VAR DOT VAR { Parser_helper.expect_keyword ~pos:$loc($1) "json" $1;
+                  Parser_helper.expect_keyword ~pos:$loc($3) "object" $3 }
+
 ty:
   | UNDERSCORE                   { `Named "_" }
   | VAR                          { `Named $1 }
   | ty QUESTION                  { `Nullable $1 }
   | LBRA ty RBRA                 { `List $2 }
-  | LBRA ty RBRA VAR VAR DOT VAR { mk_json_assoc_object_ty ~pos:$loc ($2,$4,$5,$7) }
+  | LBRA ty RBRA as_kw json_object_kw
+                                 { mk_json_object_ty ~pos:$loc($2) $2 }
   | LPAR ty_tuple RPAR           { `Tuple $2 }
   | LPAR argsty RPAR YIELDS ty   { `Arrow ($2,$5) }
   | LCUR record_ty RCUR          { `Record $2 }
@@ -385,14 +396,10 @@ record_ty:
 meth_ty:
   | VAR COLON ty            { { optional_meth = false; name = $1; typ = $3; json_name = None } }
   | VAR QUESTION COLON ty   { { optional_meth = true; name = $1; typ = $4; json_name = None } }
-  | STRING VAR VAR COLON ty {
-       match $2 with
-         |"as" ->             { optional_meth = false; name = $3; typ = $5; json_name = Some (render_string ~pos:$loc $1) }
-         | _ -> raise (Term.Parse_error ($loc, "Invalid type constructor")) }
-  | STRING VAR VAR QUESTION COLON ty {
-       match $2 with
-         |"as" ->             { optional_meth = true; name = $3; typ = $6; json_name = Some (render_string ~pos:$loc $1) }
-         | _ -> raise (Term.Parse_error ($loc, "Invalid type constructor")) }
+  | STRING as_kw VAR COLON ty
+                            { { optional_meth = false; name = $3; typ = $5; json_name = Some (render_string ~pos:$loc($1) $1) } }
+  | STRING as_kw VAR QUESTION COLON ty
+                            { { optional_meth = true; name = $3; typ = $6; json_name = Some (render_string ~pos:$loc($1) $1) } }
 
 ty_source_tracks:
   | VAR GETS ty_content { { extensible = false; tracks = [{track_name = $1; track_type = fst $3; track_params = snd $3}] } }

--- a/src/lang/parser/parser_helper.ml
+++ b/src/lang/parser/parser_helper.ml
@@ -39,16 +39,7 @@ type lexer_let_decoration =
   | `Sqlite_row
   | `Sqlite_query ]
 
-type explicit_binding = [ `Def of Parsed_term._let | `Let of Parsed_term._let ]
-type binding = [ explicit_binding | `Binding of Parsed_term._let ]
-
-let render_string_ref = ref (fun ~pos:_ _ -> assert false)
-
-(* This is filled by Lexer to make it possible to use this function in the parser. *)
-let render_string ~pos s =
-  let fn = !render_string_ref in
-  fn ~pos s
-
+let render_string ~pos (sep, s) = String_literal.render ~pos ~sep s
 let pending_comments = ref []
 let clear_comments () = pending_comments := []
 let get_pending_comments () = !pending_comments
@@ -104,8 +95,86 @@ let attach_comments term =
     !pending_comments;
   pending_comments := []
 
-let let_args ~decoration ~pat ?arglist ~def ?cast () =
-  { decoration; pat; arglist; def; cast }
+let let_args ~kind ~decoration ~pat ?arglist ~def ?cast () =
+  { kind; decoration; pat; arglist; def; cast }
+
+let mk = Parsed_term.make
+let mk_stmt ~pos stmt = { stmt; stmt_pos = pos; stmt_comments = [] }
+let mk_block ~pos block_body = { block_body; block_pos = pos }
+
+(* A block used where an expression is expected. The singleton case is by far
+   the most common (`if a then`, `def f() = e end`) and would otherwise wrap
+   every one of them in a redundant `Block` node. *)
+let expr_of_block ~pos b =
+  match b.block_body with
+    | [{ stmt = `Expr tm; _ }] -> tm
+    | _ -> mk ~pos (`Block b)
+
+let block_expr ~pos stmts = expr_of_block ~pos (mk_block ~pos stmts)
+
+(* A bare binding's left-hand side is parsed as an expression and converted
+   here. `(a, b)` is both a tuple expression and a tuple pattern, and LR(1)
+   cannot tell which until it reaches the `=`, so the grammar commits to the
+   expression and this decides afterwards. Invalid targets are reported here,
+   with a message naming what is allowed. *)
+let rec pattern_of_expr (tm : Parsed_term.t) : Parsed_term.pattern =
+  let pat_pos = tm.pos in
+  let entry =
+    match tm.term with
+      | `Var v -> `PVar [v]
+      (* `x.y.z = ...`: an invoke chain is a dotted path. *)
+      | `Invoke _ -> `PVar (path_of_invoke tm)
+      | `Tuple l -> `PTuple (List.map pattern_of_expr l)
+      | `List l ->
+          `PList
+            ( List.map
+                (function
+                  | `Term tm -> pattern_of_expr tm
+                  | `Ellipsis tm ->
+                      raise
+                        (Term.Parse_error
+                           ( tm.pos,
+                             "Invalid binding: use `...x` for the spread \
+                              element." )))
+                l,
+              None,
+              [] )
+      | `Parenthesis tm | `Block { block_body = [{ stmt = `Expr tm; _ }]; _ } ->
+          (pattern_of_expr tm).pat_entry
+      | `Methods (base, methods) ->
+          `PMeth
+            ( Option.map pattern_of_expr base,
+              List.map
+                (function
+                  | `Method (name, tm) -> (name, `Pattern (pattern_of_expr tm))
+                  | `Ellipsis tm ->
+                      raise
+                        (Term.Parse_error (tm.pos, "Invalid binding target.")))
+                methods )
+      | _ ->
+          raise
+            (Term.Parse_error
+               ( tm.pos,
+                 "Invalid binding: the left-hand side of `=` must be a \
+                  variable, a field path or a destructuring pattern." ))
+  in
+  { pat_pos; pat_entry = entry }
+
+(* `(n : int) = 3`: the annotation parses as a cast expression around the
+   target, and belongs on the binding rather than in the pattern. *)
+and binding_target (tm : Parsed_term.t) =
+  match tm.term with
+    | `Cast { cast; typ } -> (pattern_of_expr cast, Some typ)
+    | _ -> (pattern_of_expr tm, None)
+
+and path_of_invoke (tm : Parsed_term.t) : string list =
+  match tm.term with
+    | `Var v -> [v]
+    | `Invoke { invoked; meth = `String m; optional = false } ->
+        path_of_invoke invoked @ [m]
+    | _ ->
+        raise
+          (Term.Parse_error (tm.pos, "Invalid binding: not a valid field path."))
 
 let mk_json_assoc_object_ty ~pos = function
   | `Tuple [`Named "string"; ty], "as", "json", "object" -> `Json_object ty
@@ -150,7 +219,6 @@ let args_of_json_parse ~pos = function
         (Term.Parse_error
            (pos, "Invalid argument " ^ lbl ^ " for json.parse let constructor"))
 
-let mk = Parsed_term.make
 let mk_fun ~pos arguments body = mk ~pos (`Fun (arguments, body))
 
 let mk_try ?handler ?finally_block ~body_block ~pos () =
@@ -161,14 +229,5 @@ let mk_try ?handler ?finally_block ~body_block ~pos () =
          try_handler = handler;
          try_finally_block = finally_block;
        })
-
-let mk_let ~pos _let body =
-  let ast =
-    match _let with
-      | `Let v -> `Let (v, body)
-      | `Def v -> `Def (v, body)
-      | `Binding v -> `Binding (v, body)
-  in
-  mk ~pos ast
 
 let mk_encoder ~pos e p = mk ~pos (`Encoder (e, p))

--- a/src/lang/parser/parser_helper.ml
+++ b/src/lang/parser/parser_helper.ml
@@ -204,23 +204,59 @@ let mk_json_object_ty ~pos = function
              "`as json.object` describes a JSON object as a list of key/value \
               pairs, so it applies to a list of `(string * _)`." ))
 
+(* `ref`, `getter` and `source` name types but are ordinary identifiers too --
+   `ref(x)` is also a function -- so the lexer cannot single them out and the
+   grammar matches any variable applied to parentheses. *)
+type ty_constructor =
+  [ `Unary of Parsed_term.type_annotation -> Parsed_term.type_annotation
+  | `Source ]
+
+(* The type constructors, and the only place naming them: the error listing
+   what is accepted is derived from this. *)
+let ty_constructors : (string * ty_constructor) list =
+  [
+    ("ref", `Unary (fun t -> `Ref t));
+    ("getter", `Unary (fun t -> `Getter t));
+    ("source", `Source);
+  ]
+
+let unknown_type_constructor ~pos name =
+  let usage (name, kind) =
+    match kind with
+      | `Unary _ -> Printf.sprintf "`%s(t)`" name
+      | `Source -> Printf.sprintf "`%s(...)`" name
+  in
+  raise
+    (Term.Parse_error
+       ( pos,
+         Printf.sprintf "Unknown type constructor: %s. Expected one of %s." name
+           (String.concat ", " (List.map usage ty_constructors)) ))
+
 let mk_source_ty ~pos name tracks =
-  match name with
-    | "source" -> `Source (name, tracks)
-    | _ -> raise (Term.Parse_error (pos, "Invalid type constructor: " ^ name))
+  match List.assoc_opt name ty_constructors with
+    | Some `Source -> `Source (name, tracks)
+    | _ -> unknown_type_constructor ~pos name
 
 let mk_named_ty ~pos name ty =
-  match (name, ty) with
-    | "ref", Some t -> `Ref t
-    | "ref", None ->
-        raise (Term.Parse_error (pos, "ref type requires a type parameter"))
-    | "getter", Some t -> `Getter t
-    | "getter", None ->
-        raise (Term.Parse_error (pos, "getter type requires a type parameter"))
-    | "source", _ ->
+  match (List.assoc_opt name ty_constructors, ty) with
+    | None, _ -> unknown_type_constructor ~pos name
+    | Some (`Unary mk), Some t -> mk t
+    | Some (`Unary _), None ->
+        raise
+          (Term.Parse_error
+             ( pos,
+               Printf.sprintf
+                 "Type constructor %s takes a type parameter, as in `%s(int)`."
+                 name name ))
+    | Some `Source, None ->
         mk_source_ty ~pos name { Parsed_term.extensible = false; tracks = [] }
-    | _, _ ->
-        raise (Term.Parse_error (pos, "Invalid type constructor: " ^ name))
+    | Some `Source, Some _ ->
+        raise
+          (Term.Parse_error
+             ( pos,
+               "`source(...)` takes track declarations, as in \
+                `source(audio=pcm)`. Write `source` on its own for a source \
+                with any tracks." ))
 
 type let_opt_el = string * Parsed_term.t
 

--- a/src/lang/parser/parser_helper.ml
+++ b/src/lang/parser/parser_helper.ml
@@ -184,9 +184,25 @@ and path_of_invoke (tm : Parsed_term.t) : string list =
         raise
           (Term.Parse_error (tm.pos, "Invalid binding: not a valid field path."))
 
-let mk_json_assoc_object_ty ~pos = function
-  | `Tuple [`Named "string"; ty], "as", "json", "object" -> `Json_object ty
-  | _ -> raise (Term.Parse_error (pos, "Invalid type constructor"))
+(* `as`, `json` and `object` are contextual keywords: they stay ordinary
+   identifiers everywhere else, so the lexer cannot single them out and the
+   grammar matches a plain variable and checks the spelling here. *)
+let expect_keyword ~pos expected found =
+  if found <> expected then
+    raise
+      (Term.Parse_error
+         (pos, Printf.sprintf "Expected `%s`, found `%s`." expected found))
+
+(* `[(string * t)] as json.object` types a JSON object as an association
+   list. *)
+let mk_json_object_ty ~pos = function
+  | `Tuple [`Named "string"; ty] -> `Json_object ty
+  | _ ->
+      raise
+        (Term.Parse_error
+           ( pos,
+             "`as json.object` describes a JSON object as a list of key/value \
+              pairs, so it applies to a list of `(string * _)`." ))
 
 let mk_source_ty ~pos name tracks =
   match name with

--- a/src/lang/parser/parser_helper.ml
+++ b/src/lang/parser/parser_helper.ml
@@ -73,25 +73,33 @@ let sort_comments comments =
 let attach_comments term =
   List.iter
     (fun (comment_pos, c) ->
-      let closest_term = ref term in
+      let attach = ref (fun update -> term.comments <- update term.comments) in
       let distance = ref (comment_distance term.pos comment_pos) in
-      Parsed_term.iter_term
-        (fun term ->
-          match (comment_distance term.pos comment_pos, !distance) with
+      let kind_of_closest = ref `Term in
+      Parsed_term.iter_anchors
+        (fun pos kind set ->
+          match (comment_distance pos comment_pos, !distance) with
             | (t, d), (t', d')
               when 0 <= d
                    && (d' < 0
-                      || if t = `Before && t' = `After then d <= d' else d < d'
-                      ) ->
+                      ||
+                      if t = `Before && t' = `After then d <= d'
+                      else if d = d' then
+                        (* Nodes are visited outermost first, so an enclosing
+                           block spans the same lines as the statement it opens
+                           with. A doc comment belongs to the statement. *)
+                        kind = `Statement && !kind_of_closest <> `Statement
+                      else d < d') ->
                 distance := (t, d);
-                closest_term := term
+                kind_of_closest := kind;
+                attach := set
             | _ -> ())
         term;
       let comment =
         match !distance with `Before, _ -> `Before c | `After, _ -> `After c
       in
-      !closest_term.comments <-
-        sort_comments ((comment_pos, comment) :: !closest_term.comments))
+      !attach (fun comments ->
+          sort_comments ((comment_pos, comment) :: comments)))
     !pending_comments;
   pending_comments := []
 

--- a/src/lang/parser/parser_helper.mli
+++ b/src/lang/parser/parser_helper.mli
@@ -38,24 +38,30 @@ type lexer_let_decoration =
   | `Sqlite_row
   | `Sqlite_query ]
 
-type explicit_binding = [ `Def of Parsed_term._let | `Let of Parsed_term._let ]
-type binding = [ explicit_binding | `Binding of Parsed_term._let ]
 type let_opt_el = string * Parsed_term.t
 
 val clear_comments : unit -> unit
 val get_pending_comments : unit -> (pos * string list) list
 val append_comment : pos:pos -> string -> unit
 val attach_comments : Parsed_term.t -> unit
+val mk_stmt : pos:pos -> Parsed_term.statement_ast -> Parsed_term.statement
+val mk_block : pos:pos -> Parsed_term.statement list -> Parsed_term.block
 
-val mk_let :
-  pos:pos ->
-  [< `Binding of Parsed_term._let
-  | `Def of Parsed_term._let
-  | `Let of Parsed_term._let ] ->
-  Parsed_term.t ->
-  Parsed_term.t
+(** A block where an expression is expected. A single-expression block is
+    returned unwrapped, which is the common case (`if a then`, `def f() = e
+    end`) and keeps the AST free of redundant `Block` nodes. *)
+val expr_of_block : pos:pos -> Parsed_term.block -> Parsed_term.t
+
+val block_expr : pos:pos -> Parsed_term.statement list -> Parsed_term.t
+
+(** Reinterpret a bare binding's left-hand side, parsed as an expression, as a
+    pattern plus an optional type annotation. Raises [Term.Parse_error] if it is
+    not a valid target. *)
+val binding_target :
+  Parsed_term.t -> Parsed_term.pattern * Parsed_term.type_annotation option
 
 val let_args :
+  kind:Parsed_term.binding_kind ->
   decoration:Parsed_term.let_decoration ->
   pat:Parsed_term.pattern ->
   ?arglist:arglist ->
@@ -105,5 +111,4 @@ val mk_encoder :
   pos:pos -> string -> Parsed_term.encoder_params -> Parsed_term.t
 
 val args_of_json_parse : pos:pos -> (string * 'a) list -> (string * 'a) list
-val render_string_ref : (pos:pos -> char * string -> string) ref
 val render_string : pos:pos -> char * string -> string

--- a/src/lang/parser/parser_helper.mli
+++ b/src/lang/parser/parser_helper.mli
@@ -73,10 +73,12 @@ val let_args :
 val let_decoration_of_lexer_let_decoration :
   lexer_let_decoration -> Parsed_term.let_decoration
 
-val mk_json_assoc_object_ty :
-  pos:pos ->
-  Parsed_term.type_annotation * string * string * string ->
-  Parsed_term.type_annotation
+(** Check a contextual keyword's spelling, e.g. the `as` of `as json.object`.
+    Raises [Term.Parse_error] naming what was expected. *)
+val expect_keyword : pos:pos -> string -> string -> unit
+
+val mk_json_object_ty :
+  pos:pos -> Parsed_term.type_annotation -> Parsed_term.type_annotation
 
 val mk_source_ty :
   pos:pos ->

--- a/src/lang/parser/preprocessor.ml
+++ b/src/lang/parser/preprocessor.ml
@@ -22,124 +22,101 @@
 
 type tokenizer = unit -> Parser.token * Term.parsed_pos
 
+(* A string literal is read one chunk at a time, and an interpolation is read
+   as ordinary tokens, so that `"#{ r.{a = 1}.a }"` and `"#{ m["k"] }"` mean
+   what they look like: the `}` that closes an interpolation is found by
+   counting braces over *tokens*, where a nested string, comment or raw string
+   is already a single token and cannot be miscounted.
+
+   `"a #{e} b"` yields:
+     BEGIN_INTERPOLATION '"', INTERPOLATED_STRING "a ", <tokens of e>,
+     INTERPOLATED_STRING " b", END_INTERPOLATION *)
+
+(* One open interpolated string. [depth] counts the `{` currently open inside
+   the interpolation being read. *)
+type interpolation = { sep : char; mutable depth : int }
+
 let mk_tokenizer ?(fname = "") lexbuf =
   Sedlexing.set_filename lexbuf fname;
-  fun () ->
-    match Lexer.token lexbuf with
-      | Parser.PP_STRING (c, s, pos) -> (Parser.STRING (c, s), pos)
-      | Parser.PP_REGEXP (r, flags, pos) -> (Parser.REGEXP (r, flags), pos)
-      | token -> (token, Sedlexing.lexing_bytes_positions lexbuf)
-
-(* The expander turns "bla #{e} bli" into ("bla "^string(e)^" bli"). *)
-type exp_item = String of string | Expr of tokenizer | End
-
-exception Found_interpolation
-
-let expand_string ?fname tokenizer =
-  let state = Queue.create () in
-  let add pos x = Queue.add (x, pos) state in
-  let pop () = ignore (Queue.take state) in
-  let clear () = Queue.clear state in
-  let is_interpolating () =
-    try
-      Queue.iter
-        (function Expr _, _ -> raise Found_interpolation | _ -> ())
-        state;
-      false
-    with Found_interpolation -> true
+  let pending = Queue.create () in
+  (* Interpolated strings currently being read, innermost first. *)
+  let open_strings = ref [] in
+  (* Whether the next thing to read is a chunk of the innermost string rather
+     than a token. *)
+  let in_string = ref false in
+  let positions () = Sedlexing.lexing_bytes_positions lexbuf in
+  let read_chunk sep =
+    let startp, _ = positions () in
+    Lexer.read_string_chunk sep startp (Buffer.create 17) lexbuf
   in
-  let parse ~sep s pos =
-    let rex = Re.Pcre.regexp "#\\{([^}]*)\\}" in
-    let l = Re.Pcre.full_split ~rex s in
-    let l = if l = [] then [Re.Pcre.Text s] else l in
-    let add = add pos in
-    let rec parse = function
-      | Re.Pcre.Group (_, x) :: l ->
-          let x = Lexer.render_string ~pos ~sep x in
-          let lexbuf = Sedlexing.Utf8.from_string x in
-          let tokenizer = mk_tokenizer ?fname lexbuf in
-          let tokenizer () = (fst (tokenizer ()), pos) in
-          add (Expr tokenizer);
-          parse l
-      | Re.Pcre.Text x :: l ->
-          add (String x);
-          parse l
-      | Re.Pcre.NoGroup :: l | Re.Pcre.Delim _ :: l -> parse l
-      | [] -> add End
-    in
-    parse l
+  (* An empty chunk carries nothing: `"#{a}#{b}"` has no literal text between
+     the two interpolations, and emitting one would put `""` in the generated
+     `string.concat`. *)
+  let emit_chunk text pos next =
+    if text = "" then next () else (Parser.INTERPOLATED_STRING text, pos)
   in
   let rec token () =
-    if Queue.is_empty state then (
-      match tokenizer () with
-        | (Parser.STRING (sep, s), pos) as tok ->
-            parse ~sep s pos;
-            if is_interpolating () then (Parser.BEGIN_INTERPOLATION sep, pos)
-            else (
-              clear ();
-              tok)
-        | x -> x)
-    else (
-      let el, pos = Queue.peek state in
-      match el with
-        | String s ->
-            pop ();
-            (Parser.INTERPOLATED_STRING s, pos)
-        | Expr tokenizer -> (
-            match tokenizer () with
-              | Parser.EOF, _ ->
-                  pop ();
-                  token ()
-              | x, _ -> (x, pos))
-        | End ->
-            pop ();
-            (Parser.END_INTERPOLATION, pos))
-  in
-  token
-
-(** Special token in order to avoid 3.{s = "a"} to be parsed as a float followed
-    by a record. *)
-let int_meth tokenizer =
-  let q = Queue.create () in
-  let fill () =
-    match tokenizer () with
-      | Parser.PP_INT_DOT_LCUR n, (spos, epos) ->
-          let a n pos =
-            { pos with Lexing.pos_cnum = pos.Lexing.pos_cnum - n }
-          in
-          Queue.add_seq q
-            (List.to_seq
-               [
-                 (Parser.INT n, (spos, a 2 epos));
-                 (Parser.DOT, (a 2 spos, a 1 epos));
-                 (Parser.LCUR, (a 1 spos, epos));
-               ])
-      | t -> Queue.add t q
-  in
-  let token () =
-    if Queue.is_empty q then fill ();
-    Queue.pop q
-  in
-  token
-
-(* Replace DOTVAR v with DOT, VAR v
-   and NULLDOT with "_null", DOT *)
-let dotter tokenizer =
-  let state = ref None in
-  let token () =
-    match !state with
-      | Some t ->
-          state := None;
-          t
+    match Queue.take_opt pending with
+      | Some t -> t
+      | None when !in_string -> (
+          let { sep; _ } = List.hd !open_strings in
+          let startp, _ = positions () in
+          match read_chunk sep with
+            | `Interpolation text ->
+                in_string := false;
+                emit_chunk text (startp, snd (positions ())) token
+            | `Done text ->
+                in_string := false;
+                open_strings := List.tl !open_strings;
+                let pos = (startp, snd (positions ())) in
+                Queue.add (Parser.END_INTERPOLATION, pos) pending;
+                emit_chunk text pos token)
       | None -> (
-          match tokenizer () with
-            | Parser.NULLDOT, pos ->
-                state := Some (Parser.DOT, pos);
-                (Parser.VAR "_null", pos)
-            | Parser.DOTVAR v, pos ->
-                state := Some (Parser.VAR v, pos);
+          match Lexer.token lexbuf with
+            | Parser.PP_STRING_START sep -> (
+                let startp, _ = positions () in
+                match read_chunk sep with
+                  | `Done text ->
+                      (Parser.STRING (sep, text), (startp, snd (positions ())))
+                  | `Interpolation text ->
+                      let pos = (startp, snd (positions ())) in
+                      open_strings := { sep; depth = 0 } :: !open_strings;
+                      if text <> "" then
+                        Queue.add (Parser.INTERPOLATED_STRING text, pos) pending;
+                      (Parser.BEGIN_INTERPOLATION sep, pos))
+            | Parser.PP_REGEXP (r, flags, pos) -> (Parser.REGEXP (r, flags), pos)
+            (* `3.{a = 1}` lexes as one token so that `3.` is not taken for a
+               float followed by a record. *)
+            | Parser.PP_INT_DOT_LCUR n ->
+                let spos, epos = positions () in
+                let back n pos =
+                  { pos with Lexing.pos_cnum = pos.Lexing.pos_cnum - n }
+                in
+                Queue.add (Parser.DOT, (back 2 spos, back 1 epos)) pending;
+                Queue.add (Parser.LCUR, (back 1 spos, epos)) pending;
+                (Parser.INT n, (spos, back 2 epos))
+            | Parser.DOTVAR v ->
+                let pos = positions () in
+                Queue.add (Parser.VAR v, pos) pending;
                 (Parser.DOT, pos)
-            | t -> t)
+            | Parser.NULLDOT ->
+                let pos = positions () in
+                Queue.add (Parser.DOT, pos) pending;
+                (Parser.VAR "_null", pos)
+            | Parser.LCUR when !open_strings <> [] ->
+                let frame = List.hd !open_strings in
+                frame.depth <- frame.depth + 1;
+                (Parser.LCUR, positions ())
+            | Parser.RCUR when !open_strings <> [] ->
+                let frame = List.hd !open_strings in
+                if frame.depth = 0 then (
+                  (* Closes the interpolation: back to reading the string. *)
+                  in_string := true;
+                  token ())
+                else (
+                  frame.depth <- frame.depth - 1;
+                  (Parser.RCUR, positions ()))
+            | token -> (token, positions ()))
   in
   token
 
@@ -153,6 +130,7 @@ let uminus tokenizer =
         | Parser.FLOAT _, _
         | Parser.VAR _, _
         | Parser.RPAR, _
+        | Parser.RBRA, _
         | Parser.RCUR, _ ) as t ->
           no_uminus := true;
           t
@@ -210,10 +188,7 @@ let strip_newlines tokenizer =
 
 (* Wrap the lexer with its extensions *)
 let mk_tokenizer ?fname lexbuf =
-  let tokenizer =
-    mk_tokenizer ?fname lexbuf |> expand_string ?fname |> int_meth |> dotter
-    |> uminus |> strip_newlines
-  in
+  let tokenizer = mk_tokenizer ?fname lexbuf |> uminus |> strip_newlines in
   fun () ->
     let t, (startp, endp) = tokenizer () in
     (t, startp, endp)

--- a/src/lang/parser/string_literal.ml
+++ b/src/lang/parser/string_literal.ml
@@ -1,0 +1,143 @@
+(*****************************************************************************
+
+  Liquidsoap, a programmable stream generator.
+  Copyright 2003-2026 Savonet team
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details, fully stated in the COPYING
+  file at the root of the liquidsoap distribution.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA
+
+ *****************************************************************************)
+
+(** Decoding of string and regexp literal bodies.
+
+    [Lexer] stores literals raw, so that the formatter can reproduce them
+    verbatim; escapes are resolved later, by [render]. This lives outside
+    [Lexer] because [Lexer] depends on [Parser] for the token type, while
+    [Parser_helper] — which the grammar's semantic actions use — needs to decode
+    literals too. *)
+
+let skipped = [%sedlex.regexp? white_space | '\r' | '\t']
+let oct_digit = [%sedlex.regexp? '0' .. '7']
+
+(** [render ~pos ~sep s] resolves the escape sequences of a literal whose
+    delimiter is [sep]. With [sep = '/'] (a regexp literal) the escapes the
+    regexp engine handles itself are deliberately preserved.
+
+    See https://en.wikipedia.org/wiki/Escape_sequences_in_C *)
+let render ~pos ~sep s =
+  let buf = Buffer.create (String.length s) in
+  let lexbuf = Sedlexing.Utf8.from_string (Printf.sprintf "%s%c" s sep) in
+  let rec render () =
+    match%sedlex lexbuf with
+      | '\\', 'a' ->
+          Buffer.add_char buf '\x07';
+          render ()
+      | '\\', 'b' ->
+          Buffer.add_char buf '\b';
+          render ()
+      | '\\', 'e' ->
+          Buffer.add_char buf '\x1b';
+          render ()
+      | '\\', 'f' ->
+          Buffer.add_char buf '\x0c';
+          render ()
+      | '\\', 'n' ->
+          Buffer.add_char buf '\n';
+          render ()
+      | '\\', 'r' ->
+          Buffer.add_char buf '\r';
+          render ()
+      | '\\', 't' ->
+          Buffer.add_char buf '\t';
+          render ()
+      | '\\', 'v' ->
+          Buffer.add_char buf '\x0b';
+          render ()
+      | '\\', ('"' | '\'' | '/' | '\\') ->
+          let matched = Sedlexing.Utf8.lexeme lexbuf in
+          (* For regexp, we want to make sure these are kept as-is
+             and does not need any further escaping. *)
+          if sep = '/' && matched.[1] <> '/' then
+            Buffer.add_char buf matched.[0];
+          Buffer.add_char buf matched.[1];
+          render ()
+      | '\\', '?' ->
+          (* For regexp, we want to make sure \? is kept as-is
+             and does not need any further escaping. *)
+          if sep = '/' then (
+            Buffer.add_char buf '\\';
+            Buffer.add_char buf '?';
+            render ())
+          else (
+            Buffer.add_char buf '\x3f';
+            render ())
+      | '\\', 'x', ascii_hex_digit, ascii_hex_digit ->
+          let matched = Sedlexing.Utf8.lexeme lexbuf in
+          let idx = String.index matched 'x' in
+          let code = String.sub matched (idx + 1) 2 in
+          let code = int_of_string (Printf.sprintf "0x%s" code) in
+          Buffer.add_char buf (Char.chr code);
+          render ()
+      | '\\', oct_digit, oct_digit, oct_digit ->
+          let matched = Sedlexing.Utf8.lexeme lexbuf in
+          let idx = String.index matched '\\' in
+          let code = String.sub matched (idx + 1) 3 in
+          let code = min 255 (int_of_string (Printf.sprintf "0o%s" code)) in
+          Buffer.add_char buf (Char.chr code);
+          render ()
+      | ( '\\',
+          'u',
+          ascii_hex_digit,
+          ascii_hex_digit,
+          ascii_hex_digit,
+          ascii_hex_digit ) ->
+          let matched = Sedlexing.Utf8.lexeme lexbuf in
+          Buffer.add_string buf (Lang_string.unescape_utf8_char matched);
+          render ()
+      (* Multiline string support: some text \
+         Some more text *)
+      | '\\', '\n', Star skipped -> render ()
+      | '\\', any ->
+          if sep <> '/' then (
+            let pos = Pos.(to_string (of_lexing_pos pos)) in
+            Printf.printf
+              "Warning at position %s: illegal backslash escape in string.\n"
+              pos);
+          Buffer.add_string buf (Sedlexing.Utf8.lexeme lexbuf);
+          render ()
+      | Plus (Compl ('"' | '\'' | '\\' | '/')) ->
+          Buffer.add_string buf (Sedlexing.Utf8.lexeme lexbuf);
+          render ()
+      | '"' | '\'' | '/' ->
+          let matched = Sedlexing.Utf8.lexeme lexbuf in
+          let c' = matched.[0] in
+          if sep = c' then Buffer.contents buf
+          else (
+            Buffer.add_char buf c';
+            render ())
+      | eof ->
+          let msg =
+            if sep = '/' then "Regexp not terminated"
+            else "String is not terminated"
+          in
+          raise (Term.Parse_error (pos, msg))
+      | _ ->
+          let msg =
+            if sep = '/' then "Illegal regexp character: "
+            else "Illegal string character: "
+          in
+          raise (Term.Parse_error (pos, msg ^ Sedlexing.Utf8.lexeme lexbuf))
+  in
+  render ()

--- a/src/lang/parser/term_preprocessor.ml
+++ b/src/lang/parser/term_preprocessor.ml
@@ -31,21 +31,33 @@ exception Includer_error of (exn * Sedlexing.lexbuf * Printexc.raw_backtrace)
 
 let program = MenhirLib.Convert.Simplified.traditional2revised Parser.program
 
-let let_script_path ~filename tm =
-  Parser_helper.mk ~pos:tm.Parsed_term.pos
-    (`Let
-       ( {
-           Parsed_term.decoration = `None;
+(* Every program starts with a `liquidsoap.script.path` binding, so that it
+   scopes over the whole script. *)
+let let_script_path ~filename ({ Parsed_term.pos; _ } as block) =
+  let binding =
+    Parser_helper.mk_stmt ~pos
+      (`Binding
+         {
+           Parsed_term.kind = `Let;
+           decoration = `None;
            pat =
              {
-               pat_pos = tm.pos;
+               pat_pos = pos;
                pat_entry = `PVar ["liquidsoap"; "script"; "path"];
              };
            arglist = None;
            cast = None;
-           def = Parser_helper.mk ~pos:tm.pos filename;
-         },
-         tm ))
+           def = Parser_helper.mk ~pos filename;
+         })
+  in
+  match block.Parsed_term.term with
+    | `Block b ->
+        {
+          block with
+          Parsed_term.term =
+            `Block { b with block_body = binding :: b.block_body };
+        }
+    | _ -> assert false
 
 let mk_expr ?fname processor lexbuf =
   let tokenizer = Preprocessor.mk_tokenizer ?fname lexbuf in
@@ -62,19 +74,6 @@ let mk_expr ?fname processor lexbuf =
           parsed_term
 
 exception No_extra
-
-let rec concat_term (t : t) (t' : t) =
-  match t with
-    | { term = `Let (def, body) } ->
-        { t with term = `Let (def, concat_term body t') }
-    | { term = `Def (def, body) } ->
-        { t with term = `Def (def, concat_term body t') }
-    | { term = `Binding (def, body) } ->
-        { t with term = `Binding (def, concat_term body t') }
-    | { term = `Seq (t1, t2) } as tm ->
-        { tm with term = `Seq (t1, concat_term t2 t') }
-    | { term = `Eof } | { term = `Tuple [] } -> t'
-    | _ -> Parsed_term.make ~pos:t.Parsed_term.pos (`Seq (t, t'))
 
 let includer_reducer ~pos = function
   | `Include { inc_type; inc_name; inc_pos } -> (
@@ -107,318 +106,36 @@ let includer_reducer ~pos = function
               raise (Includer_error (exn, lexbuf, bt)))
       with No_extra -> Parsed_term.make ~pos (`Tuple []))
 
-let rec expand_encoder (lbl, params) =
-  ( lbl,
-    List.map
-      (function
-        | `Encoder enc -> `Encoder (expand_encoder enc)
-        | `Labelled (lbl, t) -> `Labelled (lbl, expand_term t)
-        | `Anonymous _ as v -> v)
-      params )
+(* The included program is a `Block`. Its statements are concatenated into the
+   including block, so a binding in an included file scopes over the code that
+   follows the `%include`. *)
+let included_statements ~pos ast =
+  match (includer_reducer ~pos ast).Parsed_term.term with
+    | `Block b -> b.block_body
+    | _ -> assert false
 
-and expand_term tm =
-  let expand_decoration = function
-    | `None -> `None
-    | `Recursive -> `Recursive
-    | `Replaces -> `Replaces
-    | `Eval -> `Eval
-    | `Sqlite_query -> `Sqlite_query
-    | `Sqlite_row -> `Sqlite_row
-    | `Yaml_parse -> `Yaml_parse
-    | `Xml_parse -> `Xml_parse
-    | `Json_parse l ->
-        `Json_parse (List.map (fun (lbl, t) -> (lbl, expand_term t)) l)
+(** Expand every `%include` in [tm] and normalize `Inline_if` into `If`.
+    Everything else is left alone: the recursion over the other constructors is
+    [Parsed_term.map_children], with the block hook doing the splicing. *)
+let rec expand_term tm =
+  let ast =
+    match tm.Parsed_term.term with `Inline_if p -> `If p | ast -> ast
   in
-  let expand_func_arg ({ default } as arg) =
-    { arg with default = Option.map expand_term default }
-  in
-  let expand_arglist =
-    List.map (function
-      | `Term arg -> `Term (expand_func_arg arg)
-      | `Argsof _ as el -> el)
-  in
-  let expand_app_arg =
-    List.map (function
-      | `Argsof _ as el -> el
-      | `Term (lbl, t) -> `Term (lbl, expand_term t))
-  in
-  let expand_fun_args =
-    List.map (function
-      | `Term arg -> `Term (expand_func_arg arg)
-      | `Argsof _ as v -> v)
-  in
-  let comments = ref tm.Parsed_term.comments in
-  let term =
-    match tm.Parsed_term.term with
-      | `Include _ as ast ->
-          let { term; comments = expanded_comments } =
-            expand_term (includer_reducer ~pos:tm.Parsed_term.pos ast)
-          in
-          comments := expanded_comments;
-          term
-      | `Seq ({ pos; term = `Include _ as ast }, t') ->
-          let t = expand_term (includer_reducer ~pos ast) in
-          let t' = expand_term t' in
-          let { term; comments = expanded_comments } = concat_term t t' in
-          comments := expanded_comments;
-          term
-      | `Seq (t, t') -> `Seq (expand_term t, expand_term t')
-      | `If_def ({ if_def_then_block; if_def_else_block } as if_def) ->
-          `If_def
-            {
-              if_def with
-              if_def_then_block =
-                {
-                  if_def_then_block with
-                  block_body = expand_term if_def_then_block.block_body;
-                };
-              if_def_else_block =
-                Option.map
-                  (fun b -> { b with block_body = expand_term b.block_body })
-                  if_def_else_block;
-            }
-      | `If_version
-          ({ if_version_then_block; if_version_else_block } as if_version) ->
-          `If_version
-            {
-              if_version with
-              if_version_then_block =
-                {
-                  if_version_then_block with
-                  block_body = expand_term if_version_then_block.block_body;
-                };
-              if_version_else_block =
-                Option.map
-                  (fun b -> { b with block_body = expand_term b.block_body })
-                  if_version_else_block;
-            }
-      | `If_encoder
-          ({ if_encoder_then_block; if_encoder_else_block } as if_encoder) ->
-          `If_encoder
-            {
-              if_encoder with
-              if_encoder_then_block =
-                {
-                  if_encoder_then_block with
-                  block_body = expand_term if_encoder_then_block.block_body;
-                };
-              if_encoder_else_block =
-                Option.map
-                  (fun b -> { b with block_body = expand_term b.block_body })
-                  if_encoder_else_block;
-            }
-      | `If ({ if_condition; if_then_block; if_elsif; if_else_block; _ } as _if)
-        ->
-          `If
-            {
-              _if with
-              if_condition = expand_term if_condition;
-              if_then_block =
-                {
-                  if_then_block with
-                  block_body = expand_term if_then_block.block_body;
-                };
-              if_elsif =
-                List.map
-                  (fun ({ elsif_condition; elsif_then_block; _ } as e) ->
-                    {
-                      e with
-                      elsif_condition = expand_term elsif_condition;
-                      elsif_then_block =
-                        {
-                          elsif_then_block with
-                          block_body = expand_term elsif_then_block.block_body;
-                        };
-                    })
-                  if_elsif;
-              if_else_block =
-                Option.map
-                  (fun b -> { b with block_body = expand_term b.block_body })
-                  if_else_block;
-            }
-      | `Inline_if
-          ({ if_condition; if_then_block; if_elsif; if_else_block; _ } as _if)
-        ->
-          `If
-            {
-              _if with
-              if_condition = expand_term if_condition;
-              if_then_block =
-                {
-                  if_then_block with
-                  block_body = expand_term if_then_block.block_body;
-                };
-              if_elsif =
-                List.map
-                  (fun ({ elsif_condition; elsif_then_block; _ } as e) ->
-                    {
-                      e with
-                      elsif_condition = expand_term elsif_condition;
-                      elsif_then_block =
-                        {
-                          elsif_then_block with
-                          block_body = expand_term elsif_then_block.block_body;
-                        };
-                    })
-                  if_elsif;
-              if_else_block =
-                Option.map
-                  (fun b -> { b with block_body = expand_term b.block_body })
-                  if_else_block;
-            }
-      | `While { while_condition; while_do_block } ->
-          `While
-            {
-              while_condition = expand_term while_condition;
-              while_do_block =
-                {
-                  while_do_block with
-                  block_body = expand_term while_do_block.block_body;
-                };
-            }
-      | `For ({ for_from; for_to; for_do_block } as _for) ->
-          `For
-            {
-              _for with
-              for_from = expand_term for_from;
-              for_to = expand_term for_to;
-              for_do_block =
-                {
-                  for_do_block with
-                  block_body = expand_term for_do_block.block_body;
-                };
-            }
-      | `Iterable_for ({ iterable_for_iterator; iterable_for_do_block } as _for)
-        ->
-          `Iterable_for
-            {
-              _for with
-              iterable_for_iterator = expand_term iterable_for_iterator;
-              iterable_for_do_block =
-                {
-                  iterable_for_do_block with
-                  block_body = expand_term iterable_for_do_block.block_body;
-                };
-            }
-      | `List l ->
-          `List
-            (List.map
-               (function
-                 | `Term t -> `Term (expand_term t)
-                 | `Ellipsis t -> `Ellipsis (expand_term t))
-               l)
-      | `Try { try_body_block; try_handler; try_finally_block } ->
-          `Try
-            {
-              try_body_block =
-                {
-                  try_body_block with
-                  block_body = expand_term try_body_block.block_body;
-                };
-              try_handler =
-                Option.map
-                  (fun ({ try_handler_errors_list; try_handler_block; _ } as h)
-                     ->
-                    {
-                      h with
-                      try_handler_errors_list =
-                        Option.map expand_term try_handler_errors_list;
-                      try_handler_block =
-                        {
-                          try_handler_block with
-                          block_body = expand_term try_handler_block.block_body;
-                        };
-                    })
-                  try_handler;
-              try_finally_block =
-                Option.map
-                  (fun b -> { b with block_body = expand_term b.block_body })
-                  try_finally_block;
-            }
-      | `Regexp _ as ast -> ast
-      | `Time_interval _ as ast -> ast
-      | `Time _ as ast -> ast
-      | `Def (({ decoration; arglist; def } as _let), body) ->
-          `Def
-            ( {
-                _let with
-                decoration = expand_decoration decoration;
-                def = expand_term def;
-                arglist = Option.map expand_arglist arglist;
-              },
-              expand_term body )
-      | `Let (({ decoration; arglist; def } as _let), body) ->
-          `Let
-            ( {
-                _let with
-                decoration = expand_decoration decoration;
-                def = expand_term def;
-                arglist = Option.map expand_arglist arglist;
-              },
-              expand_term body )
-      | `Binding (({ decoration; arglist; def } as _let), body) ->
-          `Binding
-            ( {
-                _let with
-                decoration = expand_decoration decoration;
-                def = expand_term def;
-                arglist = Option.map expand_arglist arglist;
-              },
-              expand_term body )
-      | `Cast { cast = t; typ } -> `Cast { cast = expand_term t; typ }
-      | `App (t, app_arg) -> `App (expand_term t, expand_app_arg app_arg)
-      | `Invoke ({ invoked; meth } as invoke) ->
-          `Invoke
-            {
-              invoke with
-              invoked = expand_term invoked;
-              meth =
-                (match meth with
-                  | `String _ as s -> s
-                  | `App (n, app_arg) -> `App (n, expand_app_arg app_arg));
-            }
-      | `Fun (fun_args, t) -> `Fun (expand_fun_args fun_args, expand_term t)
-      | `RFun (name, fun_args, t) ->
-          `RFun (name, expand_fun_args fun_args, expand_term t)
-      | `Not t -> `Not (expand_term t)
-      | `Get t -> `Get (expand_term t)
-      | `Set (t, t') -> `Set (expand_term t, expand_term t')
-      | `Methods (t, methods) ->
-          `Methods
-            ( Option.map expand_term t,
-              List.map
-                (function
-                  | `Ellipsis t -> `Ellipsis (expand_term t)
-                  | `Method (name, t) -> `Method (name, expand_term t))
-                methods )
-      | `Negative t -> `Negative (expand_term t)
-      | `Append (t, t') -> `Append (expand_term t, expand_term t')
-      | `Assoc (t, t') -> `Assoc (expand_term t, expand_term t')
-      | `Infix (t, op, t') -> `Infix (expand_term t, op, expand_term t')
-      | `BoolOp (b, l) -> `BoolOp (b, List.map expand_term l)
-      | `Coalesce (t, t') -> `Coalesce (expand_term t, expand_term t')
-      | `At (t, t') -> `At (expand_term t, expand_term t')
-      | `Simple_fun t -> `Simple_fun (expand_term t)
-      | `String_interpolation (c, l) ->
-          `String_interpolation
-            ( c,
-              List.map
-                (function
-                  | `String _ as s -> s | `Term t -> `Term (expand_term t))
-                l )
-      | `Int _ as ast -> ast
-      | `Float _ as ast -> ast
-      | `Raw_string _ as ast -> ast
-      | `String _ as ast -> ast
-      | `Bool _ as ast -> ast
-      | `Eof -> `Eof
-      | `Block t -> `Block (expand_term t)
-      | `Parenthesis t -> `Parenthesis (expand_term t)
-      | `Encoder enc -> `Encoder (expand_encoder enc)
-      | `Custom _ as ast -> ast
-      | `Open (t, t') -> `Open (expand_term t, expand_term t')
-      | `Tuple l -> `Tuple (List.map expand_term l)
-      | `Var _ as ast -> ast
-      | `Null -> `Null
-  in
-  { tm with Parsed_term.term; comments = !comments }
+  {
+    tm with
+    Parsed_term.term =
+      Parsed_term.map_children ~block:expand_block expand_term ast;
+  }
+
+and expand_block b =
+  {
+    b with
+    Parsed_term.block_body = List.concat_map expand_statement b.block_body;
+  }
+
+and expand_statement stmt =
+  match stmt.Parsed_term.stmt with
+    | `Include _ as ast ->
+        List.concat_map expand_statement
+          (included_statements ~pos:stmt.Parsed_term.stmt_pos ast)
+    | _ -> [Parsed_term.map_statement ~block:expand_block expand_term stmt]

--- a/src/lang/parser/term_preprocessor.ml
+++ b/src/lang/parser/term_preprocessor.ml
@@ -73,6 +73,8 @@ let mk_expr ?fname processor lexbuf =
           ~filename:(`String ('"', Lang_string.escape_utf8_string fname))
           parsed_term
 
+(* An `%include_extra` naming a file that is not installed. The include then
+   contributes no statements, which is how the minimal distributions build. *)
 exception No_extra
 
 let includer_reducer ~pos = function
@@ -104,7 +106,9 @@ let includer_reducer ~pos = function
             with (Parser.Error | Parsing.Parse_error) as exn ->
               let bt = Printexc.get_raw_backtrace () in
               raise (Includer_error (exn, lexbuf, bt)))
-      with No_extra -> Parsed_term.make ~pos (`Tuple []))
+      with No_extra ->
+        Parsed_term.make ~pos
+          (`Block { Parsed_term.block_body = []; block_pos = pos }))
 
 (* The included program is a `Block`. Its statements are concatenated into the
    including block, so a binding in an included file scopes over the code that

--- a/src/lang/prelude/lang_string.ml
+++ b/src/lang/prelude/lang_string.ml
@@ -308,6 +308,9 @@ let print_string ?(pager = false) s =
   let pager =
     if
       Sys.win32
+      (* Paging a redirected stream would write the pager's control sequences
+         into the output, e.g. `liquidsoap --list-functions-md > reference.md`. *)
+      || (not (Unix.isatty Unix.stdout))
       || Sys.getenv_opt "TERM" = None
       || Sys.getenv_opt "PAGER" = Some "none"
     then false

--- a/src/lang/reducer/term_reducer.ml
+++ b/src/lang/reducer/term_reducer.ml
@@ -271,4 +271,8 @@ let to_encoder_params ~throw =
   to_encoder_params ~env:[] ~to_term
 
 let to_term ~throw tm = to_term ~throw ~env:[] tm
-let needs_toplevel = Term_reducer_let.needs_toplevel
+
+(* `let eval` desugars to a call to `_eval_`, which parses a string at run time
+   and so needs the standard library to still be around. Asking the term rather
+   than remembering that we reduced one keeps this a property of the script. *)
+let needs_toplevel term = Vars.mem "_eval_" (Term.free_vars term)

--- a/src/lang/reducer/term_reducer.ml
+++ b/src/lang/reducer/term_reducer.ml
@@ -41,71 +41,35 @@ let mk_expr ?fname processor lexbuf =
   let parsed_term = Term_preprocessor.mk_expr ?fname processor lexbuf in
   Term_preprocessor.expand_term parsed_term
 
-let pp_if_reducer ~env ~pos = function
-  | `If_def
-      {
-        if_def_negative;
-        if_def_condition;
-        if_def_then_block;
-        if_def_else_block;
-      } -> (
-      let if_def_else =
-        Option.value
-          ~default:(mk_parsed ~pos (`Tuple []))
-          (Option.map (fun b -> b.block_body) if_def_else_block)
-      in
-      match
-        ( List.mem_assoc if_def_condition env
-          || Environment.has_builtin if_def_condition,
-          if_def_negative )
-      with
-        | true, false | false, true -> if_def_then_block.block_body
-        | _ -> if_def_else)
-  | `If_version
-      {
-        if_version_op;
-        if_version_version;
-        if_version_then_block;
-        if_version_else_block;
-      } -> (
-      let if_version_else =
-        Option.value
-          ~default:(mk_parsed ~pos (`Tuple []))
-          (Option.map (fun b -> b.block_body) if_version_else_block)
-      in
-      let current_version =
-        Lang_string.Version.of_string Build_config.version
-      in
-      match
-        ( if_version_op,
-          Lang_string.Version.compare current_version if_version_version )
-      with
-        | `Eq, 0 -> if_version_then_block.block_body
-        | `Geq, v when v >= 0 -> if_version_then_block.block_body
-        | `Leq, v when v <= 0 -> if_version_then_block.block_body
-        | `Gt, v when v > 0 -> if_version_then_block.block_body
-        | `Lt, v when v < 0 -> if_version_then_block.block_body
-        | _ -> if_version_else)
-  | `If_encoder
-      {
-        if_encoder_negative;
-        if_encoder_condition;
-        if_encoder_then_block;
-        if_encoder_else_block;
-      } -> (
-      let if_encoder_else =
-        Option.value
-          ~default:(mk_parsed ~pos (`Tuple []))
-          (Option.map (fun b -> b.block_body) if_encoder_else_block)
-      in
-      try
-        let encoder =
-          !Hooks.make_encoder ~pos:None (if_encoder_condition, [])
-        in
-        match (!Hooks.has_encoder encoder, if_encoder_negative) with
-          | true, false | false, true -> if_encoder_then_block.block_body
-          | _ -> if_encoder_else
-      with _ -> if_encoder_else)
+(* Select the branch of a static conditional. Returns the statements of the
+   selected block, which the caller splices into the enclosing block. *)
+let static_branch ~env { static_cond; static_then; static_else } =
+  let taken =
+    match static_cond with
+      | `Defined (negative, name) ->
+          let defined =
+            List.mem_assoc name env || Environment.has_builtin name
+          in
+          defined <> negative
+      | `Version (op, version) -> (
+          let current = Lang_string.Version.of_string Build_config.version in
+          match (op, Lang_string.Version.compare current version) with
+            | `Eq, 0 -> true
+            | `Geq, v -> v >= 0
+            | `Leq, v -> v <= 0
+            | `Gt, v -> v > 0
+            | `Lt, v -> v < 0
+            | _ -> false)
+      | `Encoder (negative, name) -> (
+          try
+            let encoder = !Hooks.make_encoder ~pos:None (name, []) in
+            !Hooks.has_encoder encoder <> negative
+            (* An unknown encoder name is treated as "not available", i.e. the
+               else branch, for both %ifencoder and %ifnencoder. *)
+          with _ -> false)
+  in
+  if taken then static_then.block_body
+  else (match static_else with Some b -> b.block_body | None -> [])
 
 let to_encoder_string = function
   | `Verbatim s -> s
@@ -125,17 +89,21 @@ and to_encoder ~env ~to_term (lbl, params) =
 let rec to_ast ~throw ~env ~pos ~comments ast =
   let to_ast = to_ast ~throw in
   let to_term = to_term ~throw in
+  let to_block = to_block ~throw in
   match ast with
-    | `Methods _ | `Block _ | `Parenthesis _ | `Eof | `Include _ -> assert false
-    | (`If_def _ as ast) | (`If_encoder _ as ast) | (`If_version _ as ast) ->
-        (to_term ~env (pp_if_reducer ~pos ~env ast)).term
+    | `Methods _ | `Block _ | `Parenthesis _ -> assert false
+    | `Static_if p ->
+        (* Value position: the selected branch is a block used as a value. *)
+        (to_block ~env { block_body = static_branch ~env p; block_pos = pos })
+          .term
     | `Get _ as ast -> get_reducer ~pos ~env ~to_term ast
     | `Set _ as ast -> set_reducer ~pos ~env ~to_term ast
-    | `Inline_if _ as ast -> if_reducer ~pos ~env ~to_term ast
-    | `If _ as ast -> if_reducer ~pos ~env ~to_term ast
-    | `While _ as ast -> while_reducer ~pos ~env ~to_term ast
-    | `For _ as ast -> for_reducer ~pos ~env ~to_term ast
-    | `Iterable_for _ as ast -> iterable_for_reducer ~pos ~env ~to_term ast
+    | `Inline_if _ as ast -> if_reducer ~pos ~env ~to_term ~to_block ast
+    | `If _ as ast -> if_reducer ~pos ~env ~to_term ~to_block ast
+    | `While _ as ast -> while_reducer ~pos ~env ~to_term ~to_block ast
+    | `For _ as ast -> for_reducer ~pos ~env ~to_term ~to_block ast
+    | `Iterable_for _ as ast ->
+        iterable_for_reducer ~pos ~env ~to_term ~to_block ast
     | `Not _ as ast -> not_reducer ~pos ~env ~to_term ast
     | `Negative _ as ast -> negative_reducer ~pos ~env ~to_term ast
     | `Append _ as ast -> append_reducer ~pos ~env ~to_term ast
@@ -143,9 +111,9 @@ let rec to_ast ~throw ~env ~pos ~comments ast =
     | `Infix _ as ast -> infix_reducer ~pos ~env ~to_term ast
     | `Bool _ as ast -> ast
     | `BoolOp _ as ast -> bool_op_reducer ~pos ~env ~to_term ast
-    | `Simple_fun _ as ast -> simple_fun_reducer ~pos ~env ~to_term ast
+    | `Simple_fun _ as ast -> simple_fun_reducer ~pos ~env ~to_block ast
     | `Regexp _ as ast -> regexp_reducer ~pos ~env ~to_term ast
-    | `Try _ as ast -> try_reducer ~pos ~env ~to_term ast
+    | `Try _ as ast -> try_reducer ~pos ~env ~to_term ~to_block ast
     | `String_interpolation (sep, l) ->
         let l =
           List.map
@@ -168,8 +136,6 @@ let rec to_ast ~throw ~env ~pos ~comments ast =
         in
         to_ast ~env ~pos ~comments
           (`App (op, [`Term ("", mk_parsed ~pos (`List l))]))
-    | `Def p | `Let p | `Binding p ->
-        mk_let ~throw ~pos ~env ~to_term ~comments p
     | `Coalesce (t, default) -> mk_coalesce ~pos ~env ~to_term ~default t
     | `At (t, t') -> `App (to_term ~env t', [("", to_term ~env t)])
     | `Time t -> mk_time_pred ~pos (during ~pos t)
@@ -211,18 +177,39 @@ and to_func ~pos ~env ~to_term ~throw ?name arguments body =
   let mk_def, arguments = expand_argsof ~throw ~pos ~env ~to_term arguments in
   { name; arguments; body = mk_def (to_term ~env body); free_vars = None }
 
+(* The scoping rule, in one place: a binding scopes over the statements that
+   follow it in its own block, and a static conditional splices the statements
+   of the branch it selects in front of them. *)
+and to_block ~throw ~env ({ block_body; block_pos } : Parsed_term.block) :
+    Term.t =
+  let rec fold ~env = function
+    | [] -> mk ~pos:block_pos (`Tuple [])
+    (* A static conditional in statement position splices the statements of the
+       branch it selects, so a binding made under `%ifdef` scopes over the rest
+       of the block. In expression position it is a value: see `to_ast`. *)
+    | { stmt = `Expr { term = `Static_if p; _ }; _ } :: rest ->
+        fold ~env (static_branch ~env p @ rest)
+    | [{ stmt = `Expr tm; _ }] -> to_term ~throw ~env tm
+    | { stmt; stmt_pos = pos; stmt_comments = comments } :: rest -> (
+        match stmt with
+          | `Expr tm -> mk ~pos (`Seq (to_term ~throw ~env tm, fold ~env rest))
+          | `Open tm -> mk ~pos (`Open (to_term ~throw ~env tm, fold ~env rest))
+          | `Binding l ->
+              mk ~pos
+                (mk_let ~throw ~pos ~env ~to_term:(to_term ~throw) ~comments
+                   ~body:(fun env -> fold ~env rest)
+                   l)
+          (* Removed by Term_preprocessor.expand_term. *)
+          | `Include _ -> assert false)
+  in
+  fold ~env block_body
+
 and to_term ~throw ~env (tm : Parsed_term.t) : Term.t =
   let to_term = to_term ~throw in
   report_annotations ~throw ~pos:tm.pos tm.annotations;
   match tm.term with
-    | `Seq ({ pos; term = `If_def _ as ast }, t')
-    | `Seq ({ pos; term = `If_encoder _ as ast }, t')
-    | `Seq ({ pos; term = `If_version _ as ast }, t') ->
-        let t = pp_if_reducer ~pos ~env ast in
-        to_term ~env (Term_preprocessor.concat_term t t')
-    | `Block tm -> to_term ~env tm
+    | `Block b -> to_block ~throw ~env b
     | `Parenthesis tm -> to_term ~env tm
-    | `Eof -> to_term ~env { tm with term = `Tuple [] }
     | `Methods (base, methods) ->
         (* let _ = src in
            let replaces _ = dst in

--- a/src/lang/reducer/term_reducer.ml
+++ b/src/lang/reducer/term_reducer.ml
@@ -272,7 +272,7 @@ let to_encoder_params ~throw =
 
 let to_term ~throw tm = to_term ~throw ~env:[] tm
 
-(* `let eval` desugars to a call to `_eval_`, which parses a string at run time
+(* `let eval` desugars to a call to `_0_eval`, which parses a string at run time
    and so needs the standard library to still be around. Asking the term rather
    than remembering that we reduced one keeps this a property of the script. *)
-let needs_toplevel term = Vars.mem "_eval_" (Term.free_vars term)
+let needs_toplevel term = Vars.mem "_0_eval" (Term.free_vars term)

--- a/src/lang/reducer/term_reducer.mli
+++ b/src/lang/reducer/term_reducer.mli
@@ -38,4 +38,6 @@ val to_encoder_params :
   Parsed_term.encoder_params ->
   Term.encoder_params
 
-val needs_toplevel : unit -> bool
+(** Whether the term uses `let eval`, and so must keep the standard library
+    available at run time. *)
+val needs_toplevel : Term.t -> bool

--- a/src/lang/reducer/term_reducer_argsof.ml
+++ b/src/lang/reducer/term_reducer_argsof.ml
@@ -205,7 +205,7 @@ let expand_argsof ~pos ~env ~to_term ~throw args =
                 | Some { pat_entry = `PVar [v] } -> (mk_def, Some v)
                 | Some pat ->
                     incr anonymous_var_id;
-                    let v = Printf.sprintf "_ann_%d" !anonymous_var_id in
+                    let v = Printf.sprintf "_0_ann_%d" !anonymous_var_id in
                     let mk_def def =
                       mk_def
                         (mk ~pos (pattern_reducer ~body:def ~pat (mk (`Var v))))

--- a/src/lang/reducer/term_reducer_helpers.ml
+++ b/src/lang/reducer/term_reducer_helpers.ml
@@ -34,7 +34,7 @@ let report_annotations ~throw ~pos annotations =
     annotations
 
 let parse_error ~pos msg = raise (Term.Parse_error (pos, msg))
-let render_string ~pos ~sep s = Lexer.render_string ~pos ~sep s
+let render_string = String_literal.render
 let mk ?pos = Term.make ?pos:(Option.map Pos.of_lexing_pos pos)
 let mk_ty ?pos = Type.make ?pos:(Option.map Pos.of_lexing_pos pos)
 let mk_var ?pos = Type.var ?pos:(Option.map Pos.of_lexing_pos pos)

--- a/src/lang/reducer/term_reducer_let.ml
+++ b/src/lang/reducer/term_reducer_let.ml
@@ -116,18 +116,13 @@ let mk_rec_fun ~pos pat arguments body =
   in
   mk ~pos (`Fun { name = Some name; arguments; body; free_vars = None })
 
-let needs_toplevel = ref false
-
 let mk_eval ~pos (pat, def, body, cast) =
-  needs_toplevel := true;
   let ty = match cast with Some ty -> ty | None -> mk_var ~pos () in
   let tty = Value.RuntimeType.to_term ty in
   let eval = mk ~pos (`Var "_eval_") in
   let def = mk ~pos (`App (eval, [("type", tty); ("", def)])) in
   let def = mk ~pos (`Cast { cast = def; typ = ty }) in
   pattern_reducer ~body ~pat def
-
-let needs_toplevel () = !needs_toplevel
 
 let string_of_let_decoration = function
   | `None -> ""

--- a/src/lang/reducer/term_reducer_let.ml
+++ b/src/lang/reducer/term_reducer_let.ml
@@ -140,8 +140,11 @@ let string_of_let_decoration = function
   | `Xml_parse -> "xml.parse"
   | `Json_parse _ -> "json.parse"
 
-let mk_let ~env ~pos ~to_term ~comments ~throw
-    ({ decoration; pat; arglist; def; cast }, body) =
+(* [body] is a continuation rather than a term: what a binding scopes over is
+   the rest of its block, which the caller folds once the extended environment
+   is known. *)
+let mk_let ~env ~pos ~to_term ~comments ~throw ~body
+    { kind = _; decoration; pat; arglist; def; cast } =
   let def = to_term ~env def in
   let mk_body def =
     let env =
@@ -159,7 +162,7 @@ let mk_let ~env ~pos ~to_term ~comments ~throw
             (path, def) :: env
         | _ -> env
     in
-    to_term ~env body
+    body env
   in
   let cast = Option.map (mk_parsed_ty ~pos ~env ~to_term) cast in
   let arglist = Option.map (expand_argsof ~throw ~pos ~env ~to_term) arglist in

--- a/src/lang/reducer/term_reducer_let.ml
+++ b/src/lang/reducer/term_reducer_let.ml
@@ -39,7 +39,7 @@ let mk_let_json_parse ~pos (args, pat, def, cast) body =
       | Some v -> v
       | None -> Term.(make (`Bool false))
   in
-  let parser = mk ~pos (`Var "_internal_json_parser_") in
+  let parser = mk ~pos (`Var "_0_json_parser") in
   let def =
     mk ~pos (`App (parser, [("json5", json5); ("type", tty); ("", def)]))
   in
@@ -49,7 +49,7 @@ let mk_let_json_parse ~pos (args, pat, def, cast) body =
 let mk_let_xml_parse ~pos (pat, def, cast) body =
   let ty = match cast with Some ty -> ty | None -> mk_var ~pos () in
   let tty = Value.RuntimeType.to_term ty in
-  let parser = mk ~pos (`Var "_internal_xml_parser_") in
+  let parser = mk ~pos (`Var "_0_xml_parser") in
   let def = mk ~pos (`App (parser, [("type", tty); ("", def)])) in
   let def = mk ~pos (`Cast { cast = def; typ = ty }) in
   pattern_reducer ~body ~pat def
@@ -57,7 +57,7 @@ let mk_let_xml_parse ~pos (pat, def, cast) body =
 let mk_let_yaml_parse ~pos (pat, def, cast) body =
   let ty = match cast with Some ty -> ty | None -> mk_var ~pos () in
   let tty = Value.RuntimeType.to_term ty in
-  let parser = mk ~pos (`Var "_internal_yaml_parser_") in
+  let parser = mk ~pos (`Var "_0_yaml_parser") in
   let def = mk ~pos (`App (parser, [("type", tty); ("", def)])) in
   let def = mk ~pos (`Cast { cast = def; typ = ty }) in
   pattern_reducer ~body ~pat def
@@ -65,7 +65,7 @@ let mk_let_yaml_parse ~pos (pat, def, cast) body =
 let mk_let_sqlite_row ~pos (pat, def, cast) body =
   let ty = match cast with Some ty -> ty | None -> mk_var ~pos () in
   let tty = Value.RuntimeType.to_term ty in
-  let parser = mk ~pos (`Var "_sqlite_row_parser_") in
+  let parser = mk ~pos (`Var "_0_sqlite_row_parser") in
   let def = mk ~pos (`App (parser, [("type", tty); ("", def)])) in
   let def = mk ~pos (`Cast { cast = def; typ = ty }) in
   pattern_reducer ~body ~pat def
@@ -76,7 +76,7 @@ let mk_let_sqlite_query ~pos (pat, def, cast) body =
   Typing.(
     ty <: mk_ty ~pos (Type.List { Type.t = inner_list_ty; json_repr = `Tuple }));
   let tty = Value.RuntimeType.to_term inner_list_ty in
-  let parser = mk ~pos (`Var "_sqlite_row_parser_") in
+  let parser = mk ~pos (`Var "_0_sqlite_row_parser") in
   let mapper =
     let query = mk ~pos (`Var "query") in
     mk ~pos (`App (parser, [("type", tty); ("", query)]))
@@ -119,7 +119,7 @@ let mk_rec_fun ~pos pat arguments body =
 let mk_eval ~pos (pat, def, body, cast) =
   let ty = match cast with Some ty -> ty | None -> mk_var ~pos () in
   let tty = Value.RuntimeType.to_term ty in
-  let eval = mk ~pos (`Var "_eval_") in
+  let eval = mk ~pos (`Var "_0_eval") in
   let def = mk ~pos (`App (eval, [("type", tty); ("", def)])) in
   let def = mk ~pos (`Cast { cast = def; typ = ty }) in
   pattern_reducer ~body ~pat def

--- a/src/lang/reducer/term_reducer_pattern.ml
+++ b/src/lang/reducer/term_reducer_pattern.ml
@@ -27,6 +27,9 @@ open Parsed_term
 include Runtime_term
 open Term_reducer_helpers
 
+(* Names the desugaring binds are spelled with a digit right after the leading
+   underscore. `Lexer.var_lit` requires an alphabetic character there, so no
+   script can write one, and user code cannot shadow what the sugar expands to. *)
 let pat_var_name =
   let idx = ref 1 in
   fun () ->

--- a/src/lang/reducer/term_reducer_sugar.ml
+++ b/src/lang/reducer/term_reducer_sugar.ml
@@ -231,19 +231,19 @@ let set_reducer ~pos ~env ~to_term = function
           typ = mk_ty ~pos Type.unit;
         }
 
-let if_reducer ~pos ~env ~to_term = function
+let if_reducer ~pos ~env ~to_term ~to_block = function
   | `Inline_if { if_condition; if_then_block; if_elsif; if_else_block; _ }
   | `If { if_condition; if_then_block; if_elsif; if_else_block; _ } ->
       let if_else =
         match if_else_block with
           | None -> mk ~pos (`Tuple [])
-          | Some b -> to_term ~env b.block_body
+          | Some b -> to_block ~env b
       in
       let branches =
-        (if_condition, if_then_block.block_body)
+        (if_condition, if_then_block)
         :: List.map
              (fun { elsif_condition; elsif_then_block; _ } ->
-               (elsif_condition, elsif_then_block.block_body))
+               (elsif_condition, elsif_then_block))
              if_elsif
       in
       let term =
@@ -255,20 +255,18 @@ let if_reducer ~pos ~env ~to_term = function
                  ( op,
                    [
                      ("", to_term ~env condition);
-                     ("then", mk_fun ~pos [] (to_term ~env _then));
+                     ("then", mk_fun ~pos [] (to_block ~env _then));
                      ("else", mk_fun ~pos [] if_else);
                    ] )))
           if_else (List.rev branches)
       in
       term.term
 
-let while_reducer ~pos ~env ~to_term = function
+let while_reducer ~pos ~env ~to_term ~to_block = function
   | `While { while_condition; while_do_block } ->
       let op = mk ~pos (`Var "while") in
       let while_condition = mk_fun ~pos [] (to_term ~env while_condition) in
-      let while_loop =
-        mk_fun ~pos [] (to_term ~env while_do_block.block_body)
-      in
+      let while_loop = mk_fun ~pos [] (to_block ~env while_do_block) in
       `App (op, [("", while_condition); ("", while_loop)])
 
 let base_for_reducer ~pos for_variable for_iterator for_loop =
@@ -288,14 +286,14 @@ let base_for_reducer ~pos for_variable for_iterator for_loop =
   in
   `App (for_op, [("", for_iterator); ("", for_loop)])
 
-let iterable_for_reducer ~pos ~env ~to_term = function
+let iterable_for_reducer ~pos ~env ~to_term ~to_block = function
   | `Iterable_for
       { iterable_for_variable; iterable_for_iterator; iterable_for_do_block } ->
       base_for_reducer ~pos iterable_for_variable
         (to_term ~env iterable_for_iterator)
-        (to_term ~env iterable_for_do_block.block_body)
+        (to_block ~env iterable_for_do_block)
 
-let for_reducer ~pos ~env ~to_term = function
+let for_reducer ~pos ~env ~to_term ~to_block = function
   | `For { for_variable; for_from; for_to; for_do_block } ->
       let to_op = mk ~pos (`Var "iterator") in
       let to_op =
@@ -307,7 +305,7 @@ let for_reducer ~pos ~env ~to_term = function
           (`App (to_op, [("", to_term ~env for_from); ("", to_term ~env for_to)]))
       in
       base_for_reducer ~pos for_variable for_condition
-        (to_term ~env for_do_block.block_body)
+        (to_block ~env for_do_block)
 
 let infix_reducer ~pos ~env ~to_term = function
   | `Infix (tm, op, tm') ->
@@ -325,13 +323,13 @@ let bool_op_reducer ~pos ~env ~to_term = function
         (to_term ~env tm).term terms
   | `BoolOp (_, []) -> assert false
 
-let simple_fun_reducer ~pos:_ ~env ~to_term = function
-  | `Simple_fun tm ->
+let simple_fun_reducer ~pos:_ ~env ~to_block = function
+  | `Simple_fun b ->
       `Fun
         {
           name = None;
           arguments = [];
-          body = to_term ~env tm;
+          body = to_block ~env b;
           free_vars = None;
         }
 
@@ -384,9 +382,9 @@ let regexp_reducer ~pos ~env:_ ~to_term:_ = function
       let op = mk ~pos (`Var "regexp") in
       `App (op, [("", regexp); ("flags", flags)])
 
-let try_reducer ~pos ~env ~to_term = function
+let try_reducer ~pos ~env ~to_term ~to_block = function
   | `Try { try_body_block; try_handler; try_finally_block } ->
-      let try_body = mk_fun ~pos [] (to_term ~env try_body_block.block_body) in
+      let try_body = mk_fun ~pos [] (to_block ~env try_body_block) in
       let try_variable =
         match try_handler with Some h -> h.try_handler_variable | None -> "_"
       in
@@ -404,15 +402,14 @@ let try_reducer ~pos ~env ~to_term = function
       let finally_pos, finally =
         match try_finally_block with
           | None -> (pos, mk ~pos (`Tuple []))
-          | Some b -> (b.block_body.pos, to_term ~env b.block_body)
+          | Some b -> (b.block_pos, to_block ~env b)
       in
       let finally = mk_fun ~pos:finally_pos [] finally in
       let handler_pos, handler =
         match try_handler with
           | None -> (pos, mk ~pos (`Tuple []))
           | Some h ->
-              ( h.try_handler_block.block_body.pos,
-                to_term ~env h.try_handler_block.block_body )
+              (h.try_handler_block.block_pos, to_block ~env h.try_handler_block)
       in
       let handler = mk_fun ~pos:handler_pos err_arg handler in
       let error_module = mk ~pos (`Var "error") in

--- a/src/lang/runtime/builtins_eval.ml
+++ b/src/lang/runtime/builtins_eval.ml
@@ -23,7 +23,7 @@
 let raise ~bt exn = Lang.raise_as_runtime ~bt ~kind:"eval" exn
 
 let _ =
-  Lang.add_builtin ~category:`Liquidsoap "_eval_"
+  Lang.add_builtin ~category:`Liquidsoap "_0_eval"
     ~descr:"Parse and evaluate a string." ~flags:[`Hidden]
     [("type", Value.RuntimeType.t, None, None); ("", Lang.string_t, None, None)]
     (Lang.univ_t ())

--- a/src/lang/runtime/builtins_json.ml
+++ b/src/lang/runtime/builtins_json.ml
@@ -333,7 +333,7 @@ let _ =
       Lang.string v)
 
 let _ =
-  Lang.add_builtin "_internal_json_parser_" ~category:`String ~flags:[`Hidden]
+  Lang.add_builtin "_0_json_parser" ~category:`String ~flags:[`Hidden]
     ~descr:"Internal json parser"
     [
       ("type", Value.RuntimeType.t, None, Some "Runtime type");

--- a/src/lang/runtime/builtins_xml.ml
+++ b/src/lang/runtime/builtins_xml.ml
@@ -295,7 +295,7 @@ and parse_untyped_xml xml =
         Lang.meth (Lang.tuple [Lang.string name; props]) [(name, props)]
 
 let _ =
-  Lang.add_builtin "_internal_xml_parser_" ~category:`String ~flags:[`Hidden]
+  Lang.add_builtin "_0_xml_parser" ~category:`String ~flags:[`Hidden]
     ~descr:"Internal xml parser"
     [
       ("type", Value.RuntimeType.t, None, Some "Runtime type");

--- a/src/lang/runtime/builtins_yaml.ml
+++ b/src/lang/runtime/builtins_yaml.ml
@@ -23,7 +23,7 @@ let rec json_of_yaml = function
   | `Null -> `Null
 
 let _ =
-  Lang.add_builtin "_internal_yaml_parser_" ~category:`String ~flags:[`Hidden]
+  Lang.add_builtin "_0_yaml_parser" ~category:`String ~flags:[`Hidden]
     ~descr:"Internal yaml parser"
     [
       ("type", Value.RuntimeType.t, None, Some "Runtime type");

--- a/src/lang/runtime/lang_eval.ml
+++ b/src/lang/runtime/lang_eval.ml
@@ -21,24 +21,31 @@ let type_term ?name ?(cache = true) ?(trim = true) ?(deprecated = false) ?ty
   in
   Runtime.type_term ?name ?stdlib ?ty ~term ~cache ~trim ~lib:false parsed_term
 
-let effective_toplevel ~stdlib toplevel =
+let effective_toplevel ~stdlib ~term toplevel =
   (* Registering defined operators at top-level prevents reclaiming memory from unused operators
      so we try to avoid it by default. We need it for all documentation. Also, as soon as the user
      script contains [let eval ...], we have to retain values at top-level as the string being
      parsed will also expect the standard library to be available. *)
-    match (stdlib, Term_reducer.needs_toplevel ()) with
+    match (stdlib, Term_reducer.needs_toplevel term) with
     | `Disabled, _ -> toplevel
     | _, true -> true
     | _ -> toplevel
 
-let eval ?(toplevel = false) ?(typecheck = true) ?cache ?deprecated ?ty ?name
-    ~stdlib s =
+(* Also returns whether the top level had to be retained, which the CLI uses to
+   decide if the top-level environments can be reclaimed. *)
+let eval_with_toplevel ?(toplevel = false) ?(typecheck = true) ?cache
+    ?deprecated ?ty ?name ~stdlib s =
   let parsed_term, term = Runtime.parse s in
-  let toplevel = effective_toplevel ~stdlib toplevel in
+  let toplevel = effective_toplevel ~stdlib ~term toplevel in
   let term =
     if typecheck then
       type_term ?name ?cache ?deprecated ?ty ~trim:(not toplevel) ~stdlib
         ~parsed_term term
     else term
   in
-  Runtime.eval_term ?name ~toplevel term
+  (Runtime.eval_term ?name ~toplevel term, toplevel)
+
+let eval ?toplevel ?typecheck ?cache ?deprecated ?ty ?name ~stdlib s =
+  fst
+    (eval_with_toplevel ?toplevel ?typecheck ?cache ?deprecated ?ty ?name
+       ~stdlib s)

--- a/src/lang/runtime/term_stdlib.ml
+++ b/src/lang/runtime/term_stdlib.ml
@@ -30,21 +30,22 @@ let rec prepend_stdlib ~term =
   | { term = `Cache_env _ } -> term
   | _ -> assert false
 
-let rec prepend_parsed_stdlib =
+(* The user script runs in the scope of the whole standard library, which with
+   statement lists is plain concatenation. *)
+let prepend_parsed_stdlib ~parsed_term stdlib =
   let open Parsed_term in
-  fun ~parsed_term -> function
-    | { term = `Let (def, body) } as tm ->
-        { tm with term = `Let (def, prepend_parsed_stdlib ~parsed_term body) }
-    | { term = `Def (def, body) } as tm ->
-        { tm with term = `Def (def, prepend_parsed_stdlib ~parsed_term body) }
-    | { term = `Binding (def, body) } as tm ->
+  match (stdlib.term, parsed_term.term) with
+    | `Block stdlib_block, `Block user_block ->
         {
-          tm with
-          term = `Binding (def, prepend_parsed_stdlib ~parsed_term body);
+          stdlib with
+          term =
+            `Block
+              {
+                stdlib_block with
+                block_body = stdlib_block.block_body @ user_block.block_body;
+              };
         }
-    | { term = `Seq (t1, t2) } as tm ->
-        { tm with term = `Seq (t1, prepend_parsed_stdlib ~parsed_term t2) }
-    | tm -> Parsed_term.make ~pos:tm.pos (`Seq (tm, parsed_term))
+    | _ -> assert false
 
 (** To be cacheable, the standard library is parsed and converted to a term. We
     add [`Cache_env] to it and type-check it. This results in having the full

--- a/src/lang/tooling/parsed_json.ml
+++ b/src/lang/tooling/parsed_json.ml
@@ -35,85 +35,71 @@ let json_of_position { Lexing.pos_fname; pos_lnum; pos_bol; pos_cnum } : Json.t
 
 let json_of_positions (p, p') = `Tuple [json_of_position p; json_of_position p']
 
-let json_of_if_def ~to_json
-    { if_def_negative; if_def_condition; if_def_then_block; if_def_else_block }
-    =
-  [
-    ("negative", `Bool if_def_negative);
-    ("condition", `String if_def_condition);
-    ("then", to_json if_def_then_block.block_body);
-    ( "else",
-      match if_def_else_block with
-        | None -> `Null
-        | Some b -> to_json b.block_body );
-  ]
+(* Block bodies are flat arrays of statements in both formats. A plain
+   expression statement is emitted inline, as the expression node itself. *)
+let json_of_static_if ~json_of_block { static_cond; static_then; static_else } =
+  let cond =
+    match static_cond with
+      | `Defined (negative, name) ->
+          [
+            ("type", `String "if_def");
+            ("negative", `Bool negative);
+            ("condition", `String name);
+          ]
+      | `Encoder (negative, name) ->
+          [
+            ("type", `String "if_encoder");
+            ("negative", `Bool negative);
+            ("condition", `String name);
+          ]
+      | `Version (op, version) ->
+          [
+            ("type", `String "if_version");
+            ( "opt",
+              `String
+                (match op with
+                  | `Eq -> "=="
+                  | `Geq -> ">="
+                  | `Leq -> "<="
+                  | `Gt -> ">"
+                  | `Lt -> "<") );
+            ("version", `String (Lang_string.Version.to_string version));
+          ]
+  in
+  cond
+  @ [
+      ("then", json_of_block static_then);
+      ( "else",
+        match static_else with None -> `Null | Some b -> json_of_block b );
+    ]
 
-let json_of_if_encoder ~to_json
-    {
-      if_encoder_negative;
-      if_encoder_condition;
-      if_encoder_then_block;
-      if_encoder_else_block;
-    } =
-  [
-    ("negative", `Bool if_encoder_negative);
-    ("condition", `String if_encoder_condition);
-    ("then", to_json if_encoder_then_block.block_body);
-    ( "else",
-      match if_encoder_else_block with
-        | None -> `Null
-        | Some b -> to_json b.block_body );
-  ]
-
-let json_of_if_version ~to_json
-    {
-      if_version_op;
-      if_version_version;
-      if_version_then_block;
-      if_version_else_block;
-    } =
-  [
-    ( "opt",
-      `String
-        (match if_version_op with
-          | `Eq -> "=="
-          | `Geq -> ">="
-          | `Leq -> "<="
-          | `Gt -> ">"
-          | `Lt -> "<") );
-    ("version", `String (Lang_string.Version.to_string if_version_version));
-    ("then", to_json if_version_then_block.block_body);
-    ( "else",
-      match if_version_else_block with
-        | None -> `Null
-        | Some b -> to_json b.block_body );
-  ]
-
-let json_of_while ~to_json { while_condition; while_do_block } =
+let json_of_while ~to_json ~json_of_block { while_condition; while_do_block } =
   [
     ("condition", to_json while_condition);
-    ("loop", to_json while_do_block.block_body);
+    ("loop", json_of_block while_do_block);
   ]
 
-let json_of_for ~to_json { for_variable; for_from; for_to; for_do_block } =
+let json_of_for ~to_json ~json_of_block
+    { for_variable; for_from; for_to; for_do_block } =
   [
     ("variable", `String for_variable);
     ("from", to_json for_from);
     ("to", to_json for_to);
-    ("loop", to_json for_do_block.block_body);
+    ("loop", json_of_block for_do_block);
   ]
 
-let json_of_iterable_for ~to_json
+let json_of_iterable_for ~to_json ~json_of_block
     { iterable_for_variable; iterable_for_iterator; iterable_for_do_block } =
   [
     ("variable", `String iterable_for_variable);
     ("iterator", to_json iterable_for_iterator);
-    ("loop", to_json iterable_for_do_block.block_body);
+    ("loop", json_of_block iterable_for_do_block);
   ]
 
-let json_of_try ~to_json { try_body_block; try_handler; try_finally_block } =
+let json_of_try ~to_json ~json_of_block
+    { try_body_block; try_handler; try_finally_block } =
   [
-    ("body", to_json try_body_block.block_body);
+    ("body", json_of_block try_body_block);
     ( "variable",
       `String
         (match try_handler with
@@ -125,12 +111,10 @@ let json_of_try ~to_json { try_body_block; try_handler; try_finally_block } =
         | _ -> `Null );
     ( "handler",
       match try_handler with
-        | Some h -> to_json h.try_handler_block.block_body
+        | Some h -> json_of_block h.try_handler_block
         | None -> `Null );
     ( "finally",
-      match try_finally_block with
-        | Some b -> to_json b.block_body
-        | None -> `Null );
+      match try_finally_block with Some b -> json_of_block b | None -> `Null );
   ]
 
 let type_node ~typ ?(extra = []) value =
@@ -217,11 +201,11 @@ and json_of_source_track_annotation { track_name; track_type; track_params } =
       ]
     (`String track_type)
 
-let json_of_if ~to_json
+let json_of_if ~to_json ~json_of_block
     { if_condition; if_then_block; if_elsif; if_else_block; _ } =
   [
     ("condition", to_json if_condition);
-    ("then", to_json if_then_block.block_body);
+    ("then", json_of_block if_then_block);
     ( "elsif",
       `Tuple
         (List.map
@@ -230,11 +214,11 @@ let json_of_if ~to_json
                (ast_node ~typ:"elsif"
                   [
                     ("condition", to_json elsif_condition);
-                    ("then", to_json elsif_then_block.block_body);
+                    ("then", json_of_block elsif_then_block);
                   ]))
            if_elsif) );
     ( "else",
-      match if_else_block with None -> `Null | Some b -> to_json b.block_body );
+      match if_else_block with None -> `Null | Some b -> json_of_block b );
   ]
 
 let rec base_json_of_pat = function
@@ -362,7 +346,8 @@ let json_of_let_decoration ~to_json : Parsed_term.let_decoration -> Json.t =
                     args) );
            ])
 
-let args_of_json_let ~to_json { decoration; pat; arglist; cast; def } =
+let args_of_json_let ~to_json { kind = _; decoration; pat; arglist; cast; def }
+    =
   [
     ("decoration", json_of_let_decoration ~to_json decoration);
     ("pat", json_of_pat pat);
@@ -379,14 +364,33 @@ let args_of_json_let ~to_json { decoration; pat; arglist; cast; def } =
     ("definition", to_json def);
   ]
 
-let json_of_let ~to_json ast =
-  let typ, args, body =
-    match ast with
-      | `Def (p, body) -> ("def", args_of_json_let ~to_json p, body)
-      | `Let (p, body) -> ("let", args_of_json_let ~to_json p, body)
-      | `Binding (p, body) -> ("binding", args_of_json_let ~to_json p, body)
-  in
-  ast_node ~typ (("body", to_json body) :: args)
+(* Emit a def node with its function body flattened into "body". *)
+let json_of_def ~to_json ~body { kind = _; decoration; pat; arglist; cast; def }
+    =
+  ast_node ~typ:"def"
+    [
+      ("decoration", json_of_let_decoration ~to_json decoration);
+      ("pat", json_of_pat pat);
+      ( "arglist",
+        match arglist with
+          | None -> `Null
+          | Some arglist ->
+              `Tuple
+                (List.map
+                   (fun arg -> `Assoc (json_of_fun_arg ~to_json arg))
+                   arglist) );
+      ( "cast",
+        match cast with None -> `Null | Some t -> json_of_type_annotation t );
+      ("body", body def);
+    ]
+
+(* `def f() = ... end` keeps its own statements under "body"; `let` and a bare
+   binding carry a single right-hand side under "definition". *)
+let json_of_binding ~to_json ~body ({ kind; _ } as p) =
+  match kind with
+    | `Def -> json_of_def ~to_json ~body p
+    | `Let -> ast_node ~typ:"let" (args_of_json_let ~to_json p)
+    | `Bare -> ast_node ~typ:"binding" (args_of_json_let ~to_json p)
 
 let json_of_app_arg ~to_json = function
   | `Term (l, v) ->
@@ -434,15 +438,22 @@ let rec to_ast_json ~to_json = function
   | `Set (t, t') ->
       ast_node ~typ:"infix"
         [("left", to_json t); ("op", `String ":="); ("right", to_json t')]
-  | `Inline_if p -> ast_node ~typ:"inline_if" (json_of_if ~to_json p)
-  | `If p -> ast_node ~typ:"if" (json_of_if ~to_json p)
-  | `If_def p -> ast_node ~typ:"if_def" (json_of_if_def ~to_json p)
-  | `If_version p -> ast_node ~typ:"if_version" (json_of_if_version ~to_json p)
-  | `If_encoder p -> ast_node ~typ:"if_encoder" (json_of_if_encoder ~to_json p)
-  | `While p -> ast_node ~typ:"while" (json_of_while ~to_json p)
-  | `For p -> ast_node ~typ:"for" (json_of_for ~to_json p)
+  | `Inline_if p ->
+      ast_node ~typ:"inline_if"
+        (json_of_if ~to_json ~json_of_block:(json_of_block ~to_json) p)
+  | `If p ->
+      ast_node ~typ:"if"
+        (json_of_if ~to_json ~json_of_block:(json_of_block ~to_json) p)
+  | `Static_if p -> json_of_static_if ~json_of_block:(json_of_block ~to_json) p
+  | `While p ->
+      ast_node ~typ:"while"
+        (json_of_while ~to_json ~json_of_block:(json_of_block ~to_json) p)
+  | `For p ->
+      ast_node ~typ:"for"
+        (json_of_for ~to_json ~json_of_block:(json_of_block ~to_json) p)
   | `Iterable_for p ->
-      ast_node ~typ:"iterable_for" (json_of_iterable_for ~to_json p)
+      ast_node ~typ:"iterable_for"
+        (json_of_iterable_for ~to_json ~json_of_block:(json_of_block ~to_json) p)
   | `Not t -> ast_node ~typ:"not" [("value", to_json t)]
   | `Negative t -> ast_node ~typ:"negative" [("value", to_json t)]
   | `String_interpolation (c, l) ->
@@ -472,7 +483,8 @@ let rec to_ast_json ~to_json = function
   | `BoolOp (op, l) ->
       ast_node ~typ:"bool"
         [("op", `String op); ("value", `Tuple (List.map to_json l))]
-  | `Simple_fun t -> ast_node ~typ:"simple_fun" [("value", to_json t)]
+  | `Simple_fun b ->
+      ast_node ~typ:"simple_fun" [("value", json_of_block ~to_json b)]
   | `Time t -> ast_node ~typ:"time" (json_of_time_el t)
   | `Time_interval (t, t') ->
       ast_node ~typ:"time_interval"
@@ -489,7 +501,9 @@ let rec to_ast_json ~to_json = function
               (List.sort Stdlib.compare
                  (List.map (fun c -> `String (Char.escaped c)) flags)) );
         ]
-  | `Try p -> ast_node ~typ:"try" (json_of_try ~to_json p)
+  | `Try p ->
+      ast_node ~typ:"try"
+        (json_of_try ~to_json ~json_of_block:(json_of_block ~to_json) p)
   | `Custom g ->
       ast_node ~typ:"ground"
         [("value", `String (Json.to_string (Term.Custom.to_json ~pos:[] g)))]
@@ -497,7 +511,7 @@ let rec to_ast_json ~to_json = function
   | `Int i -> ast_node ~typ:"ground" [("value", `String i)]
   | `Float v -> ast_node ~typ:"ground" [("value", `String v)]
   | `Parenthesis tm -> ast_node ~typ:"parenthesis" [("value", to_json tm)]
-  | `Block tm -> ast_node ~typ:"block" [("value", to_json tm)]
+  | `Block b -> ast_node ~typ:"block" [("value", json_of_block ~to_json b)]
   | `Raw_string (id, s) ->
       ast_node ~typ:"raw_string" [("id", `String id); ("value", `String s)]
   | `String (c, s) ->
@@ -543,18 +557,8 @@ let rec to_ast_json ~to_json = function
                  methods
               @ base_methods) );
         ]
-  | `Eof -> ast_node ~typ:"eof" []
   | `Open (t, t') ->
       ast_node ~typ:"open" [("left", to_json t); ("right", to_json t')]
-  | `Let _ as ast -> json_of_let ~to_json ast
-  | `Def _ as ast -> json_of_let ~to_json ast
-  | `Binding _ as ast -> json_of_let ~to_json ast
-  | `Include { inc_type = `Lib; inc_name } ->
-      ast_node ~typ:"include_lib" [("value", `String inc_name)]
-  | `Include { inc_type = `Default; inc_name } ->
-      ast_node ~typ:"include" [("value", `String inc_name)]
-  | `Include { inc_type = `Extra; inc_name } ->
-      ast_node ~typ:"include_extra" [("value", `String inc_name)]
   | `Coalesce (t, t') ->
       ast_node ~typ:"coalesce" [("left", to_json t); ("right", to_json t')]
   | `At (t, t') ->
@@ -570,6 +574,34 @@ let rec to_ast_json ~to_json = function
   | `RFun (lbl, args, body) ->
       ast_node ~typ:"rfun"
         (("name", `String lbl) :: json_of_fun ~to_json args body)
+
+and json_of_def_body ~to_json t : Json.t =
+  match t.Parsed_term.term with
+    | `Block b -> json_of_block ~to_json b
+    | _ -> `Tuple [to_json t]
+
+and json_of_block ~to_json b : Json.t =
+  `Tuple (List.map (json_of_statement ~to_json) b.block_body)
+
+and json_of_statement ~to_json ?body { stmt; stmt_pos; _ } : Json.t =
+  let body =
+    match body with Some fn -> fn | None -> json_of_def_body ~to_json
+  in
+  let node args = `Assoc (("position", json_of_positions stmt_pos) :: args) in
+  match stmt with
+    (* An expression statement is the expression node itself: the statement
+       wrapper would carry nothing the expression does not already have. *)
+    | `Expr tm -> to_json tm
+    | `Binding p -> node (json_of_binding ~to_json ~body p)
+    | `Open tm -> node (ast_node ~typ:"open" [("left", to_json tm)])
+    | `Include { inc_type; inc_name } ->
+        let typ =
+          match inc_type with
+            | `Lib -> "include_lib"
+            | `Default -> "include"
+            | `Extra -> "include_extra"
+        in
+        node (ast_node ~typ [("value", `String inc_name)])
 
 and to_encoder_json ~to_json (lbl, params) =
   [
@@ -596,62 +628,75 @@ let rec to_json { pos; term; _ } : Json.t =
    parse_string always emits this format. Block bodies are flat arrays ("body"),
    if/elsif/else use a unified "branches" array, try uses a "handler" sub-object. *)
 
-(* Flatten a body chain into a list of JSON statement nodes. *)
-let rec statements_of_chain ~to_json t : Json.t list =
-  match t.term with
-    | `Def (p, body) ->
-        `Assoc (("position", json_of_positions t.pos) :: json_of_def ~to_json p)
-        :: statements_of_chain ~to_json body
-    | `Let (p, body) ->
-        `Assoc
-          (("position", json_of_positions t.pos)
-          :: ast_node ~typ:"let" (args_of_json_let ~to_json p))
-        :: statements_of_chain ~to_json body
-    | `Binding (p, body) ->
-        `Assoc
-          (("position", json_of_positions t.pos)
-          :: ast_node ~typ:"binding" (args_of_json_let ~to_json p))
-        :: statements_of_chain ~to_json body
-    | `Seq (t1, t2) -> to_json t1 :: statements_of_chain ~to_json t2
-    | `Open (t, body) ->
-        `Assoc
-          (("position", json_of_positions t.pos)
-          :: ast_node ~typ:"open" [("left", to_json t)])
-        :: statements_of_chain ~to_json body
-    | `Eof -> []
-    | _ -> [to_json t]
-
-(* Emit a def node with its function body flattened into "body". *)
-and json_of_def ~to_json { decoration; pat; arglist; cast; def } =
-  ast_node ~typ:"def"
-    [
-      ("decoration", json_of_let_decoration ~to_json decoration);
-      ("pat", json_of_pat pat);
-      ( "arglist",
-        match arglist with
-          | None -> `Null
-          | Some arglist ->
-              `Tuple
-                (List.map
-                   (fun arg -> `Assoc (json_of_fun_arg ~to_json arg))
-                   arglist) );
-      ( "cast",
-        match cast with None -> `Null | Some t -> json_of_type_annotation t );
-      ("body", `Tuple (statements_of_chain ~to_json def));
-    ]
-
 let rec to_json_canonical ({ pos; term; _ } : Parsed_term.t) : Json.t =
   `Assoc (("position", json_of_positions pos) :: to_ast_json_canonical pos term)
 
+and block_node_canonical ?(typ = "") { Parsed_term.block_body; block_pos } =
+  let type_field = if typ = "" then [] else [("type", `String typ)] in
+  `Assoc
+    (type_field
+    @ [
+        ("position", json_of_positions block_pos);
+        ("body", statements_canonical block_body);
+      ])
+
+(* The canonical format anchors each branch on its own `ifdef_block` node, so
+   that prettier can attach comments between `%ifdef` and `%else`. *)
+and static_if_canonical { static_cond; static_then; static_else } =
+  let cond =
+    match static_cond with
+      | `Defined (negative, name) ->
+          [
+            ("type", `String "if_def");
+            ("negative", `Bool negative);
+            ("condition", `String name);
+          ]
+      | `Encoder (negative, name) ->
+          [
+            ("type", `String "if_encoder");
+            ("negative", `Bool negative);
+            ("condition", `String name);
+          ]
+      | `Version (op, version) ->
+          [
+            ("type", `String "if_version");
+            ( "opt",
+              `String
+                (match op with
+                  | `Eq -> "=="
+                  | `Geq -> ">="
+                  | `Leq -> "<="
+                  | `Gt -> ">"
+                  | `Lt -> "<") );
+            ("version", `String (Lang_string.Version.to_string version));
+          ]
+  in
+  cond
+  @ [
+      ("then_block", block_node_canonical ~typ:"ifdef_block" static_then);
+      ( "else_block",
+        match static_else with
+          | None -> `Null
+          | Some b -> block_node_canonical ~typ:"ifdef_block" b );
+    ]
+
+and statements_canonical stmts =
+  `Tuple
+    (List.map
+       (json_of_statement ~to_json:to_json_canonical ~body:body_canonical)
+       stmts)
+
+(* A term in body position: `def f() = ... end` stores its block wrapped in
+   `Block`, everything else is a single expression. *)
+and body_canonical t =
+  match t.Parsed_term.term with
+    | `Block b -> statements_canonical b.block_body
+    | _ -> `Tuple [to_json_canonical t]
+
 and to_ast_json_canonical pos term =
   let to_json = to_json_canonical in
-  let body t = `Tuple (statements_of_chain ~to_json t) in
-  let block_node ?(typ = "") { Parsed_term.block_body; block_pos } =
-    let type_field = if typ = "" then [] else [("type", `String typ)] in
-    `Assoc
-      (type_field
-      @ [("position", json_of_positions block_pos); ("body", body block_body)])
-  in
+  let body = body_canonical in
+  let block_node = block_node_canonical in
   match term with
     | `If { if_condition; if_then_block; if_elsif; if_else_block; if_end_pos }
       ->
@@ -670,7 +715,7 @@ and to_ast_json_canonical pos term =
               ("type", `String "elsif");
               ("position", json_of_positions (fst elsif_pos, then_end));
               ("condition", to_json elsif_condition);
-              ("body", body elsif_then_block.block_body);
+              ("body", statements_canonical elsif_then_block.block_body);
             ]
         in
         ast_node ~typ:"if"
@@ -683,65 +728,7 @@ and to_ast_json_canonical pos term =
                 | None -> `Null
                 | Some b -> block_node ~typ:"else_block" b );
           ]
-    | `If_def
-        {
-          if_def_negative;
-          if_def_condition;
-          if_def_then_block;
-          if_def_else_block;
-        } ->
-        ast_node ~typ:"if_def"
-          [
-            ("negative", `Bool if_def_negative);
-            ("condition", `String if_def_condition);
-            ("then_block", block_node ~typ:"ifdef_block" if_def_then_block);
-            ( "else_block",
-              match if_def_else_block with
-                | None -> `Null
-                | Some b -> block_node ~typ:"ifdef_block" b );
-          ]
-    | `If_version
-        {
-          if_version_op;
-          if_version_version;
-          if_version_then_block;
-          if_version_else_block;
-        } ->
-        ast_node ~typ:"if_version"
-          [
-            ( "opt",
-              `String
-                (match if_version_op with
-                  | `Eq -> "=="
-                  | `Geq -> ">="
-                  | `Leq -> "<="
-                  | `Gt -> ">"
-                  | `Lt -> "<") );
-            ( "version",
-              `String (Lang_string.Version.to_string if_version_version) );
-            ("then_block", block_node ~typ:"ifdef_block" if_version_then_block);
-            ( "else_block",
-              match if_version_else_block with
-                | None -> `Null
-                | Some b -> block_node ~typ:"ifdef_block" b );
-          ]
-    | `If_encoder
-        {
-          if_encoder_negative;
-          if_encoder_condition;
-          if_encoder_then_block;
-          if_encoder_else_block;
-        } ->
-        ast_node ~typ:"if_encoder"
-          [
-            ("negative", `Bool if_encoder_negative);
-            ("condition", `String if_encoder_condition);
-            ("then_block", block_node ~typ:"ifdef_block" if_encoder_then_block);
-            ( "else_block",
-              match if_encoder_else_block with
-                | None -> `Null
-                | Some b -> block_node ~typ:"ifdef_block" b );
-          ]
+    | `Static_if p -> static_if_canonical p
     | `While { while_condition; while_do_block } ->
         let header =
           `Assoc
@@ -757,7 +744,7 @@ and to_ast_json_canonical pos term =
             [
               ("type", `String "while_body");
               ("position", json_of_positions while_do_block.block_pos);
-              ("body", body while_do_block.block_body);
+              ("body", statements_canonical while_do_block.block_body);
             ]
         in
         ast_node ~typ:"while" [("parts", `Tuple [header; body_node])]
@@ -778,7 +765,7 @@ and to_ast_json_canonical pos term =
             [
               ("type", `String "for_body");
               ("position", json_of_positions for_do_block.block_pos);
-              ("body", body for_do_block.block_body);
+              ("body", statements_canonical for_do_block.block_body);
             ]
         in
         ast_node ~typ:"for" [("parts", `Tuple [header; body_node])]
@@ -801,7 +788,7 @@ and to_ast_json_canonical pos term =
             [
               ("type", `String "iterable_for_body");
               ("position", json_of_positions iterable_for_do_block.block_pos);
-              ("body", body iterable_for_do_block.block_body);
+              ("body", statements_canonical iterable_for_do_block.block_body);
             ]
         in
         ast_node ~typ:"iterable_for" [("parts", `Tuple [header; body_node])]
@@ -811,7 +798,7 @@ and to_ast_json_canonical pos term =
             [
               ("type", `String "try_body");
               ("position", json_of_positions try_body_block.block_pos);
-              ("body", body try_body_block.block_body);
+              ("body", statements_canonical try_body_block.block_body);
             ]
         in
         let catch_nodes =
@@ -836,7 +823,7 @@ and to_ast_json_canonical pos term =
                         match try_handler_errors_list with
                           | None -> `Null
                           | Some t -> to_json t );
-                      ("body", body try_handler_block.block_body);
+                      ("body", statements_canonical try_handler_block.block_body);
                     ];
                 ]
             | None -> []
@@ -849,7 +836,7 @@ and to_ast_json_canonical pos term =
                     [
                       ("type", `String "try_finally");
                       ("position", json_of_positions finally_block.block_pos);
-                      ("body", body finally_block.block_body);
+                      ("body", statements_canonical finally_block.block_body);
                     ];
                 ]
             | None -> []
@@ -877,12 +864,10 @@ and to_ast_json_canonical pos term =
                    args) );
             ("body", body fun_body);
           ]
-    | `Simple_fun t -> ast_node ~typ:"simple_fun" [("body", body t)]
-    | `Def (p, _) -> json_of_def ~to_json p
-    | `Let (p, _) -> ast_node ~typ:"let" (args_of_json_let ~to_json p)
-    | `Binding (p, _) -> ast_node ~typ:"binding" (args_of_json_let ~to_json p)
-    | `Open (t, _) -> ast_node ~typ:"open" [("left", to_json t)]
-    | `Block tm -> ast_node ~typ:"block" [("body", body tm)]
+    | `Simple_fun b ->
+        ast_node ~typ:"simple_fun" [("body", statements_canonical b.block_body)]
+    | `Block b ->
+        ast_node ~typ:"block" [("body", statements_canonical b.block_body)]
     | other -> to_ast_json ~to_json other
 
 let parse_string ?(formatter = Format.err_formatter) content =
@@ -894,6 +879,11 @@ let parse_string ?(formatter = Format.err_formatter) content =
     let term = Runtime.program tokenizer in
     let raw_comments = Parser_helper.get_pending_comments () in
     Parser_helper.attach_comments term;
+    let statements =
+      match term.Parsed_term.term with
+        | `Block b -> b.block_body
+        | _ -> assert false
+    in
     let start_pos =
       { Lexing.pos_fname = ""; pos_lnum = 1; pos_bol = 0; pos_cnum = 0 }
     in
@@ -903,7 +893,7 @@ let parse_string ?(formatter = Format.err_formatter) content =
         [
           ("type", `String "program");
           ("position", json_of_positions (start_pos, end_pos));
-          ("body", `Tuple (statements_of_chain ~to_json:to_json_canonical term));
+          ("body", statements_canonical statements);
         ]
     in
     let comments =

--- a/src/lang/tooling/parsed_json.ml
+++ b/src/lang/tooling/parsed_json.ml
@@ -201,6 +201,21 @@ and json_of_source_track_annotation { track_name; track_type; track_params } =
       ]
     (`String track_type)
 
+(* A ternary's branches are single expressions by construction, and the ABI has
+   them as expression nodes rather than statement arrays. *)
+let json_of_inline_if ~to_json ~json_of_block
+    { if_condition; if_then_block; if_else_block; _ } =
+  let branch b =
+    match b.block_body with
+      | [{ stmt = `Expr tm; _ }] -> to_json tm
+      | _ -> json_of_block b
+  in
+  [
+    ("condition", to_json if_condition);
+    ("then", branch if_then_block);
+    ("else", match if_else_block with None -> `Null | Some b -> branch b);
+  ]
+
 let json_of_if ~to_json ~json_of_block
     { if_condition; if_then_block; if_elsif; if_else_block; _ } =
   [
@@ -440,7 +455,7 @@ let rec to_ast_json ~to_json = function
         [("left", to_json t); ("op", `String ":="); ("right", to_json t')]
   | `Inline_if p ->
       ast_node ~typ:"inline_if"
-        (json_of_if ~to_json ~json_of_block:(json_of_block ~to_json) p)
+        (json_of_inline_if ~to_json ~json_of_block:(json_of_block ~to_json) p)
   | `If p ->
       ast_node ~typ:"if"
         (json_of_if ~to_json ~json_of_block:(json_of_block ~to_json) p)
@@ -683,15 +698,20 @@ and static_if_canonical { static_cond; static_then; static_else } =
 and statements_canonical stmts =
   `Tuple
     (List.map
-       (json_of_statement ~to_json:to_json_canonical ~body:body_canonical)
+       (json_of_statement ~to_json:to_json_canonical ~body:def_body_canonical)
        stmts)
 
 (* A term in body position: `def f() = ... end` stores its block wrapped in
    `Block`, everything else is a single expression. *)
-and body_canonical t =
+(* A `def` body is an implicit block, so its statements are the body. A `fun`
+   body is a single expression, so a block there was written `begin ... end`
+   and has to stay one, or the formatter would delete it. *)
+and def_body_canonical t =
   match t.Parsed_term.term with
     | `Block b -> statements_canonical b.block_body
     | _ -> `Tuple [to_json_canonical t]
+
+and body_canonical t = `Tuple [to_json_canonical t]
 
 and to_ast_json_canonical pos term =
   let to_json = to_json_canonical in

--- a/src/libs/extra/audio.liq
+++ b/src/libs/extra/audio.liq
@@ -597,7 +597,9 @@ def smooth_add(~duration=1., ~p=getter(0.2), ~normal, ~special) =
   def to_blank(x) =
     b = x.starting
     normal_volume := mkfade(start=last_p(), duration=duration, normal)
-    if null.defined(x?.ending) then
+    if
+      null.defined(x?.ending)
+    then
       special_volume :=
         mkfade(start=1. - last_p(), duration=duration, null.get(x?.ending))
       sequence([null.get(x?.ending), b])
@@ -607,7 +609,7 @@ def smooth_add(~duration=1., ~p=getter(0.2), ~normal, ~special) =
   end
 
   special =
-    fallback([special.{on_select=to_special}, blank().{on_select=to_blank}])
+    fallback([special.{on_select = to_special}, blank().{on_select = to_blank}])
 
   add(normalize=false, [normal, special])
 end

--- a/src/libs/extra/source.liq
+++ b/src/libs/extra/source.liq
@@ -35,13 +35,13 @@ def rotate.merge(~id=null("rotate.merge"), sources) =
   sources =
     list.mapi(
       fun (i, (s:source)) ->
-        if i == 0 then s.{on_select=to_first} else (s : source) end,
+        if i == 0 then s.{on_select = to_first} else (s : source) end,
       sources
     )
 
   s = rotate(sources)
   let {track_marks = _, ...tracks} = source.tracks(s)
-  s = source(tracks).{replay_metadata=false}
+  s = source(tracks).{replay_metadata = false}
   switch(id=id, [(ready, s), ({not ready()}, s)])
 end
 

--- a/tests/harbor/harbor_output_on_connect_disconnect.liq
+++ b/tests/harbor/harbor_output_on_connect_disconnect.liq
@@ -9,7 +9,10 @@ def f() =
   end
 
   o.on_connect(synchronous=false, on_connect)
-  o.on_disconnect(synchronous=false, fun (_) -> if connected() then test.pass() end)
+  o.on_disconnect(
+    synchronous=false,
+    fun (_) -> if connected() then test.pass() end
+  )
 
   l = input.http("http://localhost:3470/test")
   output.dummy(fallible=true, l)

--- a/tests/language/dune.inc
+++ b/tests/language/dune.inc
@@ -513,6 +513,25 @@
   (run %{run_test} record.liq liquidsoap %{test_liq} record.liq)))
 
 (rule
+ (alias test_record_methods_eager)
+ (package liquidsoap)
+ (deps
+  record_methods_eager.liq
+  ../../src/bin/liquidsoap.exe
+  (package liquidsoap)
+  (source_tree ../../src/libs)
+  crontab_test_cases.json
+  (:test_liq ../test.liq)
+  (:run_test ../run_test.exe))
+ (action
+  (run
+   %{run_test}
+   record_methods_eager.liq
+   liquidsoap
+   %{test_liq}
+   record_methods_eager.liq)))
+
+(rule
  (alias test_ref)
  (package liquidsoap)
  (deps
@@ -780,6 +799,7 @@
   (alias test_process)
   (alias test_rec)
   (alias test_record)
+  (alias test_record_methods_eager)
   (alias test_ref)
   (alias test_regexp)
   (alias test_replaygain)

--- a/tests/language/mime_types.liq
+++ b/tests/language/mime_types.liq
@@ -16,7 +16,8 @@ def f() =
   # Custom mime_types_extnames overrides defaults
   test.equal(
     file.mime.extension(
-      mime_types_extnames=[("image/png", ".PNG")], "image/png"
+      mime_types_extnames=[("image/png", ".PNG")],
+      "image/png"
     ),
     ".PNG"
   )
@@ -24,7 +25,8 @@ def f() =
   # Custom mime_types_extnames: unknown type returns null
   test.equal(
     file.mime.extension(
-      mime_types_extnames=[("image/png", ".png")], "audio/mpeg"
+      mime_types_extnames=[("image/png", ".png")],
+      "audio/mpeg"
     ),
     null
   )

--- a/tests/language/record_methods_eager.liq
+++ b/tests/language/record_methods_eager.liq
@@ -1,0 +1,24 @@
+def f() =
+  # Record fields are evaluated when the record is built, whether or not they
+  # are ever invoked, and whether or not the record is bound to a name first.
+  # Liquidsoap is eager: an optional argument's default is evaluated when the
+  # function is defined, for the same reason.
+  bound = ref(false)
+  r = {a = 1, b = bound := true}
+  ignore(r.a)
+  test.equal(bound(), true)
+
+  literal = ref(false)
+  ignore({a = 1, b = literal := true}.a)
+  test.equal(literal(), true)
+
+  default = ref(false)
+  def _(~x = default := true) =
+    ignore(x)
+  end
+  test.equal(default(), true)
+
+  test.pass()
+end
+
+test.check(f)

--- a/tests/language/record_methods_eager.liq
+++ b/tests/language/record_methods_eager.liq
@@ -13,7 +13,7 @@ def f() =
   test.equal(literal(), true)
 
   default = ref(false)
-  def with_default(~x = default := true) =
+  def with_default(~x=default := true) =
     ignore(x)
   end
   ignore(with_default)

--- a/tests/language/record_methods_eager.liq
+++ b/tests/language/record_methods_eager.liq
@@ -13,9 +13,10 @@ def f() =
   test.equal(literal(), true)
 
   default = ref(false)
-  def _(~x = default := true) =
+  def with_default(~x = default := true) =
     ignore(x)
   end
+  ignore(with_default)
   test.equal(default(), true)
 
   test.pass()

--- a/tests/media/test_ffmpeg_distributed_hls_setup.liq
+++ b/tests/media/test_ffmpeg_distributed_hls_setup.liq
@@ -36,7 +36,11 @@ streams = [("mp4", mp4), ("mpegts", mpegts)]
 # Fixed relative path so dune can track it as a directory target.
 output_dir = "hls_resume_output"
 
-ignore(process.run("mkdir -p #{output_dir}"))
+ignore(
+  process.run(
+    "mkdir -p #{output_dir}"
+  )
+)
 
 # Use position-only names (no timestamp) for deterministic output that
 # dune can cache across runs.

--- a/tests/regression/GH3239.liq
+++ b/tests/regression/GH3239.liq
@@ -11,7 +11,7 @@ def transition({starting, ..._}) =
   fade.in(starting)
 end
 
-s = fallback([a.{on_select=transition}, b.{on_select=transition}])
+s = fallback([a.{on_select = transition}, b.{on_select = transition}])
 
 clock.assign_new(sync='none', [s])
 

--- a/tests/regression/GH4163.liq
+++ b/tests/regression/GH4163.liq
@@ -30,7 +30,10 @@ fallback_sine =
 s =
   fallback(
     id="main_source",
-    [blank_strip.{track_sensitive=false}, fallback_sine.{track_sensitive=false}]
+    [
+      blank_strip.{track_sensitive = false},
+      fallback_sine.{track_sensitive = false}
+    ]
   )
 
 # We want to make sure that blank.strip keeps eating the blank source before switching back:

--- a/tests/regression/GH5259.liq
+++ b/tests/regression/GH5259.liq
@@ -15,10 +15,15 @@ def on_file_change({state, path = fname}) =
     state == "created"
     and string.contains(prefix="stream_", path.basename(fname))
   then
-    if not made_unavailable() then
+    if
+      not made_unavailable()
+    then
       made_unavailable := true
       file.move(atomic=true, hls_dir, saved_dir)
-      file.write(data="not a directory", hls_dir)
+      file.write(
+        data="not a directory",
+        hls_dir
+      )
     else
       test.pass()
     end
@@ -43,4 +48,11 @@ o =
 
 o.on_file_change(synchronous=true, on_file_change)
 
-thread.run(delay=20., {test.fail("HLS output did not recover")})
+thread.run(
+  delay=20.,
+  {
+    test.fail(
+      "HLS output did not recover"
+    )
+  }
+)

--- a/tests/regression/delay_track_advance.liq
+++ b/tests/regression/delay_track_advance.liq
@@ -25,7 +25,9 @@ s.on_metadata(
   fun (m) ->
     begin
       title = m["title"]
-      if title != "" and not list.mem(title, seen()) then
+      if
+        title != "" and not list.mem(title, seen())
+      then
         seen := [...seen(), title]
       end
       if list.length(seen()) >= 3 then test.pass() end

--- a/tests/regression/switch_infallible_across_transition.liq
+++ b/tests/regression/switch_infallible_across_transition.liq
@@ -12,7 +12,7 @@ frames = ref(0)
 s =
   switch(
     [
-      ({live()}, (sine(id="cutter") : source).{track_sensitive=false}),
+      ({live()}, (sine(id="cutter") : source).{track_sensitive = false}),
       ({true}, blank(id="always"))
     ]
   )
@@ -26,11 +26,7 @@ s.on_frame(
       ref.incr(frames)
       if not source.is_ready(s) then gap := true end
       if frames() mod 60 == 0 then live := not live() end
-      if
-        frames() >= 900
-      then
-        if gap() then test.fail() else test.pass() end
-      end
+      if frames() >= 900 then if gap() then test.fail() else test.pass() end end
     end
 )
 

--- a/tests/regression/switch_on_leave_chained.liq
+++ b/tests/regression/switch_on_leave_chained.liq
@@ -12,9 +12,11 @@ def track(name) =
 end
 
 # None of these ever end a track on their own, so every handoff is a preemption.
-a = (sine(id="a") : source).{track_sensitive=false, on_leave=track("a")}
-b = (sine(id="b", 550.) : source).{track_sensitive=false, on_leave=track("b")}
-c = (sine(id="c", 660.) : source).{track_sensitive=false, on_leave=track("c")}
+a = (sine(id="a") : source).{track_sensitive = false, on_leave = track("a")}
+b =
+  (sine(id="b", 550.) : source).{track_sensitive = false, on_leave = track("b")}
+c =
+  (sine(id="c", 660.) : source).{track_sensitive = false, on_leave = track("c")}
 
 use_b = ref(false)
 use_c = ref(false)
@@ -39,9 +41,7 @@ thread.run(
   delay=4.,
   {
     begin
-      log(
-        "left=#{left()}"
-      )
+      log("left=#{left()}")
       if
         list.mem("a", left()) and list.mem("b", left())
       then

--- a/tests/snapshots/README.md
+++ b/tests/snapshots/README.md
@@ -44,11 +44,11 @@ two `--auto-promote` commands.
 
 ## File extensions in `cases/`
 
-| extension     | what it is                                                             |
-| ------------- | ---------------------------------------------------------------------- |
-| `.liq`        | a case                                                                 |
-| `.invalid-liq`| a case that is deliberately not valid Liquidsoap                       |
-| `.liq-inc`    | not a case; a fixture some case pulls in with `%include`               |
+| extension      | what it is                                               |
+| -------------- | -------------------------------------------------------- |
+| `.liq`         | a case                                                   |
+| `.invalid-liq` | a case that is deliberately not valid Liquidsoap         |
+| `.liq-inc`     | not a case; a fixture some case pulls in with `%include` |
 
 Only `.liq` is picked up by the repo-wide `**/*.liq` glob that the external
 tree-sitter and lezer grammars are checked against, which is why the other two

--- a/tests/snapshots/README.md
+++ b/tests/snapshots/README.md
@@ -28,6 +28,32 @@ streaming core — so the output only depends on the language implementation.
 Scripts that use core builtins (sources, `time_in_mod`, …) still show their
 desugaring; they simply fail at the `type` stage, which is fine and expected.
 
+## The canonical suite
+
+`cases_canonical/` → `expected_canonical/` is a second, much smaller suite that
+dumps `Parsed_json.parse_string` instead: the flat, keyword-anchored JSON that
+liquidsoap-prettier consumes, spec'd in `src/lang/tooling/parsed_json.mli`.
+
+It exists because the pipeline snapshots above **strip every position**, while
+block spans and comment offsets are precisely what prettier depends on — so a
+parser change can leave `expected/` untouched and still break the formatter.
+Keep these cases few and focused on block structure; the output is verbose.
+
+Both suites share `snapshot.exe` (`--canonical` selects the second) and the same
+two `--auto-promote` commands.
+
+## File extensions in `cases/`
+
+| extension     | what it is                                                             |
+| ------------- | ---------------------------------------------------------------------- |
+| `.liq`        | a case                                                                 |
+| `.invalid-liq`| a case that is deliberately not valid Liquidsoap                       |
+| `.liq-inc`    | not a case; a fixture some case pulls in with `%include`               |
+
+Only `.liq` is picked up by the repo-wide `**/*.liq` glob that the external
+tree-sitter and lezer grammars are checked against, which is why the other two
+are spelled the way they are.
+
 ## Adding a case
 
 Drop a `.liq` file in `cases/`, then:

--- a/tests/snapshots/cases/argsof.liq
+++ b/tests/snapshots/cases/argsof.liq
@@ -1,3 +1,7 @@
-def base(~a=1, ~b=2) = a + b end
-def wrapper(%argsof(base)) = base(%argsof(base)) end
+def base(~a=1, ~b=2) =
+  a + b
+end
+def wrapper(%argsof(base)) =
+  base(%argsof(base))
+end
 wrapper(a=3)

--- a/tests/snapshots/cases/binding_bad_target.invalid-liq
+++ b/tests/snapshots/cases/binding_bad_target.invalid-liq
@@ -1,0 +1,3 @@
+# The left-hand side of a bare binding must be a valid pattern. A call is not,
+# and is reported as such rather than as a bare syntax error.
+f(1) = 2

--- a/tests/snapshots/cases/binding_bare_after_first_in_shorthand.liq
+++ b/tests/snapshots/cases/binding_bare_after_first_in_shorthand.liq
@@ -1,9 +1,10 @@
 # The record ambiguity only affects the *first* statement of a `{ ... }` body.
 # A leading `x = 1` would be the record `{ x = 1 }`, but once past it a bare
 # binding is fine. src/libs/extra/fades.liq relies on this.
-f = {
-  let a = 1
-  b = a + 1
-  b
-}
+f =
+  {
+    let a = 1
+    b = a + 1
+    b
+  }
 f()

--- a/tests/snapshots/cases/binding_bare_after_first_in_shorthand.liq
+++ b/tests/snapshots/cases/binding_bare_after_first_in_shorthand.liq
@@ -1,0 +1,9 @@
+# The record ambiguity only affects the *first* statement of a `{ ... }` body.
+# A leading `x = 1` would be the record `{ x = 1 }`, but once past it a bare
+# binding is fine. src/libs/extra/fades.liq relies on this.
+f = {
+  let a = 1
+  b = a + 1
+  b
+}
+f()

--- a/tests/snapshots/cases/binding_bare_in_shorthand.invalid-liq
+++ b/tests/snapshots/cases/binding_bare_in_shorthand.invalid-liq
@@ -1,0 +1,5 @@
+# A leading bare binding inside `{ … }` is not allowed: `{ x = 1 }` is a record
+# literal. Write `let x = 1` instead. Only the first statement is restricted,
+# see binding_bare_after_first_in_shorthand.liq.
+f = { x = 1; x + 1 }
+f()

--- a/tests/snapshots/cases/binding_forms.liq
+++ b/tests/snapshots/cases/binding_forms.liq
@@ -1,0 +1,6 @@
+# `x = e`, `let x = e` and `def x = e end` are three grammar productions
+# (`binding` / `explicit_binding` in parser.mly) that reduce to the same `let`.
+c = 1
+let d = 1
+def e = 1 end
+(c, d, e)

--- a/tests/snapshots/cases/binding_forms.liq
+++ b/tests/snapshots/cases/binding_forms.liq
@@ -2,5 +2,7 @@
 # (`binding` / `explicit_binding` in parser.mly) that reduce to the same `let`.
 c = 1
 let d = 1
-def e = 1 end
+def e =
+  1
+end
 (c, d, e)

--- a/tests/snapshots/cases/binding_let_in_shorthand.liq
+++ b/tests/snapshots/cases/binding_let_in_shorthand.liq
@@ -1,0 +1,3 @@
+# The form `{ … }` does accept: `let`, unlike a bare binding.
+f = { let x = 1; x + 1 }
+f()

--- a/tests/snapshots/cases/binding_let_in_shorthand.liq
+++ b/tests/snapshots/cases/binding_let_in_shorthand.liq
@@ -1,3 +1,7 @@
 # The form `{ … }` does accept: `let`, unlike a bare binding.
-f = { let x = 1; x + 1 }
+f =
+  {
+    let x = 1
+    x + 1
+  }
 f()

--- a/tests/snapshots/cases/binding_positions.liq
+++ b/tests/snapshots/cases/binding_positions.liq
@@ -1,0 +1,15 @@
+# A binding scopes over the rest of its block, in every block position.
+def outer() =
+  a = 1
+  a + 1
+end
+
+inner_if = if true then b = 2; b else 0 end
+
+def last_statement() =
+  # A binding as the last statement of a block: its body is `Eof`, which
+  # reduces to unit.
+  c = 3
+end
+
+(outer(), inner_if, last_statement())

--- a/tests/snapshots/cases/binding_positions.liq
+++ b/tests/snapshots/cases/binding_positions.liq
@@ -4,11 +4,19 @@ def outer() =
   a + 1
 end
 
-inner_if = if true then b = 2; b else 0 end
+inner_if =
+  if
+    true
+  then
+    b = 2
+    b
+  else
+    0
+  end
 
 def last_statement() =
-  # A binding as the last statement of a block: its body is `Eof`, which
-  # reduces to unit.
+  # A binding as the last statement of a block: nothing follows it, so the
+  # block evaluates to unit.
   c = 3
 end
 

--- a/tests/snapshots/cases/binding_targets.liq
+++ b/tests/snapshots/cases/binding_targets.liq
@@ -1,0 +1,12 @@
+# A bare binding takes the same targets as `let`: a variable, a field path, a
+# type annotation, and destructuring patterns. The left-hand side is parsed as
+# an expression and reinterpreted as a pattern.
+x = {a = 1}
+x.b = 2
+
+(p, q) = (1, 2)
+[r, s] = [3, 4]
+(n : int) = 5
+_ = 6
+
+(x.b, p, q, r, s, n)

--- a/tests/snapshots/cases/doc_comments.liq
+++ b/tests/snapshots/cases/doc_comments.liq
@@ -1,0 +1,15 @@
+# A doc comment attaches to the statement that follows it, and ends up on the
+# binding as `Doc.Value.t`. This is what `--list-functions-md` reports.
+
+# Adds one to its argument.
+# @category Programming
+def documented(x) =
+  x + 1
+end
+
+# Also documented, as a plain binding.
+plain = 1
+
+undocumented = 2
+
+(documented(plain), undocumented)

--- a/tests/snapshots/cases/included.liq-inc
+++ b/tests/snapshots/cases/included.liq-inc
@@ -1,4 +1,4 @@
-# Pulled in by pp_include.liq. Both bindings must scope over the code that
-# follows the `%include`, which is what Term_preprocessor.concat_term arranges.
+# Pulled in by pp_include.liq. Both bindings scope over the code that follows
+# the `%include`, because the included statements are spliced into that block.
 from_include = 1
 let also_from_include = 2

--- a/tests/snapshots/cases/included.liq-inc
+++ b/tests/snapshots/cases/included.liq-inc
@@ -1,0 +1,4 @@
+# Pulled in by pp_include.liq. Both bindings must scope over the code that
+# follows the `%include`, which is what Term_preprocessor.concat_term arranges.
+from_include = 1
+let also_from_include = 2

--- a/tests/snapshots/cases/iterable_for.liq
+++ b/tests/snapshots/cases/iterable_for.liq
@@ -1,1 +1,1 @@
-for x = list.iterator([1, 2, 3]) do ignore(x) end
+for x = list.iterator([1, 2, 3]) do ignore(x)  end

--- a/tests/snapshots/cases/json_as_type.liq
+++ b/tests/snapshots/cases/json_as_type.liq
@@ -1,0 +1,10 @@
+# `as` is a contextual keyword, not a reserved word: it stays an ordinary
+# identifier everywhere else. `as json.object` reads a JSON object as an
+# association list; `"name" as field` renames a field whose JSON name is not a
+# valid identifier.
+let json.parse (m : [(string * int)] as json.object) = "{\"a\": 1}"
+let json.parse (r : {"start" as spin_start: string}) = "{\"start\": \"x\"}"
+
+as = "still an identifier"
+
+(m, r.spin_start, as)

--- a/tests/snapshots/cases/json_as_type.liq
+++ b/tests/snapshots/cases/json_as_type.liq
@@ -2,9 +2,12 @@
 # identifier everywhere else. `as json.object` reads a JSON object as an
 # association list; `"name" as field` renames a field whose JSON name is not a
 # valid identifier.
-let json.parse (m : [(string * int)] as json.object) = "{\"a\": 1}"
-let json.parse (r : {"start" as spin_start: string}) = "{\"start\": \"x\"}"
+let json.parse (m : [(string*int)] as json.object) =
+  "{\"a\": 1}"
+let json.parse (r : {"start" as spin_start: string}) =
+  "{\"start\": \"x\"}"
 
-as = "still an identifier"
+as =
+  "still an identifier"
 
 (m, r.spin_start, as)

--- a/tests/snapshots/cases/json_as_type_bad.invalid-liq
+++ b/tests/snapshots/cases/json_as_type_bad.invalid-liq
@@ -1,4 +1,6 @@
-# A misspelled contextual keyword names what was expected and points at the
+# A wrong contextual keyword names what was expected and points at the
 # offending token, rather than reporting the whole type as invalid.
-let json.parse (m : [(string * int)] as json.objct) = "{}"
+# The bad keyword has to be a non-word: codespell rewrites anything close
+# enough to `object` to be in its dictionary, here and in the expected output.
+let json.parse (m : [(string * int)] as json.nope) = "{}"
 ignore(m)

--- a/tests/snapshots/cases/json_as_type_bad.invalid-liq
+++ b/tests/snapshots/cases/json_as_type_bad.invalid-liq
@@ -1,0 +1,4 @@
+# A misspelled contextual keyword names what was expected and points at the
+# offending token, rather than reporting the whole type as invalid.
+let json.parse (m : [(string * int)] as json.objct) = "{}"
+ignore(m)

--- a/tests/snapshots/cases/json_parse.liq
+++ b/tests/snapshots/cases/json_parse.liq
@@ -1,2 +1,3 @@
-let json.parse ({a} : {a: int}) = '{"a": 1}'
+let json.parse ({a} : {a: int}) =
+  '{"a": 1}'
 a

--- a/tests/snapshots/cases/pp_comments.liq
+++ b/tests/snapshots/cases/pp_comments.liq
@@ -4,5 +4,8 @@ x = 1 # trailing
 # a doc comment
 # @category Test
 ##
-def f() = x end
+
+def f() =
+  x
+end
 f()

--- a/tests/snapshots/cases/pp_ifdef_value.liq
+++ b/tests/snapshots/cases/pp_ifdef_value.liq
@@ -1,0 +1,10 @@
+# `%ifdef` in value position: the selected branch is a block used as a value,
+# not a statement splice. src/libs/playlist.liq relies on this.
+s =
+%ifdef list.length
+  1
+%else
+  2
+%endif
+
+s

--- a/tests/snapshots/cases/pp_include.liq
+++ b/tests/snapshots/cases/pp_include.liq
@@ -1,0 +1,4 @@
+%include "included.liq-inc"
+
+before = 0
+(before, from_include, also_from_include)

--- a/tests/snapshots/cases/pp_include_extra_missing.liq
+++ b/tests/snapshots/cases/pp_include_extra_missing.liq
@@ -1,0 +1,6 @@
+# An absent `%include_extra` is skipped, which is how the minimal distributions
+# build: they ship none of the files `src/libs/stdlib.liq` pulls in this way.
+%include_extra "definitely_not_here.liq-inc"
+
+before = 0
+before

--- a/tests/snapshots/cases/reserved_names.invalid-liq
+++ b/tests/snapshots/cases/reserved_names.invalid-liq
@@ -1,0 +1,7 @@
+# The desugaring binds names with a digit right after the leading underscore.
+# `Lexer.var_lit` requires an alphabetic character there, so a script cannot
+# write one, and so cannot shadow what the sugar expands to: `_0_eval`,
+# `_0_json_parser`, `_0_ann_0`, `_2_pat` and friends are all unwritable.
+# `_null` is deliberately not in that namespace -- it is a real, callable
+# builtin.
+_0_eval = 1

--- a/tests/snapshots/cases/string_interpolation_nested.liq
+++ b/tests/snapshots/cases/string_interpolation_nested.liq
@@ -1,0 +1,12 @@
+# An interpolation is read as ordinary tokens, and the `}` that closes it is
+# found by counting braces over tokens. A record, a string or another
+# interpolated string inside `#{ … }` therefore nests correctly.
+m = [("k", "v")]
+r = {a = 1}
+
+by_key = "got #{m["k"]}"
+record = "a #{ {a = 1}.a } b"
+nested = "#{ "#{r.a}" }"
+adjacent = "#{r.a}#{r.a}"
+
+(by_key, record, nested, adjacent)

--- a/tests/snapshots/cases/string_interpolation_nested.liq
+++ b/tests/snapshots/cases/string_interpolation_nested.liq
@@ -4,9 +4,11 @@
 m = [("k", "v")]
 r = {a = 1}
 
-by_key = "got #{m["k"]}"
-record = "a #{ {a = 1}.a } b"
-nested = "#{ "#{r.a}" }"
+by_key =
+  "got #{m["k"]}"
+record =
+  "a #{{a = 1}.a} b"
+nested = "#{"#{r.a}"}"
 adjacent = "#{r.a}#{r.a}"
 
 (by_key, record, nested, adjacent)

--- a/tests/snapshots/cases/type_constructor_unknown.invalid-liq
+++ b/tests/snapshots/cases/type_constructor_unknown.invalid-liq
@@ -1,0 +1,3 @@
+# The list of accepted constructors in this message is derived from the table
+# that drives the dispatch, so it cannot drift.
+ignore((1 : blah(int)))

--- a/tests/snapshots/cases/type_constructors.liq
+++ b/tests/snapshots/cases/type_constructors.liq
@@ -1,0 +1,10 @@
+# `ref` and `getter` name types but are ordinary functions too, so they are
+# recognized by name in the grammar rather than lexed as keywords.
+r = ref(1)
+ignore((r : ref(int)))
+ignore((1 : getter(int)))
+
+# Still ordinary identifiers.
+ref = "a variable"
+getter = "another"
+(ref, getter)

--- a/tests/snapshots/cases/type_constructors.liq
+++ b/tests/snapshots/cases/type_constructors.liq
@@ -5,6 +5,7 @@ ignore((r : ref(int)))
 ignore((1 : getter(int)))
 
 # Still ordinary identifiers.
-ref = "a variable"
+ref =
+  "a variable"
 getter = "another"
 (ref, getter)

--- a/tests/snapshots/cases_canonical/blocks.liq
+++ b/tests/snapshots/cases_canonical/blocks.liq
@@ -3,23 +3,11 @@
 # each spans to the start of the next keyword. Prettier uses those spans to
 # decide which block a comment belongs to.
 def f(x) =
-  if x > 0 then
-    1
-  elsif x < 0 then
-    -1
-  else
-    0
-  end
+  if x > 0 then 1 elsif x < 0 then -1 else 0 end
 end
 
-while false do
-  f(1)
-end
+while false do f(1)  end
 
-for i = 0 to 2 do
-  f(i)
-end
+for i = 0 to 2 do f(i)  end
 
-for j = [1, 2] do
-  f(j)
-end
+for j = [1, 2] do f(j)  end

--- a/tests/snapshots/cases_canonical/blocks.liq
+++ b/tests/snapshots/cases_canonical/blocks.liq
@@ -1,0 +1,25 @@
+# Every construct whose canonical JSON carries keyword-anchored block spans:
+# `then_block` starts at `then`, `else_block` at `else`, `*_body` at `do`, and
+# each spans to the start of the next keyword. Prettier uses those spans to
+# decide which block a comment belongs to.
+def f(x) =
+  if x > 0 then
+    1
+  elsif x < 0 then
+    -1
+  else
+    0
+  end
+end
+
+while false do
+  f(1)
+end
+
+for i = 0 to 2 do
+  f(i)
+end
+
+for j = [1, 2] do
+  f(j)
+end

--- a/tests/snapshots/cases_canonical/blocks_and_ternary.liq
+++ b/tests/snapshots/cases_canonical/blocks_and_ternary.liq
@@ -1,0 +1,21 @@
+# An explicit `begin ... end` must survive as a block node: a `def` body is an
+# implicit block and flattens into `body`, but a `fun` body is a single
+# expression, so a block there was written by hand and the formatter would
+# delete it if it were flattened too.
+f =
+  fun () ->
+    begin
+      a = 1
+      a
+    end
+
+def g() =
+  b = 2
+  b
+end
+
+# A ternary's branches are expression nodes, not statement arrays.
+l = [1, ...(true ? [2] : []), 3]
+h = true ? "yes" : "no"
+
+(f(), g(), l, h)

--- a/tests/snapshots/cases_canonical/comments.liq
+++ b/tests/snapshots/cases_canonical/comments.liq
@@ -1,0 +1,13 @@
+# The `comments` array: raw text plus absolute cnum offsets, reported
+# independently of the AST so prettier can place them itself.
+
+# A doc comment on a binding.
+x = 1 # trailing, same line
+
+# Leading a block.
+def g() =
+  # Inside the block.
+  x
+end
+
+g()

--- a/tests/snapshots/cases_canonical/try_blocks.liq
+++ b/tests/snapshots/cases_canonical/try_blocks.liq
@@ -1,0 +1,9 @@
+# `try` is emitted as a `parts` array of try_body / try_catch / try_finally,
+# each with its own keyword-anchored span.
+try
+  error.raise(error.not_found, "nope")
+catch err : [error.not_found] do
+  err.message
+finally
+  ()
+end

--- a/tests/snapshots/dune
+++ b/tests/snapshots/dune
@@ -48,7 +48,8 @@
 (rule
  (alias gendune)
  (deps
-  (source_tree cases))
+  (source_tree cases)
+  (source_tree cases_canonical))
  (target dune.inc.gen)
  (action
   (progn

--- a/tests/snapshots/dune.inc
+++ b/tests/snapshots/dune.inc
@@ -1063,6 +1063,25 @@
   (diff expected_canonical/blocks.expected canonical_blocks.actual)))
 
 (rule
+ (target canonical_blocks_and_ternary.actual)
+ (deps
+  (:case cases_canonical/blocks_and_ternary.liq)
+  (glob_files cases/*.liq-inc)
+  (:snapshot snapshot.exe))
+ (action
+  (with-stdout-to
+   %{target}
+   (run %{snapshot} --canonical %{case}))))
+
+(rule
+ (aliases lang_snapshot runtest)
+ (package liquidsoap)
+ (action
+  (diff
+   expected_canonical/blocks_and_ternary.expected
+   canonical_blocks_and_ternary.actual)))
+
+(rule
  (target canonical_comments.actual)
  (deps
   (:case cases_canonical/comments.liq)

--- a/tests/snapshots/dune.inc
+++ b/tests/snapshots/dune.inc
@@ -976,6 +976,42 @@
   (diff expected/type_annotation.expected type_annotation.actual)))
 
 (rule
+ (target type_constructor_unknown.actual)
+ (deps
+  (:case cases/type_constructor_unknown.invalid-liq)
+  (glob_files cases/*.liq-inc)
+  (:snapshot snapshot.exe))
+ (action
+  (with-stdout-to
+   %{target}
+   (run %{snapshot} %{case}))))
+
+(rule
+ (aliases lang_snapshot runtest)
+ (package liquidsoap)
+ (action
+  (diff
+   expected/type_constructor_unknown.expected
+   type_constructor_unknown.actual)))
+
+(rule
+ (target type_constructors.actual)
+ (deps
+  (:case cases/type_constructors.liq)
+  (glob_files cases/*.liq-inc)
+  (:snapshot snapshot.exe))
+ (action
+  (with-stdout-to
+   %{target}
+   (run %{snapshot} %{case}))))
+
+(rule
+ (aliases lang_snapshot runtest)
+ (package liquidsoap)
+ (action
+  (diff expected/type_constructors.expected type_constructors.actual)))
+
+(rule
  (target while_loop.actual)
  (deps
   (:case cases/while_loop.liq)

--- a/tests/snapshots/dune.inc
+++ b/tests/snapshots/dune.inc
@@ -2,6 +2,7 @@
  (target append_list.actual)
  (deps
   (:case cases/append_list.liq)
+  (glob_files cases/*.liq-inc)
   (:snapshot snapshot.exe))
  (action
   (with-stdout-to
@@ -18,6 +19,7 @@
  (target argsof.actual)
  (deps
   (:case cases/argsof.liq)
+  (glob_files cases/*.liq-inc)
   (:snapshot snapshot.exe))
  (action
   (with-stdout-to
@@ -34,6 +36,7 @@
  (target assoc.actual)
  (deps
   (:case cases/assoc.liq)
+  (glob_files cases/*.liq-inc)
   (:snapshot snapshot.exe))
  (action
   (with-stdout-to
@@ -47,9 +50,135 @@
   (diff expected/assoc.expected assoc.actual)))
 
 (rule
+ (target binding_bad_target.actual)
+ (deps
+  (:case cases/binding_bad_target.invalid-liq)
+  (glob_files cases/*.liq-inc)
+  (:snapshot snapshot.exe))
+ (action
+  (with-stdout-to
+   %{target}
+   (run %{snapshot} %{case}))))
+
+(rule
+ (aliases lang_snapshot runtest)
+ (package liquidsoap)
+ (action
+  (diff expected/binding_bad_target.expected binding_bad_target.actual)))
+
+(rule
+ (target binding_bare_after_first_in_shorthand.actual)
+ (deps
+  (:case cases/binding_bare_after_first_in_shorthand.liq)
+  (glob_files cases/*.liq-inc)
+  (:snapshot snapshot.exe))
+ (action
+  (with-stdout-to
+   %{target}
+   (run %{snapshot} %{case}))))
+
+(rule
+ (aliases lang_snapshot runtest)
+ (package liquidsoap)
+ (action
+  (diff
+   expected/binding_bare_after_first_in_shorthand.expected
+   binding_bare_after_first_in_shorthand.actual)))
+
+(rule
+ (target binding_bare_in_shorthand.actual)
+ (deps
+  (:case cases/binding_bare_in_shorthand.invalid-liq)
+  (glob_files cases/*.liq-inc)
+  (:snapshot snapshot.exe))
+ (action
+  (with-stdout-to
+   %{target}
+   (run %{snapshot} %{case}))))
+
+(rule
+ (aliases lang_snapshot runtest)
+ (package liquidsoap)
+ (action
+  (diff
+   expected/binding_bare_in_shorthand.expected
+   binding_bare_in_shorthand.actual)))
+
+(rule
+ (target binding_forms.actual)
+ (deps
+  (:case cases/binding_forms.liq)
+  (glob_files cases/*.liq-inc)
+  (:snapshot snapshot.exe))
+ (action
+  (with-stdout-to
+   %{target}
+   (run %{snapshot} %{case}))))
+
+(rule
+ (aliases lang_snapshot runtest)
+ (package liquidsoap)
+ (action
+  (diff expected/binding_forms.expected binding_forms.actual)))
+
+(rule
+ (target binding_let_in_shorthand.actual)
+ (deps
+  (:case cases/binding_let_in_shorthand.liq)
+  (glob_files cases/*.liq-inc)
+  (:snapshot snapshot.exe))
+ (action
+  (with-stdout-to
+   %{target}
+   (run %{snapshot} %{case}))))
+
+(rule
+ (aliases lang_snapshot runtest)
+ (package liquidsoap)
+ (action
+  (diff
+   expected/binding_let_in_shorthand.expected
+   binding_let_in_shorthand.actual)))
+
+(rule
+ (target binding_positions.actual)
+ (deps
+  (:case cases/binding_positions.liq)
+  (glob_files cases/*.liq-inc)
+  (:snapshot snapshot.exe))
+ (action
+  (with-stdout-to
+   %{target}
+   (run %{snapshot} %{case}))))
+
+(rule
+ (aliases lang_snapshot runtest)
+ (package liquidsoap)
+ (action
+  (diff expected/binding_positions.expected binding_positions.actual)))
+
+(rule
+ (target binding_targets.actual)
+ (deps
+  (:case cases/binding_targets.liq)
+  (glob_files cases/*.liq-inc)
+  (:snapshot snapshot.exe))
+ (action
+  (with-stdout-to
+   %{target}
+   (run %{snapshot} %{case}))))
+
+(rule
+ (aliases lang_snapshot runtest)
+ (package liquidsoap)
+ (action
+  (diff expected/binding_targets.expected binding_targets.actual)))
+
+(rule
  (target bool_ops.actual)
  (deps
   (:case cases/bool_ops.liq)
+  (glob_files cases/*.liq-inc)
   (:snapshot snapshot.exe))
  (action
   (with-stdout-to
@@ -66,6 +195,7 @@
  (target coalesce.actual)
  (deps
   (:case cases/coalesce.liq)
+  (glob_files cases/*.liq-inc)
   (:snapshot snapshot.exe))
  (action
   (with-stdout-to
@@ -82,6 +212,7 @@
  (target control_flow.actual)
  (deps
   (:case cases/control_flow.liq)
+  (glob_files cases/*.liq-inc)
   (:snapshot snapshot.exe))
  (action
   (with-stdout-to
@@ -98,6 +229,7 @@
  (target encoder.actual)
  (deps
   (:case cases/encoder.liq)
+  (glob_files cases/*.liq-inc)
   (:snapshot snapshot.exe))
  (action
   (with-stdout-to
@@ -114,6 +246,7 @@
  (target error_parse.actual)
  (deps
   (:case cases/error_parse.invalid-liq)
+  (glob_files cases/*.liq-inc)
   (:snapshot snapshot.exe))
  (action
   (with-stdout-to
@@ -130,6 +263,7 @@
  (target error_type.actual)
  (deps
   (:case cases/error_type.liq)
+  (glob_files cases/*.liq-inc)
   (:snapshot snapshot.exe))
  (action
   (with-stdout-to
@@ -146,6 +280,7 @@
  (target error_unbound.actual)
  (deps
   (:case cases/error_unbound.liq)
+  (glob_files cases/*.liq-inc)
   (:snapshot snapshot.exe))
  (action
   (with-stdout-to
@@ -162,6 +297,7 @@
  (target for_loop.actual)
  (deps
   (:case cases/for_loop.liq)
+  (glob_files cases/*.liq-inc)
   (:snapshot snapshot.exe))
  (action
   (with-stdout-to
@@ -178,6 +314,7 @@
  (target fun_shorthand.actual)
  (deps
   (:case cases/fun_shorthand.liq)
+  (glob_files cases/*.liq-inc)
   (:snapshot snapshot.exe))
  (action
   (with-stdout-to
@@ -194,6 +331,7 @@
  (target functions.actual)
  (deps
   (:case cases/functions.liq)
+  (glob_files cases/*.liq-inc)
   (:snapshot snapshot.exe))
  (action
   (with-stdout-to
@@ -210,6 +348,7 @@
  (target getter_coercion.actual)
  (deps
   (:case cases/getter_coercion.liq)
+  (glob_files cases/*.liq-inc)
   (:snapshot snapshot.exe))
  (action
   (with-stdout-to
@@ -226,6 +365,7 @@
  (target getters.actual)
  (deps
   (:case cases/getters.liq)
+  (glob_files cases/*.liq-inc)
   (:snapshot snapshot.exe))
  (action
   (with-stdout-to
@@ -242,6 +382,7 @@
  (target infix.actual)
  (deps
   (:case cases/infix.liq)
+  (glob_files cases/*.liq-inc)
   (:snapshot snapshot.exe))
  (action
   (with-stdout-to
@@ -258,6 +399,7 @@
  (target infix_precedence.actual)
  (deps
   (:case cases/infix_precedence.liq)
+  (glob_files cases/*.liq-inc)
   (:snapshot snapshot.exe))
  (action
   (with-stdout-to
@@ -274,6 +416,7 @@
  (target invoke_default.actual)
  (deps
   (:case cases/invoke_default.liq)
+  (glob_files cases/*.liq-inc)
   (:snapshot snapshot.exe))
  (action
   (with-stdout-to
@@ -290,6 +433,7 @@
  (target iterable_for.actual)
  (deps
   (:case cases/iterable_for.liq)
+  (glob_files cases/*.liq-inc)
   (:snapshot snapshot.exe))
  (action
   (with-stdout-to
@@ -306,6 +450,7 @@
  (target json_parse.actual)
  (deps
   (:case cases/json_parse.liq)
+  (glob_files cases/*.liq-inc)
   (:snapshot snapshot.exe))
  (action
   (with-stdout-to
@@ -322,6 +467,7 @@
  (target let_patterns.actual)
  (deps
   (:case cases/let_patterns.liq)
+  (glob_files cases/*.liq-inc)
   (:snapshot snapshot.exe))
  (action
   (with-stdout-to
@@ -338,6 +484,7 @@
  (target let_rec.actual)
  (deps
   (:case cases/let_rec.liq)
+  (glob_files cases/*.liq-inc)
   (:snapshot snapshot.exe))
  (action
   (with-stdout-to
@@ -354,6 +501,7 @@
  (target list_ops.actual)
  (deps
   (:case cases/list_ops.liq)
+  (glob_files cases/*.liq-inc)
   (:snapshot snapshot.exe))
  (action
   (with-stdout-to
@@ -370,6 +518,7 @@
  (target methods.actual)
  (deps
   (:case cases/methods.liq)
+  (glob_files cases/*.liq-inc)
   (:snapshot snapshot.exe))
  (action
   (with-stdout-to
@@ -386,6 +535,7 @@
  (target negative.actual)
  (deps
   (:case cases/negative.liq)
+  (glob_files cases/*.liq-inc)
   (:snapshot snapshot.exe))
  (action
   (with-stdout-to
@@ -402,6 +552,7 @@
  (target nested_methods.actual)
  (deps
   (:case cases/nested_methods.liq)
+  (glob_files cases/*.liq-inc)
   (:snapshot snapshot.exe))
  (action
   (with-stdout-to
@@ -418,6 +569,7 @@
  (target null_ops.actual)
  (deps
   (:case cases/null_ops.liq)
+  (glob_files cases/*.liq-inc)
   (:snapshot snapshot.exe))
  (action
   (with-stdout-to
@@ -434,6 +586,7 @@
  (target numeric_literals.actual)
  (deps
   (:case cases/numeric_literals.liq)
+  (glob_files cases/*.liq-inc)
   (:snapshot snapshot.exe))
  (action
   (with-stdout-to
@@ -450,6 +603,7 @@
  (target open_module.actual)
  (deps
   (:case cases/open_module.liq)
+  (glob_files cases/*.liq-inc)
   (:snapshot snapshot.exe))
  (action
   (with-stdout-to
@@ -466,6 +620,7 @@
  (target optional_args.actual)
  (deps
   (:case cases/optional_args.liq)
+  (glob_files cases/*.liq-inc)
   (:snapshot snapshot.exe))
  (action
   (with-stdout-to
@@ -482,6 +637,7 @@
  (target pattern_nested.actual)
  (deps
   (:case cases/pattern_nested.liq)
+  (glob_files cases/*.liq-inc)
   (:snapshot snapshot.exe))
  (action
   (with-stdout-to
@@ -498,6 +654,7 @@
  (target pattern_optional_meth.actual)
  (deps
   (:case cases/pattern_optional_meth.liq)
+  (glob_files cases/*.liq-inc)
   (:snapshot snapshot.exe))
  (action
   (with-stdout-to
@@ -514,6 +671,7 @@
  (target pp_comments.actual)
  (deps
   (:case cases/pp_comments.liq)
+  (glob_files cases/*.liq-inc)
   (:snapshot snapshot.exe))
  (action
   (with-stdout-to
@@ -530,6 +688,7 @@
  (target pp_ifdef.actual)
  (deps
   (:case cases/pp_ifdef.liq)
+  (glob_files cases/*.liq-inc)
   (:snapshot snapshot.exe))
  (action
   (with-stdout-to
@@ -543,9 +702,27 @@
   (diff expected/pp_ifdef.expected pp_ifdef.actual)))
 
 (rule
+ (target pp_ifdef_value.actual)
+ (deps
+  (:case cases/pp_ifdef_value.liq)
+  (glob_files cases/*.liq-inc)
+  (:snapshot snapshot.exe))
+ (action
+  (with-stdout-to
+   %{target}
+   (run %{snapshot} %{case}))))
+
+(rule
+ (aliases lang_snapshot runtest)
+ (package liquidsoap)
+ (action
+  (diff expected/pp_ifdef_value.expected pp_ifdef_value.actual)))
+
+(rule
  (target pp_ifversion.actual)
  (deps
   (:case cases/pp_ifversion.liq)
+  (glob_files cases/*.liq-inc)
   (:snapshot snapshot.exe))
  (action
   (with-stdout-to
@@ -559,9 +736,27 @@
   (diff expected/pp_ifversion.expected pp_ifversion.actual)))
 
 (rule
+ (target pp_include.actual)
+ (deps
+  (:case cases/pp_include.liq)
+  (glob_files cases/*.liq-inc)
+  (:snapshot snapshot.exe))
+ (action
+  (with-stdout-to
+   %{target}
+   (run %{snapshot} %{case}))))
+
+(rule
+ (aliases lang_snapshot runtest)
+ (package liquidsoap)
+ (action
+  (diff expected/pp_include.expected pp_include.actual)))
+
+(rule
  (target record_update.actual)
  (deps
   (:case cases/record_update.liq)
+  (glob_files cases/*.liq-inc)
   (:snapshot snapshot.exe))
  (action
   (with-stdout-to
@@ -578,6 +773,7 @@
  (target regexp_literal.actual)
  (deps
   (:case cases/regexp_literal.liq)
+  (glob_files cases/*.liq-inc)
   (:snapshot snapshot.exe))
  (action
   (with-stdout-to
@@ -594,6 +790,7 @@
  (target seq_and_ignore.actual)
  (deps
   (:case cases/seq_and_ignore.liq)
+  (glob_files cases/*.liq-inc)
   (:snapshot snapshot.exe))
  (action
   (with-stdout-to
@@ -610,6 +807,7 @@
  (target string_escapes.actual)
  (deps
   (:case cases/string_escapes.liq)
+  (glob_files cases/*.liq-inc)
   (:snapshot snapshot.exe))
  (action
   (with-stdout-to
@@ -626,6 +824,7 @@
  (target string_interpolation.actual)
  (deps
   (:case cases/string_interpolation.liq)
+  (glob_files cases/*.liq-inc)
   (:snapshot snapshot.exe))
  (action
   (with-stdout-to
@@ -639,9 +838,29 @@
   (diff expected/string_interpolation.expected string_interpolation.actual)))
 
 (rule
+ (target string_interpolation_nested.actual)
+ (deps
+  (:case cases/string_interpolation_nested.liq)
+  (glob_files cases/*.liq-inc)
+  (:snapshot snapshot.exe))
+ (action
+  (with-stdout-to
+   %{target}
+   (run %{snapshot} %{case}))))
+
+(rule
+ (aliases lang_snapshot runtest)
+ (package liquidsoap)
+ (action
+  (diff
+   expected/string_interpolation_nested.expected
+   string_interpolation_nested.actual)))
+
+(rule
  (target time_predicate.actual)
  (deps
   (:case cases/time_predicate.liq)
+  (glob_files cases/*.liq-inc)
   (:snapshot snapshot.exe))
  (action
   (with-stdout-to
@@ -658,6 +877,7 @@
  (target try_catch.actual)
  (deps
   (:case cases/try_catch.liq)
+  (glob_files cases/*.liq-inc)
   (:snapshot snapshot.exe))
  (action
   (with-stdout-to
@@ -674,6 +894,7 @@
  (target try_finally.actual)
  (deps
   (:case cases/try_finally.liq)
+  (glob_files cases/*.liq-inc)
   (:snapshot snapshot.exe))
  (action
   (with-stdout-to
@@ -690,6 +911,7 @@
  (target type_annotation.actual)
  (deps
   (:case cases/type_annotation.liq)
+  (glob_files cases/*.liq-inc)
   (:snapshot snapshot.exe))
  (action
   (with-stdout-to
@@ -706,6 +928,7 @@
  (target while_loop.actual)
  (deps
   (:case cases/while_loop.liq)
+  (glob_files cases/*.liq-inc)
   (:snapshot snapshot.exe))
  (action
   (with-stdout-to
@@ -717,3 +940,54 @@
  (package liquidsoap)
  (action
   (diff expected/while_loop.expected while_loop.actual)))
+
+(rule
+ (target canonical_blocks.actual)
+ (deps
+  (:case cases_canonical/blocks.liq)
+  (glob_files cases/*.liq-inc)
+  (:snapshot snapshot.exe))
+ (action
+  (with-stdout-to
+   %{target}
+   (run %{snapshot} --canonical %{case}))))
+
+(rule
+ (aliases lang_snapshot runtest)
+ (package liquidsoap)
+ (action
+  (diff expected_canonical/blocks.expected canonical_blocks.actual)))
+
+(rule
+ (target canonical_comments.actual)
+ (deps
+  (:case cases_canonical/comments.liq)
+  (glob_files cases/*.liq-inc)
+  (:snapshot snapshot.exe))
+ (action
+  (with-stdout-to
+   %{target}
+   (run %{snapshot} --canonical %{case}))))
+
+(rule
+ (aliases lang_snapshot runtest)
+ (package liquidsoap)
+ (action
+  (diff expected_canonical/comments.expected canonical_comments.actual)))
+
+(rule
+ (target canonical_try_blocks.actual)
+ (deps
+  (:case cases_canonical/try_blocks.liq)
+  (glob_files cases/*.liq-inc)
+  (:snapshot snapshot.exe))
+ (action
+  (with-stdout-to
+   %{target}
+   (run %{snapshot} --canonical %{case}))))
+
+(rule
+ (aliases lang_snapshot runtest)
+ (package liquidsoap)
+ (action
+  (diff expected_canonical/try_blocks.expected canonical_try_blocks.actual)))

--- a/tests/snapshots/dune.inc
+++ b/tests/snapshots/dune.inc
@@ -464,6 +464,40 @@
   (diff expected/iterable_for.expected iterable_for.actual)))
 
 (rule
+ (target json_as_type.actual)
+ (deps
+  (:case cases/json_as_type.liq)
+  (glob_files cases/*.liq-inc)
+  (:snapshot snapshot.exe))
+ (action
+  (with-stdout-to
+   %{target}
+   (run %{snapshot} %{case}))))
+
+(rule
+ (aliases lang_snapshot runtest)
+ (package liquidsoap)
+ (action
+  (diff expected/json_as_type.expected json_as_type.actual)))
+
+(rule
+ (target json_as_type_bad.actual)
+ (deps
+  (:case cases/json_as_type_bad.invalid-liq)
+  (glob_files cases/*.liq-inc)
+  (:snapshot snapshot.exe))
+ (action
+  (with-stdout-to
+   %{target}
+   (run %{snapshot} %{case}))))
+
+(rule
+ (aliases lang_snapshot runtest)
+ (package liquidsoap)
+ (action
+  (diff expected/json_as_type_bad.expected json_as_type_bad.actual)))
+
+(rule
  (target json_parse.actual)
  (deps
   (:case cases/json_parse.liq)

--- a/tests/snapshots/dune.inc
+++ b/tests/snapshots/dune.inc
@@ -804,6 +804,25 @@
   (diff expected/pp_include.expected pp_include.actual)))
 
 (rule
+ (target pp_include_extra_missing.actual)
+ (deps
+  (:case cases/pp_include_extra_missing.liq)
+  (glob_files cases/*.liq-inc)
+  (:snapshot snapshot.exe))
+ (action
+  (with-stdout-to
+   %{target}
+   (run %{snapshot} %{case}))))
+
+(rule
+ (aliases lang_snapshot runtest)
+ (package liquidsoap)
+ (action
+  (diff
+   expected/pp_include_extra_missing.expected
+   pp_include_extra_missing.actual)))
+
+(rule
  (target record_update.actual)
  (deps
   (:case cases/record_update.liq)

--- a/tests/snapshots/dune.inc
+++ b/tests/snapshots/dune.inc
@@ -838,6 +838,23 @@
   (diff expected/regexp_literal.expected regexp_literal.actual)))
 
 (rule
+ (target reserved_names.actual)
+ (deps
+  (:case cases/reserved_names.invalid-liq)
+  (glob_files cases/*.liq-inc)
+  (:snapshot snapshot.exe))
+ (action
+  (with-stdout-to
+   %{target}
+   (run %{snapshot} %{case}))))
+
+(rule
+ (aliases lang_snapshot runtest)
+ (package liquidsoap)
+ (action
+  (diff expected/reserved_names.expected reserved_names.actual)))
+
+(rule
  (target seq_and_ignore.actual)
  (deps
   (:case cases/seq_and_ignore.liq)

--- a/tests/snapshots/dune.inc
+++ b/tests/snapshots/dune.inc
@@ -226,6 +226,23 @@
   (diff expected/control_flow.expected control_flow.actual)))
 
 (rule
+ (target doc_comments.actual)
+ (deps
+  (:case cases/doc_comments.liq)
+  (glob_files cases/*.liq-inc)
+  (:snapshot snapshot.exe))
+ (action
+  (with-stdout-to
+   %{target}
+   (run %{snapshot} %{case}))))
+
+(rule
+ (aliases lang_snapshot runtest)
+ (package liquidsoap)
+ (action
+  (diff expected/doc_comments.expected doc_comments.actual)))
+
+(rule
  (target encoder.actual)
  (deps
   (:case cases/encoder.liq)

--- a/tests/snapshots/expected/append_list.expected
+++ b/tests/snapshots/expected/append_list.expected
@@ -2,41 +2,47 @@
 [1, 2] @ [3, 4]
 --- parsed ---
 {
-  "type": "infix",
-  "left": {
-    "type": "list",
-    "value": [
-      {
-      "type": "term",
-      "value": { "type": "ground", "value": "1" }
+  "type": "block",
+  "value": [
+    {
+    "type": "infix",
+    "left": {
+      "type": "list",
+      "value": [
+        {
+        "type": "term",
+        "value": { "type": "ground", "value": "1" }
+      },
+        {
+        "type": "term",
+        "value": { "type": "ground", "value": "2" }
+      }
+      ]
     },
-      {
-      "type": "term",
-      "value": { "type": "ground", "value": "2" }
+    "op": "@",
+    "right": {
+      "type": "list",
+      "value": [
+        {
+        "type": "term",
+        "value": { "type": "ground", "value": "3" }
+      },
+        {
+        "type": "term",
+        "value": { "type": "ground", "value": "4" }
+      }
+      ]
     }
-    ]
-  },
-  "op": "@",
-  "right": {
-    "type": "list",
-    "value": [
-      {
-      "type": "term",
-      "value": { "type": "ground", "value": "3" }
-    },
-      {
-      "type": "term",
-      "value": { "type": "ground", "value": "4" }
-    }
-    ]
   }
+  ]
 }
 --- hash ---
-31c8043d953d7b3f649c8c0bc2f2022d
+9346863f202a44e5bc80626a51e6192e
 --- term ---
 [3, 4]([1, 2])
 --- type ---
-At line 1, char 9-15:
+At cases/append_list.liq, line 1, char 9-15:
+[1, 2] @ [3, 4]
 
 Error 5: this value has type
   [_]

--- a/tests/snapshots/expected/argsof.expected
+++ b/tests/snapshots/expected/argsof.expected
@@ -1,6 +1,10 @@
 === argsof.liq ===
-def base(~a=1, ~b=2) = a + b end
-def wrapper(%argsof(base)) = base(%argsof(base)) end
+def base(~a=1, ~b=2) =
+  a + b
+end
+def wrapper(%argsof(base)) =
+  base(%argsof(base))
+end
 wrapper(a=3)
 --- parsed ---
 {

--- a/tests/snapshots/expected/argsof.expected
+++ b/tests/snapshots/expected/argsof.expected
@@ -4,23 +4,46 @@ def wrapper(%argsof(base)) = base(%argsof(base)) end
 wrapper(a=3)
 --- parsed ---
 {
-  "type": "def",
-  "body": {
+  "type": "block",
+  "value": [
+    {
     "type": "def",
-    "body": {
-      "type": "app",
-      "op": { "type": "var", "value": "wrapper" },
-      "args": [
-        {
-        "type": "term",
-        "value": {
-          "type": "app_arg",
-          "label": "a",
-          "value": { "type": "ground", "value": "3" }
-        }
+    "decoration": null,
+    "pat": { "type": "pvar", "value": [ "base" ] },
+    "arglist": [
+      {
+      "type": "term",
+      "value": {
+        "type": "fun_arg",
+        "label": "a",
+        "as_variable": null,
+        "typ": null,
+        "default": { "type": "ground", "value": "1" }
       }
-      ]
     },
+      {
+      "type": "term",
+      "value": {
+        "type": "fun_arg",
+        "label": "b",
+        "as_variable": null,
+        "typ": null,
+        "default": { "type": "ground", "value": "2" }
+      }
+    }
+    ],
+    "cast": null,
+    "body": [
+      {
+      "type": "infix",
+      "left": { "type": "var", "value": "a" },
+      "op": "+",
+      "right": { "type": "var", "value": "b" }
+    }
+    ]
+  },
+    {
+    "type": "def",
     "decoration": null,
     "pat": { "type": "pvar", "value": [ "wrapper" ] },
     "arglist": [
@@ -32,7 +55,8 @@ wrapper(a=3)
     }
     ],
     "cast": null,
-    "definition": {
+    "body": [
+      {
       "type": "app",
       "op": { "type": "var", "value": "base" },
       "args": [
@@ -44,41 +68,26 @@ wrapper(a=3)
       }
       ]
     }
-  },
-  "decoration": null,
-  "pat": { "type": "pvar", "value": [ "base" ] },
-  "arglist": [
-    {
-    "type": "term",
-    "value": {
-      "type": "fun_arg",
-      "label": "a",
-      "as_variable": null,
-      "typ": null,
-      "default": { "type": "ground", "value": "1" }
-    }
+    ]
   },
     {
-    "type": "term",
-    "value": {
-      "type": "fun_arg",
-      "label": "b",
-      "as_variable": null,
-      "typ": null,
-      "default": { "type": "ground", "value": "2" }
+    "type": "app",
+    "op": { "type": "var", "value": "wrapper" },
+    "args": [
+      {
+      "type": "term",
+      "value": {
+        "type": "app_arg",
+        "label": "a",
+        "value": { "type": "ground", "value": "3" }
+      }
     }
+    ]
   }
-  ],
-  "cast": null,
-  "definition": {
-    "type": "infix",
-    "left": { "type": "var", "value": "a" },
-    "op": "+",
-    "right": { "type": "var", "value": "b" }
-  }
+  ]
 }
 --- hash ---
-3128e45dbc1bebcdb2a9c13c90fde250
+2c650336bfa19bdf288865f942c87764
 --- term ---
 base = fun (~a=1, ~b=2) -> +(a, b)
 wrapper = fun (~a=1, ~b=2) -> base(a=a, b=b)

--- a/tests/snapshots/expected/assoc.expected
+++ b/tests/snapshots/expected/assoc.expected
@@ -3,56 +3,61 @@ l = [("a", "1"), ("b", "2")]
 l["a"]
 --- parsed ---
 {
-  "type": "binding",
-  "body": {
+  "type": "block",
+  "value": [
+    {
+    "type": "binding",
+    "decoration": null,
+    "pat": { "type": "pvar", "value": [ "l" ] },
+    "arglist": null,
+    "cast": null,
+    "definition": {
+      "type": "list",
+      "value": [
+        {
+        "type": "term",
+        "value": {
+          "type": "tuple",
+          "value": [
+            {
+            "type": "string",
+            "value": "\"a\""
+          },
+            {
+            "type": "string",
+            "value": "\"1\""
+          }
+          ]
+        }
+      },
+        {
+        "type": "term",
+        "value": {
+          "type": "tuple",
+          "value": [
+            {
+            "type": "string",
+            "value": "\"b\""
+          },
+            {
+            "type": "string",
+            "value": "\"2\""
+          }
+          ]
+        }
+      }
+      ]
+    }
+  },
+    {
     "type": "assoc",
     "left": { "type": "var", "value": "l" },
     "right": { "type": "string", "value": "\"a\"" }
-  },
-  "decoration": null,
-  "pat": { "type": "pvar", "value": [ "l" ] },
-  "arglist": null,
-  "cast": null,
-  "definition": {
-    "type": "list",
-    "value": [
-      {
-      "type": "term",
-      "value": {
-        "type": "tuple",
-        "value": [
-          {
-          "type": "string",
-          "value": "\"a\""
-        },
-          {
-          "type": "string",
-          "value": "\"1\""
-        }
-        ]
-      }
-    },
-      {
-      "type": "term",
-      "value": {
-        "type": "tuple",
-        "value": [
-          {
-          "type": "string",
-          "value": "\"b\""
-        },
-          {
-          "type": "string",
-          "value": "\"2\""
-        }
-        ]
-      }
-    }
-    ]
   }
+  ]
 }
 --- hash ---
-b2b8613347ff262c0a002f96a61b78ba
+41f472e859836825227a48e7db0b099d
 --- term ---
 l = [("a", "1"), ("b", "2")]
 _[_](l, "a")

--- a/tests/snapshots/expected/binding_bad_target.expected
+++ b/tests/snapshots/expected/binding_bad_target.expected
@@ -1,0 +1,9 @@
+=== binding_bad_target.invalid-liq ===
+# The left-hand side of a bare binding must be a valid pattern. A call is not,
+# and is reported as such rather than as a bare syntax error.
+f(1) = 2
+--- parsed ---
+At cases/binding_bad_target.invalid-liq, line 3, char 0-4:
+f(1) = 2
+
+Error 3: Invalid binding: the left-hand side of `=` must be a variable, a field path or a destructuring pattern.

--- a/tests/snapshots/expected/binding_bare_after_first_in_shorthand.expected
+++ b/tests/snapshots/expected/binding_bare_after_first_in_shorthand.expected
@@ -63,6 +63,8 @@ f = fun () -> a = 1
 b = +(a, 1)
 b
 f()
+--- doc ---
+f: The record ambiguity only affects the *first* statement of a `{ ... }` body. A leading `x = 1` would be the record `{ x = 1 }`, but once past it a bare binding is fine. src/libs/extra/fades.liq relies on this.
 --- type ---
 int
 --- value ---

--- a/tests/snapshots/expected/binding_bare_after_first_in_shorthand.expected
+++ b/tests/snapshots/expected/binding_bare_after_first_in_shorthand.expected
@@ -1,0 +1,69 @@
+=== binding_bare_after_first_in_shorthand.liq ===
+# The record ambiguity only affects the *first* statement of a `{ ... }` body.
+# A leading `x = 1` would be the record `{ x = 1 }`, but once past it a bare
+# binding is fine. src/libs/extra/fades.liq relies on this.
+f = {
+  let a = 1
+  b = a + 1
+  b
+}
+f()
+--- parsed ---
+{
+  "type": "block",
+  "value": [
+    {
+    "type": "binding",
+    "decoration": null,
+    "pat": { "type": "pvar", "value": [ "f" ] },
+    "arglist": null,
+    "cast": null,
+    "definition": {
+      "type": "simple_fun",
+      "value": [
+        {
+        "type": "let",
+        "decoration": null,
+        "pat": { "type": "pvar", "value": [ "a" ] },
+        "arglist": null,
+        "cast": null,
+        "definition": { "type": "ground", "value": "1" }
+      },
+        {
+        "type": "binding",
+        "decoration": null,
+        "pat": { "type": "pvar", "value": [ "b" ] },
+        "arglist": null,
+        "cast": null,
+        "definition": {
+          "type": "infix",
+          "left": { "type": "var", "value": "a" },
+          "op": "+",
+          "right": { "type": "ground", "value": "1" }
+        }
+      },
+        {
+        "type": "var",
+        "value": "b"
+      }
+      ]
+    }
+  },
+    {
+    "type": "app",
+    "op": { "type": "var", "value": "f" },
+    "args": []
+  }
+  ]
+}
+--- hash ---
+ea2c3b373a4655197062f947d19e346e
+--- term ---
+f = fun () -> a = 1
+b = +(a, 1)
+b
+f()
+--- type ---
+int
+--- value ---
+2

--- a/tests/snapshots/expected/binding_bare_after_first_in_shorthand.expected
+++ b/tests/snapshots/expected/binding_bare_after_first_in_shorthand.expected
@@ -2,11 +2,12 @@
 # The record ambiguity only affects the *first* statement of a `{ ... }` body.
 # A leading `x = 1` would be the record `{ x = 1 }`, but once past it a bare
 # binding is fine. src/libs/extra/fades.liq relies on this.
-f = {
-  let a = 1
-  b = a + 1
-  b
-}
+f =
+  {
+    let a = 1
+    b = a + 1
+    b
+  }
 f()
 --- parsed ---
 {

--- a/tests/snapshots/expected/binding_bare_in_shorthand.expected
+++ b/tests/snapshots/expected/binding_bare_in_shorthand.expected
@@ -1,0 +1,11 @@
+=== binding_bare_in_shorthand.invalid-liq ===
+# A leading bare binding inside `{ … }` is not allowed: `{ x = 1 }` is a record
+# literal. Write `let x = 1` instead. Only the first statement is restricted,
+# see binding_bare_after_first_in_shorthand.liq.
+f = { x = 1; x + 1 }
+f()
+--- parsed ---
+At cases/binding_bare_in_shorthand.invalid-liq, line 4, char 11:
+f = { x = 1; x + 1 }
+
+Error 2: Parse error

--- a/tests/snapshots/expected/binding_forms.expected
+++ b/tests/snapshots/expected/binding_forms.expected
@@ -59,6 +59,8 @@ c = 1
 d = 1
 e = 1
 (c, d, e)
+--- doc ---
+c: `x = e`, `let x = e` and `def x = e end` are three grammar productions (`binding` / `explicit_binding` in parser.mly) that reduce to the same `let`.
 --- type ---
 int * int * int
 --- value ---

--- a/tests/snapshots/expected/binding_forms.expected
+++ b/tests/snapshots/expected/binding_forms.expected
@@ -1,0 +1,65 @@
+=== binding_forms.liq ===
+# `x = e`, `let x = e` and `def x = e end` are three grammar productions
+# (`binding` / `explicit_binding` in parser.mly) that reduce to the same `let`.
+c = 1
+let d = 1
+def e = 1 end
+(c, d, e)
+--- parsed ---
+{
+  "type": "block",
+  "value": [
+    {
+    "type": "binding",
+    "decoration": null,
+    "pat": { "type": "pvar", "value": [ "c" ] },
+    "arglist": null,
+    "cast": null,
+    "definition": { "type": "ground", "value": "1" }
+  },
+    {
+    "type": "let",
+    "decoration": null,
+    "pat": { "type": "pvar", "value": [ "d" ] },
+    "arglist": null,
+    "cast": null,
+    "definition": { "type": "ground", "value": "1" }
+  },
+    {
+    "type": "def",
+    "decoration": null,
+    "pat": { "type": "pvar", "value": [ "e" ] },
+    "arglist": null,
+    "cast": null,
+    "body": [ { "type": "ground", "value": "1" } ]
+  },
+    {
+    "type": "tuple",
+    "value": [
+      {
+      "type": "var",
+      "value": "c"
+    },
+      {
+      "type": "var",
+      "value": "d"
+    },
+      {
+      "type": "var",
+      "value": "e"
+    }
+    ]
+  }
+  ]
+}
+--- hash ---
+4999b6a7f8dc2cb3af5eba94d86e8aea
+--- term ---
+c = 1
+d = 1
+e = 1
+(c, d, e)
+--- type ---
+int * int * int
+--- value ---
+(1, 1, 1)

--- a/tests/snapshots/expected/binding_forms.expected
+++ b/tests/snapshots/expected/binding_forms.expected
@@ -3,7 +3,9 @@
 # (`binding` / `explicit_binding` in parser.mly) that reduce to the same `let`.
 c = 1
 let d = 1
-def e = 1 end
+def e =
+  1
+end
 (c, d, e)
 --- parsed ---
 {

--- a/tests/snapshots/expected/binding_let_in_shorthand.expected
+++ b/tests/snapshots/expected/binding_let_in_shorthand.expected
@@ -1,0 +1,51 @@
+=== binding_let_in_shorthand.liq ===
+# The form `{ … }` does accept: `let`, unlike a bare binding.
+f = { let x = 1; x + 1 }
+f()
+--- parsed ---
+{
+  "type": "block",
+  "value": [
+    {
+    "type": "binding",
+    "decoration": null,
+    "pat": { "type": "pvar", "value": [ "f" ] },
+    "arglist": null,
+    "cast": null,
+    "definition": {
+      "type": "simple_fun",
+      "value": [
+        {
+        "type": "let",
+        "decoration": null,
+        "pat": { "type": "pvar", "value": [ "x" ] },
+        "arglist": null,
+        "cast": null,
+        "definition": { "type": "ground", "value": "1" }
+      },
+        {
+        "type": "infix",
+        "left": { "type": "var", "value": "x" },
+        "op": "+",
+        "right": { "type": "ground", "value": "1" }
+      }
+      ]
+    }
+  },
+    {
+    "type": "app",
+    "op": { "type": "var", "value": "f" },
+    "args": []
+  }
+  ]
+}
+--- hash ---
+125c829ab0a6c9a6c819b35dce2d7676
+--- term ---
+f = fun () -> x = 1
++(x, 1)
+f()
+--- type ---
+int
+--- value ---
+2

--- a/tests/snapshots/expected/binding_let_in_shorthand.expected
+++ b/tests/snapshots/expected/binding_let_in_shorthand.expected
@@ -1,6 +1,10 @@
 === binding_let_in_shorthand.liq ===
 # The form `{ … }` does accept: `let`, unlike a bare binding.
-f = { let x = 1; x + 1 }
+f =
+  {
+    let x = 1
+    x + 1
+  }
 f()
 --- parsed ---
 {

--- a/tests/snapshots/expected/binding_let_in_shorthand.expected
+++ b/tests/snapshots/expected/binding_let_in_shorthand.expected
@@ -45,6 +45,8 @@ f()
 f = fun () -> x = 1
 +(x, 1)
 f()
+--- doc ---
+f: The form `{ … }` does accept: `let`, unlike a bare binding.
 --- type ---
 int
 --- value ---

--- a/tests/snapshots/expected/binding_positions.expected
+++ b/tests/snapshots/expected/binding_positions.expected
@@ -1,0 +1,122 @@
+=== binding_positions.liq ===
+# A binding scopes over the rest of its block, in every block position.
+def outer() =
+  a = 1
+  a + 1
+end
+
+inner_if = if true then b = 2; b else 0 end
+
+def last_statement() =
+  # A binding as the last statement of a block: its body is `Eof`, which
+  # reduces to unit.
+  c = 3
+end
+
+(outer(), inner_if, last_statement())
+--- parsed ---
+{
+  "type": "block",
+  "value": [
+    {
+    "type": "def",
+    "decoration": null,
+    "pat": { "type": "pvar", "value": [ "outer" ] },
+    "arglist": [],
+    "cast": null,
+    "body": [
+      {
+      "type": "binding",
+      "decoration": null,
+      "pat": { "type": "pvar", "value": [ "a" ] },
+      "arglist": null,
+      "cast": null,
+      "definition": { "type": "ground", "value": "1" }
+    },
+      {
+      "type": "infix",
+      "left": { "type": "var", "value": "a" },
+      "op": "+",
+      "right": { "type": "ground", "value": "1" }
+    }
+    ]
+  },
+    {
+    "type": "binding",
+    "decoration": null,
+    "pat": { "type": "pvar", "value": [ "inner_if" ] },
+    "arglist": null,
+    "cast": null,
+    "definition": {
+      "type": "if",
+      "condition": { "type": "ground", "value": "true" },
+      "then": [
+        {
+        "type": "binding",
+        "decoration": null,
+        "pat": { "type": "pvar", "value": [ "b" ] },
+        "arglist": null,
+        "cast": null,
+        "definition": { "type": "ground", "value": "2" }
+      },
+        {
+        "type": "var",
+        "value": "b"
+      }
+      ],
+      "elsif": [],
+      "else": [ { "type": "ground", "value": "0" } ]
+    }
+  },
+    {
+    "type": "def",
+    "decoration": null,
+    "pat": { "type": "pvar", "value": [ "last_statement" ] },
+    "arglist": [],
+    "cast": null,
+    "body": [
+      {
+      "type": "binding",
+      "decoration": null,
+      "pat": { "type": "pvar", "value": [ "c" ] },
+      "arglist": null,
+      "cast": null,
+      "definition": { "type": "ground", "value": "3" }
+    }
+    ]
+  },
+    {
+    "type": "tuple",
+    "value": [
+      {
+      "type": "app",
+      "op": { "type": "var", "value": "outer" },
+      "args": []
+    },
+      {
+      "type": "var",
+      "value": "inner_if"
+    },
+      {
+      "type": "app",
+      "op": { "type": "var", "value": "last_statement" },
+      "args": []
+    }
+    ]
+  }
+  ]
+}
+--- hash ---
+5a9a1e1ed260610a6d06e6955c2b2a67
+--- term ---
+outer = fun () -> a = 1
++(a, 1)
+inner_if = if(true, then=fun () -> b = 2
+b, else={0})
+last_statement = fun () -> c = 3
+()
+(outer(), inner_if, last_statement())
+--- type ---
+int * int * unit
+--- value ---
+(2, 2, ())

--- a/tests/snapshots/expected/binding_positions.expected
+++ b/tests/snapshots/expected/binding_positions.expected
@@ -124,6 +124,8 @@ b, else={0})
 last_statement = fun () -> c = 3
 ()
 (outer(), inner_if, last_statement())
+--- doc ---
+outer: A binding scopes over the rest of its block, in every block position.
 --- type ---
 int * int * unit
 --- value ---

--- a/tests/snapshots/expected/binding_positions.expected
+++ b/tests/snapshots/expected/binding_positions.expected
@@ -5,11 +5,19 @@ def outer() =
   a + 1
 end
 
-inner_if = if true then b = 2; b else 0 end
+inner_if =
+  if
+    true
+  then
+    b = 2
+    b
+  else
+    0
+  end
 
 def last_statement() =
-  # A binding as the last statement of a block: its body is `Eof`, which
-  # reduces to unit.
+  # A binding as the last statement of a block: nothing follows it, so the
+  # block evaluates to unit.
   c = 3
 end
 

--- a/tests/snapshots/expected/binding_targets.expected
+++ b/tests/snapshots/expected/binding_targets.expected
@@ -170,6 +170,8 @@ r = list.nth(_pat0, 0)
 n = (5 : int)
 _ = 6
 (x.b, p, q, r, s, n)
+--- doc ---
+x: A bare binding takes the same targets as `let`: a variable, a field path, a type annotation, and destructuring patterns. The left-hand side is parsed as an expression and reinterpreted as a pattern.
 --- type ---
 int * int * int * int * int * int
 --- value ---

--- a/tests/snapshots/expected/binding_targets.expected
+++ b/tests/snapshots/expected/binding_targets.expected
@@ -1,0 +1,176 @@
+=== binding_targets.liq ===
+# A bare binding takes the same targets as `let`: a variable, a field path, a
+# type annotation, and destructuring patterns. The left-hand side is parsed as
+# an expression and reinterpreted as a pattern.
+x = {a = 1}
+x.b = 2
+
+(p, q) = (1, 2)
+[r, s] = [3, 4]
+(n : int) = 5
+_ = 6
+
+(x.b, p, q, r, s, n)
+--- parsed ---
+{
+  "type": "block",
+  "value": [
+    {
+    "type": "binding",
+    "decoration": null,
+    "pat": { "type": "pvar", "value": [ "x" ] },
+    "arglist": null,
+    "cast": null,
+    "definition": {
+      "type": "methods",
+      "base": null,
+      "methods": [
+        {
+        "type": "method",
+        "name": "a",
+        "value": { "type": "ground", "value": "1" }
+      }
+      ]
+    }
+  },
+    {
+    "type": "binding",
+    "decoration": null,
+    "pat": { "type": "pvar", "value": [ "x", "b" ] },
+    "arglist": null,
+    "cast": null,
+    "definition": { "type": "ground", "value": "2" }
+  },
+    {
+    "type": "binding",
+    "decoration": null,
+    "pat": {
+      "type": "ptuple",
+      "value": [
+        {
+        "type": "pvar",
+        "value": [ "p" ]
+      },
+        {
+        "type": "pvar",
+        "value": [ "q" ]
+      }
+      ]
+    },
+    "arglist": null,
+    "cast": null,
+    "definition": {
+      "type": "tuple",
+      "value": [
+        {
+        "type": "ground",
+        "value": "1"
+      },
+        {
+        "type": "ground",
+        "value": "2"
+      }
+      ]
+    }
+  },
+    {
+    "type": "binding",
+    "decoration": null,
+    "pat": {
+      "type": "plist",
+      "left": [
+        {
+        "type": "pvar",
+        "value": [ "r" ]
+      },
+        {
+        "type": "pvar",
+        "value": [ "s" ]
+      }
+      ],
+      "middle": null,
+      "right": []
+    },
+    "arglist": null,
+    "cast": null,
+    "definition": {
+      "type": "list",
+      "value": [
+        {
+        "type": "term",
+        "value": { "type": "ground", "value": "3" }
+      },
+        {
+        "type": "term",
+        "value": { "type": "ground", "value": "4" }
+      }
+      ]
+    }
+  },
+    {
+    "type": "binding",
+    "decoration": null,
+    "pat": { "type": "pvar", "value": [ "n" ] },
+    "arglist": null,
+    "cast": { "type": "type_annotation", "subtype": "named", "value": "int" },
+    "definition": { "type": "ground", "value": "5" }
+  },
+    {
+    "type": "binding",
+    "decoration": null,
+    "pat": { "type": "pvar", "value": [ "_" ] },
+    "arglist": null,
+    "cast": null,
+    "definition": { "type": "ground", "value": "6" }
+  },
+    {
+    "type": "tuple",
+    "value": [
+      {
+      "type": "invoke",
+      "invoked": { "type": "var", "value": "x" },
+      "optional": false,
+      "meth": { "type": "var", "value": "b" }
+    },
+      {
+      "type": "var",
+      "value": "p"
+    },
+      {
+      "type": "var",
+      "value": "q"
+    },
+      {
+      "type": "var",
+      "value": "r"
+    },
+      {
+      "type": "var",
+      "value": "s"
+    },
+      {
+      "type": "var",
+      "value": "n"
+    }
+    ]
+  }
+  ]
+}
+--- hash ---
+a31d24ebcf3f785efcc0c74ccf24b04c
+--- term ---
+x = {a=1}
+let x.b = 2
+let (p, q) = (1, 2)
+_pat0 = [3, 4]
+_pat1 = list.length(_pat0)
+if(<(_pat1, 2), then=fun () -> error.raise(error.register("not_found"), "List value does not have enough elements to fit the extraction pattern!"), else={()})
+s = list.nth(_pat0, 1)
+r = list.nth(_pat0, 0)
+n = (5 : int)
+_ = 6
+(x.b, p, q, r, s, n)
+--- type ---
+int * int * int * int * int * int
+--- value ---
+(2, 1, 2, 3, 4, 5)

--- a/tests/snapshots/expected/bool_ops.expected
+++ b/tests/snapshots/expected/bool_ops.expected
@@ -2,31 +2,36 @@
 true and false or not true
 --- parsed ---
 {
-  "type": "bool",
-  "op": "and",
+  "type": "block",
   "value": [
     {
-    "type": "ground",
-    "value": "true"
-  },
-    {
     "type": "bool",
-    "op": "or",
+    "op": "and",
     "value": [
       {
       "type": "ground",
-      "value": "false"
+      "value": "true"
     },
       {
-      "type": "not",
-      "value": { "type": "ground", "value": "true" }
+      "type": "bool",
+      "op": "or",
+      "value": [
+        {
+        "type": "ground",
+        "value": "false"
+      },
+        {
+        "type": "not",
+        "value": { "type": "ground", "value": "true" }
+      }
+      ]
     }
     ]
   }
   ]
 }
 --- hash ---
-64920271173667b323678224208ccfd2
+119b8113c392cbd3cda80ec442acc78d
 --- term ---
 and({true}, fun () -> or({false}, fun () -> not(true)))
 --- type ---

--- a/tests/snapshots/expected/coalesce.expected
+++ b/tests/snapshots/expected/coalesce.expected
@@ -3,20 +3,25 @@ x = null
 x ?? 3
 --- parsed ---
 {
-  "type": "binding",
-  "body": {
+  "type": "block",
+  "value": [
+    {
+    "type": "binding",
+    "decoration": null,
+    "pat": { "type": "pvar", "value": [ "x" ] },
+    "arglist": null,
+    "cast": null,
+    "definition": { "type": "null" }
+  },
+    {
     "type": "coalesce",
     "left": { "type": "var", "value": "x" },
     "right": { "type": "ground", "value": "3" }
-  },
-  "decoration": null,
-  "pat": { "type": "pvar", "value": [ "x" ] },
-  "arglist": null,
-  "cast": null,
-  "definition": { "type": "null" }
+  }
+  ]
 }
 --- hash ---
-a3275fcfcf909af982d9950ed6bd6b70
+000977c6d3776c748a31878f6d4b9d9c
 --- term ---
 x = null
 _null.default(x, {3})

--- a/tests/snapshots/expected/control_flow.expected
+++ b/tests/snapshots/expected/control_flow.expected
@@ -2,19 +2,24 @@
 if 1 < 2 then "yes" else "no" end
 --- parsed ---
 {
-  "type": "if",
-  "condition": {
-    "type": "infix",
-    "left": { "type": "ground", "value": "1" },
-    "op": "<",
-    "right": { "type": "ground", "value": "2" }
-  },
-  "then": { "type": "string", "value": "\"yes\"" },
-  "elsif": [],
-  "else": { "type": "string", "value": "\"no\"" }
+  "type": "block",
+  "value": [
+    {
+    "type": "if",
+    "condition": {
+      "type": "infix",
+      "left": { "type": "ground", "value": "1" },
+      "op": "<",
+      "right": { "type": "ground", "value": "2" }
+    },
+    "then": [ { "type": "string", "value": "\"yes\"" } ],
+    "elsif": [],
+    "else": [ { "type": "string", "value": "\"no\"" } ]
+  }
+  ]
 }
 --- hash ---
-1047d9b107fd19c2c9638357ea639822
+6999b77cc8c25237630401861d654f05
 --- term ---
 if(<(1, 2), then={"yes"}, else={"no"})
 --- type ---

--- a/tests/snapshots/expected/doc_comments.expected
+++ b/tests/snapshots/expected/doc_comments.expected
@@ -1,0 +1,101 @@
+=== doc_comments.liq ===
+# A doc comment attaches to the statement that follows it, and ends up on the
+# binding as `Doc.Value.t`. This is what `--list-functions-md` reports.
+
+# Adds one to its argument.
+# @category Programming
+def documented(x) =
+  x + 1
+end
+
+# Also documented, as a plain binding.
+plain = 1
+
+undocumented = 2
+
+(documented(plain), undocumented)
+--- parsed ---
+{
+  "type": "block",
+  "value": [
+    {
+    "type": "def",
+    "decoration": null,
+    "pat": { "type": "pvar", "value": [ "documented" ] },
+    "arglist": [
+      {
+      "type": "term",
+      "value": {
+        "type": "fun_arg",
+        "label": "",
+        "as_variable": { "type": "pvar", "value": [ "x" ] },
+        "typ": null,
+        "default": null
+      }
+    }
+    ],
+    "cast": null,
+    "body": [
+      {
+      "type": "infix",
+      "left": { "type": "var", "value": "x" },
+      "op": "+",
+      "right": { "type": "ground", "value": "1" }
+    }
+    ]
+  },
+    {
+    "type": "binding",
+    "decoration": null,
+    "pat": { "type": "pvar", "value": [ "plain" ] },
+    "arglist": null,
+    "cast": null,
+    "definition": { "type": "ground", "value": "1" }
+  },
+    {
+    "type": "binding",
+    "decoration": null,
+    "pat": { "type": "pvar", "value": [ "undocumented" ] },
+    "arglist": null,
+    "cast": null,
+    "definition": { "type": "ground", "value": "2" }
+  },
+    {
+    "type": "tuple",
+    "value": [
+      {
+      "type": "app",
+      "op": { "type": "var", "value": "documented" },
+      "args": [
+        {
+        "type": "term",
+        "value": {
+          "type": "app_arg",
+          "label": "",
+          "value": { "type": "var", "value": "plain" }
+        }
+      }
+      ]
+    },
+      {
+      "type": "var",
+      "value": "undocumented"
+    }
+    ]
+  }
+  ]
+}
+--- hash ---
+c5c31848ed6f91b9ed4be34691c5d6b7
+--- term ---
+documented = fun (x) -> +(x, 1)
+plain = 1
+undocumented = 2
+(documented(plain), undocumented)
+--- doc ---
+documented: Adds one to its argument.
+plain: Also documented, as a plain binding.
+--- type ---
+int * int
+--- value ---
+(2, 2)

--- a/tests/snapshots/expected/encoder.expected
+++ b/tests/snapshots/expected/encoder.expected
@@ -2,26 +2,31 @@
 %mp3(bitrate = 128, stereo)
 --- parsed ---
 {
-  "type": "encoder",
-  "label": "mp3",
-  "params": [
+  "type": "block",
+  "value": [
     {
-    "type": "infix",
-    "left": { "type": "var", "value": "bitrate" },
-    "op": "=",
-    "right": { "type": "ground", "value": "128" }
-  },
-    {
-    "type": "var",
-    "value": "stereo"
+    "type": "encoder",
+    "label": "mp3",
+    "params": [
+      {
+      "type": "infix",
+      "left": { "type": "var", "value": "bitrate" },
+      "op": "=",
+      "right": { "type": "ground", "value": "128" }
+    },
+      {
+      "type": "var",
+      "value": "stereo"
+    }
+    ]
   }
   ]
 }
 --- hash ---
-4399310c4161c4a499a9a7d3ac76f041
+9105682d6bfc7be26df924a1767a538b
 --- term ---
 %mp3(bitrate=128, stereo)
 --- type ---
-At line 2, char 0-0:
+At cases/encoder.liq, line 2, char 0-0:
 
 Error 9: Failure: Encoders are not implemented!

--- a/tests/snapshots/expected/error_parse.expected
+++ b/tests/snapshots/expected/error_parse.expected
@@ -1,6 +1,7 @@
 === error_parse.invalid-liq ===
 def f( =
 --- parsed ---
-At line 1, char 7:
+At cases/error_parse.invalid-liq, line 1, char 7:
+def f( =
 
 Error 2: Parse error

--- a/tests/snapshots/expected/error_type.expected
+++ b/tests/snapshots/expected/error_type.expected
@@ -2,19 +2,25 @@
 1 + "one"
 --- parsed ---
 {
-  "type": "infix",
-  "left": { "type": "ground", "value": "1" },
-  "op": "+",
-  "right": { "type": "string", "value": "\"one\"" }
+  "type": "block",
+  "value": [
+    {
+    "type": "infix",
+    "left": { "type": "ground", "value": "1" },
+    "op": "+",
+    "right": { "type": "string", "value": "\"one\"" }
+  }
+  ]
 }
 --- hash ---
-31170116e0aedccf2a7a43899a869dfc
+bbb537d8225c0776f09ea07947c90aab
 --- term ---
 +(1, "one")
 --- type ---
-At line 1, char 4-9:
+At cases/error_type.liq, line 1, char 4-9:
+1 + "one"
 
 Error 5: this value has type
   string
 but it should be a subtype of
-  int (inferred at line 1, char 0)
+  int (inferred at cases/error_type.liq, line 1, char 0)

--- a/tests/snapshots/expected/error_unbound.expected
+++ b/tests/snapshots/expected/error_unbound.expected
@@ -1,12 +1,16 @@
 === error_unbound.liq ===
 undefined_variable
 --- parsed ---
-{ "type": "var", "value": "undefined_variable" }
+{
+  "type": "block",
+  "value": [ { "type": "var", "value": "undefined_variable" } ]
+}
 --- hash ---
-85659f605d2206b1c269ea49a5144d54
+20d2d1bd6cc78ad3607ad9c150b4c081
 --- term ---
 undefined_variable
 --- type ---
-At line 1, char 0-18:
+At cases/error_unbound.liq, line 1, char 0-18:
+undefined_variable
 
 Error 4: Undefined variable undefined_variable

--- a/tests/snapshots/expected/for_loop.expected
+++ b/tests/snapshots/expected/for_loop.expected
@@ -2,27 +2,34 @@
 for i = 1 to 3 do ignore(i)  end
 --- parsed ---
 {
-  "type": "for",
-  "variable": "i",
-  "from": { "type": "ground", "value": "1" },
-  "to": { "type": "ground", "value": "3" },
-  "loop": {
-    "type": "app",
-    "op": { "type": "var", "value": "ignore" },
-    "args": [
+  "type": "block",
+  "value": [
+    {
+    "type": "for",
+    "variable": "i",
+    "from": { "type": "ground", "value": "1" },
+    "to": { "type": "ground", "value": "3" },
+    "loop": [
       {
-      "type": "term",
-      "value": {
-        "type": "app_arg",
-        "label": "",
-        "value": { "type": "var", "value": "i" }
+      "type": "app",
+      "op": { "type": "var", "value": "ignore" },
+      "args": [
+        {
+        "type": "term",
+        "value": {
+          "type": "app_arg",
+          "label": "",
+          "value": { "type": "var", "value": "i" }
+        }
       }
+      ]
     }
     ]
   }
+  ]
 }
 --- hash ---
-159d6d67edcb20f24da5bd6a42a2685c
+b7a185a0643fbbc1f2289f534926cabd
 --- term ---
 for(iterator.int(1, 3), fun (i) -> ignore(i))
 --- type ---

--- a/tests/snapshots/expected/fun_shorthand.expected
+++ b/tests/snapshots/expected/fun_shorthand.expected
@@ -3,28 +3,35 @@ f = {1 + 1}
 f()
 --- parsed ---
 {
-  "type": "binding",
-  "body": {
+  "type": "block",
+  "value": [
+    {
+    "type": "binding",
+    "decoration": null,
+    "pat": { "type": "pvar", "value": [ "f" ] },
+    "arglist": null,
+    "cast": null,
+    "definition": {
+      "type": "simple_fun",
+      "value": [
+        {
+        "type": "infix",
+        "left": { "type": "ground", "value": "1" },
+        "op": "+",
+        "right": { "type": "ground", "value": "1" }
+      }
+      ]
+    }
+  },
+    {
     "type": "app",
     "op": { "type": "var", "value": "f" },
     "args": []
-  },
-  "decoration": null,
-  "pat": { "type": "pvar", "value": [ "f" ] },
-  "arglist": null,
-  "cast": null,
-  "definition": {
-    "type": "simple_fun",
-    "value": {
-      "type": "infix",
-      "left": { "type": "ground", "value": "1" },
-      "op": "+",
-      "right": { "type": "ground", "value": "1" }
-    }
   }
+  ]
 }
 --- hash ---
-521434f303ada8a80912cc38a9962948
+d8f0b44d791411c9686d34f3133f1646
 --- term ---
 f = fun () -> +(1, 1)
 f()

--- a/tests/snapshots/expected/functions.expected
+++ b/tests/snapshots/expected/functions.expected
@@ -6,8 +6,60 @@ end
 f(named=1, 2)
 --- parsed ---
 {
-  "type": "def",
-  "body": {
+  "type": "block",
+  "value": [
+    {
+    "type": "def",
+    "decoration": null,
+    "pat": { "type": "pvar", "value": [ "f" ] },
+    "arglist": [
+      {
+      "type": "term",
+      "value": {
+        "type": "fun_arg",
+        "label": "named",
+        "as_variable": null,
+        "typ": null,
+        "default": null
+      }
+    },
+      {
+      "type": "term",
+      "value": {
+        "type": "fun_arg",
+        "label": "opt",
+        "as_variable": null,
+        "typ": null,
+        "default": { "type": "ground", "value": "1" }
+      }
+    },
+      {
+      "type": "term",
+      "value": {
+        "type": "fun_arg",
+        "label": "",
+        "as_variable": { "type": "pvar", "value": [ "x" ] },
+        "typ": null,
+        "default": null
+      }
+    }
+    ],
+    "cast": null,
+    "body": [
+      {
+      "type": "infix",
+      "left": {
+        "type": "infix",
+        "left": { "type": "var", "value": "named" },
+        "op": "+",
+        "right": { "type": "var", "value": "opt" }
+      },
+      "op": "+",
+      "right": { "type": "var", "value": "x" }
+    }
+    ]
+  },
+    {
     "type": "app",
     "op": { "type": "var", "value": "f" },
     "args": [
@@ -28,56 +80,11 @@ f(named=1, 2)
       }
     }
     ]
-  },
-  "decoration": null,
-  "pat": { "type": "pvar", "value": [ "f" ] },
-  "arglist": [
-    {
-    "type": "term",
-    "value": {
-      "type": "fun_arg",
-      "label": "named",
-      "as_variable": null,
-      "typ": null,
-      "default": null
-    }
-  },
-    {
-    "type": "term",
-    "value": {
-      "type": "fun_arg",
-      "label": "opt",
-      "as_variable": null,
-      "typ": null,
-      "default": { "type": "ground", "value": "1" }
-    }
-  },
-    {
-    "type": "term",
-    "value": {
-      "type": "fun_arg",
-      "label": "",
-      "as_variable": { "type": "pvar", "value": [ "x" ] },
-      "typ": null,
-      "default": null
-    }
   }
-  ],
-  "cast": null,
-  "definition": {
-    "type": "infix",
-    "left": {
-      "type": "infix",
-      "left": { "type": "var", "value": "named" },
-      "op": "+",
-      "right": { "type": "var", "value": "opt" }
-    },
-    "op": "+",
-    "right": { "type": "var", "value": "x" }
-  }
+  ]
 }
 --- hash ---
-b35cb2019fb7224bb65c5bb0f8b92694
+efedaebbe68347cb7ca60d8c10a1cc3b
 --- term ---
 f = fun (~named, ~opt=1, x) -> +(+(named, opt), x)
 f(named=1, 2)

--- a/tests/snapshots/expected/getter_coercion.expected
+++ b/tests/snapshots/expected/getter_coercion.expected
@@ -3,8 +3,30 @@ g = getter(1)
 getter.get(g)
 --- parsed ---
 {
-  "type": "binding",
-  "body": {
+  "type": "block",
+  "value": [
+    {
+    "type": "binding",
+    "decoration": null,
+    "pat": { "type": "pvar", "value": [ "g" ] },
+    "arglist": null,
+    "cast": null,
+    "definition": {
+      "type": "app",
+      "op": { "type": "var", "value": "getter" },
+      "args": [
+        {
+        "type": "term",
+        "value": {
+          "type": "app_arg",
+          "label": "",
+          "value": { "type": "ground", "value": "1" }
+        }
+      }
+      ]
+    }
+  },
+    {
     "type": "invoke",
     "invoked": { "type": "var", "value": "getter" },
     "optional": false,
@@ -22,28 +44,11 @@ getter.get(g)
       }
       ]
     }
-  },
-  "decoration": null,
-  "pat": { "type": "pvar", "value": [ "g" ] },
-  "arglist": null,
-  "cast": null,
-  "definition": {
-    "type": "app",
-    "op": { "type": "var", "value": "getter" },
-    "args": [
-      {
-      "type": "term",
-      "value": {
-        "type": "app_arg",
-        "label": "",
-        "value": { "type": "ground", "value": "1" }
-      }
-    }
-    ]
   }
+  ]
 }
 --- hash ---
-db689303f96189efdfcff5a0f365e3e1
+af82e6e1fad0992081c69a49e7965fbc
 --- term ---
 g = getter(1)
 getter.get(g)

--- a/tests/snapshots/expected/getters.expected
+++ b/tests/snapshots/expected/getters.expected
@@ -91,6 +91,8 @@ end
 --- term ---
 f = fun (x) -> getter.get(x)
 (f(1), f({2}))
+--- doc ---
+f: `{e}` is shorthand for `fun () -> e`, which is what makes a getter.
 --- type ---
 int * int
 --- value ---

--- a/tests/snapshots/expected/getters.expected
+++ b/tests/snapshots/expected/getters.expected
@@ -7,8 +7,48 @@ end
 (f(1), f({2}))
 --- parsed ---
 {
-  "type": "def",
-  "body": {
+  "type": "block",
+  "value": [
+    {
+    "type": "def",
+    "decoration": null,
+    "pat": { "type": "pvar", "value": [ "f" ] },
+    "arglist": [
+      {
+      "type": "term",
+      "value": {
+        "type": "fun_arg",
+        "label": "",
+        "as_variable": { "type": "pvar", "value": [ "x" ] },
+        "typ": null,
+        "default": null
+      }
+    }
+    ],
+    "cast": null,
+    "body": [
+      {
+      "type": "invoke",
+      "invoked": { "type": "var", "value": "getter" },
+      "optional": false,
+      "meth": {
+        "type": "app",
+        "op": { "type": "var", "value": "get" },
+        "args": [
+          {
+          "type": "term",
+          "value": {
+            "type": "app_arg",
+            "label": "",
+            "value": { "type": "var", "value": "x" }
+          }
+        }
+        ]
+      }
+    }
+    ]
+  },
+    {
     "type": "tuple",
     "value": [
       {
@@ -36,51 +76,18 @@ end
           "label": "",
           "value": {
             "type": "simple_fun",
-            "value": { "type": "ground", "value": "2" }
+            "value": [ { "type": "ground", "value": "2" } ]
           }
         }
       }
       ]
     }
     ]
-  },
-  "decoration": null,
-  "pat": { "type": "pvar", "value": [ "f" ] },
-  "arglist": [
-    {
-    "type": "term",
-    "value": {
-      "type": "fun_arg",
-      "label": "",
-      "as_variable": { "type": "pvar", "value": [ "x" ] },
-      "typ": null,
-      "default": null
-    }
   }
-  ],
-  "cast": null,
-  "definition": {
-    "type": "invoke",
-    "invoked": { "type": "var", "value": "getter" },
-    "optional": false,
-    "meth": {
-      "type": "app",
-      "op": { "type": "var", "value": "get" },
-      "args": [
-        {
-        "type": "term",
-        "value": {
-          "type": "app_arg",
-          "label": "",
-          "value": { "type": "var", "value": "x" }
-        }
-      }
-      ]
-    }
-  }
+  ]
 }
 --- hash ---
-4d752d60131ac9378ddaad3458975c2f
+414c1885ec485d9194cee95b03211666
 --- term ---
 f = fun (x) -> getter.get(x)
 (f(1), f({2}))

--- a/tests/snapshots/expected/infix.expected
+++ b/tests/snapshots/expected/infix.expected
@@ -2,23 +2,28 @@
 1 + 2 * 3 - 4
 --- parsed ---
 {
-  "type": "infix",
-  "left": {
+  "type": "block",
+  "value": [
+    {
     "type": "infix",
-    "left": { "type": "ground", "value": "1" },
-    "op": "+",
-    "right": {
+    "left": {
       "type": "infix",
-      "left": { "type": "ground", "value": "2" },
-      "op": "*",
-      "right": { "type": "ground", "value": "3" }
-    }
-  },
-  "op": "-",
-  "right": { "type": "ground", "value": "4" }
+      "left": { "type": "ground", "value": "1" },
+      "op": "+",
+      "right": {
+        "type": "infix",
+        "left": { "type": "ground", "value": "2" },
+        "op": "*",
+        "right": { "type": "ground", "value": "3" }
+      }
+    },
+    "op": "-",
+    "right": { "type": "ground", "value": "4" }
+  }
+  ]
 }
 --- hash ---
-a96eaf7021dc249948effc3714fc55f8
+8c908ab414895f24881d9df993282556
 --- term ---
 -(+(1, *(2, 3)), 4)
 --- type ---

--- a/tests/snapshots/expected/infix_precedence.expected
+++ b/tests/snapshots/expected/infix_precedence.expected
@@ -2,47 +2,52 @@
 (1 + 2 == 3, 1 < 2 and 3 >= 2, "a" ^ "b")
 --- parsed ---
 {
-  "type": "tuple",
+  "type": "block",
   "value": [
     {
-    "type": "infix",
-    "left": {
-      "type": "infix",
-      "left": { "type": "ground", "value": "1" },
-      "op": "+",
-      "right": { "type": "ground", "value": "2" }
-    },
-    "op": "==",
-    "right": { "type": "ground", "value": "3" }
-  },
-    {
-    "type": "bool",
-    "op": "and",
+    "type": "tuple",
     "value": [
       {
       "type": "infix",
-      "left": { "type": "ground", "value": "1" },
-      "op": "<",
-      "right": { "type": "ground", "value": "2" }
+      "left": {
+        "type": "infix",
+        "left": { "type": "ground", "value": "1" },
+        "op": "+",
+        "right": { "type": "ground", "value": "2" }
+      },
+      "op": "==",
+      "right": { "type": "ground", "value": "3" }
+    },
+      {
+      "type": "bool",
+      "op": "and",
+      "value": [
+        {
+        "type": "infix",
+        "left": { "type": "ground", "value": "1" },
+        "op": "<",
+        "right": { "type": "ground", "value": "2" }
+      },
+        {
+        "type": "infix",
+        "left": { "type": "ground", "value": "3" },
+        "op": ">=",
+        "right": { "type": "ground", "value": "2" }
+      }
+      ]
     },
       {
       "type": "infix",
-      "left": { "type": "ground", "value": "3" },
-      "op": ">=",
-      "right": { "type": "ground", "value": "2" }
+      "left": { "type": "string", "value": "\"a\"" },
+      "op": "^",
+      "right": { "type": "string", "value": "\"b\"" }
     }
     ]
-  },
-    {
-    "type": "infix",
-    "left": { "type": "string", "value": "\"a\"" },
-    "op": "^",
-    "right": { "type": "string", "value": "\"b\"" }
   }
   ]
 }
 --- hash ---
-4e075b3871ecf302e13ac311613d67ae
+f4c710640b8f8871ed5d1d8f9c4634ba
 --- term ---
 (==(+(1, 2), 3), and(fun () -> <(1, 2), fun () -> >=(3, 2)), ^("a", "b"))
 --- type ---

--- a/tests/snapshots/expected/invoke_default.expected
+++ b/tests/snapshots/expected/invoke_default.expected
@@ -3,8 +3,27 @@ r = {a = 1}
 r?.a ?? 0
 --- parsed ---
 {
-  "type": "binding",
-  "body": {
+  "type": "block",
+  "value": [
+    {
+    "type": "binding",
+    "decoration": null,
+    "pat": { "type": "pvar", "value": [ "r" ] },
+    "arglist": null,
+    "cast": null,
+    "definition": {
+      "type": "methods",
+      "base": null,
+      "methods": [
+        {
+        "type": "method",
+        "name": "a",
+        "value": { "type": "ground", "value": "1" }
+      }
+      ]
+    }
+  },
+    {
     "type": "coalesce",
     "left": {
       "type": "invoke",
@@ -13,25 +32,11 @@ r?.a ?? 0
       "meth": { "type": "var", "value": "a" }
     },
     "right": { "type": "ground", "value": "0" }
-  },
-  "decoration": null,
-  "pat": { "type": "pvar", "value": [ "r" ] },
-  "arglist": null,
-  "cast": null,
-  "definition": {
-    "type": "methods",
-    "base": null,
-    "methods": [
-      {
-      "type": "method",
-      "name": "a",
-      "value": { "type": "ground", "value": "1" }
-    }
-    ]
   }
+  ]
 }
 --- hash ---
-30b23f36634cc6f3bf7c3d3a78d0f9a8
+21adb5087478236aeca83cef57825f68
 --- term ---
 r = {a=1}
 (r.a ?? 0)

--- a/tests/snapshots/expected/iterable_for.expected
+++ b/tests/snapshots/expected/iterable_for.expected
@@ -2,64 +2,72 @@
 for x = list.iterator([1, 2, 3]) do ignore(x) end
 --- parsed ---
 {
-  "type": "iterable_for",
-  "variable": "x",
-  "iterator": {
-    "type": "invoke",
-    "invoked": { "type": "var", "value": "list" },
-    "optional": false,
-    "meth": {
+  "type": "block",
+  "value": [
+    {
+    "type": "iterable_for",
+    "variable": "x",
+    "iterator": {
+      "type": "invoke",
+      "invoked": { "type": "var", "value": "list" },
+      "optional": false,
+      "meth": {
+        "type": "app",
+        "op": { "type": "var", "value": "iterator" },
+        "args": [
+          {
+          "type": "term",
+          "value": {
+            "type": "app_arg",
+            "label": "",
+            "value": {
+              "type": "list",
+              "value": [
+                {
+                "type": "term",
+                "value": { "type": "ground", "value": "1" }
+              },
+                {
+                "type": "term",
+                "value": { "type": "ground", "value": "2" }
+              },
+                {
+                "type": "term",
+                "value": { "type": "ground", "value": "3" }
+              }
+              ]
+            }
+          }
+        }
+        ]
+      }
+    },
+    "loop": [
+      {
       "type": "app",
-      "op": { "type": "var", "value": "iterator" },
+      "op": { "type": "var", "value": "ignore" },
       "args": [
         {
         "type": "term",
         "value": {
           "type": "app_arg",
           "label": "",
-          "value": {
-            "type": "list",
-            "value": [
-              {
-              "type": "term",
-              "value": { "type": "ground", "value": "1" }
-            },
-              {
-              "type": "term",
-              "value": { "type": "ground", "value": "2" }
-            },
-              {
-              "type": "term",
-              "value": { "type": "ground", "value": "3" }
-            }
-            ]
-          }
+          "value": { "type": "var", "value": "x" }
         }
       }
       ]
     }
-  },
-  "loop": {
-    "type": "app",
-    "op": { "type": "var", "value": "ignore" },
-    "args": [
-      {
-      "type": "term",
-      "value": {
-        "type": "app_arg",
-        "label": "",
-        "value": { "type": "var", "value": "x" }
-      }
-    }
     ]
   }
+  ]
 }
 --- hash ---
-78a1ec263395a31bb34d931b86d029fd
+ae42910cd311b37e94795ae6f1f713a2
 --- term ---
 for(list.iterator([1, 2, 3]), fun (x) -> ignore(x))
 --- type ---
-At line 1, char 8-12:
+At cases/iterable_for.liq, line 1, char 8-12:
+for x = list.iterator([1, 2, 3]) do ignore(x) end
 
 Error 5: this value has no method `iterator`
   Its type is {

--- a/tests/snapshots/expected/iterable_for.expected
+++ b/tests/snapshots/expected/iterable_for.expected
@@ -1,5 +1,5 @@
 === iterable_for.liq ===
-for x = list.iterator([1, 2, 3]) do ignore(x) end
+for x = list.iterator([1, 2, 3]) do ignore(x)  end
 --- parsed ---
 {
   "type": "block",
@@ -67,7 +67,7 @@ ae42910cd311b37e94795ae6f1f713a2
 for(list.iterator([1, 2, 3]), fun (x) -> ignore(x))
 --- type ---
 At cases/iterable_for.liq, line 1, char 8-12:
-for x = list.iterator([1, 2, 3]) do ignore(x) end
+for x = list.iterator([1, 2, 3]) do ignore(x)  end
 
 Error 5: this value has no method `iterator`
   Its type is {

--- a/tests/snapshots/expected/json_as_type.expected
+++ b/tests/snapshots/expected/json_as_type.expected
@@ -3,10 +3,13 @@
 # identifier everywhere else. `as json.object` reads a JSON object as an
 # association list; `"name" as field` renames a field whose JSON name is not a
 # valid identifier.
-let json.parse (m : [(string * int)] as json.object) = "{\"a\": 1}"
-let json.parse (r : {"start" as spin_start: string}) = "{\"start\": \"x\"}"
+let json.parse (m : [(string*int)] as json.object) =
+  "{\"a\": 1}"
+let json.parse (r : {"start" as spin_start: string}) =
+  "{\"start\": \"x\"}"
 
-as = "still an identifier"
+as =
+  "still an identifier"
 
 (m, r.spin_start, as)
 --- parsed ---

--- a/tests/snapshots/expected/json_as_type.expected
+++ b/tests/snapshots/expected/json_as_type.expected
@@ -1,0 +1,99 @@
+=== json_as_type.liq ===
+# `as` is a contextual keyword, not a reserved word: it stays an ordinary
+# identifier everywhere else. `as json.object` reads a JSON object as an
+# association list; `"name" as field` renames a field whose JSON name is not a
+# valid identifier.
+let json.parse (m : [(string * int)] as json.object) = "{\"a\": 1}"
+let json.parse (r : {"start" as spin_start: string}) = "{\"start\": \"x\"}"
+
+as = "still an identifier"
+
+(m, r.spin_start, as)
+--- parsed ---
+{
+  "type": "block",
+  "value": [
+    {
+    "type": "let",
+    "decoration": { "type": "var", "value": "json.parse" },
+    "pat": { "type": "pvar", "value": [ "m" ] },
+    "arglist": null,
+    "cast": {
+      "type": "type_annotation",
+      "subtype": "json_object",
+      "value": {
+        "type": "type_annotation",
+        "subtype": "named",
+        "value": "int"
+      }
+    },
+    "definition": { "type": "string", "value": "\"{\\\"a\\\": 1}\"" }
+  },
+    {
+    "type": "let",
+    "decoration": { "type": "var", "value": "json.parse" },
+    "pat": { "type": "pvar", "value": [ "r" ] },
+    "arglist": null,
+    "cast": {
+      "type": "type_annotation",
+      "subtype": "record",
+      "value": [
+        {
+        "type": "type_annotation",
+        "subtype": "method_annotation",
+        "value": {
+          "type": "type_annotation",
+          "subtype": "named",
+          "value": "string"
+        },
+        "optional": false,
+        "name": "spin_start",
+        "json_name": "start"
+      }
+      ]
+    },
+    "definition": {
+      "type": "string",
+      "value": "\"{\\\"start\\\": \\\"x\\\"}\""
+    }
+  },
+    {
+    "type": "binding",
+    "decoration": null,
+    "pat": { "type": "pvar", "value": [ "as" ] },
+    "arglist": null,
+    "cast": null,
+    "definition": { "type": "string", "value": "\"still an identifier\"" }
+  },
+    {
+    "type": "tuple",
+    "value": [
+      {
+      "type": "var",
+      "value": "m"
+    },
+      {
+      "type": "invoke",
+      "invoked": { "type": "var", "value": "r" },
+      "optional": false,
+      "meth": { "type": "var", "value": "spin_start" }
+    },
+      {
+      "type": "var",
+      "value": "as"
+    }
+    ]
+  }
+  ]
+}
+--- hash ---
+bcf8db21b96e03b3e36edc416d1c2022
+--- term ---
+m = (_internal_json_parser_(json5=false, type=type, "{\"a\": 1}") : [string * int] as json.object)
+r = (_internal_json_parser_(json5=false, type=type, "{\"start\": \"x\"}") : {"start" as spin_start : string})
+as = "still an identifier"
+(m, r.spin_start, as)
+--- type ---
+[string * int] as json.object * string * string
+--- value ---
+([("a", 1)], "x", "still an identifier")

--- a/tests/snapshots/expected/json_as_type.expected
+++ b/tests/snapshots/expected/json_as_type.expected
@@ -89,8 +89,8 @@ as = "still an identifier"
 --- hash ---
 bcf8db21b96e03b3e36edc416d1c2022
 --- term ---
-m = (_internal_json_parser_(json5=false, type=type, "{\"a\": 1}") : [string * int] as json.object)
-r = (_internal_json_parser_(json5=false, type=type, "{\"start\": \"x\"}") : {"start" as spin_start : string})
+m = (_0_json_parser(json5=false, type=type, "{\"a\": 1}") : [string * int] as json.object)
+r = (_0_json_parser(json5=false, type=type, "{\"start\": \"x\"}") : {"start" as spin_start : string})
 as = "still an identifier"
 (m, r.spin_start, as)
 --- type ---

--- a/tests/snapshots/expected/json_as_type_bad.expected
+++ b/tests/snapshots/expected/json_as_type_bad.expected
@@ -1,10 +1,12 @@
 === json_as_type_bad.invalid-liq ===
-# A misspelled contextual keyword names what was expected and points at the
+# A wrong contextual keyword names what was expected and points at the
 # offending token, rather than reporting the whole type as invalid.
-let json.parse (m : [(string * int)] as json.objct) = "{}"
+# The bad keyword has to be a non-word: codespell rewrites anything close
+# enough to `object` to be in its dictionary, here and in the expected output.
+let json.parse (m : [(string * int)] as json.nope) = "{}"
 ignore(m)
 --- parsed ---
-At cases/json_as_type_bad.invalid-liq, line 3, char 44-50:
-let json.parse (m : [(string * int)] as json.objct) = "{}"
+At cases/json_as_type_bad.invalid-liq, line 5, char 44-49:
+let json.parse (m : [(string * int)] as json.nope) = "{}"
 
-Error 3: Expected `object`, found `objct`.
+Error 3: Expected `object`, found `nope`.

--- a/tests/snapshots/expected/json_as_type_bad.expected
+++ b/tests/snapshots/expected/json_as_type_bad.expected
@@ -1,0 +1,10 @@
+=== json_as_type_bad.invalid-liq ===
+# A misspelled contextual keyword names what was expected and points at the
+# offending token, rather than reporting the whole type as invalid.
+let json.parse (m : [(string * int)] as json.objct) = "{}"
+ignore(m)
+--- parsed ---
+At cases/json_as_type_bad.invalid-liq, line 3, char 44-50:
+let json.parse (m : [(string * int)] as json.objct) = "{}"
+
+Error 3: Expected `object`, found `objct`.

--- a/tests/snapshots/expected/json_parse.expected
+++ b/tests/snapshots/expected/json_parse.expected
@@ -3,33 +3,41 @@ let json.parse ({a} : {a: int}) = '{"a": 1}'
 a
 --- parsed ---
 {
-  "type": "let",
-  "body": { "type": "var", "value": "a" },
-  "decoration": { "type": "var", "value": "json.parse" },
-  "pat": { "type": "pmeth", "value": [ { "type": "var", "value": "a" } ] },
-  "arglist": null,
-  "cast": {
-    "type": "type_annotation",
-    "subtype": "record",
-    "value": [
-      {
+  "type": "block",
+  "value": [
+    {
+    "type": "let",
+    "decoration": { "type": "var", "value": "json.parse" },
+    "pat": { "type": "pmeth", "value": [ { "type": "var", "value": "a" } ] },
+    "arglist": null,
+    "cast": {
       "type": "type_annotation",
-      "subtype": "method_annotation",
-      "value": {
+      "subtype": "record",
+      "value": [
+        {
         "type": "type_annotation",
-        "subtype": "named",
-        "value": "int"
-      },
-      "optional": false,
-      "name": "a",
-      "json_name": null
-    }
-    ]
+        "subtype": "method_annotation",
+        "value": {
+          "type": "type_annotation",
+          "subtype": "named",
+          "value": "int"
+        },
+        "optional": false,
+        "name": "a",
+        "json_name": null
+      }
+      ]
+    },
+    "definition": { "type": "string", "value": "'{\"a\": 1}'" }
   },
-  "definition": { "type": "string", "value": "'{\"a\": 1}'" }
+    {
+    "type": "var",
+    "value": "a"
+  }
+  ]
 }
 --- hash ---
-972cb196e3f67259137e78ca0283e978
+2a969f235d1c6f2db6979ad098ae1888
 --- term ---
 _pat0 = (_internal_json_parser_(json5=false, type=type, "{\"a\": 1}") : {a : int})
 a = _pat0.a

--- a/tests/snapshots/expected/json_parse.expected
+++ b/tests/snapshots/expected/json_parse.expected
@@ -1,5 +1,6 @@
 === json_parse.liq ===
-let json.parse ({a} : {a: int}) = '{"a": 1}'
+let json.parse ({a} : {a: int}) =
+  '{"a": 1}'
 a
 --- parsed ---
 {

--- a/tests/snapshots/expected/json_parse.expected
+++ b/tests/snapshots/expected/json_parse.expected
@@ -39,7 +39,7 @@ a
 --- hash ---
 2a969f235d1c6f2db6979ad098ae1888
 --- term ---
-_pat0 = (_internal_json_parser_(json5=false, type=type, "{\"a\": 1}") : {a : int})
+_pat0 = (_0_json_parser(json5=false, type=type, "{\"a\": 1}") : {a : int})
 a = _pat0.a
 a
 --- type ---

--- a/tests/snapshots/expected/let_patterns.expected
+++ b/tests/snapshots/expected/let_patterns.expected
@@ -5,64 +5,52 @@ let {foo} = {foo = 3, bar = 4}
 (a, b, c, x, y, foo)
 --- parsed ---
 {
-  "type": "let",
-  "body": {
+  "type": "block",
+  "value": [
+    {
     "type": "let",
-    "body": {
-      "type": "let",
-      "body": {
-        "type": "tuple",
-        "value": [
-          {
-          "type": "var",
-          "value": "a"
-        },
-          {
-          "type": "var",
-          "value": "b"
-        },
-          {
-          "type": "var",
-          "value": "c"
-        },
-          {
-          "type": "var",
-          "value": "x"
-        },
-          {
-          "type": "var",
-          "value": "y"
-        },
-          {
-          "type": "var",
-          "value": "foo"
-        }
-        ]
+    "decoration": null,
+    "pat": {
+      "type": "plist",
+      "left": [
+        {
+        "type": "pvar",
+        "value": [ "a" ]
       },
-      "decoration": null,
-      "pat": {
-        "type": "pmeth",
-        "value": [ { "type": "var", "value": "foo" } ]
-      },
-      "arglist": null,
-      "cast": null,
-      "definition": {
-        "type": "methods",
-        "base": null,
-        "methods": [
-          {
-          "type": "method",
-          "name": "foo",
-          "value": { "type": "ground", "value": "3" }
-        },
-          {
-          "type": "method",
-          "name": "bar",
-          "value": { "type": "ground", "value": "4" }
-        }
-        ]
+        {
+        "type": "pvar",
+        "value": [ "b" ]
       }
+      ],
+      "middle": "c",
+      "right": []
     },
+    "arglist": null,
+    "cast": null,
+    "definition": {
+      "type": "list",
+      "value": [
+        {
+        "type": "term",
+        "value": { "type": "ground", "value": "1" }
+      },
+        {
+        "type": "term",
+        "value": { "type": "ground", "value": "2" }
+      },
+        {
+        "type": "term",
+        "value": { "type": "ground", "value": "3" }
+      },
+        {
+        "type": "term",
+        "value": { "type": "ground", "value": "4" }
+      }
+      ]
+    }
+  },
+    {
+    "type": "let",
     "decoration": null,
     "pat": {
       "type": "ptuple",
@@ -93,48 +81,65 @@ let {foo} = {foo = 3, bar = 4}
       ]
     }
   },
-  "decoration": null,
-  "pat": {
-    "type": "plist",
-    "left": [
-      {
-      "type": "pvar",
-      "value": [ "a" ]
+    {
+    "type": "let",
+    "decoration": null,
+    "pat": {
+      "type": "pmeth",
+      "value": [ { "type": "var", "value": "foo" } ]
     },
-      {
-      "type": "pvar",
-      "value": [ "b" ]
+    "arglist": null,
+    "cast": null,
+    "definition": {
+      "type": "methods",
+      "base": null,
+      "methods": [
+        {
+        "type": "method",
+        "name": "foo",
+        "value": { "type": "ground", "value": "3" }
+      },
+        {
+        "type": "method",
+        "name": "bar",
+        "value": { "type": "ground", "value": "4" }
+      }
+      ]
     }
-    ],
-    "middle": "c",
-    "right": []
   },
-  "arglist": null,
-  "cast": null,
-  "definition": {
-    "type": "list",
+    {
+    "type": "tuple",
     "value": [
       {
-      "type": "term",
-      "value": { "type": "ground", "value": "1" }
+      "type": "var",
+      "value": "a"
     },
       {
-      "type": "term",
-      "value": { "type": "ground", "value": "2" }
+      "type": "var",
+      "value": "b"
     },
       {
-      "type": "term",
-      "value": { "type": "ground", "value": "3" }
+      "type": "var",
+      "value": "c"
     },
       {
-      "type": "term",
-      "value": { "type": "ground", "value": "4" }
+      "type": "var",
+      "value": "x"
+    },
+      {
+      "type": "var",
+      "value": "y"
+    },
+      {
+      "type": "var",
+      "value": "foo"
     }
     ]
   }
+  ]
 }
 --- hash ---
-c64dd274b5c59995632b4364efe7943a
+a1734de72beb8112bcd0abaa667a3993
 --- term ---
 _pat0 = [1, 2, 3, 4]
 _pat1 = list.length(_pat0)

--- a/tests/snapshots/expected/let_rec.expected
+++ b/tests/snapshots/expected/let_rec.expected
@@ -5,8 +5,66 @@ end
 fact(5)
 --- parsed ---
 {
-  "type": "def",
-  "body": {
+  "type": "block",
+  "value": [
+    {
+    "type": "def",
+    "decoration": { "type": "var", "value": "rec" },
+    "pat": { "type": "pvar", "value": [ "fact" ] },
+    "arglist": [
+      {
+      "type": "term",
+      "value": {
+        "type": "fun_arg",
+        "label": "",
+        "as_variable": { "type": "pvar", "value": [ "n" ] },
+        "typ": null,
+        "default": null
+      }
+    }
+    ],
+    "cast": null,
+    "body": [
+      {
+      "type": "if",
+      "condition": {
+        "type": "infix",
+        "left": { "type": "var", "value": "n" },
+        "op": "<=",
+        "right": { "type": "ground", "value": "1" }
+      },
+      "then": [ { "type": "ground", "value": "1" } ],
+      "elsif": [],
+      "else": [
+        {
+        "type": "infix",
+        "left": { "type": "var", "value": "n" },
+        "op": "*",
+        "right": {
+          "type": "app",
+          "op": { "type": "var", "value": "fact" },
+          "args": [
+            {
+            "type": "term",
+            "value": {
+              "type": "app_arg",
+              "label": "",
+              "value": {
+                "type": "infix",
+                "left": { "type": "var", "value": "n" },
+                "op": "-",
+                "right": { "type": "ground", "value": "1" }
+              }
+            }
+          }
+          ]
+        }
+      }
+      ]
+    }
+    ]
+  },
+    {
     "type": "app",
     "op": { "type": "var", "value": "fact" },
     "args": [
@@ -19,60 +77,11 @@ fact(5)
       }
     }
     ]
-  },
-  "decoration": { "type": "var", "value": "rec" },
-  "pat": { "type": "pvar", "value": [ "fact" ] },
-  "arglist": [
-    {
-    "type": "term",
-    "value": {
-      "type": "fun_arg",
-      "label": "",
-      "as_variable": { "type": "pvar", "value": [ "n" ] },
-      "typ": null,
-      "default": null
-    }
   }
-  ],
-  "cast": null,
-  "definition": {
-    "type": "if",
-    "condition": {
-      "type": "infix",
-      "left": { "type": "var", "value": "n" },
-      "op": "<=",
-      "right": { "type": "ground", "value": "1" }
-    },
-    "then": { "type": "ground", "value": "1" },
-    "elsif": [],
-    "else": {
-      "type": "infix",
-      "left": { "type": "var", "value": "n" },
-      "op": "*",
-      "right": {
-        "type": "app",
-        "op": { "type": "var", "value": "fact" },
-        "args": [
-          {
-          "type": "term",
-          "value": {
-            "type": "app_arg",
-            "label": "",
-            "value": {
-              "type": "infix",
-              "left": { "type": "var", "value": "n" },
-              "op": "-",
-              "right": { "type": "ground", "value": "1" }
-            }
-          }
-        }
-        ]
-      }
-    }
-  }
+  ]
 }
 --- hash ---
-d26e7eadfaa8b0b71adda2a9b15181c6
+651778ea958a654e22211c9acff56cab
 --- term ---
 def rec fact(n) =
   if(<=(n, 1), then={1}, else=fun () -> *(n, fact(-(n, 1))))

--- a/tests/snapshots/expected/list_ops.expected
+++ b/tests/snapshots/expected/list_ops.expected
@@ -3,8 +3,33 @@ l = [1, 2, 3]
 [0, ...l, 4]
 --- parsed ---
 {
-  "type": "binding",
-  "body": {
+  "type": "block",
+  "value": [
+    {
+    "type": "binding",
+    "decoration": null,
+    "pat": { "type": "pvar", "value": [ "l" ] },
+    "arglist": null,
+    "cast": null,
+    "definition": {
+      "type": "list",
+      "value": [
+        {
+        "type": "term",
+        "value": { "type": "ground", "value": "1" }
+      },
+        {
+        "type": "term",
+        "value": { "type": "ground", "value": "2" }
+      },
+        {
+        "type": "term",
+        "value": { "type": "ground", "value": "3" }
+      }
+      ]
+    }
+  },
+    {
     "type": "list",
     "value": [
       {
@@ -20,31 +45,11 @@ l = [1, 2, 3]
       "value": { "type": "ground", "value": "4" }
     }
     ]
-  },
-  "decoration": null,
-  "pat": { "type": "pvar", "value": [ "l" ] },
-  "arglist": null,
-  "cast": null,
-  "definition": {
-    "type": "list",
-    "value": [
-      {
-      "type": "term",
-      "value": { "type": "ground", "value": "1" }
-    },
-      {
-      "type": "term",
-      "value": { "type": "ground", "value": "2" }
-    },
-      {
-      "type": "term",
-      "value": { "type": "ground", "value": "3" }
-    }
-    ]
   }
+  ]
 }
 --- hash ---
-0b8de44d63429383530400b9d14a968f
+5a5d7b7d281997f697ee292613186983
 --- term ---
 l = [1, 2, 3]
 _::_(0, list.append(l, [4]))

--- a/tests/snapshots/expected/methods.expected
+++ b/tests/snapshots/expected/methods.expected
@@ -3,40 +3,45 @@ v = "x".{count = 3, twice = fun () -> 6}
 v.count
 --- parsed ---
 {
-  "type": "binding",
-  "body": {
+  "type": "block",
+  "value": [
+    {
+    "type": "binding",
+    "decoration": null,
+    "pat": { "type": "pvar", "value": [ "v" ] },
+    "arglist": null,
+    "cast": null,
+    "definition": {
+      "type": "methods",
+      "base": { "type": "string", "value": "\"x\"" },
+      "methods": [
+        {
+        "type": "method",
+        "name": "count",
+        "value": { "type": "ground", "value": "3" }
+      },
+        {
+        "type": "method",
+        "name": "twice",
+        "value": {
+          "type": "fun",
+          "arguments": [],
+          "body": { "type": "ground", "value": "6" }
+        }
+      }
+      ]
+    }
+  },
+    {
     "type": "invoke",
     "invoked": { "type": "var", "value": "v" },
     "optional": false,
     "meth": { "type": "var", "value": "count" }
-  },
-  "decoration": null,
-  "pat": { "type": "pvar", "value": [ "v" ] },
-  "arglist": null,
-  "cast": null,
-  "definition": {
-    "type": "methods",
-    "base": { "type": "string", "value": "\"x\"" },
-    "methods": [
-      {
-      "type": "method",
-      "name": "count",
-      "value": { "type": "ground", "value": "3" }
-    },
-      {
-      "type": "method",
-      "name": "twice",
-      "value": {
-        "type": "fun",
-        "arguments": [],
-        "body": { "type": "ground", "value": "6" }
-      }
-    }
-    ]
   }
+  ]
 }
 --- hash ---
-ec355eba01df35a7df302351033e4531
+60f3fe20435e8fe9419d6296563e581c
 --- term ---
 v = "x".{twice={6}, count=3}
 v.count

--- a/tests/snapshots/expected/negative.expected
+++ b/tests/snapshots/expected/negative.expected
@@ -3,8 +3,17 @@ x = 3
 (-x, -1, 1 - -2)
 --- parsed ---
 {
-  "type": "binding",
-  "body": {
+  "type": "block",
+  "value": [
+    {
+    "type": "binding",
+    "decoration": null,
+    "pat": { "type": "pvar", "value": [ "x" ] },
+    "arglist": null,
+    "cast": null,
+    "definition": { "type": "ground", "value": "3" }
+  },
+    {
     "type": "tuple",
     "value": [
       {
@@ -25,15 +34,11 @@ x = 3
       }
     }
     ]
-  },
-  "decoration": null,
-  "pat": { "type": "pvar", "value": [ "x" ] },
-  "arglist": null,
-  "cast": null,
-  "definition": { "type": "ground", "value": "3" }
+  }
+  ]
 }
 --- hash ---
-37ff9cbfafd948c4fcc896e3b52b6282
+7ad67eca690659e3e6da3796bead63a5
 --- term ---
 x = 3
 (~-(x), ~-(1), -(1, ~-(2)))

--- a/tests/snapshots/expected/nested_methods.expected
+++ b/tests/snapshots/expected/nested_methods.expected
@@ -3,8 +3,47 @@ v = ().{a = ().{b = ().{c = 1}}}
 v.a.b.c
 --- parsed ---
 {
-  "type": "binding",
-  "body": {
+  "type": "block",
+  "value": [
+    {
+    "type": "binding",
+    "decoration": null,
+    "pat": { "type": "pvar", "value": [ "v" ] },
+    "arglist": null,
+    "cast": null,
+    "definition": {
+      "type": "methods",
+      "base": { "type": "tuple", "value": [] },
+      "methods": [
+        {
+        "type": "method",
+        "name": "a",
+        "value": {
+          "type": "methods",
+          "base": { "type": "tuple", "value": [] },
+          "methods": [
+            {
+            "type": "method",
+            "name": "b",
+            "value": {
+              "type": "methods",
+              "base": { "type": "tuple", "value": [] },
+              "methods": [
+                {
+                "type": "method",
+                "name": "c",
+                "value": { "type": "ground", "value": "1" }
+              }
+              ]
+            }
+          }
+          ]
+        }
+      }
+      ]
+    }
+  },
+    {
     "type": "invoke",
     "invoked": {
       "type": "invoke",
@@ -19,45 +58,11 @@ v.a.b.c
     },
     "optional": false,
     "meth": { "type": "var", "value": "c" }
-  },
-  "decoration": null,
-  "pat": { "type": "pvar", "value": [ "v" ] },
-  "arglist": null,
-  "cast": null,
-  "definition": {
-    "type": "methods",
-    "base": { "type": "tuple", "value": [] },
-    "methods": [
-      {
-      "type": "method",
-      "name": "a",
-      "value": {
-        "type": "methods",
-        "base": { "type": "tuple", "value": [] },
-        "methods": [
-          {
-          "type": "method",
-          "name": "b",
-          "value": {
-            "type": "methods",
-            "base": { "type": "tuple", "value": [] },
-            "methods": [
-              {
-              "type": "method",
-              "name": "c",
-              "value": { "type": "ground", "value": "1" }
-            }
-            ]
-          }
-        }
-        ]
-      }
-    }
-    ]
   }
+  ]
 }
 --- hash ---
-d6126113119a3abc8140d3e4f5e781e1
+27a9f60a62fee9b7055bcac5e13f6545
 --- term ---
 v = {a={b={c=1}}}
 v.a.b.c

--- a/tests/snapshots/expected/null_ops.expected
+++ b/tests/snapshots/expected/null_ops.expected
@@ -3,8 +3,17 @@ x = null
 (null.defined(x), x ?? 1)
 --- parsed ---
 {
-  "type": "binding",
-  "body": {
+  "type": "block",
+  "value": [
+    {
+    "type": "binding",
+    "decoration": null,
+    "pat": { "type": "pvar", "value": [ "x" ] },
+    "arglist": null,
+    "cast": null,
+    "definition": { "type": "null" }
+  },
+    {
     "type": "tuple",
     "value": [
       {
@@ -32,20 +41,17 @@ x = null
       "right": { "type": "ground", "value": "1" }
     }
     ]
-  },
-  "decoration": null,
-  "pat": { "type": "pvar", "value": [ "x" ] },
-  "arglist": null,
-  "cast": null,
-  "definition": { "type": "null" }
+  }
+  ]
 }
 --- hash ---
-a057ef51cf27cf6eebeafbe1678ca8c9
+a498f3fdb792cd666f14af766e27ac40
 --- term ---
 x = null
 (_null.defined(x), _null.default(x, {1}))
 --- type ---
-At line 2, char 1-6:
+At cases/null_ops.liq, line 2, char 1-6:
+(null.defined(x), x ?? 1)
 
 Error 5: this value has no method `defined`
   Its type is ((?'A) -> 'A?)

--- a/tests/snapshots/expected/numeric_literals.expected
+++ b/tests/snapshots/expected/numeric_literals.expected
@@ -2,32 +2,37 @@
 (0xff, 0o17, 1_000, 1.5, 3.)
 --- parsed ---
 {
-  "type": "tuple",
+  "type": "block",
   "value": [
     {
-    "type": "ground",
-    "value": "0xff"
-  },
-    {
-    "type": "ground",
-    "value": "0o17"
-  },
-    {
-    "type": "ground",
-    "value": "1_000"
-  },
-    {
-    "type": "ground",
-    "value": "1.5"
-  },
-    {
-    "type": "ground",
-    "value": "3."
+    "type": "tuple",
+    "value": [
+      {
+      "type": "ground",
+      "value": "0xff"
+    },
+      {
+      "type": "ground",
+      "value": "0o17"
+    },
+      {
+      "type": "ground",
+      "value": "1_000"
+    },
+      {
+      "type": "ground",
+      "value": "1.5"
+    },
+      {
+      "type": "ground",
+      "value": "3."
+    }
+    ]
   }
   ]
 }
 --- hash ---
-c9fdec8c5b8abb3056716b38b0ac3dad
+49de830fdee8419fbbd963c924239e35
 --- term ---
 (0xff, 0o17, 1000, 1.5, 3.0)
 --- type ---

--- a/tests/snapshots/expected/open_module.expected
+++ b/tests/snapshots/expected/open_module.expected
@@ -3,9 +3,13 @@ open list
 length([1, 2])
 --- parsed ---
 {
-  "type": "open",
-  "left": { "type": "var", "value": "list" },
-  "right": {
+  "type": "block",
+  "value": [
+    {
+    "type": "open",
+    "left": { "type": "var", "value": "list" }
+  },
+    {
     "type": "app",
     "op": { "type": "var", "value": "length" },
     "args": [
@@ -31,9 +35,10 @@ length([1, 2])
     }
     ]
   }
+  ]
 }
 --- hash ---
-de8263689327b08f5b7a37d6f1affabc
+8b53ad1f6d25cba05e41fed60b35000b
 --- term ---
 open list
 length([1, 2])

--- a/tests/snapshots/expected/optional_args.expected
+++ b/tests/snapshots/expected/optional_args.expected
@@ -6,8 +6,67 @@ end
 f(y=5, 1)
 --- parsed ---
 {
-  "type": "def",
-  "body": {
+  "type": "block",
+  "value": [
+    {
+    "type": "def",
+    "decoration": null,
+    "pat": { "type": "pvar", "value": [ "f" ] },
+    "arglist": [
+      {
+      "type": "term",
+      "value": {
+        "type": "fun_arg",
+        "label": "x",
+        "as_variable": null,
+        "typ": null,
+        "default": { "type": "null" }
+      }
+    },
+      {
+      "type": "term",
+      "value": {
+        "type": "fun_arg",
+        "label": "y",
+        "as_variable": null,
+        "typ": null,
+        "default": { "type": "ground", "value": "2" }
+      }
+    },
+      {
+      "type": "term",
+      "value": {
+        "type": "fun_arg",
+        "label": "",
+        "as_variable": { "type": "pvar", "value": [ "z" ] },
+        "typ": null,
+        "default": null
+      }
+    }
+    ],
+    "cast": null,
+    "body": [
+      {
+      "type": "infix",
+      "left": {
+        "type": "infix",
+        "left": {
+          "type": "parenthesis",
+          "value": {
+            "type": "coalesce",
+            "left": { "type": "var", "value": "x" },
+            "right": { "type": "ground", "value": "0" }
+          }
+        },
+        "op": "+",
+        "right": { "type": "var", "value": "y" }
+      },
+      "op": "+",
+      "right": { "type": "var", "value": "z" }
+    }
+    ]
+  },
+    {
     "type": "app",
     "op": { "type": "var", "value": "f" },
     "args": [
@@ -28,63 +87,11 @@ f(y=5, 1)
       }
     }
     ]
-  },
-  "decoration": null,
-  "pat": { "type": "pvar", "value": [ "f" ] },
-  "arglist": [
-    {
-    "type": "term",
-    "value": {
-      "type": "fun_arg",
-      "label": "x",
-      "as_variable": null,
-      "typ": null,
-      "default": { "type": "null" }
-    }
-  },
-    {
-    "type": "term",
-    "value": {
-      "type": "fun_arg",
-      "label": "y",
-      "as_variable": null,
-      "typ": null,
-      "default": { "type": "ground", "value": "2" }
-    }
-  },
-    {
-    "type": "term",
-    "value": {
-      "type": "fun_arg",
-      "label": "",
-      "as_variable": { "type": "pvar", "value": [ "z" ] },
-      "typ": null,
-      "default": null
-    }
   }
-  ],
-  "cast": null,
-  "definition": {
-    "type": "infix",
-    "left": {
-      "type": "infix",
-      "left": {
-        "type": "parenthesis",
-        "value": {
-          "type": "coalesce",
-          "left": { "type": "var", "value": "x" },
-          "right": { "type": "ground", "value": "0" }
-        }
-      },
-      "op": "+",
-      "right": { "type": "var", "value": "y" }
-    },
-    "op": "+",
-    "right": { "type": "var", "value": "z" }
-  }
+  ]
 }
 --- hash ---
-af45357a23b02f74bacf48f6d2aa10e5
+bf9ef2a267979a563166d50a6e8ff228
 --- term ---
 f = fun (~x=null, ~y=2, z) -> +(+(_null.default(x, {0}), y), z)
 f(y=5, 1)

--- a/tests/snapshots/expected/pattern_nested.expected
+++ b/tests/snapshots/expected/pattern_nested.expected
@@ -3,8 +3,74 @@ let [x, [y, z]] = [[1], [2, 3]]
 (x, y, z)
 --- parsed ---
 {
-  "type": "let",
-  "body": {
+  "type": "block",
+  "value": [
+    {
+    "type": "let",
+    "decoration": null,
+    "pat": {
+      "type": "plist",
+      "left": [
+        {
+        "type": "pvar",
+        "value": [ "x" ]
+      },
+        {
+        "type": "plist",
+        "left": [
+          {
+          "type": "pvar",
+          "value": [ "y" ]
+        },
+          {
+          "type": "pvar",
+          "value": [ "z" ]
+        }
+        ],
+        "middle": null,
+        "right": []
+      }
+      ],
+      "middle": null,
+      "right": []
+    },
+    "arglist": null,
+    "cast": null,
+    "definition": {
+      "type": "list",
+      "value": [
+        {
+        "type": "term",
+        "value": {
+          "type": "list",
+          "value": [
+            {
+            "type": "term",
+            "value": { "type": "ground", "value": "1" }
+          }
+          ]
+        }
+      },
+        {
+        "type": "term",
+        "value": {
+          "type": "list",
+          "value": [
+            {
+            "type": "term",
+            "value": { "type": "ground", "value": "2" }
+          },
+            {
+            "type": "term",
+            "value": { "type": "ground", "value": "3" }
+          }
+          ]
+        }
+      }
+      ]
+    }
+  },
+    {
     "type": "tuple",
     "value": [
       {
@@ -20,72 +86,11 @@ let [x, [y, z]] = [[1], [2, 3]]
       "value": "z"
     }
     ]
-  },
-  "decoration": null,
-  "pat": {
-    "type": "plist",
-    "left": [
-      {
-      "type": "pvar",
-      "value": [ "x" ]
-    },
-      {
-      "type": "plist",
-      "left": [
-        {
-        "type": "pvar",
-        "value": [ "y" ]
-      },
-        {
-        "type": "pvar",
-        "value": [ "z" ]
-      }
-      ],
-      "middle": null,
-      "right": []
-    }
-    ],
-    "middle": null,
-    "right": []
-  },
-  "arglist": null,
-  "cast": null,
-  "definition": {
-    "type": "list",
-    "value": [
-      {
-      "type": "term",
-      "value": {
-        "type": "list",
-        "value": [
-          {
-          "type": "term",
-          "value": { "type": "ground", "value": "1" }
-        }
-        ]
-      }
-    },
-      {
-      "type": "term",
-      "value": {
-        "type": "list",
-        "value": [
-          {
-          "type": "term",
-          "value": { "type": "ground", "value": "2" }
-        },
-          {
-          "type": "term",
-          "value": { "type": "ground", "value": "3" }
-        }
-        ]
-      }
-    }
-    ]
   }
+  ]
 }
 --- hash ---
-2e22064665d7c994f8d88e0f78e092fa
+ec04c3b0cea3480dadaca14d6b239163
 --- term ---
 _pat0 = [[1], [2, 3]]
 _pat1 = list.length(_pat0)

--- a/tests/snapshots/expected/pattern_optional_meth.expected
+++ b/tests/snapshots/expected/pattern_optional_meth.expected
@@ -3,8 +3,39 @@ let {a, b?} = {a = 1}
 (a, b)
 --- parsed ---
 {
-  "type": "let",
-  "body": {
+  "type": "block",
+  "value": [
+    {
+    "type": "let",
+    "decoration": null,
+    "pat": {
+      "type": "pmeth",
+      "value": [
+        {
+        "type": "var",
+        "value": "a"
+      },
+        {
+        "type": "var",
+        "value": "b?"
+      }
+      ]
+    },
+    "arglist": null,
+    "cast": null,
+    "definition": {
+      "type": "methods",
+      "base": null,
+      "methods": [
+        {
+        "type": "method",
+        "name": "a",
+        "value": { "type": "ground", "value": "1" }
+      }
+      ]
+    }
+  },
+    {
     "type": "tuple",
     "value": [
       {
@@ -16,37 +47,11 @@ let {a, b?} = {a = 1}
       "value": "b"
     }
     ]
-  },
-  "decoration": null,
-  "pat": {
-    "type": "pmeth",
-    "value": [
-      {
-      "type": "var",
-      "value": "a"
-    },
-      {
-      "type": "var",
-      "value": "b?"
-    }
-    ]
-  },
-  "arglist": null,
-  "cast": null,
-  "definition": {
-    "type": "methods",
-    "base": null,
-    "methods": [
-      {
-      "type": "method",
-      "name": "a",
-      "value": { "type": "ground", "value": "1" }
-    }
-    ]
   }
+  ]
 }
 --- hash ---
-2f7b8c3c3c161d7b89e4ff2165c66251
+69431f68a7ea92151ce5083ff2a4f627
 --- term ---
 _pat0 = {a=1}
 a = _pat0.a

--- a/tests/snapshots/expected/pp_comments.expected
+++ b/tests/snapshots/expected/pp_comments.expected
@@ -37,10 +37,6 @@ f()
 --- hash ---
 8f8d9ac30bd97d1933b788bc1cc11a1a
 --- term ---
-x = 1
-f = fun () -> x
-f()
---- type ---
-int
---- value ---
-1
+At cases/pp_comments.liq, line 9, char 0-0:
+
+Error 9: Failure: Unknown category: Test (at cases/pp_comments.liq, line 2 char 6 - line 6 char 2).

--- a/tests/snapshots/expected/pp_comments.expected
+++ b/tests/snapshots/expected/pp_comments.expected
@@ -9,28 +9,33 @@ def f() = x end
 f()
 --- parsed ---
 {
-  "type": "binding",
-  "body": {
+  "type": "block",
+  "value": [
+    {
+    "type": "binding",
+    "decoration": null,
+    "pat": { "type": "pvar", "value": [ "x" ] },
+    "arglist": null,
+    "cast": null,
+    "definition": { "type": "ground", "value": "1" }
+  },
+    {
     "type": "def",
-    "body": {
-      "type": "app",
-      "op": { "type": "var", "value": "f" },
-      "args": []
-    },
     "decoration": null,
     "pat": { "type": "pvar", "value": [ "f" ] },
     "arglist": [],
     "cast": null,
-    "definition": { "type": "var", "value": "x" }
+    "body": [ { "type": "var", "value": "x" } ]
   },
-  "decoration": null,
-  "pat": { "type": "pvar", "value": [ "x" ] },
-  "arglist": null,
-  "cast": null,
-  "definition": { "type": "ground", "value": "1" }
+    {
+    "type": "app",
+    "op": { "type": "var", "value": "f" },
+    "args": []
+  }
+  ]
 }
 --- hash ---
-6e89741aca6b0574086d98f972175ff3
+8f8d9ac30bd97d1933b788bc1cc11a1a
 --- term ---
 x = 1
 f = fun () -> x

--- a/tests/snapshots/expected/pp_comments.expected
+++ b/tests/snapshots/expected/pp_comments.expected
@@ -5,7 +5,10 @@ x = 1 # trailing
 # a doc comment
 # @category Test
 ##
-def f() = x end
+
+def f() =
+  x
+end
 f()
 --- parsed ---
 {
@@ -37,6 +40,6 @@ f()
 --- hash ---
 8f8d9ac30bd97d1933b788bc1cc11a1a
 --- term ---
-At cases/pp_comments.liq, line 9, char 0-0:
+At cases/pp_comments.liq, line 12, char 0-0:
 
 Error 9: Failure: Unknown category: Test (at cases/pp_comments.liq, line 2 char 6 - line 6 char 2).

--- a/tests/snapshots/expected/pp_ifdef.expected
+++ b/tests/snapshots/expected/pp_ifdef.expected
@@ -7,34 +7,41 @@ x = 2
 x
 --- parsed ---
 {
-  "type": "seq",
-  "left": {
+  "type": "block",
+  "value": [
+    {
     "type": "if_def",
     "negative": false,
     "condition": "list.length",
-    "then": {
+    "then": [
+      {
       "type": "binding",
-      "body": { "type": "eof" },
       "decoration": null,
       "pat": { "type": "pvar", "value": [ "x" ] },
       "arglist": null,
       "cast": null,
       "definition": { "type": "ground", "value": "1" }
-    },
-    "else": {
+    }
+    ],
+    "else": [
+      {
       "type": "binding",
-      "body": { "type": "eof" },
       "decoration": null,
       "pat": { "type": "pvar", "value": [ "x" ] },
       "arglist": null,
       "cast": null,
       "definition": { "type": "ground", "value": "2" }
     }
+    ]
   },
-  "right": { "type": "var", "value": "x" }
+    {
+    "type": "var",
+    "value": "x"
+  }
+  ]
 }
 --- hash ---
-acfc1873139d0c22402886fb61fbcfa8
+59b59d1ea23154f836168f9311924443
 --- term ---
 x = 1
 x

--- a/tests/snapshots/expected/pp_ifdef_value.expected
+++ b/tests/snapshots/expected/pp_ifdef_value.expected
@@ -1,0 +1,44 @@
+=== pp_ifdef_value.liq ===
+# `%ifdef` in value position: the selected branch is a block used as a value,
+# not a statement splice. src/libs/playlist.liq relies on this.
+s =
+%ifdef list.length
+  1
+%else
+  2
+%endif
+
+s
+--- parsed ---
+{
+  "type": "block",
+  "value": [
+    {
+    "type": "binding",
+    "decoration": null,
+    "pat": { "type": "pvar", "value": [ "s" ] },
+    "arglist": null,
+    "cast": null,
+    "definition": {
+      "type": "if_def",
+      "negative": false,
+      "condition": "list.length",
+      "then": [ { "type": "ground", "value": "1" } ],
+      "else": [ { "type": "ground", "value": "2" } ]
+    }
+  },
+    {
+    "type": "var",
+    "value": "s"
+  }
+  ]
+}
+--- hash ---
+84d551af3206b61f83b6dfa3737f691b
+--- term ---
+s = 1
+s
+--- type ---
+int
+--- value ---
+1

--- a/tests/snapshots/expected/pp_ifdef_value.expected
+++ b/tests/snapshots/expected/pp_ifdef_value.expected
@@ -38,6 +38,8 @@ s
 --- term ---
 s = 1
 s
+--- doc ---
+s: `%ifdef` in value position: the selected branch is a block used as a value, not a statement splice. src/libs/playlist.liq relies on this.
 --- type ---
 int
 --- value ---

--- a/tests/snapshots/expected/pp_ifversion.expected
+++ b/tests/snapshots/expected/pp_ifversion.expected
@@ -6,14 +6,19 @@
 %endif
 --- parsed ---
 {
-  "type": "if_version",
-  "opt": ">=",
-  "version": "2.0.0",
-  "then": { "type": "string", "value": "\"new\"" },
-  "else": { "type": "string", "value": "\"old\"" }
+  "type": "block",
+  "value": [
+    {
+    "type": "if_version",
+    "opt": ">=",
+    "version": "2.0.0",
+    "then": [ { "type": "string", "value": "\"new\"" } ],
+    "else": [ { "type": "string", "value": "\"old\"" } ]
+  }
+  ]
 }
 --- hash ---
-45520dbc0360fab3f0566554e1ffc525
+d0d42a8f788e468f68b57714594348a9
 --- term ---
 "new"
 --- type ---

--- a/tests/snapshots/expected/pp_include.expected
+++ b/tests/snapshots/expected/pp_include.expected
@@ -1,0 +1,72 @@
+=== pp_include.liq ===
+%include "included.liq-inc"
+
+before = 0
+(before, from_include, also_from_include)
+--- parsed ---
+{
+  "type": "block",
+  "value": [
+    {
+    "type": "let",
+    "decoration": null,
+    "pat": { "type": "pvar", "value": [ "liquidsoap", "script", "path" ] },
+    "arglist": null,
+    "cast": null,
+    "definition": { "type": "string", "value": "\"cases/included.liq-inc\"" }
+  },
+    {
+    "type": "binding",
+    "decoration": null,
+    "pat": { "type": "pvar", "value": [ "from_include" ] },
+    "arglist": null,
+    "cast": null,
+    "definition": { "type": "ground", "value": "1" }
+  },
+    {
+    "type": "let",
+    "decoration": null,
+    "pat": { "type": "pvar", "value": [ "also_from_include" ] },
+    "arglist": null,
+    "cast": null,
+    "definition": { "type": "ground", "value": "2" }
+  },
+    {
+    "type": "binding",
+    "decoration": null,
+    "pat": { "type": "pvar", "value": [ "before" ] },
+    "arglist": null,
+    "cast": null,
+    "definition": { "type": "ground", "value": "0" }
+  },
+    {
+    "type": "tuple",
+    "value": [
+      {
+      "type": "var",
+      "value": "before"
+    },
+      {
+      "type": "var",
+      "value": "from_include"
+    },
+      {
+      "type": "var",
+      "value": "also_from_include"
+    }
+    ]
+  }
+  ]
+}
+--- hash ---
+cb5449a59bfa50872c40ab85b328440d
+--- term ---
+let liquidsoap.script.path = "cases/included.liq-inc"
+from_include = 1
+also_from_include = 2
+before = 0
+(before, from_include, also_from_include)
+--- type ---
+int * int * int
+--- value ---
+(0, 1, 2)

--- a/tests/snapshots/expected/pp_include.expected
+++ b/tests/snapshots/expected/pp_include.expected
@@ -66,6 +66,8 @@ from_include = 1
 also_from_include = 2
 before = 0
 (before, from_include, also_from_include)
+--- doc ---
+from_include: Pulled in by pp_include.liq. Both bindings scope over the code that follows the `%include`, because the included statements are spliced into that block.
 --- type ---
 int * int * int
 --- value ---

--- a/tests/snapshots/expected/pp_include_extra_missing.expected
+++ b/tests/snapshots/expected/pp_include_extra_missing.expected
@@ -1,0 +1,34 @@
+=== pp_include_extra_missing.liq ===
+# An absent `%include_extra` is skipped, which is how the minimal distributions
+# build: they ship none of the files `src/libs/stdlib.liq` pulls in this way.
+%include_extra "definitely_not_here.liq-inc"
+
+before = 0
+before
+--- parsed ---
+{
+  "type": "block",
+  "value": [
+    {
+    "type": "binding",
+    "decoration": null,
+    "pat": { "type": "pvar", "value": [ "before" ] },
+    "arglist": null,
+    "cast": null,
+    "definition": { "type": "ground", "value": "0" }
+  },
+    {
+    "type": "var",
+    "value": "before"
+  }
+  ]
+}
+--- hash ---
+e54ce4809b8da0393d408bba07b6db83
+--- term ---
+before = 0
+before
+--- type ---
+int
+--- value ---
+0

--- a/tests/snapshots/expected/record_update.expected
+++ b/tests/snapshots/expected/record_update.expected
@@ -3,8 +3,32 @@ r = {a = 1, b = 2}
 r.{a = 3}
 --- parsed ---
 {
-  "type": "binding",
-  "body": {
+  "type": "block",
+  "value": [
+    {
+    "type": "binding",
+    "decoration": null,
+    "pat": { "type": "pvar", "value": [ "r" ] },
+    "arglist": null,
+    "cast": null,
+    "definition": {
+      "type": "methods",
+      "base": null,
+      "methods": [
+        {
+        "type": "method",
+        "name": "a",
+        "value": { "type": "ground", "value": "1" }
+      },
+        {
+        "type": "method",
+        "name": "b",
+        "value": { "type": "ground", "value": "2" }
+      }
+      ]
+    }
+  },
+    {
     "type": "methods",
     "base": { "type": "var", "value": "r" },
     "methods": [
@@ -14,30 +38,11 @@ r.{a = 3}
       "value": { "type": "ground", "value": "3" }
     }
     ]
-  },
-  "decoration": null,
-  "pat": { "type": "pvar", "value": [ "r" ] },
-  "arglist": null,
-  "cast": null,
-  "definition": {
-    "type": "methods",
-    "base": null,
-    "methods": [
-      {
-      "type": "method",
-      "name": "a",
-      "value": { "type": "ground", "value": "1" }
-    },
-      {
-      "type": "method",
-      "name": "b",
-      "value": { "type": "ground", "value": "2" }
-    }
-    ]
   }
+  ]
 }
 --- hash ---
-8cb7841f35d8ae9b791e870de58b0ca8
+d73ffe44b758e7cda98ac46bec2e37b7
 --- term ---
 r = {b=2, a=1}
 r.{a=3}

--- a/tests/snapshots/expected/regexp_literal.expected
+++ b/tests/snapshots/expected/regexp_literal.expected
@@ -3,8 +3,17 @@ r = r/ab+c/gi
 r.test("abbc")
 --- parsed ---
 {
-  "type": "binding",
-  "body": {
+  "type": "block",
+  "value": [
+    {
+    "type": "binding",
+    "decoration": null,
+    "pat": { "type": "pvar", "value": [ "r" ] },
+    "arglist": null,
+    "cast": null,
+    "definition": { "type": "regexp", "name": "ab+c", "flags": [ "g", "i" ] }
+  },
+    {
     "type": "invoke",
     "invoked": { "type": "var", "value": "r" },
     "optional": false,
@@ -22,15 +31,11 @@ r.test("abbc")
       }
       ]
     }
-  },
-  "decoration": null,
-  "pat": { "type": "pvar", "value": [ "r" ] },
-  "arglist": null,
-  "cast": null,
-  "definition": { "type": "regexp", "name": "ab+c", "flags": [ "g", "i" ] }
+  }
+  ]
 }
 --- hash ---
-a6984d8dd9a09a17f778e5be689aae3b
+1737ceef0f2e746f8e8adf03277ae928
 --- term ---
 r = regexp("ab+c", flags=["i", "g"])
 r.test("abbc")

--- a/tests/snapshots/expected/reserved_names.expected
+++ b/tests/snapshots/expected/reserved_names.expected
@@ -1,0 +1,13 @@
+=== reserved_names.invalid-liq ===
+# The desugaring binds names with a digit right after the leading underscore.
+# `Lexer.var_lit` requires an alphabetic character there, so a script cannot
+# write one, and so cannot shadow what the sugar expands to: `_0_eval`,
+# `_0_json_parser`, `_0_ann_0`, `_2_pat` and friends are all unwritable.
+# `_null` is deliberately not in that namespace -- it is a real, callable
+# builtin.
+_0_eval = 1
+--- parsed ---
+At cases/reserved_names.invalid-liq, line 7, char 1-3:
+_0_eval = 1
+
+Error 2: Parse error

--- a/tests/snapshots/expected/seq_and_ignore.expected
+++ b/tests/snapshots/expected/seq_and_ignore.expected
@@ -4,8 +4,9 @@ ignore("two")
 3
 --- parsed ---
 {
-  "type": "seq",
-  "left": {
+  "type": "block",
+  "value": [
+    {
     "type": "app",
     "op": { "type": "var", "value": "ignore" },
     "args": [
@@ -19,27 +20,28 @@ ignore("two")
     }
     ]
   },
-  "right": {
-    "type": "seq",
-    "left": {
-      "type": "app",
-      "op": { "type": "var", "value": "ignore" },
-      "args": [
-        {
-        "type": "term",
-        "value": {
-          "type": "app_arg",
-          "label": "",
-          "value": { "type": "string", "value": "\"two\"" }
-        }
+    {
+    "type": "app",
+    "op": { "type": "var", "value": "ignore" },
+    "args": [
+      {
+      "type": "term",
+      "value": {
+        "type": "app_arg",
+        "label": "",
+        "value": { "type": "string", "value": "\"two\"" }
       }
-      ]
-    },
-    "right": { "type": "ground", "value": "3" }
+    }
+    ]
+  },
+    {
+    "type": "ground",
+    "value": "3"
   }
+  ]
 }
 --- hash ---
-618d28af57eb5cdb415f7d41153cd1e9
+5e29bdd9399c8264af73e9d404f0b2bf
 --- term ---
 ignore(1)
 ignore("two")

--- a/tests/snapshots/expected/string_escapes.expected
+++ b/tests/snapshots/expected/string_escapes.expected
@@ -2,28 +2,33 @@
 ("a\nb", 'c\td', "eéf", "g\x41h")
 --- parsed ---
 {
-  "type": "tuple",
+  "type": "block",
   "value": [
     {
-    "type": "string",
-    "value": "\"a\\nb\""
-  },
-    {
-    "type": "string",
-    "value": "'c\\td'"
-  },
-    {
-    "type": "string",
-    "value": "\"eéf\""
-  },
-    {
-    "type": "string",
-    "value": "\"g\\x41h\""
+    "type": "tuple",
+    "value": [
+      {
+      "type": "string",
+      "value": "\"a\\nb\""
+    },
+      {
+      "type": "string",
+      "value": "'c\\td'"
+    },
+      {
+      "type": "string",
+      "value": "\"eéf\""
+    },
+      {
+      "type": "string",
+      "value": "\"g\\x41h\""
+    }
+    ]
   }
   ]
 }
 --- hash ---
-d3ff333a4386fccaf2f63842b8f8fb83
+ad1ee50fb0ef57f25d2ccb744a21d9d1
 --- term ---
 ("a\nb", "c\td", "eéf", "gAh")
 --- type ---

--- a/tests/snapshots/expected/string_interpolation.expected
+++ b/tests/snapshots/expected/string_interpolation.expected
@@ -3,8 +3,17 @@ name = "world"
 "hello #{name}!"
 --- parsed ---
 {
-  "type": "binding",
-  "body": {
+  "type": "block",
+  "value": [
+    {
+    "type": "binding",
+    "decoration": null,
+    "pat": { "type": "pvar", "value": [ "name" ] },
+    "arglist": null,
+    "cast": null,
+    "definition": { "type": "string", "value": "\"world\"" }
+  },
+    {
     "type": "string_interpolation",
     "value": [
       {
@@ -28,15 +37,11 @@ name = "world"
       "value": "\""
     }
     ]
-  },
-  "decoration": null,
-  "pat": { "type": "pvar", "value": [ "name" ] },
-  "arglist": null,
-  "cast": null,
-  "definition": { "type": "string", "value": "\"world\"" }
+  }
+  ]
 }
 --- hash ---
-a41cf1995824e09bfcbde93750e8478e
+1b648c5d32246c787af7097170555513
 --- term ---
 name = "world"
 string.concat(["hello ", string(name), "!"])

--- a/tests/snapshots/expected/string_interpolation_nested.expected
+++ b/tests/snapshots/expected/string_interpolation_nested.expected
@@ -1,0 +1,262 @@
+=== string_interpolation_nested.liq ===
+# An interpolation is read as ordinary tokens, and the `}` that closes it is
+# found by counting braces over tokens. A record, a string or another
+# interpolated string inside `#{ … }` therefore nests correctly.
+m = [("k", "v")]
+r = {a = 1}
+
+by_key = "got #{m["k"]}"
+record = "a #{ {a = 1}.a } b"
+nested = "#{ "#{r.a}" }"
+adjacent = "#{r.a}#{r.a}"
+
+(by_key, record, nested, adjacent)
+--- parsed ---
+{
+  "type": "block",
+  "value": [
+    {
+    "type": "binding",
+    "decoration": null,
+    "pat": { "type": "pvar", "value": [ "m" ] },
+    "arglist": null,
+    "cast": null,
+    "definition": {
+      "type": "list",
+      "value": [
+        {
+        "type": "term",
+        "value": {
+          "type": "tuple",
+          "value": [
+            {
+            "type": "string",
+            "value": "\"k\""
+          },
+            {
+            "type": "string",
+            "value": "\"v\""
+          }
+          ]
+        }
+      }
+      ]
+    }
+  },
+    {
+    "type": "binding",
+    "decoration": null,
+    "pat": { "type": "pvar", "value": [ "r" ] },
+    "arglist": null,
+    "cast": null,
+    "definition": {
+      "type": "methods",
+      "base": null,
+      "methods": [
+        {
+        "type": "method",
+        "name": "a",
+        "value": { "type": "ground", "value": "1" }
+      }
+      ]
+    }
+  },
+    {
+    "type": "binding",
+    "decoration": null,
+    "pat": { "type": "pvar", "value": [ "by_key" ] },
+    "arglist": null,
+    "cast": null,
+    "definition": {
+      "type": "string_interpolation",
+      "value": [
+        {
+        "type": "interpolated_string",
+        "value": "\""
+      },
+        {
+        "type": "interpolated_string",
+        "value": "got "
+      },
+        {
+        "type": "interpolated_term",
+        "value": {
+          "type": "assoc",
+          "left": { "type": "var", "value": "m" },
+          "right": { "type": "string", "value": "\"k\"" }
+        }
+      },
+        {
+        "type": "interpolated_string",
+        "value": "\""
+      }
+      ]
+    }
+  },
+    {
+    "type": "binding",
+    "decoration": null,
+    "pat": { "type": "pvar", "value": [ "record" ] },
+    "arglist": null,
+    "cast": null,
+    "definition": {
+      "type": "string_interpolation",
+      "value": [
+        {
+        "type": "interpolated_string",
+        "value": "\""
+      },
+        {
+        "type": "interpolated_string",
+        "value": "a "
+      },
+        {
+        "type": "interpolated_term",
+        "value": {
+          "type": "invoke",
+          "invoked": {
+            "type": "methods",
+            "base": null,
+            "methods": [
+              {
+              "type": "method",
+              "name": "a",
+              "value": { "type": "ground", "value": "1" }
+            }
+            ]
+          },
+          "optional": false,
+          "meth": { "type": "var", "value": "a" }
+        }
+      },
+        {
+        "type": "interpolated_string",
+        "value": " b"
+      },
+        {
+        "type": "interpolated_string",
+        "value": "\""
+      }
+      ]
+    }
+  },
+    {
+    "type": "binding",
+    "decoration": null,
+    "pat": { "type": "pvar", "value": [ "nested" ] },
+    "arglist": null,
+    "cast": null,
+    "definition": {
+      "type": "string_interpolation",
+      "value": [
+        {
+        "type": "interpolated_string",
+        "value": "\""
+      },
+        {
+        "type": "interpolated_term",
+        "value": {
+          "type": "string_interpolation",
+          "value": [
+            {
+            "type": "interpolated_string",
+            "value": "\""
+          },
+            {
+            "type": "interpolated_term",
+            "value": {
+              "type": "invoke",
+              "invoked": { "type": "var", "value": "r" },
+              "optional": false,
+              "meth": { "type": "var", "value": "a" }
+            }
+          },
+            {
+            "type": "interpolated_string",
+            "value": "\""
+          }
+          ]
+        }
+      },
+        {
+        "type": "interpolated_string",
+        "value": "\""
+      }
+      ]
+    }
+  },
+    {
+    "type": "binding",
+    "decoration": null,
+    "pat": { "type": "pvar", "value": [ "adjacent" ] },
+    "arglist": null,
+    "cast": null,
+    "definition": {
+      "type": "string_interpolation",
+      "value": [
+        {
+        "type": "interpolated_string",
+        "value": "\""
+      },
+        {
+        "type": "interpolated_term",
+        "value": {
+          "type": "invoke",
+          "invoked": { "type": "var", "value": "r" },
+          "optional": false,
+          "meth": { "type": "var", "value": "a" }
+        }
+      },
+        {
+        "type": "interpolated_term",
+        "value": {
+          "type": "invoke",
+          "invoked": { "type": "var", "value": "r" },
+          "optional": false,
+          "meth": { "type": "var", "value": "a" }
+        }
+      },
+        {
+        "type": "interpolated_string",
+        "value": "\""
+      }
+      ]
+    }
+  },
+    {
+    "type": "tuple",
+    "value": [
+      {
+      "type": "var",
+      "value": "by_key"
+    },
+      {
+      "type": "var",
+      "value": "record"
+    },
+      {
+      "type": "var",
+      "value": "nested"
+    },
+      {
+      "type": "var",
+      "value": "adjacent"
+    }
+    ]
+  }
+  ]
+}
+--- hash ---
+785def64d2144f373e62aa381a984f0d
+--- term ---
+m = [("k", "v")]
+r = {a=1}
+by_key = string.concat(["got ", string(_[_](m, "k"))])
+record = string.concat(["a ", string({a=1}.a), " b"])
+nested = string.concat([string(string.concat([string(r.a)]))])
+adjacent = string.concat([string(r.a), string(r.a)])
+(by_key, record, nested, adjacent)
+--- type ---
+string * string * string * string
+--- value ---
+("got v", "a 1 b", "1", "11")

--- a/tests/snapshots/expected/string_interpolation_nested.expected
+++ b/tests/snapshots/expected/string_interpolation_nested.expected
@@ -256,6 +256,8 @@ record = string.concat(["a ", string({a=1}.a), " b"])
 nested = string.concat([string(string.concat([string(r.a)]))])
 adjacent = string.concat([string(r.a), string(r.a)])
 (by_key, record, nested, adjacent)
+--- doc ---
+m: An interpolation is read as ordinary tokens, and the `}` that closes it is found by counting braces over tokens. A record, a string or another interpolated string inside `#{ … }` therefore nests correctly.
 --- type ---
 string * string * string * string
 --- value ---

--- a/tests/snapshots/expected/string_interpolation_nested.expected
+++ b/tests/snapshots/expected/string_interpolation_nested.expected
@@ -5,9 +5,11 @@
 m = [("k", "v")]
 r = {a = 1}
 
-by_key = "got #{m["k"]}"
-record = "a #{ {a = 1}.a } b"
-nested = "#{ "#{r.a}" }"
+by_key =
+  "got #{m["k"]}"
+record =
+  "a #{{a = 1}.a} b"
+nested = "#{"#{r.a}"}"
 adjacent = "#{r.a}#{r.a}"
 
 (by_key, record, nested, adjacent)

--- a/tests/snapshots/expected/time_predicate.expected
+++ b/tests/snapshots/expected/time_predicate.expected
@@ -2,27 +2,33 @@
 10h-12h
 --- parsed ---
 {
-  "type": "time_interval",
-  "left": {
-    "type": "time",
-    "week": null,
-    "hours": 10,
-    "minutes": null,
-    "seconds": null
-  },
-  "right": {
-    "type": "time",
-    "week": null,
-    "hours": 12,
-    "minutes": null,
-    "seconds": null
+  "type": "block",
+  "value": [
+    {
+    "type": "time_interval",
+    "left": {
+      "type": "time",
+      "week": null,
+      "hours": 10,
+      "minutes": null,
+      "seconds": null
+    },
+    "right": {
+      "type": "time",
+      "week": null,
+      "hours": 12,
+      "minutes": null,
+      "seconds": null
+    }
   }
+  ]
 }
 --- hash ---
-399f1328cc6b3379033388a7e72d4182
+858caea84adebcca6bdae020cc6a98ac
 --- term ---
 time_in_mod(36000, 43200, 86400)
 --- type ---
-At line 1, char 0-7:
+At cases/time_predicate.liq, line 1, char 0-7:
+10h-12h
 
 Error 4: Undefined variable time_in_mod

--- a/tests/snapshots/expected/try_catch.expected
+++ b/tests/snapshots/expected/try_catch.expected
@@ -6,68 +6,78 @@ catch err : [error.not_found] do
 end
 --- parsed ---
 {
-  "type": "try",
-  "body": {
-    "type": "invoke",
-    "invoked": { "type": "var", "value": "error" },
-    "optional": false,
-    "meth": {
-      "type": "app",
-      "op": { "type": "var", "value": "raise" },
-      "args": [
-        {
-        "type": "term",
-        "value": {
-          "type": "app_arg",
-          "label": "",
+  "type": "block",
+  "value": [
+    {
+    "type": "try",
+    "body": [
+      {
+      "type": "invoke",
+      "invoked": { "type": "var", "value": "error" },
+      "optional": false,
+      "meth": {
+        "type": "app",
+        "op": { "type": "var", "value": "raise" },
+        "args": [
+          {
+          "type": "term",
           "value": {
-            "type": "invoke",
-            "invoked": { "type": "var", "value": "error" },
-            "optional": false,
-            "meth": { "type": "var", "value": "not_found" }
+            "type": "app_arg",
+            "label": "",
+            "value": {
+              "type": "invoke",
+              "invoked": { "type": "var", "value": "error" },
+              "optional": false,
+              "meth": { "type": "var", "value": "not_found" }
+            }
+          }
+        },
+          {
+          "type": "term",
+          "value": {
+            "type": "app_arg",
+            "label": "",
+            "value": { "type": "string", "value": "\"nope\"" }
           }
         }
-      },
+        ]
+      }
+    }
+    ],
+    "variable": "err",
+    "errors_list": {
+      "type": "list",
+      "value": [
         {
         "type": "term",
         "value": {
-          "type": "app_arg",
-          "label": "",
-          "value": { "type": "string", "value": "\"nope\"" }
+          "type": "invoke",
+          "invoked": { "type": "var", "value": "error" },
+          "optional": false,
+          "meth": { "type": "var", "value": "not_found" }
         }
       }
       ]
-    }
-  },
-  "variable": "err",
-  "errors_list": {
-    "type": "list",
-    "value": [
+    },
+    "handler": [
       {
-      "type": "term",
-      "value": {
-        "type": "invoke",
-        "invoked": { "type": "var", "value": "error" },
-        "optional": false,
-        "meth": { "type": "var", "value": "not_found" }
-      }
+      "type": "invoke",
+      "invoked": { "type": "var", "value": "err" },
+      "optional": false,
+      "meth": { "type": "var", "value": "message" }
     }
-    ]
-  },
-  "handler": {
-    "type": "invoke",
-    "invoked": { "type": "var", "value": "err" },
-    "optional": false,
-    "meth": { "type": "var", "value": "message" }
-  },
-  "finally": null
+    ],
+    "finally": null
+  }
+  ]
 }
 --- hash ---
-43675712c2cc2253be15e78c1d467166
+0cf8b4287e9d04e6e3f24ef6126b36cb
 --- term ---
 error.catch(errors=[error.not_found], body=fun () -> error.raise(error.not_found, "nope"), catch=fun (err) -> err.message, finally={()})
 --- type ---
-At line 3, char 13-18:
+At cases/try_catch.liq, line 3, char 13-18:
+catch err : [error.not_found] do
 
 Error 5: this value has no method `not_found`
   Its type is {

--- a/tests/snapshots/expected/try_finally.expected
+++ b/tests/snapshots/expected/try_finally.expected
@@ -8,54 +8,60 @@ end
 r()
 --- parsed ---
 {
-  "type": "binding",
-  "body": {
-    "type": "seq",
-    "left": {
-      "type": "try",
-      "body": {
-        "type": "infix",
-        "left": { "type": "var", "value": "r" },
-        "op": ":=",
-        "right": { "type": "ground", "value": "1" }
-      },
-      "variable": "_",
-      "errors_list": null,
-      "handler": null,
-      "finally": {
-        "type": "infix",
-        "left": { "type": "var", "value": "r" },
-        "op": ":=",
-        "right": { "type": "ground", "value": "2" }
-      }
-    },
-    "right": {
+  "type": "block",
+  "value": [
+    {
+    "type": "binding",
+    "decoration": null,
+    "pat": { "type": "pvar", "value": [ "r" ] },
+    "arglist": null,
+    "cast": null,
+    "definition": {
       "type": "app",
-      "op": { "type": "var", "value": "r" },
-      "args": []
+      "op": { "type": "var", "value": "ref" },
+      "args": [
+        {
+        "type": "term",
+        "value": {
+          "type": "app_arg",
+          "label": "",
+          "value": { "type": "ground", "value": "0" }
+        }
+      }
+      ]
     }
   },
-  "decoration": null,
-  "pat": { "type": "pvar", "value": [ "r" ] },
-  "arglist": null,
-  "cast": null,
-  "definition": {
-    "type": "app",
-    "op": { "type": "var", "value": "ref" },
-    "args": [
+    {
+    "type": "try",
+    "body": [
       {
-      "type": "term",
-      "value": {
-        "type": "app_arg",
-        "label": "",
-        "value": { "type": "ground", "value": "0" }
-      }
+      "type": "infix",
+      "left": { "type": "var", "value": "r" },
+      "op": ":=",
+      "right": { "type": "ground", "value": "1" }
+    }
+    ],
+    "variable": "_",
+    "errors_list": null,
+    "handler": null,
+    "finally": [
+      {
+      "type": "infix",
+      "left": { "type": "var", "value": "r" },
+      "op": ":=",
+      "right": { "type": "ground", "value": "2" }
     }
     ]
+  },
+    {
+    "type": "app",
+    "op": { "type": "var", "value": "r" },
+    "args": []
   }
+  ]
 }
 --- hash ---
-c2138805e99e5458f17f12f65dee8b28
+f7c87e793beef4ef392bad627c9aa06b
 --- term ---
 r = ref(0)
 error.catch(errors=null, body=fun () -> (r.set(1) : unit), catch=fun (_) -> (), finally=fun () -> (r.set(2) : unit))

--- a/tests/snapshots/expected/type_annotation.expected
+++ b/tests/snapshots/expected/type_annotation.expected
@@ -2,12 +2,21 @@
 (1 : int)
 --- parsed ---
 {
-  "type": "cast",
-  "left": { "type": "ground", "value": "1" },
-  "right": { "type": "type_annotation", "subtype": "named", "value": "int" }
+  "type": "block",
+  "value": [
+    {
+    "type": "cast",
+    "left": { "type": "ground", "value": "1" },
+    "right": {
+      "type": "type_annotation",
+      "subtype": "named",
+      "value": "int"
+    }
+  }
+  ]
 }
 --- hash ---
-42faf6fad780f1f7f1854c0b4e6f61e4
+11c35a73c82c38ef3ebabd583cac0bf1
 --- term ---
 (1 : int)
 --- type ---

--- a/tests/snapshots/expected/type_constructor_unknown.expected
+++ b/tests/snapshots/expected/type_constructor_unknown.expected
@@ -1,0 +1,9 @@
+=== type_constructor_unknown.invalid-liq ===
+# The list of accepted constructors in this message is derived from the table
+# that drives the dispatch, so it cannot drift.
+ignore((1 : blah(int)))
+--- parsed ---
+At cases/type_constructor_unknown.invalid-liq, line 3, char 12-21:
+ignore((1 : blah(int)))
+
+Error 3: Unknown type constructor: blah. Expected one of `ref(t)`, `getter(t)`, `source(...)`.

--- a/tests/snapshots/expected/type_constructors.expected
+++ b/tests/snapshots/expected/type_constructors.expected
@@ -1,0 +1,135 @@
+=== type_constructors.liq ===
+# `ref` and `getter` name types but are ordinary functions too, so they are
+# recognized by name in the grammar rather than lexed as keywords.
+r = ref(1)
+ignore((r : ref(int)))
+ignore((1 : getter(int)))
+
+# Still ordinary identifiers.
+ref = "a variable"
+getter = "another"
+(ref, getter)
+--- parsed ---
+{
+  "type": "block",
+  "value": [
+    {
+    "type": "binding",
+    "decoration": null,
+    "pat": { "type": "pvar", "value": [ "r" ] },
+    "arglist": null,
+    "cast": null,
+    "definition": {
+      "type": "app",
+      "op": { "type": "var", "value": "ref" },
+      "args": [
+        {
+        "type": "term",
+        "value": {
+          "type": "app_arg",
+          "label": "",
+          "value": { "type": "ground", "value": "1" }
+        }
+      }
+      ]
+    }
+  },
+    {
+    "type": "app",
+    "op": { "type": "var", "value": "ignore" },
+    "args": [
+      {
+      "type": "term",
+      "value": {
+        "type": "app_arg",
+        "label": "",
+        "value": {
+          "type": "cast",
+          "left": { "type": "var", "value": "r" },
+          "right": {
+            "type": "type_annotation",
+            "subtype": "ref",
+            "value": {
+              "type": "type_annotation",
+              "subtype": "named",
+              "value": "int"
+            }
+          }
+        }
+      }
+    }
+    ]
+  },
+    {
+    "type": "app",
+    "op": { "type": "var", "value": "ignore" },
+    "args": [
+      {
+      "type": "term",
+      "value": {
+        "type": "app_arg",
+        "label": "",
+        "value": {
+          "type": "cast",
+          "left": { "type": "ground", "value": "1" },
+          "right": {
+            "type": "type_annotation",
+            "subtype": "getter",
+            "value": {
+              "type": "type_annotation",
+              "subtype": "named",
+              "value": "int"
+            }
+          }
+        }
+      }
+    }
+    ]
+  },
+    {
+    "type": "binding",
+    "decoration": null,
+    "pat": { "type": "pvar", "value": [ "ref" ] },
+    "arglist": null,
+    "cast": null,
+    "definition": { "type": "string", "value": "\"a variable\"" }
+  },
+    {
+    "type": "binding",
+    "decoration": null,
+    "pat": { "type": "pvar", "value": [ "getter" ] },
+    "arglist": null,
+    "cast": null,
+    "definition": { "type": "string", "value": "\"another\"" }
+  },
+    {
+    "type": "tuple",
+    "value": [
+      {
+      "type": "var",
+      "value": "ref"
+    },
+      {
+      "type": "var",
+      "value": "getter"
+    }
+    ]
+  }
+  ]
+}
+--- hash ---
+400e47ff308e750430db503ff900ee85
+--- term ---
+r = ref(1)
+ignore((r : (() -> int).{set : (int) -> unit}))
+ignore((1 : {int}))
+ref = "a variable"
+getter = "another"
+(ref, getter)
+--- doc ---
+r: `ref` and `getter` name types but are ordinary functions too, so they are recognized by name in the grammar rather than lexed as keywords.
+ref: Still ordinary identifiers.
+--- type ---
+string * string
+--- value ---
+("a variable", "another")

--- a/tests/snapshots/expected/type_constructors.expected
+++ b/tests/snapshots/expected/type_constructors.expected
@@ -6,7 +6,8 @@ ignore((r : ref(int)))
 ignore((1 : getter(int)))
 
 # Still ordinary identifiers.
-ref = "a variable"
+ref =
+  "a variable"
 getter = "another"
 (ref, getter)
 --- parsed ---

--- a/tests/snapshots/expected/while_loop.expected
+++ b/tests/snapshots/expected/while_loop.expected
@@ -3,8 +3,30 @@ n = ref(0)
 while n() < 3 do n := n() + 1  end
 --- parsed ---
 {
-  "type": "binding",
-  "body": {
+  "type": "block",
+  "value": [
+    {
+    "type": "binding",
+    "decoration": null,
+    "pat": { "type": "pvar", "value": [ "n" ] },
+    "arglist": null,
+    "cast": null,
+    "definition": {
+      "type": "app",
+      "op": { "type": "var", "value": "ref" },
+      "args": [
+        {
+        "type": "term",
+        "value": {
+          "type": "app_arg",
+          "label": "",
+          "value": { "type": "ground", "value": "0" }
+        }
+      }
+      ]
+    }
+  },
+    {
     "type": "while",
     "condition": {
       "type": "infix",
@@ -16,7 +38,8 @@ while n() < 3 do n := n() + 1  end
       "op": "<",
       "right": { "type": "ground", "value": "3" }
     },
-    "loop": {
+    "loop": [
+      {
       "type": "infix",
       "left": { "type": "var", "value": "n" },
       "op": ":=",
@@ -31,28 +54,12 @@ while n() < 3 do n := n() + 1  end
         "right": { "type": "ground", "value": "1" }
       }
     }
-  },
-  "decoration": null,
-  "pat": { "type": "pvar", "value": [ "n" ] },
-  "arglist": null,
-  "cast": null,
-  "definition": {
-    "type": "app",
-    "op": { "type": "var", "value": "ref" },
-    "args": [
-      {
-      "type": "term",
-      "value": {
-        "type": "app_arg",
-        "label": "",
-        "value": { "type": "ground", "value": "0" }
-      }
-    }
     ]
   }
+  ]
 }
 --- hash ---
-fac37728de195176c3cba0b8da7b7cf4
+f2baa58b54f809f927dfb9887f543a09
 --- term ---
 n = ref(0)
 while(fun () -> <(n(), 3), fun () -> (n.set(+(n(), 1)) : unit))

--- a/tests/snapshots/expected_canonical/blocks.expected
+++ b/tests/snapshots/expected_canonical/blocks.expected
@@ -1,0 +1,883 @@
+=== blocks.liq ===
+# Every construct whose canonical JSON carries keyword-anchored block spans:
+# `then_block` starts at `then`, `else_block` at `else`, `*_body` at `do`, and
+# each spans to the start of the next keyword. Prettier uses those spans to
+# decide which block a comment belongs to.
+def f(x) =
+  if x > 0 then
+    1
+  elsif x < 0 then
+    -1
+  else
+    0
+  end
+end
+
+while false do
+  f(1)
+end
+
+for i = 0 to 2 do
+  f(i)
+end
+
+for j = [1, 2] do
+  f(j)
+end
+--- canonical ---
+{
+  "ast": {
+    "type": "program",
+    "position": [
+      {
+      "fname": "",
+      "lnum": 1,
+      "bol": 0,
+      "cnum": 0
+    },
+      {
+      "fname": "",
+      "lnum": 1,
+      "bol": 0,
+      "cnum": 444
+    }
+    ],
+    "body": [
+      {
+      "position": [
+        {
+        "fname": "",
+        "lnum": 5,
+        "bol": 275,
+        "cnum": 275
+      },
+        {
+        "fname": "",
+        "lnum": 13,
+        "bol": 353,
+        "cnum": 356
+      }
+      ],
+      "type": "def",
+      "decoration": null,
+      "pat": { "type": "pvar", "value": [ "f" ] },
+      "arglist": [
+        {
+        "type": "term",
+        "value": {
+          "type": "fun_arg",
+          "label": "",
+          "as_variable": { "type": "pvar", "value": [ "x" ] },
+          "typ": null,
+          "default": null
+        }
+      }
+      ],
+      "cast": null,
+      "body": [
+        {
+        "position": [
+          {
+          "fname": "",
+          "lnum": 6,
+          "bol": 286,
+          "cnum": 288
+        },
+          {
+          "fname": "",
+          "lnum": 12,
+          "bol": 347,
+          "cnum": 352
+        }
+        ],
+        "type": "if",
+        "condition": {
+          "position": [
+            {
+            "fname": "",
+            "lnum": 6,
+            "bol": 286,
+            "cnum": 291
+          },
+            {
+            "fname": "",
+            "lnum": 6,
+            "bol": 286,
+            "cnum": 296
+          }
+          ],
+          "type": "infix",
+          "left": {
+            "position": [
+              {
+              "fname": "",
+              "lnum": 6,
+              "bol": 286,
+              "cnum": 291
+            },
+              {
+              "fname": "",
+              "lnum": 6,
+              "bol": 286,
+              "cnum": 292
+            }
+            ],
+            "type": "var",
+            "value": "x"
+          },
+          "op": ">",
+          "right": {
+            "position": [
+              {
+              "fname": "",
+              "lnum": 6,
+              "bol": 286,
+              "cnum": 295
+            },
+              {
+              "fname": "",
+              "lnum": 6,
+              "bol": 286,
+              "cnum": 296
+            }
+            ],
+            "type": "ground",
+            "value": "0"
+          }
+        },
+        "then_block": {
+          "type": "then_block",
+          "position": [
+            {
+            "fname": "",
+            "lnum": 6,
+            "bol": 286,
+            "cnum": 297
+          },
+            {
+            "fname": "",
+            "lnum": 8,
+            "bol": 308,
+            "cnum": 310
+          }
+          ],
+          "body": [
+            {
+            "position": [
+              {
+              "fname": "",
+              "lnum": 7,
+              "bol": 302,
+              "cnum": 306
+            },
+              {
+              "fname": "",
+              "lnum": 7,
+              "bol": 302,
+              "cnum": 307
+            }
+            ],
+            "type": "ground",
+            "value": "1"
+          }
+          ]
+        },
+        "elsif": [
+          {
+          "type": "elsif",
+          "position": [
+            {
+            "fname": "",
+            "lnum": 8,
+            "bol": 308,
+            "cnum": 310
+          },
+            {
+            "fname": "",
+            "lnum": 10,
+            "bol": 334,
+            "cnum": 336
+          }
+          ],
+          "condition": {
+            "position": [
+              {
+              "fname": "",
+              "lnum": 8,
+              "bol": 308,
+              "cnum": 316
+            },
+              {
+              "fname": "",
+              "lnum": 8,
+              "bol": 308,
+              "cnum": 321
+            }
+            ],
+            "type": "infix",
+            "left": {
+              "position": [
+                {
+                "fname": "",
+                "lnum": 8,
+                "bol": 308,
+                "cnum": 316
+              },
+                {
+                "fname": "",
+                "lnum": 8,
+                "bol": 308,
+                "cnum": 317
+              }
+              ],
+              "type": "var",
+              "value": "x"
+            },
+            "op": "<",
+            "right": {
+              "position": [
+                {
+                "fname": "",
+                "lnum": 8,
+                "bol": 308,
+                "cnum": 320
+              },
+                {
+                "fname": "",
+                "lnum": 8,
+                "bol": 308,
+                "cnum": 321
+              }
+              ],
+              "type": "ground",
+              "value": "0"
+            }
+          },
+          "body": [
+            {
+            "position": [
+              {
+              "fname": "",
+              "lnum": 9,
+              "bol": 327,
+              "cnum": 331
+            },
+              {
+              "fname": "",
+              "lnum": 9,
+              "bol": 327,
+              "cnum": 333
+            }
+            ],
+            "type": "negative",
+            "value": {
+              "position": [
+                {
+                "fname": "",
+                "lnum": 9,
+                "bol": 327,
+                "cnum": 332
+              },
+                {
+                "fname": "",
+                "lnum": 9,
+                "bol": 327,
+                "cnum": 333
+              }
+              ],
+              "type": "ground",
+              "value": "1"
+            }
+          }
+          ]
+        }
+        ],
+        "else_block": {
+          "type": "else_block",
+          "position": [
+            {
+            "fname": "",
+            "lnum": 10,
+            "bol": 334,
+            "cnum": 336
+          },
+            {
+            "fname": "",
+            "lnum": 12,
+            "bol": 347,
+            "cnum": 349
+          }
+          ],
+          "body": [
+            {
+            "position": [
+              {
+              "fname": "",
+              "lnum": 11,
+              "bol": 341,
+              "cnum": 345
+            },
+              {
+              "fname": "",
+              "lnum": 11,
+              "bol": 341,
+              "cnum": 346
+            }
+            ],
+            "type": "ground",
+            "value": "0"
+          }
+          ]
+        }
+      }
+      ]
+    },
+      {
+      "position": [
+        {
+        "fname": "",
+        "lnum": 15,
+        "bol": 358,
+        "cnum": 358
+      },
+        {
+        "fname": "",
+        "lnum": 17,
+        "bol": 380,
+        "cnum": 383
+      }
+      ],
+      "type": "while",
+      "parts": [
+        {
+        "type": "while_header",
+        "position": [
+          {
+          "fname": "",
+          "lnum": 15,
+          "bol": 358,
+          "cnum": 358
+        },
+          {
+          "fname": "",
+          "lnum": 15,
+          "bol": 358,
+          "cnum": 370
+        }
+        ],
+        "condition": {
+          "position": [
+            {
+            "fname": "",
+            "lnum": 15,
+            "bol": 358,
+            "cnum": 364
+          },
+            {
+            "fname": "",
+            "lnum": 15,
+            "bol": 358,
+            "cnum": 369
+          }
+          ],
+          "type": "ground",
+          "value": "false"
+        }
+      },
+        {
+        "type": "while_body",
+        "position": [
+          {
+          "fname": "",
+          "lnum": 15,
+          "bol": 358,
+          "cnum": 370
+        },
+          {
+          "fname": "",
+          "lnum": 17,
+          "bol": 380,
+          "cnum": 380
+        }
+        ],
+        "body": [
+          {
+          "position": [
+            {
+            "fname": "",
+            "lnum": 16,
+            "bol": 373,
+            "cnum": 375
+          },
+            {
+            "fname": "",
+            "lnum": 16,
+            "bol": 373,
+            "cnum": 379
+          }
+          ],
+          "type": "app",
+          "op": {
+            "position": [
+              {
+              "fname": "",
+              "lnum": 16,
+              "bol": 373,
+              "cnum": 375
+            },
+              {
+              "fname": "",
+              "lnum": 16,
+              "bol": 373,
+              "cnum": 377
+            }
+            ],
+            "type": "var",
+            "value": "f"
+          },
+          "args": [
+            {
+            "position": [
+              {
+              "fname": "",
+              "lnum": 16,
+              "bol": 373,
+              "cnum": 377
+            },
+              {
+              "fname": "",
+              "lnum": 16,
+              "bol": 373,
+              "cnum": 378
+            }
+            ],
+            "type": "term",
+            "value": {
+              "type": "app_arg",
+              "label": "",
+              "value": {
+                "position": [
+                  {
+                  "fname": "",
+                  "lnum": 16,
+                  "bol": 373,
+                  "cnum": 377
+                },
+                  {
+                  "fname": "",
+                  "lnum": 16,
+                  "bol": 373,
+                  "cnum": 378
+                }
+                ],
+                "type": "ground",
+                "value": "1"
+              }
+            }
+          }
+          ]
+        }
+        ]
+      }
+      ]
+    },
+      {
+      "position": [
+        {
+        "fname": "",
+        "lnum": 19,
+        "bol": 385,
+        "cnum": 385
+      },
+        {
+        "fname": "",
+        "lnum": 21,
+        "bol": 410,
+        "cnum": 413
+      }
+      ],
+      "type": "for",
+      "parts": [
+        {
+        "type": "for_header",
+        "position": [
+          {
+          "fname": "",
+          "lnum": 19,
+          "bol": 385,
+          "cnum": 385
+        },
+          {
+          "fname": "",
+          "lnum": 19,
+          "bol": 385,
+          "cnum": 400
+        }
+        ],
+        "variable": "i",
+        "from": {
+          "position": [
+            {
+            "fname": "",
+            "lnum": 19,
+            "bol": 385,
+            "cnum": 393
+          },
+            {
+            "fname": "",
+            "lnum": 19,
+            "bol": 385,
+            "cnum": 394
+          }
+          ],
+          "type": "ground",
+          "value": "0"
+        },
+        "to": {
+          "position": [
+            {
+            "fname": "",
+            "lnum": 19,
+            "bol": 385,
+            "cnum": 398
+          },
+            {
+            "fname": "",
+            "lnum": 19,
+            "bol": 385,
+            "cnum": 399
+          }
+          ],
+          "type": "ground",
+          "value": "2"
+        }
+      },
+        {
+        "type": "for_body",
+        "position": [
+          {
+          "fname": "",
+          "lnum": 19,
+          "bol": 385,
+          "cnum": 400
+        },
+          {
+          "fname": "",
+          "lnum": 21,
+          "bol": 410,
+          "cnum": 410
+        }
+        ],
+        "body": [
+          {
+          "position": [
+            {
+            "fname": "",
+            "lnum": 20,
+            "bol": 403,
+            "cnum": 405
+          },
+            {
+            "fname": "",
+            "lnum": 20,
+            "bol": 403,
+            "cnum": 409
+          }
+          ],
+          "type": "app",
+          "op": {
+            "position": [
+              {
+              "fname": "",
+              "lnum": 20,
+              "bol": 403,
+              "cnum": 405
+            },
+              {
+              "fname": "",
+              "lnum": 20,
+              "bol": 403,
+              "cnum": 407
+            }
+            ],
+            "type": "var",
+            "value": "f"
+          },
+          "args": [
+            {
+            "position": [
+              {
+              "fname": "",
+              "lnum": 20,
+              "bol": 403,
+              "cnum": 407
+            },
+              {
+              "fname": "",
+              "lnum": 20,
+              "bol": 403,
+              "cnum": 408
+            }
+            ],
+            "type": "term",
+            "value": {
+              "type": "app_arg",
+              "label": "",
+              "value": {
+                "position": [
+                  {
+                  "fname": "",
+                  "lnum": 20,
+                  "bol": 403,
+                  "cnum": 407
+                },
+                  {
+                  "fname": "",
+                  "lnum": 20,
+                  "bol": 403,
+                  "cnum": 408
+                }
+                ],
+                "type": "var",
+                "value": "i"
+              }
+            }
+          }
+          ]
+        }
+        ]
+      }
+      ]
+    },
+      {
+      "position": [
+        {
+        "fname": "",
+        "lnum": 23,
+        "bol": 415,
+        "cnum": 415
+      },
+        {
+        "fname": "",
+        "lnum": 25,
+        "bol": 440,
+        "cnum": 443
+      }
+      ],
+      "type": "iterable_for",
+      "parts": [
+        {
+        "type": "iterable_for_header",
+        "position": [
+          {
+          "fname": "",
+          "lnum": 23,
+          "bol": 415,
+          "cnum": 415
+        },
+          {
+          "fname": "",
+          "lnum": 23,
+          "bol": 415,
+          "cnum": 430
+        }
+        ],
+        "variable": "j",
+        "iterator": {
+          "position": [
+            {
+            "fname": "",
+            "lnum": 23,
+            "bol": 415,
+            "cnum": 423
+          },
+            {
+            "fname": "",
+            "lnum": 23,
+            "bol": 415,
+            "cnum": 429
+          }
+          ],
+          "type": "list",
+          "value": [
+            {
+            "position": [
+              {
+              "fname": "",
+              "lnum": 23,
+              "bol": 415,
+              "cnum": 424
+            },
+              {
+              "fname": "",
+              "lnum": 23,
+              "bol": 415,
+              "cnum": 425
+            }
+            ],
+            "type": "term",
+            "value": {
+              "position": [
+                {
+                "fname": "",
+                "lnum": 23,
+                "bol": 415,
+                "cnum": 424
+              },
+                {
+                "fname": "",
+                "lnum": 23,
+                "bol": 415,
+                "cnum": 425
+              }
+              ],
+              "type": "ground",
+              "value": "1"
+            }
+          },
+            {
+            "position": [
+              {
+              "fname": "",
+              "lnum": 23,
+              "bol": 415,
+              "cnum": 427
+            },
+              {
+              "fname": "",
+              "lnum": 23,
+              "bol": 415,
+              "cnum": 428
+            }
+            ],
+            "type": "term",
+            "value": {
+              "position": [
+                {
+                "fname": "",
+                "lnum": 23,
+                "bol": 415,
+                "cnum": 427
+              },
+                {
+                "fname": "",
+                "lnum": 23,
+                "bol": 415,
+                "cnum": 428
+              }
+              ],
+              "type": "ground",
+              "value": "2"
+            }
+          }
+          ]
+        }
+      },
+        {
+        "type": "iterable_for_body",
+        "position": [
+          {
+          "fname": "",
+          "lnum": 23,
+          "bol": 415,
+          "cnum": 430
+        },
+          {
+          "fname": "",
+          "lnum": 25,
+          "bol": 440,
+          "cnum": 440
+        }
+        ],
+        "body": [
+          {
+          "position": [
+            {
+            "fname": "",
+            "lnum": 24,
+            "bol": 433,
+            "cnum": 435
+          },
+            {
+            "fname": "",
+            "lnum": 24,
+            "bol": 433,
+            "cnum": 439
+          }
+          ],
+          "type": "app",
+          "op": {
+            "position": [
+              {
+              "fname": "",
+              "lnum": 24,
+              "bol": 433,
+              "cnum": 435
+            },
+              {
+              "fname": "",
+              "lnum": 24,
+              "bol": 433,
+              "cnum": 437
+            }
+            ],
+            "type": "var",
+            "value": "f"
+          },
+          "args": [
+            {
+            "position": [
+              {
+              "fname": "",
+              "lnum": 24,
+              "bol": 433,
+              "cnum": 437
+            },
+              {
+              "fname": "",
+              "lnum": 24,
+              "bol": 433,
+              "cnum": 438
+            }
+            ],
+            "type": "term",
+            "value": {
+              "type": "app_arg",
+              "label": "",
+              "value": {
+                "position": [
+                  {
+                  "fname": "",
+                  "lnum": 24,
+                  "bol": 433,
+                  "cnum": 437
+                },
+                  {
+                  "fname": "",
+                  "lnum": 24,
+                  "bol": 433,
+                  "cnum": 438
+                }
+                ],
+                "type": "var",
+                "value": "j"
+              }
+            }
+          }
+          ]
+        }
+        ]
+      }
+      ]
+    }
+    ]
+  },
+  "comments": [
+    {
+    "start": 0,
+    "end": 274,
+    "lnum": 1,
+    "value": "# Every construct whose canonical JSON carries keyword-anchored block spans:\n# `then_block` starts at `then`, `else_block` at `else`, `*_body` at `do`, and\n# each spans to the start of the next keyword. Prettier uses those spans to\n# decide which block a comment belongs to."
+  }
+  ]
+}

--- a/tests/snapshots/expected_canonical/blocks.expected
+++ b/tests/snapshots/expected_canonical/blocks.expected
@@ -4,26 +4,14 @@
 # each spans to the start of the next keyword. Prettier uses those spans to
 # decide which block a comment belongs to.
 def f(x) =
-  if x > 0 then
-    1
-  elsif x < 0 then
-    -1
-  else
-    0
-  end
+  if x > 0 then 1 elsif x < 0 then -1 else 0 end
 end
 
-while false do
-  f(1)
-end
+while false do f(1)  end
 
-for i = 0 to 2 do
-  f(i)
-end
+for i = 0 to 2 do f(i)  end
 
-for j = [1, 2] do
-  f(j)
-end
+for j = [1, 2] do f(j)  end
 --- canonical ---
 {
   "ast": {
@@ -39,7 +27,7 @@ end
       "fname": "",
       "lnum": 1,
       "bol": 0,
-      "cnum": 444
+      "cnum": 423
     }
     ],
     "body": [
@@ -53,9 +41,9 @@ end
       },
         {
         "fname": "",
-        "lnum": 13,
-        "bol": 353,
-        "cnum": 356
+        "lnum": 7,
+        "bol": 335,
+        "cnum": 338
       }
       ],
       "type": "def",
@@ -85,9 +73,9 @@ end
         },
           {
           "fname": "",
-          "lnum": 12,
-          "bol": 347,
-          "cnum": 352
+          "lnum": 6,
+          "bol": 286,
+          "cnum": 334
         }
         ],
         "type": "if",
@@ -156,9 +144,9 @@ end
           },
             {
             "fname": "",
-            "lnum": 8,
-            "bol": 308,
-            "cnum": 310
+            "lnum": 6,
+            "bol": 286,
+            "cnum": 304
           }
           ],
           "body": [
@@ -166,15 +154,15 @@ end
             "position": [
               {
               "fname": "",
-              "lnum": 7,
-              "bol": 302,
-              "cnum": 306
+              "lnum": 6,
+              "bol": 286,
+              "cnum": 302
             },
               {
               "fname": "",
-              "lnum": 7,
-              "bol": 302,
-              "cnum": 307
+              "lnum": 6,
+              "bol": 286,
+              "cnum": 303
             }
             ],
             "type": "ground",
@@ -188,30 +176,30 @@ end
           "position": [
             {
             "fname": "",
-            "lnum": 8,
-            "bol": 308,
-            "cnum": 310
+            "lnum": 6,
+            "bol": 286,
+            "cnum": 304
           },
             {
             "fname": "",
-            "lnum": 10,
-            "bol": 334,
-            "cnum": 336
+            "lnum": 6,
+            "bol": 286,
+            "cnum": 324
           }
           ],
           "condition": {
             "position": [
               {
               "fname": "",
-              "lnum": 8,
-              "bol": 308,
-              "cnum": 316
+              "lnum": 6,
+              "bol": 286,
+              "cnum": 310
             },
               {
               "fname": "",
-              "lnum": 8,
-              "bol": 308,
-              "cnum": 321
+              "lnum": 6,
+              "bol": 286,
+              "cnum": 315
             }
             ],
             "type": "infix",
@@ -219,15 +207,15 @@ end
               "position": [
                 {
                 "fname": "",
-                "lnum": 8,
-                "bol": 308,
-                "cnum": 316
+                "lnum": 6,
+                "bol": 286,
+                "cnum": 310
               },
                 {
                 "fname": "",
-                "lnum": 8,
-                "bol": 308,
-                "cnum": 317
+                "lnum": 6,
+                "bol": 286,
+                "cnum": 311
               }
               ],
               "type": "var",
@@ -238,15 +226,15 @@ end
               "position": [
                 {
                 "fname": "",
-                "lnum": 8,
-                "bol": 308,
-                "cnum": 320
+                "lnum": 6,
+                "bol": 286,
+                "cnum": 314
               },
                 {
                 "fname": "",
-                "lnum": 8,
-                "bol": 308,
-                "cnum": 321
+                "lnum": 6,
+                "bol": 286,
+                "cnum": 315
               }
               ],
               "type": "ground",
@@ -258,15 +246,15 @@ end
             "position": [
               {
               "fname": "",
-              "lnum": 9,
-              "bol": 327,
-              "cnum": 331
+              "lnum": 6,
+              "bol": 286,
+              "cnum": 321
             },
               {
               "fname": "",
-              "lnum": 9,
-              "bol": 327,
-              "cnum": 333
+              "lnum": 6,
+              "bol": 286,
+              "cnum": 323
             }
             ],
             "type": "negative",
@@ -274,15 +262,15 @@ end
               "position": [
                 {
                 "fname": "",
-                "lnum": 9,
-                "bol": 327,
-                "cnum": 332
+                "lnum": 6,
+                "bol": 286,
+                "cnum": 322
               },
                 {
                 "fname": "",
-                "lnum": 9,
-                "bol": 327,
-                "cnum": 333
+                "lnum": 6,
+                "bol": 286,
+                "cnum": 323
               }
               ],
               "type": "ground",
@@ -297,15 +285,15 @@ end
           "position": [
             {
             "fname": "",
-            "lnum": 10,
-            "bol": 334,
-            "cnum": 336
+            "lnum": 6,
+            "bol": 286,
+            "cnum": 324
           },
             {
             "fname": "",
-            "lnum": 12,
-            "bol": 347,
-            "cnum": 349
+            "lnum": 6,
+            "bol": 286,
+            "cnum": 331
           }
           ],
           "body": [
@@ -313,15 +301,15 @@ end
             "position": [
               {
               "fname": "",
-              "lnum": 11,
-              "bol": 341,
-              "cnum": 345
+              "lnum": 6,
+              "bol": 286,
+              "cnum": 329
             },
               {
               "fname": "",
-              "lnum": 11,
-              "bol": 341,
-              "cnum": 346
+              "lnum": 6,
+              "bol": 286,
+              "cnum": 330
             }
             ],
             "type": "ground",
@@ -336,15 +324,15 @@ end
       "position": [
         {
         "fname": "",
-        "lnum": 15,
-        "bol": 358,
-        "cnum": 358
+        "lnum": 9,
+        "bol": 340,
+        "cnum": 340
       },
         {
         "fname": "",
-        "lnum": 17,
-        "bol": 380,
-        "cnum": 383
+        "lnum": 9,
+        "bol": 340,
+        "cnum": 364
       }
       ],
       "type": "while",
@@ -354,30 +342,30 @@ end
         "position": [
           {
           "fname": "",
-          "lnum": 15,
-          "bol": 358,
-          "cnum": 358
+          "lnum": 9,
+          "bol": 340,
+          "cnum": 340
         },
           {
           "fname": "",
-          "lnum": 15,
-          "bol": 358,
-          "cnum": 370
+          "lnum": 9,
+          "bol": 340,
+          "cnum": 352
         }
         ],
         "condition": {
           "position": [
             {
             "fname": "",
-            "lnum": 15,
-            "bol": 358,
-            "cnum": 364
+            "lnum": 9,
+            "bol": 340,
+            "cnum": 346
           },
             {
             "fname": "",
-            "lnum": 15,
-            "bol": 358,
-            "cnum": 369
+            "lnum": 9,
+            "bol": 340,
+            "cnum": 351
           }
           ],
           "type": "ground",
@@ -389,15 +377,15 @@ end
         "position": [
           {
           "fname": "",
-          "lnum": 15,
-          "bol": 358,
-          "cnum": 370
+          "lnum": 9,
+          "bol": 340,
+          "cnum": 352
         },
           {
           "fname": "",
-          "lnum": 17,
-          "bol": 380,
-          "cnum": 380
+          "lnum": 9,
+          "bol": 340,
+          "cnum": 361
         }
         ],
         "body": [
@@ -405,15 +393,15 @@ end
           "position": [
             {
             "fname": "",
-            "lnum": 16,
-            "bol": 373,
-            "cnum": 375
+            "lnum": 9,
+            "bol": 340,
+            "cnum": 355
           },
             {
             "fname": "",
-            "lnum": 16,
-            "bol": 373,
-            "cnum": 379
+            "lnum": 9,
+            "bol": 340,
+            "cnum": 359
           }
           ],
           "type": "app",
@@ -421,15 +409,15 @@ end
             "position": [
               {
               "fname": "",
-              "lnum": 16,
-              "bol": 373,
-              "cnum": 375
+              "lnum": 9,
+              "bol": 340,
+              "cnum": 355
             },
               {
               "fname": "",
-              "lnum": 16,
-              "bol": 373,
-              "cnum": 377
+              "lnum": 9,
+              "bol": 340,
+              "cnum": 357
             }
             ],
             "type": "var",
@@ -440,15 +428,15 @@ end
             "position": [
               {
               "fname": "",
-              "lnum": 16,
-              "bol": 373,
-              "cnum": 377
+              "lnum": 9,
+              "bol": 340,
+              "cnum": 357
             },
               {
               "fname": "",
-              "lnum": 16,
-              "bol": 373,
-              "cnum": 378
+              "lnum": 9,
+              "bol": 340,
+              "cnum": 358
             }
             ],
             "type": "term",
@@ -459,15 +447,15 @@ end
                 "position": [
                   {
                   "fname": "",
-                  "lnum": 16,
-                  "bol": 373,
-                  "cnum": 377
+                  "lnum": 9,
+                  "bol": 340,
+                  "cnum": 357
                 },
                   {
                   "fname": "",
-                  "lnum": 16,
-                  "bol": 373,
-                  "cnum": 378
+                  "lnum": 9,
+                  "bol": 340,
+                  "cnum": 358
                 }
                 ],
                 "type": "ground",
@@ -485,15 +473,15 @@ end
       "position": [
         {
         "fname": "",
-        "lnum": 19,
-        "bol": 385,
-        "cnum": 385
+        "lnum": 11,
+        "bol": 366,
+        "cnum": 366
       },
         {
         "fname": "",
-        "lnum": 21,
-        "bol": 410,
-        "cnum": 413
+        "lnum": 11,
+        "bol": 366,
+        "cnum": 393
       }
       ],
       "type": "for",
@@ -503,15 +491,15 @@ end
         "position": [
           {
           "fname": "",
-          "lnum": 19,
-          "bol": 385,
-          "cnum": 385
+          "lnum": 11,
+          "bol": 366,
+          "cnum": 366
         },
           {
           "fname": "",
-          "lnum": 19,
-          "bol": 385,
-          "cnum": 400
+          "lnum": 11,
+          "bol": 366,
+          "cnum": 381
         }
         ],
         "variable": "i",
@@ -519,15 +507,15 @@ end
           "position": [
             {
             "fname": "",
-            "lnum": 19,
-            "bol": 385,
-            "cnum": 393
+            "lnum": 11,
+            "bol": 366,
+            "cnum": 374
           },
             {
             "fname": "",
-            "lnum": 19,
-            "bol": 385,
-            "cnum": 394
+            "lnum": 11,
+            "bol": 366,
+            "cnum": 375
           }
           ],
           "type": "ground",
@@ -537,15 +525,15 @@ end
           "position": [
             {
             "fname": "",
-            "lnum": 19,
-            "bol": 385,
-            "cnum": 398
+            "lnum": 11,
+            "bol": 366,
+            "cnum": 379
           },
             {
             "fname": "",
-            "lnum": 19,
-            "bol": 385,
-            "cnum": 399
+            "lnum": 11,
+            "bol": 366,
+            "cnum": 380
           }
           ],
           "type": "ground",
@@ -557,15 +545,15 @@ end
         "position": [
           {
           "fname": "",
-          "lnum": 19,
-          "bol": 385,
-          "cnum": 400
+          "lnum": 11,
+          "bol": 366,
+          "cnum": 381
         },
           {
           "fname": "",
-          "lnum": 21,
-          "bol": 410,
-          "cnum": 410
+          "lnum": 11,
+          "bol": 366,
+          "cnum": 390
         }
         ],
         "body": [
@@ -573,15 +561,15 @@ end
           "position": [
             {
             "fname": "",
-            "lnum": 20,
-            "bol": 403,
-            "cnum": 405
+            "lnum": 11,
+            "bol": 366,
+            "cnum": 384
           },
             {
             "fname": "",
-            "lnum": 20,
-            "bol": 403,
-            "cnum": 409
+            "lnum": 11,
+            "bol": 366,
+            "cnum": 388
           }
           ],
           "type": "app",
@@ -589,15 +577,15 @@ end
             "position": [
               {
               "fname": "",
-              "lnum": 20,
-              "bol": 403,
-              "cnum": 405
+              "lnum": 11,
+              "bol": 366,
+              "cnum": 384
             },
               {
               "fname": "",
-              "lnum": 20,
-              "bol": 403,
-              "cnum": 407
+              "lnum": 11,
+              "bol": 366,
+              "cnum": 386
             }
             ],
             "type": "var",
@@ -608,15 +596,15 @@ end
             "position": [
               {
               "fname": "",
-              "lnum": 20,
-              "bol": 403,
-              "cnum": 407
+              "lnum": 11,
+              "bol": 366,
+              "cnum": 386
             },
               {
               "fname": "",
-              "lnum": 20,
-              "bol": 403,
-              "cnum": 408
+              "lnum": 11,
+              "bol": 366,
+              "cnum": 387
             }
             ],
             "type": "term",
@@ -627,15 +615,15 @@ end
                 "position": [
                   {
                   "fname": "",
-                  "lnum": 20,
-                  "bol": 403,
-                  "cnum": 407
+                  "lnum": 11,
+                  "bol": 366,
+                  "cnum": 386
                 },
                   {
                   "fname": "",
-                  "lnum": 20,
-                  "bol": 403,
-                  "cnum": 408
+                  "lnum": 11,
+                  "bol": 366,
+                  "cnum": 387
                 }
                 ],
                 "type": "var",
@@ -653,15 +641,15 @@ end
       "position": [
         {
         "fname": "",
-        "lnum": 23,
-        "bol": 415,
-        "cnum": 415
+        "lnum": 13,
+        "bol": 395,
+        "cnum": 395
       },
         {
         "fname": "",
-        "lnum": 25,
-        "bol": 440,
-        "cnum": 443
+        "lnum": 13,
+        "bol": 395,
+        "cnum": 422
       }
       ],
       "type": "iterable_for",
@@ -671,15 +659,15 @@ end
         "position": [
           {
           "fname": "",
-          "lnum": 23,
-          "bol": 415,
-          "cnum": 415
+          "lnum": 13,
+          "bol": 395,
+          "cnum": 395
         },
           {
           "fname": "",
-          "lnum": 23,
-          "bol": 415,
-          "cnum": 430
+          "lnum": 13,
+          "bol": 395,
+          "cnum": 410
         }
         ],
         "variable": "j",
@@ -687,15 +675,15 @@ end
           "position": [
             {
             "fname": "",
-            "lnum": 23,
-            "bol": 415,
-            "cnum": 423
+            "lnum": 13,
+            "bol": 395,
+            "cnum": 403
           },
             {
             "fname": "",
-            "lnum": 23,
-            "bol": 415,
-            "cnum": 429
+            "lnum": 13,
+            "bol": 395,
+            "cnum": 409
           }
           ],
           "type": "list",
@@ -704,15 +692,15 @@ end
             "position": [
               {
               "fname": "",
-              "lnum": 23,
-              "bol": 415,
-              "cnum": 424
+              "lnum": 13,
+              "bol": 395,
+              "cnum": 404
             },
               {
               "fname": "",
-              "lnum": 23,
-              "bol": 415,
-              "cnum": 425
+              "lnum": 13,
+              "bol": 395,
+              "cnum": 405
             }
             ],
             "type": "term",
@@ -720,15 +708,15 @@ end
               "position": [
                 {
                 "fname": "",
-                "lnum": 23,
-                "bol": 415,
-                "cnum": 424
+                "lnum": 13,
+                "bol": 395,
+                "cnum": 404
               },
                 {
                 "fname": "",
-                "lnum": 23,
-                "bol": 415,
-                "cnum": 425
+                "lnum": 13,
+                "bol": 395,
+                "cnum": 405
               }
               ],
               "type": "ground",
@@ -739,15 +727,15 @@ end
             "position": [
               {
               "fname": "",
-              "lnum": 23,
-              "bol": 415,
-              "cnum": 427
+              "lnum": 13,
+              "bol": 395,
+              "cnum": 407
             },
               {
               "fname": "",
-              "lnum": 23,
-              "bol": 415,
-              "cnum": 428
+              "lnum": 13,
+              "bol": 395,
+              "cnum": 408
             }
             ],
             "type": "term",
@@ -755,15 +743,15 @@ end
               "position": [
                 {
                 "fname": "",
-                "lnum": 23,
-                "bol": 415,
-                "cnum": 427
+                "lnum": 13,
+                "bol": 395,
+                "cnum": 407
               },
                 {
                 "fname": "",
-                "lnum": 23,
-                "bol": 415,
-                "cnum": 428
+                "lnum": 13,
+                "bol": 395,
+                "cnum": 408
               }
               ],
               "type": "ground",
@@ -778,15 +766,15 @@ end
         "position": [
           {
           "fname": "",
-          "lnum": 23,
-          "bol": 415,
-          "cnum": 430
+          "lnum": 13,
+          "bol": 395,
+          "cnum": 410
         },
           {
           "fname": "",
-          "lnum": 25,
-          "bol": 440,
-          "cnum": 440
+          "lnum": 13,
+          "bol": 395,
+          "cnum": 419
         }
         ],
         "body": [
@@ -794,15 +782,15 @@ end
           "position": [
             {
             "fname": "",
-            "lnum": 24,
-            "bol": 433,
-            "cnum": 435
+            "lnum": 13,
+            "bol": 395,
+            "cnum": 413
           },
             {
             "fname": "",
-            "lnum": 24,
-            "bol": 433,
-            "cnum": 439
+            "lnum": 13,
+            "bol": 395,
+            "cnum": 417
           }
           ],
           "type": "app",
@@ -810,15 +798,15 @@ end
             "position": [
               {
               "fname": "",
-              "lnum": 24,
-              "bol": 433,
-              "cnum": 435
+              "lnum": 13,
+              "bol": 395,
+              "cnum": 413
             },
               {
               "fname": "",
-              "lnum": 24,
-              "bol": 433,
-              "cnum": 437
+              "lnum": 13,
+              "bol": 395,
+              "cnum": 415
             }
             ],
             "type": "var",
@@ -829,15 +817,15 @@ end
             "position": [
               {
               "fname": "",
-              "lnum": 24,
-              "bol": 433,
-              "cnum": 437
+              "lnum": 13,
+              "bol": 395,
+              "cnum": 415
             },
               {
               "fname": "",
-              "lnum": 24,
-              "bol": 433,
-              "cnum": 438
+              "lnum": 13,
+              "bol": 395,
+              "cnum": 416
             }
             ],
             "type": "term",
@@ -848,15 +836,15 @@ end
                 "position": [
                   {
                   "fname": "",
-                  "lnum": 24,
-                  "bol": 433,
-                  "cnum": 437
+                  "lnum": 13,
+                  "bol": 395,
+                  "cnum": 415
                 },
                   {
                   "fname": "",
-                  "lnum": 24,
-                  "bol": 433,
-                  "cnum": 438
+                  "lnum": 13,
+                  "bol": 395,
+                  "cnum": 416
                 }
                 ],
                 "type": "var",

--- a/tests/snapshots/expected_canonical/blocks_and_ternary.expected
+++ b/tests/snapshots/expected_canonical/blocks_and_ternary.expected
@@ -1,0 +1,725 @@
+=== blocks_and_ternary.liq ===
+# An explicit `begin ... end` must survive as a block node: a `def` body is an
+# implicit block and flattens into `body`, but a `fun` body is a single
+# expression, so a block there was written by hand and the formatter would
+# delete it if it were flattened too.
+f =
+  fun () ->
+    begin
+      a = 1
+      a
+    end
+
+def g() =
+  b = 2
+  b
+end
+
+# A ternary's branches are expression nodes, not statement arrays.
+l = [1, ...(true ? [2] : []), 3]
+h = true ? "yes" : "no"
+
+(f(), g(), l, h)
+--- canonical ---
+{
+  "ast": {
+    "type": "program",
+    "position": [
+      {
+      "fname": "",
+      "lnum": 1,
+      "bol": 0,
+      "cnum": 0
+    },
+      {
+      "fname": "",
+      "lnum": 1,
+      "bol": 0,
+      "cnum": 488
+    }
+    ],
+    "body": [
+      {
+      "position": [
+        {
+        "fname": "",
+        "lnum": 5,
+        "bol": 264,
+        "cnum": 264
+      },
+        {
+        "fname": "",
+        "lnum": 10,
+        "bol": 310,
+        "cnum": 317
+      }
+      ],
+      "type": "binding",
+      "decoration": null,
+      "pat": { "type": "pvar", "value": [ "f" ] },
+      "arglist": null,
+      "cast": null,
+      "definition": {
+        "position": [
+          {
+          "fname": "",
+          "lnum": 6,
+          "bol": 268,
+          "cnum": 270
+        },
+          {
+          "fname": "",
+          "lnum": 10,
+          "bol": 310,
+          "cnum": 317
+        }
+        ],
+        "type": "fun",
+        "arguments": [],
+        "body": [
+          {
+          "position": [
+            {
+            "fname": "",
+            "lnum": 7,
+            "bol": 280,
+            "cnum": 284
+          },
+            {
+            "fname": "",
+            "lnum": 10,
+            "bol": 310,
+            "cnum": 317
+          }
+          ],
+          "type": "block",
+          "body": [
+            {
+            "position": [
+              {
+              "fname": "",
+              "lnum": 8,
+              "bol": 290,
+              "cnum": 296
+            },
+              {
+              "fname": "",
+              "lnum": 8,
+              "bol": 290,
+              "cnum": 301
+            }
+            ],
+            "type": "binding",
+            "decoration": null,
+            "pat": { "type": "pvar", "value": [ "a" ] },
+            "arglist": null,
+            "cast": null,
+            "definition": {
+              "position": [
+                {
+                "fname": "",
+                "lnum": 8,
+                "bol": 290,
+                "cnum": 300
+              },
+                {
+                "fname": "",
+                "lnum": 8,
+                "bol": 290,
+                "cnum": 301
+              }
+              ],
+              "type": "ground",
+              "value": "1"
+            }
+          },
+            {
+            "position": [
+              {
+              "fname": "",
+              "lnum": 9,
+              "bol": 302,
+              "cnum": 308
+            },
+              {
+              "fname": "",
+              "lnum": 9,
+              "bol": 302,
+              "cnum": 309
+            }
+            ],
+            "type": "var",
+            "value": "a"
+          }
+          ]
+        }
+        ]
+      }
+    },
+      {
+      "position": [
+        {
+        "fname": "",
+        "lnum": 12,
+        "bol": 319,
+        "cnum": 319
+      },
+        {
+        "fname": "",
+        "lnum": 15,
+        "bol": 341,
+        "cnum": 344
+      }
+      ],
+      "type": "def",
+      "decoration": null,
+      "pat": { "type": "pvar", "value": [ "g" ] },
+      "arglist": [],
+      "cast": null,
+      "body": [
+        {
+        "position": [
+          {
+          "fname": "",
+          "lnum": 13,
+          "bol": 329,
+          "cnum": 331
+        },
+          {
+          "fname": "",
+          "lnum": 13,
+          "bol": 329,
+          "cnum": 336
+        }
+        ],
+        "type": "binding",
+        "decoration": null,
+        "pat": { "type": "pvar", "value": [ "b" ] },
+        "arglist": null,
+        "cast": null,
+        "definition": {
+          "position": [
+            {
+            "fname": "",
+            "lnum": 13,
+            "bol": 329,
+            "cnum": 335
+          },
+            {
+            "fname": "",
+            "lnum": 13,
+            "bol": 329,
+            "cnum": 336
+          }
+          ],
+          "type": "ground",
+          "value": "2"
+        }
+      },
+        {
+        "position": [
+          {
+          "fname": "",
+          "lnum": 14,
+          "bol": 337,
+          "cnum": 339
+        },
+          {
+          "fname": "",
+          "lnum": 14,
+          "bol": 337,
+          "cnum": 340
+        }
+        ],
+        "type": "var",
+        "value": "b"
+      }
+      ]
+    },
+      {
+      "position": [
+        {
+        "fname": "",
+        "lnum": 18,
+        "bol": 413,
+        "cnum": 413
+      },
+        {
+        "fname": "",
+        "lnum": 18,
+        "bol": 413,
+        "cnum": 445
+      }
+      ],
+      "type": "binding",
+      "decoration": null,
+      "pat": { "type": "pvar", "value": [ "l" ] },
+      "arglist": null,
+      "cast": null,
+      "definition": {
+        "position": [
+          {
+          "fname": "",
+          "lnum": 18,
+          "bol": 413,
+          "cnum": 417
+        },
+          {
+          "fname": "",
+          "lnum": 18,
+          "bol": 413,
+          "cnum": 445
+        }
+        ],
+        "type": "list",
+        "value": [
+          {
+          "position": [
+            {
+            "fname": "",
+            "lnum": 18,
+            "bol": 413,
+            "cnum": 418
+          },
+            {
+            "fname": "",
+            "lnum": 18,
+            "bol": 413,
+            "cnum": 419
+          }
+          ],
+          "type": "term",
+          "value": {
+            "position": [
+              {
+              "fname": "",
+              "lnum": 18,
+              "bol": 413,
+              "cnum": 418
+            },
+              {
+              "fname": "",
+              "lnum": 18,
+              "bol": 413,
+              "cnum": 419
+            }
+            ],
+            "type": "ground",
+            "value": "1"
+          }
+        },
+          {
+          "position": [
+            {
+            "fname": "",
+            "lnum": 18,
+            "bol": 413,
+            "cnum": 424
+          },
+            {
+            "fname": "",
+            "lnum": 18,
+            "bol": 413,
+            "cnum": 441
+          }
+          ],
+          "type": "ellipsis",
+          "value": {
+            "position": [
+              {
+              "fname": "",
+              "lnum": 18,
+              "bol": 413,
+              "cnum": 424
+            },
+              {
+              "fname": "",
+              "lnum": 18,
+              "bol": 413,
+              "cnum": 441
+            }
+            ],
+            "type": "parenthesis",
+            "value": {
+              "position": [
+                {
+                "fname": "",
+                "lnum": 18,
+                "bol": 413,
+                "cnum": 425
+              },
+                {
+                "fname": "",
+                "lnum": 18,
+                "bol": 413,
+                "cnum": 440
+              }
+              ],
+              "type": "inline_if",
+              "condition": {
+                "position": [
+                  {
+                  "fname": "",
+                  "lnum": 18,
+                  "bol": 413,
+                  "cnum": 425
+                },
+                  {
+                  "fname": "",
+                  "lnum": 18,
+                  "bol": 413,
+                  "cnum": 429
+                }
+                ],
+                "type": "ground",
+                "value": "true"
+              },
+              "then": {
+                "position": [
+                  {
+                  "fname": "",
+                  "lnum": 18,
+                  "bol": 413,
+                  "cnum": 432
+                },
+                  {
+                  "fname": "",
+                  "lnum": 18,
+                  "bol": 413,
+                  "cnum": 435
+                }
+                ],
+                "type": "list",
+                "value": [
+                  {
+                  "position": [
+                    {
+                    "fname": "",
+                    "lnum": 18,
+                    "bol": 413,
+                    "cnum": 433
+                  },
+                    {
+                    "fname": "",
+                    "lnum": 18,
+                    "bol": 413,
+                    "cnum": 434
+                  }
+                  ],
+                  "type": "term",
+                  "value": {
+                    "position": [
+                      {
+                      "fname": "",
+                      "lnum": 18,
+                      "bol": 413,
+                      "cnum": 433
+                    },
+                      {
+                      "fname": "",
+                      "lnum": 18,
+                      "bol": 413,
+                      "cnum": 434
+                    }
+                    ],
+                    "type": "ground",
+                    "value": "2"
+                  }
+                }
+                ]
+              },
+              "else": {
+                "position": [
+                  {
+                  "fname": "",
+                  "lnum": 18,
+                  "bol": 413,
+                  "cnum": 438
+                },
+                  {
+                  "fname": "",
+                  "lnum": 18,
+                  "bol": 413,
+                  "cnum": 440
+                }
+                ],
+                "type": "list",
+                "value": []
+              }
+            }
+          }
+        },
+          {
+          "position": [
+            {
+            "fname": "",
+            "lnum": 18,
+            "bol": 413,
+            "cnum": 443
+          },
+            {
+            "fname": "",
+            "lnum": 18,
+            "bol": 413,
+            "cnum": 444
+          }
+          ],
+          "type": "term",
+          "value": {
+            "position": [
+              {
+              "fname": "",
+              "lnum": 18,
+              "bol": 413,
+              "cnum": 443
+            },
+              {
+              "fname": "",
+              "lnum": 18,
+              "bol": 413,
+              "cnum": 444
+            }
+            ],
+            "type": "ground",
+            "value": "3"
+          }
+        }
+        ]
+      }
+    },
+      {
+      "position": [
+        {
+        "fname": "",
+        "lnum": 19,
+        "bol": 446,
+        "cnum": 446
+      },
+        {
+        "fname": "",
+        "lnum": 19,
+        "bol": 446,
+        "cnum": 469
+      }
+      ],
+      "type": "binding",
+      "decoration": null,
+      "pat": { "type": "pvar", "value": [ "h" ] },
+      "arglist": null,
+      "cast": null,
+      "definition": {
+        "position": [
+          {
+          "fname": "",
+          "lnum": 19,
+          "bol": 446,
+          "cnum": 450
+        },
+          {
+          "fname": "",
+          "lnum": 19,
+          "bol": 446,
+          "cnum": 469
+        }
+        ],
+        "type": "inline_if",
+        "condition": {
+          "position": [
+            {
+            "fname": "",
+            "lnum": 19,
+            "bol": 446,
+            "cnum": 450
+          },
+            {
+            "fname": "",
+            "lnum": 19,
+            "bol": 446,
+            "cnum": 454
+          }
+          ],
+          "type": "ground",
+          "value": "true"
+        },
+        "then": {
+          "position": [
+            {
+            "fname": "",
+            "lnum": 19,
+            "bol": 446,
+            "cnum": 457
+          },
+            {
+            "fname": "",
+            "lnum": 19,
+            "bol": 446,
+            "cnum": 462
+          }
+          ],
+          "type": "string",
+          "value": "\"yes\""
+        },
+        "else": {
+          "position": [
+            {
+            "fname": "",
+            "lnum": 19,
+            "bol": 446,
+            "cnum": 465
+          },
+            {
+            "fname": "",
+            "lnum": 19,
+            "bol": 446,
+            "cnum": 469
+          }
+          ],
+          "type": "string",
+          "value": "\"no\""
+        }
+      }
+    },
+      {
+      "position": [
+        {
+        "fname": "",
+        "lnum": 21,
+        "bol": 471,
+        "cnum": 471
+      },
+        {
+        "fname": "",
+        "lnum": 21,
+        "bol": 471,
+        "cnum": 487
+      }
+      ],
+      "type": "tuple",
+      "value": [
+        {
+        "position": [
+          {
+          "fname": "",
+          "lnum": 21,
+          "bol": 471,
+          "cnum": 472
+        },
+          {
+          "fname": "",
+          "lnum": 21,
+          "bol": 471,
+          "cnum": 475
+        }
+        ],
+        "type": "app",
+        "op": {
+          "position": [
+            {
+            "fname": "",
+            "lnum": 21,
+            "bol": 471,
+            "cnum": 472
+          },
+            {
+            "fname": "",
+            "lnum": 21,
+            "bol": 471,
+            "cnum": 474
+          }
+          ],
+          "type": "var",
+          "value": "f"
+        },
+        "args": []
+      },
+        {
+        "position": [
+          {
+          "fname": "",
+          "lnum": 21,
+          "bol": 471,
+          "cnum": 477
+        },
+          {
+          "fname": "",
+          "lnum": 21,
+          "bol": 471,
+          "cnum": 480
+        }
+        ],
+        "type": "app",
+        "op": {
+          "position": [
+            {
+            "fname": "",
+            "lnum": 21,
+            "bol": 471,
+            "cnum": 477
+          },
+            {
+            "fname": "",
+            "lnum": 21,
+            "bol": 471,
+            "cnum": 479
+          }
+          ],
+          "type": "var",
+          "value": "g"
+        },
+        "args": []
+      },
+        {
+        "position": [
+          {
+          "fname": "",
+          "lnum": 21,
+          "bol": 471,
+          "cnum": 482
+        },
+          {
+          "fname": "",
+          "lnum": 21,
+          "bol": 471,
+          "cnum": 483
+        }
+        ],
+        "type": "var",
+        "value": "l"
+      },
+        {
+        "position": [
+          {
+          "fname": "",
+          "lnum": 21,
+          "bol": 471,
+          "cnum": 485
+        },
+          {
+          "fname": "",
+          "lnum": 21,
+          "bol": 471,
+          "cnum": 486
+        }
+        ],
+        "type": "var",
+        "value": "h"
+      }
+      ]
+    }
+    ]
+  },
+  "comments": [
+    {
+    "start": 0,
+    "end": 263,
+    "lnum": 1,
+    "value": "# An explicit `begin ... end` must survive as a block node: a `def` body is an\n# implicit block and flattens into `body`, but a `fun` body is a single\n# expression, so a block there was written by hand and the formatter would\n# delete it if it were flattened too."
+  },
+    {
+    "start": 346,
+    "end": 412,
+    "lnum": 17,
+    "value": "# A ternary's branches are expression nodes, not statement arrays."
+  }
+  ]
+}

--- a/tests/snapshots/expected_canonical/comments.expected
+++ b/tests/snapshots/expected_canonical/comments.expected
@@ -1,0 +1,184 @@
+=== comments.liq ===
+# The `comments` array: raw text plus absolute cnum offsets, reported
+# independently of the AST so prettier can place them itself.
+
+# A doc comment on a binding.
+x = 1 # trailing, same line
+
+# Leading a block.
+def g() =
+  # Inside the block.
+  x
+end
+
+g()
+--- canonical ---
+{
+  "ast": {
+    "type": "program",
+    "position": [
+      {
+      "fname": "",
+      "lnum": 1,
+      "bol": 0,
+      "cnum": 0
+    },
+      {
+      "fname": "",
+      "lnum": 1,
+      "bol": 0,
+      "cnum": 256
+    }
+    ],
+    "body": [
+      {
+      "position": [
+        {
+        "fname": "",
+        "lnum": 5,
+        "bol": 163,
+        "cnum": 163
+      },
+        {
+        "fname": "",
+        "lnum": 5,
+        "bol": 163,
+        "cnum": 168
+      }
+      ],
+      "type": "binding",
+      "decoration": null,
+      "pat": { "type": "pvar", "value": [ "x" ] },
+      "arglist": null,
+      "cast": null,
+      "definition": {
+        "position": [
+          {
+          "fname": "",
+          "lnum": 5,
+          "bol": 163,
+          "cnum": 167
+        },
+          {
+          "fname": "",
+          "lnum": 5,
+          "bol": 163,
+          "cnum": 168
+        }
+        ],
+        "type": "ground",
+        "value": "1"
+      }
+    },
+      {
+      "position": [
+        {
+        "fname": "",
+        "lnum": 8,
+        "bol": 211,
+        "cnum": 211
+      },
+        {
+        "fname": "",
+        "lnum": 11,
+        "bol": 247,
+        "cnum": 250
+      }
+      ],
+      "type": "def",
+      "decoration": null,
+      "pat": { "type": "pvar", "value": [ "g" ] },
+      "arglist": [],
+      "cast": null,
+      "body": [
+        {
+        "position": [
+          {
+          "fname": "",
+          "lnum": 10,
+          "bol": 243,
+          "cnum": 245
+        },
+          {
+          "fname": "",
+          "lnum": 10,
+          "bol": 243,
+          "cnum": 246
+        }
+        ],
+        "type": "var",
+        "value": "x"
+      }
+      ]
+    },
+      {
+      "position": [
+        {
+        "fname": "",
+        "lnum": 13,
+        "bol": 252,
+        "cnum": 252
+      },
+        {
+        "fname": "",
+        "lnum": 13,
+        "bol": 252,
+        "cnum": 255
+      }
+      ],
+      "type": "app",
+      "op": {
+        "position": [
+          {
+          "fname": "",
+          "lnum": 13,
+          "bol": 252,
+          "cnum": 252
+        },
+          {
+          "fname": "",
+          "lnum": 13,
+          "bol": 252,
+          "cnum": 254
+        }
+        ],
+        "type": "var",
+        "value": "g"
+      },
+      "args": []
+    }
+    ]
+  },
+  "comments": [
+    {
+    "start": 0,
+    "end": 131,
+    "lnum": 1,
+    "value": "# The `comments` array: raw text plus absolute cnum offsets, reported\n# independently of the AST so prettier can place them itself."
+  },
+    {
+    "start": 133,
+    "end": 162,
+    "lnum": 4,
+    "value": "# A doc comment on a binding."
+  },
+    {
+    "start": 169,
+    "end": 190,
+    "lnum": 5,
+    "value": "# trailing, same line"
+  },
+    {
+    "start": 192,
+    "end": 210,
+    "lnum": 7,
+    "value": "# Leading a block."
+  },
+    {
+    "start": 223,
+    "end": 242,
+    "lnum": 9,
+    "value": "# Inside the block."
+  }
+  ]
+}

--- a/tests/snapshots/expected_canonical/try_blocks.expected
+++ b/tests/snapshots/expected_canonical/try_blocks.expected
@@ -1,0 +1,384 @@
+=== try_blocks.liq ===
+# `try` is emitted as a `parts` array of try_body / try_catch / try_finally,
+# each with its own keyword-anchored span.
+try
+  error.raise(error.not_found, "nope")
+catch err : [error.not_found] do
+  err.message
+finally
+  ()
+end
+--- canonical ---
+{
+  "ast": {
+    "type": "program",
+    "position": [
+      {
+      "fname": "",
+      "lnum": 1,
+      "bol": 0,
+      "cnum": 0
+    },
+      {
+      "fname": "",
+      "lnum": 1,
+      "bol": 0,
+      "cnum": 227
+    }
+    ],
+    "body": [
+      {
+      "position": [
+        {
+        "fname": "",
+        "lnum": 3,
+        "bol": 120,
+        "cnum": 120
+      },
+        {
+        "fname": "",
+        "lnum": 9,
+        "bol": 223,
+        "cnum": 226
+      }
+      ],
+      "type": "try",
+      "parts": [
+        {
+        "type": "try_body",
+        "position": [
+          {
+          "fname": "",
+          "lnum": 3,
+          "bol": 120,
+          "cnum": 120
+        },
+          {
+          "fname": "",
+          "lnum": 5,
+          "bol": 163,
+          "cnum": 163
+        }
+        ],
+        "body": [
+          {
+          "position": [
+            {
+            "fname": "",
+            "lnum": 4,
+            "bol": 124,
+            "cnum": 126
+          },
+            {
+            "fname": "",
+            "lnum": 4,
+            "bol": 124,
+            "cnum": 162
+          }
+          ],
+          "type": "invoke",
+          "invoked": {
+            "position": [
+              {
+              "fname": "",
+              "lnum": 4,
+              "bol": 124,
+              "cnum": 126
+            },
+              {
+              "fname": "",
+              "lnum": 4,
+              "bol": 124,
+              "cnum": 131
+            }
+            ],
+            "type": "var",
+            "value": "error"
+          },
+          "optional": false,
+          "meth": {
+            "type": "app",
+            "op": { "type": "var", "value": "raise" },
+            "args": [
+              {
+              "position": [
+                {
+                "fname": "",
+                "lnum": 4,
+                "bol": 124,
+                "cnum": 138
+              },
+                {
+                "fname": "",
+                "lnum": 4,
+                "bol": 124,
+                "cnum": 153
+              }
+              ],
+              "type": "term",
+              "value": {
+                "type": "app_arg",
+                "label": "",
+                "value": {
+                  "position": [
+                    {
+                    "fname": "",
+                    "lnum": 4,
+                    "bol": 124,
+                    "cnum": 138
+                  },
+                    {
+                    "fname": "",
+                    "lnum": 4,
+                    "bol": 124,
+                    "cnum": 153
+                  }
+                  ],
+                  "type": "invoke",
+                  "invoked": {
+                    "position": [
+                      {
+                      "fname": "",
+                      "lnum": 4,
+                      "bol": 124,
+                      "cnum": 138
+                    },
+                      {
+                      "fname": "",
+                      "lnum": 4,
+                      "bol": 124,
+                      "cnum": 143
+                    }
+                    ],
+                    "type": "var",
+                    "value": "error"
+                  },
+                  "optional": false,
+                  "meth": { "type": "var", "value": "not_found" }
+                }
+              }
+            },
+              {
+              "position": [
+                {
+                "fname": "",
+                "lnum": 4,
+                "bol": 124,
+                "cnum": 155
+              },
+                {
+                "fname": "",
+                "lnum": 4,
+                "bol": 124,
+                "cnum": 161
+              }
+              ],
+              "type": "term",
+              "value": {
+                "type": "app_arg",
+                "label": "",
+                "value": {
+                  "position": [
+                    {
+                    "fname": "",
+                    "lnum": 4,
+                    "bol": 124,
+                    "cnum": 155
+                  },
+                    {
+                    "fname": "",
+                    "lnum": 4,
+                    "bol": 124,
+                    "cnum": 161
+                  }
+                  ],
+                  "type": "string",
+                  "value": "\"nope\""
+                }
+              }
+            }
+            ]
+          }
+        }
+        ]
+      },
+        {
+        "type": "try_catch",
+        "position": [
+          {
+          "fname": "",
+          "lnum": 5,
+          "bol": 163,
+          "cnum": 163
+        },
+          {
+          "fname": "",
+          "lnum": 7,
+          "bol": 210,
+          "cnum": 210
+        }
+        ],
+        "variable": "err",
+        "errors_list": {
+          "position": [
+            {
+            "fname": "",
+            "lnum": 5,
+            "bol": 163,
+            "cnum": 175
+          },
+            {
+            "fname": "",
+            "lnum": 5,
+            "bol": 163,
+            "cnum": 192
+          }
+          ],
+          "type": "list",
+          "value": [
+            {
+            "position": [
+              {
+              "fname": "",
+              "lnum": 5,
+              "bol": 163,
+              "cnum": 176
+            },
+              {
+              "fname": "",
+              "lnum": 5,
+              "bol": 163,
+              "cnum": 191
+            }
+            ],
+            "type": "term",
+            "value": {
+              "position": [
+                {
+                "fname": "",
+                "lnum": 5,
+                "bol": 163,
+                "cnum": 176
+              },
+                {
+                "fname": "",
+                "lnum": 5,
+                "bol": 163,
+                "cnum": 191
+              }
+              ],
+              "type": "invoke",
+              "invoked": {
+                "position": [
+                  {
+                  "fname": "",
+                  "lnum": 5,
+                  "bol": 163,
+                  "cnum": 176
+                },
+                  {
+                  "fname": "",
+                  "lnum": 5,
+                  "bol": 163,
+                  "cnum": 181
+                }
+                ],
+                "type": "var",
+                "value": "error"
+              },
+              "optional": false,
+              "meth": { "type": "var", "value": "not_found" }
+            }
+          }
+          ]
+        },
+        "body": [
+          {
+          "position": [
+            {
+            "fname": "",
+            "lnum": 6,
+            "bol": 196,
+            "cnum": 198
+          },
+            {
+            "fname": "",
+            "lnum": 6,
+            "bol": 196,
+            "cnum": 209
+          }
+          ],
+          "type": "invoke",
+          "invoked": {
+            "position": [
+              {
+              "fname": "",
+              "lnum": 6,
+              "bol": 196,
+              "cnum": 198
+            },
+              {
+              "fname": "",
+              "lnum": 6,
+              "bol": 196,
+              "cnum": 201
+            }
+            ],
+            "type": "var",
+            "value": "err"
+          },
+          "optional": false,
+          "meth": { "type": "var", "value": "message" }
+        }
+        ]
+      },
+        {
+        "type": "try_finally",
+        "position": [
+          {
+          "fname": "",
+          "lnum": 7,
+          "bol": 210,
+          "cnum": 210
+        },
+          {
+          "fname": "",
+          "lnum": 9,
+          "bol": 223,
+          "cnum": 223
+        }
+        ],
+        "body": [
+          {
+          "position": [
+            {
+            "fname": "",
+            "lnum": 8,
+            "bol": 218,
+            "cnum": 220
+          },
+            {
+            "fname": "",
+            "lnum": 8,
+            "bol": 218,
+            "cnum": 222
+          }
+          ],
+          "type": "tuple",
+          "value": []
+        }
+        ]
+      }
+      ]
+    }
+    ]
+  },
+  "comments": [
+    {
+    "start": 0,
+    "end": 119,
+    "lnum": 1,
+    "value": "# `try` is emitted as a `parts` array of try_body / try_catch / try_finally,\n# each with its own keyword-anchored span."
+  }
+  ]
+}

--- a/tests/snapshots/gen_dune.ml
+++ b/tests/snapshots/gen_dune.ml
@@ -1,35 +1,48 @@
-let () =
-  let location = Sys.getcwd () in
-  let cases =
-    List.filter
-      (fun f ->
-        match Filename.extension f with
-          | ".liq" -> true
-          (* Cases that are deliberately unparsable are named `.invalid-liq`,
-             so that the repo-wide `**/*.liq` glob the external tree-sitter and
-             lezer grammars are checked against does not pick them up. *)
-          | ".invalid-liq" -> true
-          | _ -> false)
-      (Build_tools.read_files ~location "cases")
-  in
-  List.iter
-    (fun case ->
-      let name = Filename.remove_extension case in
-      Printf.printf
-        {|
+(* Emit one pair of rules per case: run snapshot.exe over it, then diff the
+   result against the checked-in expected file. See README.md. *)
+
+let is_case f =
+  match Filename.extension f with
+    | ".liq" -> true
+    (* Cases that are deliberately unparsable are named `.invalid-liq`, so that
+       the repo-wide `**/*.liq` glob the external tree-sitter and lezer grammars
+       are checked against does not pick them up. Files meant to be pulled in by
+       a case's `%include` use `.liq-inc`, for the same reason. *)
+    | ".invalid-liq" -> true
+    | _ -> false
+
+(* [flag] is passed to snapshot.exe ahead of the case; [prefix] keeps the
+   generated target names of the two suites apart. *)
+let emit_rules ~cases_dir ~expected_dir ~prefix ~flag case =
+  let target = prefix ^ Filename.remove_extension case in
+  Printf.printf
+    {|
 (rule
  (target %s.actual)
  (deps
-  (:case cases/%s)
+  (:case %s/%s)
+  (glob_files cases/*.liq-inc)
   (:snapshot snapshot.exe))
  (action
-  (with-stdout-to %%{target} (run %%{snapshot} %%{case}))))
+  (with-stdout-to %%{target} (run %%{snapshot} %s%%{case}))))
 
 (rule
  (aliases lang_snapshot runtest)
  (package liquidsoap)
  (action
-  (diff expected/%s.expected %s.actual)))
+  (diff %s/%s.expected %s.actual)))
 |}
-        name case name name)
-    cases
+    target cases_dir case flag expected_dir
+    (Filename.remove_extension case)
+    target
+
+let () =
+  let location = Sys.getcwd () in
+  let suite ~cases_dir ~expected_dir ~prefix ~flag =
+    List.iter
+      (emit_rules ~cases_dir ~expected_dir ~prefix ~flag)
+      (List.filter is_case (Build_tools.read_files ~location cases_dir))
+  in
+  suite ~cases_dir:"cases" ~expected_dir:"expected" ~prefix:"" ~flag:"";
+  suite ~cases_dir:"cases_canonical" ~expected_dir:"expected_canonical"
+    ~prefix:"canonical_" ~flag:"--canonical "

--- a/tests/snapshots/snapshot.ml
+++ b/tests/snapshots/snapshot.ml
@@ -70,6 +70,24 @@ let describe_error ~buffer ~throw exn =
         |> List.filter (fun l -> not (is_backtrace_frame l))
         |> String.concat "\n" |> String.trim
 
+(* Doc comments attach to *statements*, and nothing else in this dump would
+   show them, so a binding silently losing its documentation would not fail any
+   other section. *)
+let rec doc_bindings (tm : Term.t) =
+  match tm.Term.term with
+    | `Let { Term.doc; pat; def; body; _ } ->
+        let name =
+          match pat with
+            | `PVar l -> String.concat "." l
+            | `PTuple l -> "(" ^ String.concat ", " l ^ ")"
+        in
+        (match doc with
+          | Some d -> [(name, d.Doc.Value.description)]
+          | None -> [])
+        @ doc_bindings def @ doc_bindings body
+    | `Seq (a, b) -> doc_bindings a @ doc_bindings b
+    | _ -> []
+
 let read_source file =
   let ic = open_in_bin file in
   Fun.protect
@@ -118,10 +136,15 @@ let run_file file =
            what relative include paths resolve against. Running it here also makes
            the `hash` section below the actual cache key: [Term_cache] hashes the
            expanded parsed term. *)
+        (* Comments are collected by the lexer into a global and attached
+           afterwards, exactly as Term_preprocessor.mk_expr does; without this
+           no binding would carry its doc comment. *)
+        Parser_helper.clear_comments ();
         let parsed =
-          Term_preprocessor.expand_term
-            (Runtime.program (Preprocessor.mk_tokenizer ~fname:file lexbuf))
+          Runtime.program (Preprocessor.mk_tokenizer ~fname:file lexbuf)
         in
+        Parser_helper.attach_comments parsed;
+        let parsed = Term_preprocessor.expand_term parsed in
         print_string
           (Json.to_string ~compact:false
              (without_positions (Liquidsoap_tooling.Parsed_json.to_json parsed)));
@@ -142,6 +165,18 @@ let run_file file =
             print_endline (stable_generated_names (Term.to_string term));
             term))
   in
+  ignore
+    (Option.map
+       (fun term ->
+         match doc_bindings term with
+           | [] -> ()
+           | docs ->
+               section "doc";
+               List.iter
+                 (fun (name, description) ->
+                   Printf.printf "%s: %s\n" name description)
+                 docs)
+       term);
   let typed =
     Option.bind term (fun term ->
         stage "type" (fun () ->

--- a/tests/snapshots/snapshot.ml
+++ b/tests/snapshots/snapshot.ml
@@ -12,7 +12,12 @@
    error messages are part of the snapshot too.
 
    Everything runs against [liquidsoap_lang] alone, with no standard library
-   and no streaming core, so the output only depends on the language. *)
+   and no streaming core, so the output only depends on the language.
+
+   With [--canonical], it instead dumps [Parsed_json.parse_string]: the flat,
+   keyword-anchored JSON that liquidsoap-prettier consumes, positions included.
+   That is a separate contract from the [parsed] section above — it is spec'd in
+   [parsed_json.mli] — and positions are exactly what it turns on. *)
 
 open Liquidsoap_lang
 
@@ -65,16 +70,30 @@ let describe_error ~buffer ~throw exn =
         |> List.filter (fun l -> not (is_backtrace_frame l))
         |> String.concat "\n" |> String.trim
 
-let run_file file =
+let read_source file =
+  let ic = open_in_bin file in
+  Fun.protect
+    ~finally:(fun () -> close_in ic)
+    (fun () -> really_input_string ic (in_channel_length ic))
+
+let echo_source file source =
   Printf.printf "=== %s ===\n" (Filename.basename file);
-  let source =
-    let ic = open_in_bin file in
-    Fun.protect
-      ~finally:(fun () -> close_in ic)
-      (fun () -> really_input_string ic (in_channel_length ic))
-  in
   print_string source;
-  if not (String.ends_with ~suffix:"\n" source) then print_newline ();
+  if not (String.ends_with ~suffix:"\n" source) then print_newline ()
+
+(* The prettier ABI: block spans and comment offsets, which the pipeline
+   snapshots above deliberately strip. Nothing else covers this. *)
+let run_canonical_file file =
+  let source = read_source file in
+  echo_source file source;
+  section "canonical";
+  match Liquidsoap_tooling.Parsed_json.parse_string source with
+    | json -> print_endline (Json.to_string ~compact:false json)
+    | exception exn -> print_endline (Printexc.to_string exn)
+
+let run_file file =
+  let source = read_source file in
+  echo_source file source;
   let buffer = Buffer.create 1024 in
   let formatter = Format.formatter_of_buffer buffer in
   let lexbuf = Sedlexing.Utf8.from_string source in
@@ -95,7 +114,14 @@ let run_file file =
   in
   let parsed =
     stage "parsed" (fun () ->
-        let parsed = Runtime.program (Preprocessor.mk_tokenizer lexbuf) in
+        (* [expand_term] is what splices `%include`d files in, and the filename is
+           what relative include paths resolve against. Running it here also makes
+           the `hash` section below the actual cache key: [Term_cache] hashes the
+           expanded parsed term. *)
+        let parsed =
+          Term_preprocessor.expand_term
+            (Runtime.program (Preprocessor.mk_tokenizer ~fname:file lexbuf))
+        in
         print_string
           (Json.to_string ~compact:false
              (without_positions (Liquidsoap_tooling.Parsed_json.to_json parsed)));
@@ -129,5 +155,7 @@ let run_file file =
              print_endline (Value.to_string (Evaluation.eval term)))))
 
 let () =
-  let files = List.tl (Array.to_list Sys.argv) in
-  List.iter run_file (List.sort compare files)
+  match List.tl (Array.to_list Sys.argv) with
+    | "--canonical" :: files ->
+        List.iter run_canonical_file (List.sort compare files)
+    | files -> List.iter run_file (List.sort compare files)

--- a/tests/streams/random.liq
+++ b/tests/streams/random.liq
@@ -11,7 +11,7 @@ end
 
 s1 = metadata.map(insert_missing=true, id="s1-map", m1, s1)
 s1_ready = ref(true)
-s1 = switch(id="s1", [(s1_ready, s1.{track_sensitive=false})])
+s1 = switch(id="s1", [(s1_ready, s1.{track_sensitive = false})])
 s1_weight = ref(1)
 s2 = blank(duration=0.04)
 
@@ -21,7 +21,7 @@ end
 
 s2 = metadata.map(insert_missing=true, id="s2-map", m2, s2)
 s2_ready = ref(false)
-s2 = switch(id="s2", [(s2_ready, s2.{track_sensitive=false})])
+s2 = switch(id="s2", [(s2_ready, s2.{track_sensitive = false})])
 s2_weight = ref(1)
 round = ref(1)
 
@@ -48,7 +48,7 @@ def f(m) =
   selected := list.cons(m["id"], selected())
 end
 
-s = random([s1.{weight=s1_weight}, s2.{weight=s2_weight}])
+s = random([s1.{weight = s1_weight}, s2.{weight = s2_weight}])
 s.on_track(synchronous=true, f)
 output.dummy(fallible=true, s)
 

--- a/tests/streams/rotate.liq
+++ b/tests/streams/rotate.liq
@@ -60,8 +60,8 @@ def ot(m) =
   end
 end
 
-radio = rotate(id="rotate", [music.{weight=3}, jingles.{weight=1}])
-radio = rotate(id="rotate2", [radio.{weight=1}, music2.{weight=1}])
+radio = rotate(id="rotate", [music.{weight = 3}, jingles.{weight = 1}])
+radio = rotate(id="rotate2", [radio.{weight = 1}, music2.{weight = 1}])
 
 radio.on_track(synchronous=true, ot)
 


### PR DESCRIPTION
## Why

The front end had three layers doing overlapping work — five stacked token transducers, the grammar, and a whole-AST pre-pass — and most of the odd corner cases came from one choice: a block was a right-nested `Let`/`Seq` chain, so a binding's body was "everything after it" and anything expanding to several statements had to re-thread the tail.

## Approach

A few principles, applied consistently:

- **A block is a list of statements.** Scope is "the rest of the block", written once in the reducer. `%include` and `%ifdef` splice a list instead of surgically re-threading a chain.
- **Lexical structure belongs to the lexer.** String interpolation is lexed in place rather than pre-split by a regexp over the raw literal, so positions survive and nesting works.
- **Nesting is resolved over tokens, not characters.** The `}` closing an interpolation is found by counting braces in the token stream, where a nested string, comment or regexp is already a single token and cannot be miscounted. (JS gets this by letting the parser decide where the expression ends and re-scanning; menhir can't consult parser state, and token-level counting is the closest correct equivalent.)
- **Contextual keywords stay identifiers.** `as`, `json`, `ref`, `source` are matched as plain variables and checked in the action, so nothing becomes reserved — but the check is named and reports the offending token.
- **Ambiguity LR can't defer is resolved after parsing.** `(a, b)` is both a tuple expression and a tuple pattern, so a bare binding's left-hand side is parsed as an expression and reinterpreted, which also turns "Syntax error!" into a message naming what a binding target may be.
- **The grammar stays conflict-free.** `--strict` makes any new ambiguity a build error; it caught two during this work.
- **Optimisations must not change semantics, and compiler state belongs to the term.** Term trimming no longer decides whether effects happen, and `needs_toplevel` is derived from the term rather than remembered in a global.
- **What the sugar expands to is not part of the language.** Desugared names now start with an underscore followed by a digit, which the lexer rejects as an identifier, so a script cannot bind them.

## Behaviour

| expression | before | after |
| --- | --- | --- |
| `"#{m["key"]}"` | silently misparsed, failed later on an undefined variable | `"value"` |
| `"#{ {a = 1}.a }"` | `Error 2: Parse error` | `"1"` |
| `"#{ "#{x}" }"` | inner interpolation not expanded | expands |
| error inside `#{ … }` | reported at the start of the string | reported at the offending token |
| `l[0] - 1` | two statements, `l[0]` then `-1` | one subtraction |
| `r.field = 1`, `(a, b) = t`, `(n : int) = 3` | `Error 2: Parse error` | bind, as `let` already did |
| `f(1) = 2` | `Error 2: Parse error` | names what a binding target may be |
| `(s : source(bogus))` | accepted, parameter silently discarded | reports that `source(...)` takes track declarations |
| `{a = 1, b = f()}.a` | `f()` skipped under trimming, run otherwise | always run, as with any eager language |
| `--list-functions-md > out.md` | pager control sequences in the file | plain markdown |
| `_internal_json_parser_ = …` then `let json.parse` | the script's binding hijacked the desugaring | the name is unwritable |

A leading bare binding inside `{ … }` still needs `let`, since `{ x = 1 }` is a record literal. Only the first statement is restricted, which is what `src/libs/extra/fades.liq` already relied on.

## Tests

New snapshot cases for binding targets and positions, invalid targets, nested interpolation, `%include` splicing, `%ifdef` in value position, doc comments and type constructors. A second snapshot suite covers the formatter's JSON with positions kept, which nothing guarded before. `tests/language/record_methods_eager.liq` pins the evaluation order fix and fails without it.

Checked at each step: the whole standard library parses and typechecks, and `--list-functions-md` over it is byte-identical to `main`; the formatter's JSON is unchanged; menhir reports no conflicts.

## Follow-ups

The pinned `liquidsoap-prettier` pre-commit hook rejects the new binding syntax, so these commits skip it. The three parsers that track this grammar are updated in:

| | |
| --- | --- |
| savonet/tree-sitter-liquidsoap#4 | binding targets, plus `def _(x)`, missing `scanner.c` in three bindings, and a test glob that silently skipped `tests/snapshots/cases` |
| savonet/codemirror-lang-liquidsoap#2 | binding targets, and the same test glob |
| savonet/liquidsoap-prettier#10 | builds again against the current library layout; the new syntax ships with that project's next release |

The two grammar PRs are harmless before this one and required after it, so they should land first or alongside.
