### PR TITLE
hls: wait for a keyframe before splitting a segment (2.4.x)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,15 @@
 
 ## Fixed:
 
+- HLS: `EXT-X-TARGETDURATION` now covers the longest segment in the playlist
+  instead of always announcing `segment_duration`. A segment that overshoots,
+  which already happened at frame boundaries, made the playlist violate the HLS
+  specification (#5266)
+- HLS: added `wait_for_keyframe`. When reaching `segment_duration` with no
+  keyframe to split on, the output waits for the next one instead of splitting
+  anyway, which is what the `ffmpeg` HLS muxer does with `-hls_time`. Segments
+  then last longer than `segment_duration` but start on a keyframe. Defaults to
+  `false` on this branch, keeping the existing behaviour (#5266)
 - Fixed `file.watch` losing track of a file that gets replaced rather than
   written in place: an inotify watch follows the inode, so a writer doing the
   usual write-to-temporary-then-rename silenced the watcher for good. The

--- a/doc/content/hls_output.md
+++ b/doc/content/hls_output.md
@@ -37,8 +37,13 @@ Keyframes are very common in video codecs and can exist in audio codecs.
 In order to make sure that a HLS playlist can be decoded starting from any segment, liquidsoap tries to split segments on keyframe boundaries. When not possible,
 you will see a warning in the logs.
 
-Segment split is forced when reaching the value specified by `EXT-X-TARGETDURATION` to follow the HLS specifications. For metadata and extra tags, segment split will
-occur at the next keyframe.
+Segment split is forced when reaching `segment_duration`, so that segments stay close to the requested length. When no keyframe is available at that point, the
+segment is split anyway and a warning is logged: the resulting segment does not start with a keyframe and cannot be decoded on its own. For metadata and extra tags,
+segment split always waits for the next keyframe.
+
+Passing `wait_for_keyframe=true` makes the duration split wait as well, which is what the `ffmpeg` HLS muxer does with `-hls_time`. Segments then last until the next
+keyframe, longer than `segment_duration`, and `EXT-X-TARGETDURATION` grows to cover them. Use it when you do not control the keyframe frequency, typically when
+relaying an existing stream with `%ffmpeg(%audio.copy, %video.copy)`.
 
 To make sure that all these requirements operate correctly, you should make sure to set a keyframe frequency in your encoder's settings that generates at lease one
 keyframe per segment.

--- a/src/core/base/outputs/hls_output.ml
+++ b/src/core/base/outputs/hls_output.ml
@@ -120,6 +120,15 @@ let hls_proto frame_t =
         Lang.float_t,
         Some (Lang.float 10.),
         Some "Segment duration (in seconds)." );
+      ( "wait_for_keyframe",
+        Lang.bool_t,
+        Some (Lang.bool false),
+        Some
+          "When reaching `segment_duration` with no keyframe to split on, wait \
+           for the next one instead of splitting anyway. Segments then last \
+           longer than `segment_duration` and `EXT-X-TARGETDURATION` follows \
+           them, but they can always be decoded on their own. This is what the \
+           `ffmpeg` HLS muxer does with `-hls_time`." );
       ( "segment_name",
         segment_name_t,
         Some default_name,
@@ -435,6 +444,7 @@ class hls_output p =
   in
   let strict_persist = Lang.to_bool (List.assoc "strict_persist" p) in
   (* better choice? *)
+  let wait_for_keyframe = Lang.to_bool (List.assoc "wait_for_keyframe" p) in
   let segment_duration = Lang.to_float (List.assoc "segment_duration" p) in
   let segment_ticks =
     Frame.main_of_seconds segment_duration / Lazy.force Frame.size
@@ -847,6 +857,12 @@ class hls_output p =
               (current_discontinuity, id - 1)
           | [] -> (0, 0)
       in
+      (* Every segment has to fit within the announced target duration. *)
+      let target_duration =
+        List.fold_left
+          (fun d (_, { len }) -> Float.max d (Frame.seconds_of_main len))
+          segment_duration segments
+      in
       let filename = self#playlist_name s in
       self#log#debug "Writing playlist %s.." s.name;
       let oc = self#open_out (fun () -> filename) in
@@ -856,7 +872,7 @@ class hls_output p =
           oc#output_string "#EXTM3U\r\n";
           oc#output_string
             (Printf.sprintf "#EXT-X-TARGETDURATION:%d\r\n"
-               (int_of_float (ceil segment_duration)));
+               (int_of_float (ceil target_duration)));
           oc#output_string (Printf.sprintf "#EXT-X-VERSION:%d\r\n" x_version);
           oc#output_string
             (Printf.sprintf "#EXT-X-MEDIA-SEQUENCE:%d\r\n" media_sequence);
@@ -1065,7 +1081,7 @@ class hls_output p =
             "Terminating current segment %d on stream %s to make expected \
              length"
             segment.id s.name,
-          true )
+          not wait_for_keyframe )
       else if s.id3_enabled && pending_metadata s.metadata then
         ( true,
           Printf.sprintf

--- a/tests/streams/dune.inc
+++ b/tests/streams/dune.inc
@@ -928,6 +928,35 @@
  (action (run %{run_test} hls_main_playlist.liq liquidsoap %{test_liq} hls_main_playlist.liq)))
   
 (rule
+ (alias hls_wait_for_keyframe)
+ (package liquidsoap)
+ (deps
+  hls_wait_for_keyframe.liq
+  ./file1.mp3
+  ./file2.mp3
+  ./file3.mp3
+  ./jingle1.mp3
+  ./jingle2.mp3
+  ./jingle3.mp3
+  ./file1.png
+  ./file2.png
+  ./jingles
+  ./playlist
+  ./huge_playlist
+  ./replaygain_track_gain.mp3
+  ./r128_track_gain.mp3
+  ./replaygain_r128_track_gain.mp3
+  ./replaygain_track_gain.opus
+  ./r128_track_gain.opus
+  ./replaygain_r128_track_gain.opus
+  ./without_replaygain_track_gain.mp3
+  ../../src/bin/liquidsoap.exe
+  (package liquidsoap)
+  (:test_liq ../test.liq)
+  (:run_test ../run_test.exe))
+ (action (run %{run_test} hls_wait_for_keyframe.liq liquidsoap %{test_liq} hls_wait_for_keyframe.liq)))
+  
+(rule
  (alias huge-playlist)
  (package liquidsoap)
  (deps
@@ -2034,6 +2063,7 @@
     (alias hls_id3v2)
     (alias hls_large_frame)
     (alias hls_main_playlist)
+    (alias hls_wait_for_keyframe)
     (alias huge-playlist)
     (alias icecast_last_meta)
     (alias icecast_no_restart)

--- a/tests/streams/hls_wait_for_keyframe.liq
+++ b/tests/streams/hls_wait_for_keyframe.liq
@@ -1,0 +1,99 @@
+# Regression test for #5266.
+#
+# With keyframes further apart than `segment_duration`, the output used to
+# split anyway, producing segments that do not start on a keyframe and cannot
+# be decoded on their own. `wait_for_keyframe` holds the segment open until the
+# encoder offers a split point, and `EXT-X-TARGETDURATION` has to grow to cover
+# the segments that result.
+
+tmp_dir = file.temp_dir("tmp")
+on_cleanup({file.rmdir(tmp_dir)})
+
+s = mksafe(sine())
+v = video.testsrc()
+s = source({audio=source.tracks(s).audio, video=source.tracks(v).video})
+
+clock.assign_new(sync="none", [s])
+
+# One keyframe every 100 frames, i.e. every 4s at 25fps, for 1s segments.
+enc =
+  %ffmpeg(
+    format = "mpegts",
+    %audio(codec = "aac", b = "64k"),
+    %video(codec = "libx264", g = 100, b = "300k", preset = "ultrafast")
+  )
+
+segment_duration = 1.
+
+done = ref(false)
+
+def check(fname) =
+  extinf = r/#EXTINF:([0-9.]+),/
+  targetdur = r/#EXT-X-TARGETDURATION:([0-9]+)/
+
+  longest = ref(0.)
+  target = ref(-1.)
+
+  def scan(line) =
+    if
+      extinf.test(line)
+    then
+      d = float_of_string(list.assoc(1, extinf.exec(line)))
+      longest := max(longest(), d)
+    elsif
+      targetdur.test(line)
+    then
+      target := float_of_string(list.assoc(1, targetdur.exec(line)))
+    end
+  end
+
+  list.iter(scan, string.split(separator="\n", file.contents(fname)))
+
+  if
+    0. < longest() and 0. <= target()
+  then
+    done := true
+
+    # Segments run to the keyframe interval, 4s, rather than being cut at
+    # segment_duration. Without waiting they come out just past 1s.
+    if
+      longest() < 3.
+    then
+      print(
+        "longest segment is #{longest()}s, expected it to reach the keyframe"
+      )
+      test.fail()
+      # Every segment fits in the announced target duration.
+    elsif
+      target() < longest()
+    then
+      print(
+        "EXT-X-TARGETDURATION #{target()} is below the longest segment #{
+          longest()
+        }"
+      )
+      test.fail()
+    else
+      test.pass()
+    end
+  end
+end
+
+playlist = path.concat(tmp_dir, "stream.m3u8")
+
+def poll() =
+  if not done() and file.exists(playlist) then check(playlist) end
+end
+
+thread.run(delay=1., every=0.5, poll)
+
+output.file.hls(
+  wait_for_keyframe=true,
+  segment_duration=segment_duration,
+  segments=10,
+  tmp_dir,
+  [("stream", enc)],
+  s
+)
+
+thread.run(delay=60., test.fail)


### PR DESCRIPTION
Backport of #5327 to `v2.4.x-latest`, re-verified against this branch. `CHANGES.md` is updated under 2.4.6.

The one difference: `wait_for_keyframe` defaults to `false` here, so this branch's behaviour is unchanged unless you opt in.

## Reproducing it

Keyframes every 4s, segments asked every 1s, so most splits land with no keyframe available:

```liquidsoap
enc = %ffmpeg(format="mpegts", %audio(codec="aac", b="64k"),
              %video(codec="libx264", g=100, b="300k", preset="ultrafast"))
output.file.hls(segment_duration=1., segments=10, ".", [("s", enc)], s)
```

20s of that logs `Splitting segment without a new keyframe!` 13 times, and the segments it writes are not media:

```
$ ffprobe -v error -select_streams v:0 -count_frames s_12.ts
non-existing PPS 0 referenced
no frame!
Stream #0:2: Video: h264, none, 25 fps          <- no resolution
```

The playlist is also invalid on its own terms, and was before this change: `#EXT-X-TARGETDURATION:1` while carrying `#EXTINF:1.300`. Segments already overshoot at frame boundaries, and RFC 8216 §4.3.3.1 requires every segment to fit within the announced target duration.

`ffmpeg -hls_time 1` on the same encode, as the reporter described:

```
#EXT-X-TARGETDURATION:4
#EXTINF:4.000000,
```

100 video frames per segment, clean decode.

## Changes

**`wait_for_keyframe`, default `false`.** When the duration target is reached with no keyframe to split on, wait for the next one instead of splitting anyway. The machinery was already there: `should_reopen` returns whether a split may proceed without a segmentable position, and metadata and extra-tag splits already decline to. This only changes what happens in the case that is currently broken; when keyframes line up with `segment_duration`, nothing moves.

On `main` this defaults to `true`; here it stays `false` to keep backward compatibility.

**`EXT-X-TARGETDURATION` is the longest segment in the playlist** rather than `segment_duration`. Required once segments may run long, and a fix on its own for the `1.300` case above.

With `wait_for_keyframe=true`: 0 forced splits, `EXT-X-TARGETDURATION:5`, `EXTINF:4.020`, and segments start on a keyframe.

## Test

`tests/streams/hls_wait_for_keyframe.liq` runs the setup above and asserts, from the playlist, that segments reach the keyframe interval rather than being cut at `segment_duration`, and that the target duration covers the longest one. It fails with `wait_for_keyframe=false` ("longest segment is 1.3s") and passes with `true`. The existing HLS tests stay green.

## Something else this turned up, not fixed here

Splitting on a keyframe is necessary but not sufficient. With `wait_for_keyframe` on, the segment does start on a keyframe, and ffmpeg still decodes exactly one frame out of each segment past the first:

```
$ ffmpeg -v error -i s_3.ts -map 0:v -f null -
[h264] non-existing PPS 0 referenced
frame=    1
```

against 100 for an `ffmpeg -hls_time` segment of the same encode. Concatenate our segments and the stream is perfect — 401 frames, 16.04s, 25fps — so the data is all there and only per-segment independence is broken.

I could not pin the cause and do not want to guess in a commit message. Two things I ruled out: the parameter sets are present (`trace_headers` finds 2 SPS and 2 PPS per segment, same as ffmpeg's), and the segments are correctly TS-aligned (size a multiple of 188, first byte `0x47`). Worth its own issue; it is arguably the larger half of what the reporter is seeing, and this PR does not close it.
