### PR TITLE
Fix a batch of issues reported by @vitoyucepi (2.4.x)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,9 @@
 
 ## Fixed:
 
+- Anything logged while evaluating the script, deprecation warnings in
+  particular, was silently dropped when liquidsoap exited before reaching the
+  streaming loop, e.g. on `No output defined, nothing to do.` (#3375)
 - Added Unifier path compression to avoid unbounded deref cost growth (#5257)
 - Fixed unbounded buffer growth (#5287)
 - Fixed `sequence` dropping the first chunk of a source, along with its

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,8 @@
 - `output.file` reports `Unix` errors, e.g. `Permission denied` when creating the
   destination directory, as `system` errors, like it already did for `Sys_error`
   (#2437)
+- `rotate` and `random` name the switch they build internally after themselves,
+  e.g. `schedule_rotate`, instead of leaving it with an anonymous id (#3851)
 - Added Unifier path compression to avoid unbounded deref cost growth (#5257)
 - Fixed unbounded buffer growth (#5287)
 - Fixed `sequence` dropping the first chunk of a source, along with its

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,12 @@
 - Liquidsoap no longer exits when started as `root`: it now logs a warning
   instead. Container detection through `/proc/1/cgroup` does not work under
   cgroup v2, which made the check fire on plain `docker run` (#3406)
+- Fixed `output.file` and the other piped outputs ignoring the delay returned by
+  `reopen_on_error` when the failure happened while opening the file: the output
+  stays `Idle` in that case and retried on every streaming cycle (#2437)
+- `output.file` reports `Unix` errors, e.g. `Permission denied` when creating the
+  destination directory, as `system` errors, like it already did for `Sys_error`
+  (#2437)
 - Added Unifier path compression to avoid unbounded deref cost growth (#5257)
 - Fixed unbounded buffer growth (#5287)
 - Fixed `sequence` dropping the first chunk of a source, along with its

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,9 @@
   (#2437)
 - `rotate` and `random` name the switch they build internally after themselves,
   e.g. `schedule_rotate`, instead of leaving it with an anonymous id (#3851)
+- Fixed `clock.create` documenting and reporting sync modes, `"CPU"` and
+  `"unsynced"`, that it does not accept. The accepted values are `"auto"`,
+  `"cpu"`, `"none"` and `"passive"`
 - Added Unifier path compression to avoid unbounded deref cost growth (#5257)
 - Fixed unbounded buffer growth (#5287)
 - Fixed `sequence` dropping the first chunk of a source, along with its

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,9 @@
 - Anything logged while evaluating the script, deprecation warnings in
   particular, was silently dropped when liquidsoap exited before reaching the
   streaming loop, e.g. on `No output defined, nothing to do.` (#3375)
+- Liquidsoap no longer exits when started as `root`: it now logs a warning
+  instead. Container detection through `/proc/1/cgroup` does not work under
+  cgroup v2, which made the check fire on plain `docker run` (#3406)
 - Added Unifier path compression to avoid unbounded deref cost growth (#5257)
 - Fixed unbounded buffer growth (#5287)
 - Fixed `sequence` dropping the first chunk of a source, along with its

--- a/src/bin/runtime/main.ml
+++ b/src/bin/runtime/main.ml
@@ -70,6 +70,23 @@ let root_error () =
     | false, _, 0 -> Some "root guid (group)"
     | _ -> None
 
+(* Dtools drops everything that was logged before the log was started. Anything
+   logged while evaluating the script is thus lost when we exit before
+   reaching the streaming loop, e.g. when no output was defined. *)
+let log_started = ref false
+
+let start_log () =
+  if not !log_started then (
+    log_started := true;
+    Dtools.Init.exec Dtools.Log.start)
+
+(* Tooling modes (--check, -h, --list-settings, ...) set [run_streams] to
+   [false] and are expected to stay quiet, so we only flush pending logs when
+   the script was meant to run. *)
+let stop_log () =
+  if !run_streams then start_log ();
+  if !log_started then Dtools.Init.exec Dtools.Log.stop
+
 let eval_mode : [ `Parse_only | `Parse_and_type | `Eval | `Eval_toplevel ] ref =
   ref `Eval
 
@@ -143,7 +160,7 @@ let eval () =
     eval_script script;
     log#important "User script loaded in %.02f seconds." (Sys.time () -. t)
   with Liquidsoap_lang.Runtime.Error ->
-    Dtools.Init.exec Dtools.Log.stop;
+    stop_log ();
     flush_all ();
     exit 1
 
@@ -599,7 +616,7 @@ let final_cleanup () =
   log#important "Cleaning downloaded files...";
   Request.cleanup ();
   log#important "Freeing memory...";
-  Dtools.Init.exec Dtools.Log.stop;
+  stop_log ();
   flush_all ();
   Gc.full_major ();
   Gc.full_major ()
@@ -738,7 +755,7 @@ let () =
             exit (-1));
 
       check_directories ();
-      Dtools.Init.exec Dtools.Log.start);
+      start_log ());
 
   Lifecycle.on_start ~name:"main application start" (fun () ->
       (* See http://caml.inria.fr/mantis/print_bug_page.php?bug_id=4640 for

--- a/src/bin/runtime/main.ml
+++ b/src/bin/runtime/main.ml
@@ -56,14 +56,14 @@ let allow_root =
   Dtools.Conf.bool
     ~p:(Configure.conf_init#plug "allow_root")
     ~d:(Lazy.force Utils.is_docker)
-    "Allow liquidsoap to run as root"
+    "Do not warn when liquidsoap is run as root"
     ~comments:
       [
-        "This should be reserved for advanced dynamic uses of liquidsoap ";
-        "such as running inside an isolated environment like docker.";
+        "Running as root should be reserved for advanced dynamic uses of ";
+        "liquidsoap such as running inside an isolated environment like docker.";
       ]
 
-let root_error () =
+let root_warning () =
   match (allow_root#get, Unix.geteuid (), Unix.getegid ()) with
     | false, 0, 0 -> Some "root euid & guid (user & group)"
     | false, 0, _ -> Some "root euid (user)"
@@ -621,10 +621,6 @@ let final_cleanup () =
   Gc.full_major ();
   Gc.full_major ()
 
-let sync_cleanup () =
-  initial_cleanup ();
-  final_cleanup ()
-
 let () =
   (* Shutdown *)
   Lifecycle.before_core_shutdown ~name:"log shutdown" (fun () ->
@@ -744,18 +740,16 @@ let () =
 
       if Dtools.Init.conf_daemon#get then daemonize ();
 
-      (match root_error () with
+      check_directories ();
+      start_log ();
+
+      match root_warning () with
         | None -> ()
         | Some err ->
-            Printf.eprintf
-              "init: security exit, %s. Override with settings.init.allow_root \
-               := true\n"
-              err;
-            sync_cleanup ();
-            exit (-1));
-
-      check_directories ();
-      start_log ());
+            log#severe
+              "WARNING: liquidsoap is running with %s. Set \
+               `settings.init.allow_root := true` to silence this warning."
+              err);
 
   Lifecycle.on_start ~name:"main application start" (fun () ->
       (* See http://caml.inria.fr/mantis/print_bug_page.php?bug_id=4640 for

--- a/src/core/base/outputs/pipe_output.ml
+++ b/src/core/base/outputs/pipe_output.ml
@@ -379,12 +379,17 @@ class virtual piped_output ?clock ~name p =
               "Error while streaming: %s, will re-open in %.02fs"
               (Printexc.to_string exn) reopen_delay
 
+    (* [open_date] is in the future while we are waiting to re-open after an
+       error. Failing to open the pipe leaves the output in its [`Idle] state so,
+       without this guard, the next streaming cycle would retry right away and
+       the delay returned by [reopen_on_error] would be ignored. *)
     method! output =
-      try base#output
-      with exn ->
-        let bt = Printexc.get_raw_backtrace () in
-        (try self#cleanup_pipe with _ -> ());
-        self#reopen_on_error ~bt exn
+      if self#is_open || open_date <= Unix.gettimeofday () then (
+        try base#output
+        with exn ->
+          let bt = Printexc.get_raw_backtrace () in
+          (try self#cleanup_pipe with _ -> ());
+          self#reopen_on_error ~bt exn)
 
     method! send b = if self#is_open then base#send b
 
@@ -432,7 +437,7 @@ class virtual ['a] chan_output p =
       try
         self#output_substring chan b ofs len;
         if flush then self#flush chan
-      with Sys_error _ as exn ->
+      with (Sys_error _ | Unix.Unix_error _) as exn ->
         let bt = Printexc.get_raw_backtrace () in
         Lang.raise_as_runtime ~bt ~kind:"system" exn
 
@@ -483,7 +488,7 @@ class virtual ['a] file_output_base p =
               Utils.ensure_dir ~perm:dir_perm filename;
               Atomic.set current_filename (Some filename);
               (filename, mode, perm)
-            with Sys_error _ as exn ->
+            with (Sys_error _ | Unix.Unix_error _) as exn ->
               let bt = Printexc.get_raw_backtrace () in
               Lang.raise_as_runtime ~bt ~kind:"system" exn)
 
@@ -491,7 +496,7 @@ class virtual ['a] file_output_base p =
       try
         let filename, mode, perm = self#prepare_filename in
         self#open_out_gen mode perm filename
-      with Sys_error _ as exn ->
+      with (Sys_error _ | Unix.Unix_error _) as exn ->
         let bt = Printexc.get_raw_backtrace () in
         Lang.raise_as_runtime ~bt ~kind:"system" exn
 
@@ -504,7 +509,7 @@ class virtual ['a] file_output_base p =
           | Some f -> self#on_close f
           | None -> ());
         Atomic.set current_filename None
-      with Sys_error _ as exn ->
+      with (Sys_error _ | Unix.Unix_error _) as exn ->
         let bt = Printexc.get_raw_backtrace () in
         Lang.raise_as_runtime ~bt ~kind:"system" exn
 

--- a/src/core/builtins/builtins_clock.ml
+++ b/src/core/builtins/builtins_clock.ml
@@ -64,9 +64,8 @@ let _ =
         Lang.string_t,
         Some (Lang.string "auto"),
         Some
-          "Clock sync mode. Should be one of: `\"auto\"`, `\"CPU\"`, \
-           `\"unsynced\"` or `\"passive\"`. Defaults to `\"auto\"`. Defaults \
-           to: \"auto\"" );
+          "Clock sync mode. Should be one of: `\"auto\"`, `\"cpu\"`, \
+           `\"none\"` or `\"passive\"`. Defaults to `\"auto\"`." );
     ]
     Lang_clock.ClockValue.t
     (fun p ->
@@ -88,8 +87,8 @@ let _ =
           raise
             (Error.Invalid_value
                ( sync,
-                 "Invalid sync mode! Should be one of: `\"auto\"`, `\"CPU\"`, \
-                  `\"unsynced\"` or `\"passive\"`",
+                 "Invalid sync mode! Should be one of: `\"auto\"`, `\"cpu\"`, \
+                  `\"none\"` or `\"passive\"`",
                  [] ))
       in
       Lang_clock.ClockValue.to_value

--- a/src/libs/switches.liq
+++ b/src/libs/switches.liq
@@ -142,7 +142,10 @@ def rotate(
   s.on_track(synchronous=true, f)
 
   def replaces s =
-    fallback(id=id, track_sensitive=true, s::sources)
+    rotation = s
+    s = fallback(id=id, track_sensitive=true, rotation::sources)
+    source.set_id(rotation, "#{source.id(s)}.rotate")
+    s
   end
 
   s
@@ -233,7 +236,10 @@ def replaces random(
   s.on_track(synchronous=true, f)
 
   def replaces s =
-    fallback(id=id, track_sensitive=true, s::sources)
+    selection = s
+    s = fallback(id=id, track_sensitive=true, selection::sources)
+    source.set_id(selection, "#{source.id(s)}.random")
+    s
   end
 
   s

--- a/tests/regression/dune.inc
+++ b/tests/regression/dune.inc
@@ -1570,6 +1570,23 @@
  (action (run %{run_test} output_on_track liquidsoap %{test_liq} output_on_track.liq)))
   
 (rule
+ (alias output_reopen_on_error_delay)
+ (package liquidsoap)
+ 
+ (deps
+  output_reopen_on_error_delay.liq
+  ../media/all_media_files
+  ../../src/bin/liquidsoap.exe
+  ../streams/file1.png
+  ../streams/file1.mp3
+  ./theora-test.mp4
+  (package liquidsoap)
+  (source_tree ../../src/libs)
+  (:test_liq ../test.liq)
+  (:run_test ../run_test.exe))
+ (action (run %{run_test} output_reopen_on_error_delay liquidsoap %{test_liq} output_reopen_on_error_delay.liq)))
+  
+(rule
  (alias playlist-id)
  (package liquidsoap)
  
@@ -1816,6 +1833,7 @@
     (alias metadata_cache)
     (alias output_on_metadata)
     (alias output_on_track)
+    (alias output_reopen_on_error_delay)
     (alias playlist-id)
     (alias replaygain)
     (alias seek_track_map)

--- a/tests/regression/output_reopen_on_error_delay.liq
+++ b/tests/regression/output_reopen_on_error_delay.liq
@@ -1,0 +1,44 @@
+# Failing to open the file leaves the output in its `Idle` state, so the delay
+# returned by `reopen_on_error` used to be ignored and the output retried on
+# every streaming cycle.
+
+dir = file.temp_dir("liq", "reopen")
+
+# A regular file where the output expects a directory: creating the output's
+# parent directory then always fails.
+blocker = path.concat(dir, "blocker")
+file.write(data="", blocker)
+target = path.concat(blocker, "out.wav")
+
+attempts = ref(0)
+
+def on_error(_) =
+  ref.incr(attempts)
+  1.
+end
+
+output.file(%wav, target, sine(), fallible=true, reopen_on_error=on_error)
+
+def check() =
+  # One immediate attempt plus roughly one per second: a handful, not one per
+  # streaming cycle.
+  if
+    attempts() == 0
+  then
+    print(
+      "reopen_on_error was never called"
+    )
+    test.fail()
+  elsif
+    attempts() > 10
+  then
+    print(
+      "reopen_on_error was called #{attempts()} times in 3s, delay ignored"
+    )
+    test.fail()
+  else
+    test.pass()
+  end
+end
+
+thread.run(delay=3., check)


### PR DESCRIPTION
Backport to `v2.4.x-latest` of the @vitoyucepi issue batch fixed on `main`. Each fix was reproduced and re-verified against this branch, not just cherry-picked. `CHANGES.md` is updated under 2.4.6.

One fix from the `main` PR is missing here: the `%mp3` segfault on Alpine (#3936) lives in the lame bindings, which `main` vendors under `src/modules/synced/lame` and this branch still consumes from opam. It reaches 2.4.x only through an `ocaml-lame` release.

## Running as root exits (#3406)

`init.allow_root` defaults to `Utils.is_docker`, which greps `/proc/1/cgroup` for `docker` or `lxc`. Under cgroup v2 that file is just `0::/`, so the detection never fires and liquidsoap refuses to start as root inside a plain `docker run` — including for `liquidsoap --interactive`, where there is nothing to protect. Running as root is now a warning rather than a fatal exit, which is the direction agreed on in the issue thread. `init.allow_root` is kept and now means "do not warn".

## Log output dropped when exiting before the streaming loop (#3375)

The reported symptom was that the `"set" is deprecated` warning never shows up. It is not container-specific: dtools buffers log entries until the log is started, and `Dtools.Log.stop` discards the queue when the log was never started. Every message emitted while evaluating the script — deprecation warnings, the version banner, anything a script logs at startup — was therefore lost whenever liquidsoap exited before reaching the streaming loop, which is exactly what the reporter's script did (`No output defined, nothing to do.`).

The log is now started before those exits so the queue is flushed. Tooling modes set `run_streams` to `false` and stay silent as before, so `--check`, `-h`, `--list-settings` and friends produce no new output.

## `reopen_on_error` delay ignored, `output.file` errors not catchable (#2437)

Two things here. Errors from `output.file` are catchable today through `reopen_on_error`, but the delay it returns was ignored when the failure happened while *opening* the file: `start` raising leaves the output in its `Idle` state, so the next streaming cycle immediately tried to start it again. In practice the callback fired on every streaming cycle — 156 times in three seconds in the added test — instead of once per delay. The output now skips its cycle while it is waiting to re-open.

Separately, `Utils.ensure_dir` raises `Unix.Unix_error`, which the `Sys_error`-only handlers in `file_output_base` did not convert, so a permission error on the destination directory reached the callback as `kind="output"` rather than `kind="system"`. Both are now handled the same way.

## Anonymous internal sources in `rotate` and `random` (#3851)

Both operators build an internal switch that was left with a generated id, so logs read `[switch.3:3] Switch to Music_A.` with nothing tying it to the operator it belongs to. The internal switch is now named after the operator, e.g. `schedule_rotate` and `shuffle_random`.

## `clock.create` sync modes

Drive-by: the parameter documentation and the error message advertise `"CPU"` and `"unsynced"`, neither of which the parser accepts — following the documentation gives `Invalid sync mode!` listing the very value you passed. The accepted values are `"auto"`, `"cpu"`, `"none"` and `"passive"`, and that is what is documented and reported now.

## Tests

`tests/regression/output_reopen_on_error_delay.liq` points a file output at a path whose parent cannot be created and counts `reopen_on_error` calls over three seconds. It fails on the unpatched tree (156 calls) and passes with the fix. The other changes are either not testable in-process (the root check needs uid 0, the log flush needs to observe a subprocess's stdout) or are documentation.

## Issues looked at and deliberately not fixed here

- **#3971, blank frames in CUE playlists.** Root-caused, but not a liquidsoap bug: the gap is ffmpeg's mp3 seek. `ffmpeg -ss 1 -i 1.mp3` on its own emits ~140ms of silence, and liquidsoap's decoder discards pre-target packets rather than decoding them, so the codec starts cold. Feeding it the packet before the target is not enough — closing the gap means seeking well before the cue point and decode-discarding on every cue-in. Worth doing separately, not as part of this batch.
- **#3061, `start=false` ignored.** No longer reproduces on `main` or on `v2.4.x-latest`: the output stays stopped in both. Can be closed.
- **#3343, playlist order after reload.** Not reproducible here. The reproduction needs inotify to deliver the truncate and the write as separate events; on macOS the watcher polls, and reloads land on the complete file with correct ordering every time.
- **#4785 / #4859 (ogg/opus through `%ffmpeg`), #3824 (unicode regexp), #4502, #3543, #1829, #2841** are upstream (ffmpeg, ocaml-re) or need the larger rewrites already discussed in their threads.
