### PR TITLE
hls: keep segment boundaries on the segment_duration grid

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -63,6 +63,11 @@
 
 ## Fixed:
 
+- Fixed HLS segment boundaries drifting away from `segment_duration`: a segment
+  closing on a stale split position re-anchored the next boundary on it instead
+  of the segment grid. The drift rate depends on the encoder's frame size, so
+  variants using different codecs, e.g. HE-AAC and AAC-LC, diverged from each
+  other without bound (#5319).
 - Inline `ffmpeg.encode.*` operators report unrecognized codec options, as the
   container encoder does.
 - Fixed `%ffmpeg` copy encoder initializing the video stream twice and setting the

--- a/src/core/outputs/hls_output.ml
+++ b/src/core/outputs/hls_output.ml
@@ -198,6 +198,9 @@ type segment = {
   mutable out_channel : atomic_out_channel option;
   (* Segment length in main ticks. *)
   mutable len : int;
+  (* Part of [len] carried over from the previous segment: excluded from the
+     split decision so that boundaries stay on the [segment_duration] grid. *)
+  mutable carried_len : int;
   mutable last_segmentable_position : (int * int) option;
 }
 
@@ -232,6 +235,7 @@ let json_of_segment
       filename;
       segment_extra_tags;
       len;
+      carried_len;
       last_segmentable_position;
     } =
   `Assoc
@@ -245,6 +249,7 @@ let json_of_segment
     @ [
         ("extra_tags", `Tuple (List.map (fun s -> `String s) segment_extra_tags));
         ("len", `Int len);
+        ("carried_len", `Int carried_len);
       ]
     @ json_optional "last_segmentable_position"
         (fun (len, offset) -> `Tuple [`Int len; `Int offset])
@@ -266,6 +271,9 @@ let segment_of_json = function
           l
       in
       let len = parse_json_int "len" l in
+      let carried_len =
+        match List.assoc_opt "carried_len" l with Some (`Int i) -> i | _ -> 0
+      in
       let init_filename =
         parse_json_optional "init_filename"
           (function `String s -> s | _ -> raise Invalid_state)
@@ -289,6 +297,7 @@ let segment_of_json = function
         current_discontinuity;
         init_filename;
         len;
+        carried_len;
         segment_extra_tags;
         filename;
         out_channel = None;
@@ -790,6 +799,7 @@ class hls_output p =
           discontinuous;
           current_discontinuity;
           len = 0;
+          carried_len = 0;
           segment_extra_tags;
           init_filename =
             (match s.init_state with `Has_init f -> Some f | _ -> None);
@@ -827,7 +837,8 @@ class hls_output p =
           let segment = Option.get s.current_segment in
           let oc = Option.get segment.out_channel in
           oc#output_string rem;
-          segment.len <- current_len - len
+          segment.len <- current_len - len;
+          segment.carried_len <- current_len - len
       | _ -> assert false
 
     method private cleanup_streams =
@@ -1103,7 +1114,7 @@ class hls_output p =
         | Some _ -> raise Encoder.Not_enough_data
 
     method private should_reopen ~segment ~len s =
-      if segment.len + len > segment_main_duration then
+      if segment.len - segment.carried_len + len > segment_main_duration then
         ( true,
           Printf.sprintf
             "Terminating current segment %d on stream %s to make expected \

--- a/tests/regression/GH5319.liq
+++ b/tests/regression/GH5319.liq
@@ -1,0 +1,51 @@
+# See: https://github.com/savonet/liquidsoap/issues/5319
+# Segments used to be anchored on the previous split position instead of the
+# `segment_duration` grid, so their boundaries drifted backwards. The drift
+# rate depends on the encoder's frame size, which made HLS variants using
+# different codecs diverge from each other.
+
+tmp_dir = file.temp_dir("tmp")
+on_cleanup({file.rmdir(tmp_dir)})
+
+s = sine()
+clock.assign_new(sync="none", [s])
+
+segments = 10
+segment_duration = 2.
+total = ref(0.)
+count = ref(0)
+
+def segment_name(m) =
+  if
+    0 < m.position
+  then
+    total := total() + m.duration
+    ref.incr(count)
+    if
+      count() == segments
+    then
+      expected = float(segments) * segment_duration
+
+      # A single segment can be off by one frame, the total cannot drift.
+      if
+        abs(total() - expected) <= frame.duration()
+      then
+        test.pass()
+      else
+        test.fail(
+          "#{segments} segments last #{total()}s, expected #{expected}s"
+        )
+      end
+    end
+  end
+  "#{m.stream_name}_#{m.position}.#{m.extname}"
+end
+
+output.file.hls(
+  segment_name=segment_name,
+  segments=4,
+  segment_duration=segment_duration,
+  tmp_dir,
+  [("stream", %ffmpeg(format = "mpegts", %audio(codec = "aac")))],
+  s
+)

--- a/tests/regression/dune.inc
+++ b/tests/regression/dune.inc
@@ -1306,6 +1306,24 @@
   (run %{run_test} GH5287 liquidsoap %{test_liq} GH5287.liq)))
 
 (rule
+ (alias test_GH5319)
+ (package liquidsoap)
+ (deps
+  GH5319.liq
+  (glob_files ../media/**)
+  ../liquidsoap-test-assets
+  ../../src/bin/liquidsoap.exe
+  ../streams/file1.png
+  ../streams/file1.mp3
+  ./theora-test.mp4
+  (package liquidsoap)
+  (source_tree ../../src/libs)
+  (:test_liq ../test.liq)
+  (:run_test ../run_test.exe))
+ (action
+  (run %{run_test} GH5319 liquidsoap %{test_liq} GH5319.liq)))
+
+(rule
  (alias test_LS268)
  (package liquidsoap)
  (deps
@@ -2383,6 +2401,7 @@
   (alias test_GH5259)
   (alias test_GH5261)
   (alias test_GH5287)
+  (alias test_GH5319)
   (alias test_LS268)
   (alias test_LS354-1)
   (alias test_LS354-2)


### PR DESCRIPTION
Fixes #5319.

A segment that closes on a stale split position carries the leftover data over to the next segment. That carried length was also counted towards the next split decision, which anchored each boundary on the previous split position instead of the segment grid — so boundaries drifted backwards permanently and never recovered.

A split position goes stale when a liquidsoap frame produces no encoder packet, which requires the codec's frame to be larger than two liquidsoap frames (2048-sample HE-AAC against the default 960-sample frame, for instance). The drift rate is therefore codec-dependent, and HLS variants mixing HE-AAC and AAC-LC diverge from each other without bound — about 10.7 ms per segment in the report.

The carried length is now tracked separately: it still counts towards the segment's advertised duration, since that media really is in the file, but not towards the next split decision. It is persisted in the state file and defaults to `0`, so existing `persist_at` files still load.

`tests/regression/GH5319.liq` sums ten segment durations and asserts the total has not drifted by more than one frame. It fails without the fix (`10 segments last 19.8s, expected 20.0s`) and passes with it. The five existing `hls_*` tests still pass.
