### PR TITLE
clock: contain errors raised while shutting down a failed source (2.4.x)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -42,6 +42,11 @@
   of the segment grid. The drift rate depends on the encoder's frame size, so
   variants using different codecs, e.g. HE-AAC and AAC-LC, diverged from each
   other without bound (#5319).
+- Fixed a clock's `on_error` handler being defeated by the shutdown of the
+  source it just contained: putting the failed source to sleep runs its cleanup,
+  e.g. `output.file.hls` closing its current segment when `persist_at` is set,
+  and an error raised there escaped uncaught and killed the process. Shutdown
+  errors are logged instead (#5260)
 
 ---
 

--- a/src/core/base/source.ml
+++ b/src/core/base/source.ml
@@ -384,7 +384,19 @@ class virtual operator ?(stack = []) ?clock ~name sources =
           | `Passive | `Active _ ->
               Clock.detach self#clock (self :> Clock.source)
           | `Output _ -> ());
-        List.iter (fun fn -> fn ()) on_sleep)
+        (* Sources are typically put to sleep while already failing: a shutdown
+           error escaping here would kill the clock thread, defeating the
+           clock's [on_error] containment. *)
+        List.iter
+          (fun fn ->
+            try fn ()
+            with exn ->
+              let bt = Printexc.get_raw_backtrace () in
+              Utils.log_exception ~log
+                ~bt:(Printexc.raw_backtrace_to_string bt)
+                (Printf.sprintf "Error while shutting down source %s: %s!"
+                   self#id (Printexc.to_string exn)))
+          on_sleep)
 
     method sleep (src : Clock.activation) =
       if not (WeakQueue.exists activations (fun a -> a == src)) then (

--- a/tests/regression/GH5260.liq
+++ b/tests/regression/GH5260.liq
@@ -1,0 +1,64 @@
+# Regression test for https://github.com/savonet/liquidsoap/issues/5260
+# An error raised while shutting down a failed output must not kill the clock
+# thread: the clock keeps animating its remaining sources.
+
+failed = ref(false)
+frames_after_failure = ref(0)
+
+failing = sine()
+
+def fail_once() =
+  if
+    not failed()
+  then
+    failed := true
+    error.raise(
+      error.failure,
+      "streaming failure"
+    )
+  end
+end
+
+failing.on_frame(synchronous=true, fail_once)
+
+o = output.dummy(failing)
+o.on_stop(
+  synchronous=true,
+  fun () ->
+    error.raise(
+      error.failure,
+      "cleanup failure"
+    )
+)
+
+# Same clock as the failing output: it must keep ticking once the failure has
+# been contained.
+healthy = sine()
+
+def check() =
+  if
+    failed()
+  then
+    frames_after_failure := frames_after_failure() + 1
+    if frames_after_failure() >= 20 then test.pass() end
+  end
+end
+
+healthy.on_frame(synchronous=true, check)
+output.dummy(healthy)
+
+clock.assign_new(
+  id="failing",
+  sync="none",
+  on_error=fun (_) -> (),
+  [failing, healthy]
+)
+
+thread.run(
+  delay=20.,
+  {
+    test.fail(
+      "clock stopped ticking after the failed output was shut down"
+    )
+  }
+)

--- a/tests/regression/dune.inc
+++ b/tests/regression/dune.inc
@@ -1145,6 +1145,23 @@
  (action (run %{run_test} GH5148 liquidsoap %{test_liq} GH5148.liq)))
   
 (rule
+ (alias GH5260)
+ (package liquidsoap)
+ 
+ (deps
+  GH5260.liq
+  ../media/all_media_files
+  ../../src/bin/liquidsoap.exe
+  ../streams/file1.png
+  ../streams/file1.mp3
+  ./theora-test.mp4
+  (package liquidsoap)
+  (source_tree ../../src/libs)
+  (:test_liq ../test.liq)
+  (:run_test ../run_test.exe))
+ (action (run %{run_test} GH5260 liquidsoap %{test_liq} GH5260.liq)))
+  
+(rule
  (alias GH5287)
  (package liquidsoap)
  
@@ -1825,6 +1842,7 @@
     (alias GH5019)
     (alias GH5110)
     (alias GH5148)
+    (alias GH5260)
     (alias GH5287)
     (alias GH5319)
     (alias LS268)


### PR DESCRIPTION
Backport of #5260's fix to `v2.4.x-latest`. The `main` PR carries the same change and closes the issue.

A clock's `on_error` handler is supposed to contain a source failure: the failed source is detached and the clock keeps running. It could be defeated by the detach itself. Putting a source to sleep runs its shutdown handlers, which for an output means `#stop`, and `#stop` frequently touches the very resource that just failed. The reported case is `output.file.hls` with `persist_at` set: on stop it saves its state and closes the current segment, which hits the same failed rename that triggered the original error. That second exception escaped the clock thread uncaught, so the containment the user asked for was undone by the cleanup that followed it.

On this branch the reporter's script reproduces verbatim: `on_error` logs its message, then the process dies with `Fatal error: exception Permission denied in rename(...)` and exit code 2.

The escape route is the same whether the detach runs synchronously or is deferred to the end of the tick, because both go through `Source.actual_sleep`. The fix is there: the `on_sleep` handlers now run under a guard that logs the error and continues to the next handler, so a source that is already failing cannot take the clock thread with it on the way out. `Clock.has_stopped` already swallowed these errors silently on the global-shutdown path; that case is now logged too.

`tests/regression/GH5260.liq` builds that shape without any filesystem dependency: a source that raises once while streaming, an output whose `on_stop` raises, and a second, healthy output on the same clock. The test passes only if the clock keeps producing frames for the healthy output after the failure has been contained. It fails without the fix, with the process dying on the cleanup error.
