### PR TITLE
file_watcher: watch the directory, not the file inode (2.4.x)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,13 @@
 
 ## Fixed:
 
+- Fixed `file.watch` losing track of a file that gets replaced rather than
+  written in place: an inotify watch follows the inode, so a writer doing the
+  usual write-to-temporary-then-rename silenced the watcher for good. The
+  containing directory is watched instead. `playlist` with `reload_mode="watch"`
+  also waits for a burst of events to settle before reloading, so a writer that
+  truncates before writing no longer triggers two racing reloads and plays
+  tracks out of order (#3343)
 - Anything logged while evaluating the script, deprecation warnings in
   particular, was silently dropped when liquidsoap exited before reaching the
   streaming loop, e.g. on `No output defined, nothing to do.` (#3375)

--- a/src/core/optionals/file_watcher/liq_file_watcher.inotify.ml
+++ b/src/core/optionals/file_watcher/liq_file_watcher.inotify.ml
@@ -34,8 +34,19 @@ type watch =
   (unit -> unit) ->
   unwatch
 
+(* An inotify watch follows the inode, not the path. Watching a file directly
+   therefore stops reporting as soon as that file is replaced rather than
+   modified in place, which is what a writer doing the usual write-to-temporary
+   then rename does. We watch the containing directory instead and keep the
+   basename to sort out which events are ours. *)
+type handler = {
+  wd : Inotify.watch;
+  basename : string option;
+  callback : unit -> unit;
+}
+
 let fd = ref (None : Unix.file_descr option)
-let handlers = ref []
+let handlers = ref ([] : handler list)
 let m = Mutex.create ()
 let log = Log.make ["inotify"]
 
@@ -45,11 +56,17 @@ let rec watchdog () =
     Mutex_utils.mutexify m (fun _ ->
         let events = Inotify.read fd in
         List.iter
-          (fun (wd, _, _, _) ->
-            match List.assoc wd !handlers with
-              | f -> f ()
-              | exception Not_found -> (
-                  try Inotify.rm_watch fd wd with _ -> ()))
+          (fun (wd, _, _, name) ->
+            (* Watch descriptors are per path, so watches on two files of the
+               same directory share one and all of them have to be considered. *)
+              match List.filter (fun h -> h.wd = wd) !handlers with
+              | [] -> ( try Inotify.rm_watch fd wd with _ -> ())
+              | l ->
+                  List.iter
+                    (fun h ->
+                      if h.basename = None || h.basename = name then
+                        h.callback ())
+                    l)
           events;
         [watchdog ()])
   in
@@ -64,6 +81,10 @@ let watch : watch =
         fd := Some (Inotify.create ());
         Duppy.Task.add Tutils.scheduler (watchdog ()));
       let fd = Option.get !fd in
+      let watched, basename =
+        if Sys.is_directory file then (file, None)
+        else (Filename.dirname file, Some (Filename.basename file))
+      in
       let event_conv = function
         | `Modify ->
             [
@@ -72,17 +93,19 @@ let watch : watch =
               Inotify.S_Delete;
               Inotify.S_Create;
             ]
-            @ if Sys.is_directory file then [] else [Inotify.S_Modify]
+            @ if basename = None then [] else [Inotify.S_Modify]
       in
       let e = List.flatten (List.map event_conv e) in
-      let wd = Inotify.add_watch fd file e in
-      handlers := (wd, f) :: !handlers;
+      let wd = Inotify.add_watch fd watched e in
+      let handler = { wd; basename; callback = f } in
+      handlers := handler :: !handlers;
       Mutex_utils.mutexify m (fun () ->
-          (try Inotify.rm_watch fd wd
-           with exn ->
-             let bt = Printexc.get_backtrace () in
-             Utils.log_exception ~log ~bt
-               (Printf.sprintf "Error while removing file watch handler: %s"
-                  (Printexc.to_string exn)));
-          handlers := List.remove_assoc wd !handlers))
+          handlers := List.filter (fun h -> h != handler) !handlers;
+          if not (List.exists (fun h -> h.wd = wd) !handlers) then (
+            try Inotify.rm_watch fd wd
+            with exn ->
+              let bt = Printexc.get_backtrace () in
+              Utils.log_exception ~log ~bt
+                (Printf.sprintf "Error while removing file watch handler: %s"
+                   (Printexc.to_string exn)))))
     ()

--- a/src/libs/playlist.liq
+++ b/src/libs/playlist.liq
@@ -1215,11 +1215,34 @@ def replaces playlist(
   elsif
     reload_mode == "watch"
   then
+    # A writer that truncates before writing, `cat new > playlist.m3u` being the
+    # usual one, fires the watcher twice, and the first event sees the file
+    # empty or half written. Let the burst settle before reloading, or the two
+    # reloads race each other and the playlist restarts twice.
+    settle = 0.5
+    reload_scheduled = ref(false)
+
+    def on_watch_event() =
+      if
+        not reload_scheduled()
+      then
+        reload_scheduled := true
+        thread.run(
+          delay=settle,
+          fun () ->
+            begin
+              reload_scheduled := false
+              s.reload()
+            end
+        )
+      end
+    end
+
     watcher =
       if
         file.exists(playlist_uri())
       then
-        ref(null(file.watch(playlist_uri(), s.reload)))
+        ref(null(file.watch(playlist_uri(), on_watch_event)))
       else
         ref(null)
       end
@@ -1234,7 +1257,7 @@ def replaces playlist(
         if null.defined(w) then null.get(w).unwatch() end
         watched_uri := uri
         watcher :=
-          if file.exists(uri) then file.watch(uri, s.reload) else null end
+          if file.exists(uri) then file.watch(uri, on_watch_event) else null end
       end
     end
 

--- a/tests/language/dune.inc
+++ b/tests/language/dune.inc
@@ -169,6 +169,19 @@
  (action (run %{run_test} file.watch2.liq liquidsoap %{test_liq} file.watch2.liq)))
   
 (rule
+ (alias file.watch3)
+ (package liquidsoap)
+ (deps
+  file.watch3.liq
+  ../../src/bin/liquidsoap.exe
+  (package liquidsoap)
+  (source_tree ../../src/libs)
+  crontab_test_cases.json
+  (:test_liq ../test.liq)
+  (:run_test ../run_test.exe))
+ (action (run %{run_test} file.watch3.liq liquidsoap %{test_liq} file.watch3.liq)))
+  
+(rule
  (alias file_protocol)
  (package liquidsoap)
  (deps
@@ -638,6 +651,7 @@
     (alias file)
     (alias file.watch)
     (alias file.watch2)
+    (alias file.watch3)
     (alias file_protocol)
     (alias functions)
     (alias getter)

--- a/tests/language/file.watch3.liq
+++ b/tests/language/file.watch3.liq
@@ -1,0 +1,38 @@
+# Regression test for #3343.
+#
+# An inotify watch follows the inode, so watching the file itself stopped
+# reporting as soon as a writer replaced it instead of writing in place --
+# which is what the usual write-to-temporary-then-rename does.
+
+uname_s =
+  string.trim(
+    process.run(
+      "uname -s"
+    ).stdout
+  )
+
+if uname_s == "Darwin" then test.skip() end
+
+success = ref(false)
+fname = file.temp("liq", "test")
+tmp = "#{fname}.tmp"
+
+on_cleanup({file.remove(fname)})
+
+file.write(data="abc", fname)
+file.watch(fname, {success := true})
+
+def replace() =
+  file.write(data="xxx", tmp)
+  file.move(force=true, tmp, fname)
+end
+
+thread.run(delay=1., replace)
+
+def check() =
+  if success() then test.pass() else test.fail() end
+end
+
+thread.run(delay=3., check)
+
+output.dummy(blank())

--- a/tests/regression/output_reopen_on_error_delay.liq
+++ b/tests/regression/output_reopen_on_error_delay.liq
@@ -1,3 +1,5 @@
+# Regression test for #2437.
+#
 # Failing to open the file leaves the output in its `Idle` state, so the delay
 # returned by `reopen_on_error` used to be ignored and the output retried on
 # every streaming cycle.


### PR DESCRIPTION
Backport of #5325 to `v2.4.x-latest`, re-verified against this branch. `CHANGES.md` is updated under 2.4.6. Fixes #3343, and with it the failure @kingpalethe reported further down the same thread. They are two symptoms of one cause, and between them they leave no way to update a watched playlist correctly.

## What is happening

`file.watch` puts the inotify watch on the file itself, and an inotify watch follows the inode. Measured on Linux with `inotifywait` on a single file:

```
printf b > pl.m3u          ->  pl.m3u MODIFY
                               pl.m3u MODIFY      # truncate, then write
cp pl.m3u t; mv -f t pl.m3u ->  (nothing)
printf c > pl.m3u          ->  (nothing, ever again)
```

So:

- **Replacing the file** — write to a temporary, rename over the target, which is what any careful writer does — kills the watch silently. The playlist never reloads again. That is @kingpalethe's report.
- **Writing in place** with `cat new > pl.m3u` fires **twice**, because truncating is itself a modification, and the first event lands on an empty or half written file. Two reloads then race each other and the streaming thread's `next()`. That is the original report: on the `main` image the playlist restarts mid-list and repeats tracks —

  ```
  -- watch event --
  -- watch event --
  TRACK 3.mp3
  TRACK 4.mp3
  TRACK 3.mp3     <- back to 3
  TRACK 1.mp3
  ```

  On `v2.4.2` the ordering survives but the first track plays twice.

macOS never showed either, which is why this sat open: the mtime backend polls the *path* and coalesces by construction.

## The fix

**`liq_file_watcher.inotify.ml`** — for a file target, watch the containing directory and filter events on the basename, which is what the mtime backend effectively does. Same `inotifywait` sequence against a directory watch reports all three writes, the rename as `MOVED_TO`.

A watch descriptor is per path, so two watches on files in one directory now share one. Handlers are therefore matched by descriptor *and* name rather than looked up with `List.assoc`, and a descriptor is only removed once its last handler is gone.

**`playlist.liq`** — with `reload_mode="watch"`, let a burst settle (0.5s) before reloading. Watching the directory does not make the double event go away — truncate-then-write is genuinely two modifications — so without this the race stays.

## Tests

`tests/language/file.watch3.liq`, alongside the existing `file.watch`/`file.watch2`: write a temporary, rename it over the watched file, assert the callback fires. It skips on Darwin like `file.watch.liq` does, since it is about the inotify backend specifically.

## What is verified, and what is not

- The syscall behaviour above, on Linux, both before and after.
- The new matching logic compiles against the real `Inotify` API and behaves: a standalone probe using the same types and patterns fires 4 callbacks across write → rename → write, where the old file watch stopped at 2 and went silent at the rename, and unwatch leaves no handler behind.
- The `playlist.liq` side and the full build, on macOS.

Not verified: `liq_file_watcher.inotify.ml` compiled *in tree*. Nothing I can reach builds it — the inotify backend is Linux only and the Linux box I have needs a system `libcurl` I did not want to install on it. CI covers it.

Also names the issue in the `reopen_on_error` regression test added by #5323, which went in without the reference.
