### PR TITLE
clock: contain errors raised while shutting down a failed source

### DIFF
--- a/src/core/source/source.ml
+++ b/src/core/source/source.ml
@@ -422,7 +422,19 @@ class virtual operator ?(stack = []) ?clock ~name sources =
           | `Passive | `Active _ ->
               Clock.detach self#clock (self :> Clock.source)
           | `Output _ -> ());
-        List.iter (fun fn -> fn ()) on_sleep)
+        (* Sources are typically put to sleep while already failing: a shutdown
+           error escaping here would kill the clock thread, defeating the
+           clock's [on_error] containment. *)
+        List.iter
+          (fun fn ->
+            try fn ()
+            with exn ->
+              let bt = Printexc.get_raw_backtrace () in
+              Utils.log_exception ~log
+                ~bt:(Printexc.raw_backtrace_to_string bt)
+                (Printf.sprintf "Error while shutting down source %s: %s!"
+                   self#id (Printexc.to_string exn)))
+          on_sleep)
 
     method sleep (src : Clock.activation) =
       if not (WeakQueue.exists activations (fun a -> a == src)) then (

--- a/tests/regression/GH5260.liq
+++ b/tests/regression/GH5260.liq
@@ -1,0 +1,64 @@
+# Regression test for https://github.com/savonet/liquidsoap/issues/5260
+# An error raised while shutting down a failed output must not kill the clock
+# thread: the clock keeps animating its remaining sources.
+
+failed = ref(false)
+frames_after_failure = ref(0)
+
+failing = sine()
+
+def fail_once() =
+  if
+    not failed()
+  then
+    failed := true
+    error.raise(
+      error.failure,
+      "streaming failure"
+    )
+  end
+end
+
+failing.on_frame(synchronous=true, fail_once)
+
+o = output.dummy(failing)
+o.on_stop(
+  synchronous=true,
+  fun () ->
+    error.raise(
+      error.failure,
+      "cleanup failure"
+    )
+)
+
+# Same clock as the failing output: it must keep ticking once the failure has
+# been contained.
+healthy = sine()
+
+def check() =
+  if
+    failed()
+  then
+    frames_after_failure := frames_after_failure() + 1
+    if frames_after_failure() >= 20 then test.pass() end
+  end
+end
+
+healthy.on_frame(synchronous=true, check)
+output.dummy(healthy)
+
+clock.assign_new(
+  id="failing",
+  sync="none",
+  on_error=fun (_) -> (),
+  [failing, healthy]
+)
+
+thread.run(
+  delay=20.,
+  {
+    test.fail(
+      "clock stopped ticking after the failed output was shut down"
+    )
+  }
+)

--- a/tests/regression/dune.inc
+++ b/tests/regression/dune.inc
@@ -1270,6 +1270,24 @@
   (run %{run_test} GH5259 liquidsoap %{test_liq} GH5259.liq)))
 
 (rule
+ (alias test_GH5260)
+ (package liquidsoap)
+ (deps
+  GH5260.liq
+  (glob_files ../media/**)
+  ../liquidsoap-test-assets
+  ../../src/bin/liquidsoap.exe
+  ../streams/file1.png
+  ../streams/file1.mp3
+  ./theora-test.mp4
+  (package liquidsoap)
+  (source_tree ../../src/libs)
+  (:test_liq ../test.liq)
+  (:run_test ../run_test.exe))
+ (action
+  (run %{run_test} GH5260 liquidsoap %{test_liq} GH5260.liq)))
+
+(rule
  (alias test_GH5261)
  (package liquidsoap)
  (deps
@@ -2445,6 +2463,7 @@
   (alias test_GH5110)
   (alias test_GH5148)
   (alias test_GH5259)
+  (alias test_GH5260)
   (alias test_GH5261)
   (alias test_GH5287)
   (alias test_GH5319)


### PR DESCRIPTION
Closes #5260.

A clock's `on_error` handler is supposed to contain a source failure: the failed source is detached and the clock keeps running. It could be defeated by the detach itself. Putting a source to sleep runs its shutdown handlers, which for an output means `#stop`, and `#stop` frequently touches the very resource that just failed. The reported case is `output.file.hls` with `persist_at` set: on stop it saves its state and closes the current segment, which hits the same failed rename that triggered the original error. That second exception escaped the clock thread uncaught, so the containment the user asked for was undone by the cleanup that followed it.

The escape route is the same whether the detach runs synchronously or is deferred to the end of the tick, because both go through `Source.actual_sleep`. The fix is there: the `on_sleep` handlers now run under a guard that logs the error and continues to the next handler, so a source that is already failing cannot take the clock thread with it on the way out. `Clock.has_stopped` already swallowed these errors silently on the global-shutdown path; that case is now logged too.

On `main` the HLS trigger specifically no longer reaches the clock, since #5259 gave the HLS output a `reopen_on_error` retry, but the defect itself is unchanged and any output whose shutdown raises reproduces it.

`tests/regression/GH5260.liq` builds that shape without any filesystem dependency: a source that raises once while streaming, an output whose `on_stop` raises, and a second, healthy output on the same clock. The test passes only if the clock keeps producing frames for the healthy output after the failure has been contained. It fails without the fix, with the clock thread aborting on the cleanup error.
