### PR TITLE
hls: keep segment boundaries on the segment_duration grid (backport of #5320)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,11 @@
   header was looked up before normalization, so clients never received
   in-stream metadata (thanks to @uhthomas, #5279)
 - Fixed `srt` restart logic (##5309)
+- Fixed HLS segment boundaries drifting away from `segment_duration`: a segment
+  closing on a stale split position re-anchored the next boundary on it instead
+  of the segment grid. The drift rate depends on the encoder's frame size, so
+  variants using different codecs, e.g. HE-AAC and AAC-LC, diverged from each
+  other without bound (#5319).
 
 ---
 

--- a/src/core/base/outputs/hls_output.ml
+++ b/src/core/base/outputs/hls_output.ml
@@ -193,6 +193,9 @@ type segment = {
   mutable out_channel : atomic_out_channel option;
   (* Segment length in main ticks. *)
   mutable len : int;
+  (* Part of [len] carried over from the previous segment: excluded from the
+     split decision so that boundaries stay on the [segment_duration] grid. *)
+  mutable carried_len : int;
   mutable last_segmentable_position : (int * int) option;
 }
 
@@ -227,6 +230,7 @@ let json_of_segment
       filename;
       segment_extra_tags;
       len;
+      carried_len;
       last_segmentable_position;
     } =
   `Assoc
@@ -240,6 +244,7 @@ let json_of_segment
     @ [
         ("extra_tags", `Tuple (List.map (fun s -> `String s) segment_extra_tags));
         ("len", `Int len);
+        ("carried_len", `Int carried_len);
       ]
     @ json_optional "last_segmentable_position"
         (fun (len, offset) -> `Tuple [`Int len; `Int offset])
@@ -261,6 +266,9 @@ let segment_of_json = function
           l
       in
       let len = parse_json_int "len" l in
+      let carried_len =
+        match List.assoc_opt "carried_len" l with Some (`Int i) -> i | _ -> 0
+      in
       let init_filename =
         parse_json_optional "init_filename"
           (function `String s -> s | _ -> raise Invalid_state)
@@ -284,6 +292,7 @@ let segment_of_json = function
         current_discontinuity;
         init_filename;
         len;
+        carried_len;
         segment_extra_tags;
         filename;
         out_channel = None;
@@ -743,6 +752,7 @@ class hls_output p =
           discontinuous;
           current_discontinuity;
           len = 0;
+          carried_len = 0;
           segment_extra_tags;
           init_filename =
             (match s.init_state with `Has_init f -> Some f | _ -> None);
@@ -792,7 +802,8 @@ class hls_output p =
           let segment = Option.get s.current_segment in
           let oc = Option.get segment.out_channel in
           oc#output_string rem;
-          segment.len <- current_len - len
+          segment.len <- current_len - len;
+          segment.carried_len <- current_len - len
       | _ -> assert false
 
     method private cleanup_streams =
@@ -1048,7 +1059,7 @@ class hls_output p =
         | Some _ -> raise Encoder.Not_enough_data
 
     method private should_reopen ~segment ~len s =
-      if segment.len + len > segment_main_duration then
+      if segment.len - segment.carried_len + len > segment_main_duration then
         ( true,
           Printf.sprintf
             "Terminating current segment %d on stream %s to make expected \

--- a/tests/regression/GH5319.liq
+++ b/tests/regression/GH5319.liq
@@ -1,0 +1,51 @@
+# See: https://github.com/savonet/liquidsoap/issues/5319
+# Segments used to be anchored on the previous split position instead of the
+# `segment_duration` grid, so their boundaries drifted backwards. The drift
+# rate depends on the encoder's frame size, which made HLS variants using
+# different codecs diverge from each other.
+
+tmp_dir = file.temp_dir("tmp")
+on_cleanup({file.rmdir(tmp_dir)})
+
+s = sine()
+clock.assign_new(sync="none", [s])
+
+segments = 10
+segment_duration = 2.
+total = ref(0.)
+count = ref(0)
+
+def segment_name(m) =
+  if
+    0 < m.position
+  then
+    total := total() + m.duration
+    ref.incr(count)
+    if
+      count() == segments
+    then
+      expected = float(segments) * segment_duration
+
+      # A single segment can be off by one frame, the total cannot drift.
+      if
+        abs(total() - expected) <= frame.duration()
+      then
+        test.pass()
+      else
+        test.fail(
+          "#{segments} segments last #{total()}s, expected #{expected}s"
+        )
+      end
+    end
+  end
+  "#{m.stream_name}_#{m.position}.#{m.extname}"
+end
+
+output.file.hls(
+  segment_name=segment_name,
+  segments=4,
+  segment_duration=segment_duration,
+  tmp_dir,
+  [("stream", %ffmpeg(format = "mpegts", %audio(codec = "aac")))],
+  s
+)

--- a/tests/regression/dune.inc
+++ b/tests/regression/dune.inc
@@ -1162,6 +1162,23 @@
  (action (run %{run_test} GH5287 liquidsoap %{test_liq} GH5287.liq)))
   
 (rule
+ (alias GH5319)
+ (package liquidsoap)
+ 
+ (deps
+  GH5319.liq
+  ../media/all_media_files
+  ../../src/bin/liquidsoap.exe
+  ../streams/file1.png
+  ../streams/file1.mp3
+  ./theora-test.mp4
+  (package liquidsoap)
+  (source_tree ../../src/libs)
+  (:test_liq ../test.liq)
+  (:run_test ../run_test.exe))
+ (action (run %{run_test} GH5319 liquidsoap %{test_liq} GH5319.liq)))
+  
+(rule
  (alias LS268)
  (package liquidsoap)
  
@@ -1792,6 +1809,7 @@
     (alias GH5110)
     (alias GH5148)
     (alias GH5287)
+    (alias GH5319)
     (alias LS268)
     (alias LS354-1)
     (alias LS354-2)


### PR DESCRIPTION
Backport of #5320 to `v2.4.x-latest`. Fixes #5319, which was reported against 2.4.5 and reproduced on `2.4.6+git@799bd57dc`.

A segment that closes on a stale split position carries the leftover data over to the next segment. That carried length was also counted towards the next split decision, which anchored each boundary on the previous split position instead of the segment grid — so boundaries drifted backwards permanently and never recovered.

A split position goes stale when a liquidsoap frame produces no encoder packet, which requires the codec's frame to be larger than two liquidsoap frames (2048-sample HE-AAC against the default 960-sample frame, for instance). The drift rate is therefore codec-dependent, and HLS variants mixing HE-AAC and AAC-LC diverge from each other without bound — about 10.7 ms per segment in the report.

The carried length is now tracked separately: it still counts towards the segment's advertised duration, since that media really is in the file, but not towards the next split decision. It is persisted in the state file and defaults to `0`, so existing `persist_at` files still load.

The patch applies verbatim, at `src/core/base/outputs/hls_output.ml` on this branch. The `CHANGES.md` entry is placed in the `2.4.6 (unreleased)` section rather than the one from #5320.

`tests/regression/GH5319.liq` sums ten segment durations and asserts the total has not drifted by more than one frame. Verified on this branch: it fails without the fix (`10 segments last 19.8s, expected 20.0s`) and passes with it.
