### PR TITLE
ffmpeg/filter: build the graph again when its input comes back

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -63,6 +63,20 @@
 
 ## Fixed:
 
+- An FFmpeg filter graph is no longer finished off by an input that runs dry.
+  A source is unavailable for all sorts of passing reasons, a `buffer` filling
+  up or a queue waiting on a request, and liquidsoap has no way to tell those
+  from a stream that is over, so the graph treats every one of them as the end:
+  it flushes the filters, hands over the tail they were holding and tears the
+  graph down. What is new is that this is no longer final. avfilter cannot
+  reopen a graph that has seen end of file, so when the input comes back the
+  graph is built again from what the script described, and each generation is
+  announced as a new stream so its timestamps line up with the last. Graphs
+  holding a lookahead, `loudnorm` in particular, went silent within a second of
+  starting behind a `buffer` (#3944).
+- An FFmpeg filter graph dropped the tail its filters were holding at end of
+  stream: the sink never asked its duration converter for what it had left. A
+  5.00s source through `loudnorm` produced 2.08s, and now produces 4.98s.
 - Fixed the ffmpeg decoder leaving up to ~150ms of silence after a seek: the
   packets between the seek point and the target were dropped without being
   decoded, so codecs carrying state across packets, mp3 and its bit reservoir

--- a/doc/content/ffmpeg_filters.md
+++ b/doc/content/ffmpeg_filters.md
@@ -61,6 +61,8 @@ When applying FFmpeg filters to sources with both audio and video, pass all trac
 
 A graph is a single source, whatever its number of outputs. All of its outputs are produced together and share one buffer, one set of track marks and one readiness state: a track boundary reaching any output cuts every output of that graph. Consequently they must be consumed at converging rates, since waiting on the slowest lets the others accumulate; past `settings.ffmpeg.filter_max_buffer` (10s by default) this raises rather than growing without bound. For the same reason, `id` on any of the outputs names the graph itself, so passing it on more than one output of the same graph leaves the last one in effect.
 
+A graph lives for as long as its inputs keep delivering. When one runs dry — a `buffer` filling up, a request queue waiting on a resolution, a file-based source reaching its end — the graph is told the stream is over, hands over whatever its filters were holding back, and is torn down. It is built again from scratch when the input comes back, so a passing gap costs nothing but the filters' internal state: `loudnorm` measures the loudness of the new generation from zero, as it would on a fresh stream. Sources that run dry often and filters that take a while to settle therefore do not mix well; give such a graph an input that stays available, with `mksafe` for instance.
+
 Here is an example:
 
 ```{.liquidsoap include="ffmpeg-filter-hflip2.liq"}

--- a/src/core/optionals/ffmpeg/filter/builtins_ffmpeg_filter_parse.ml
+++ b/src/core/optionals/ffmpeg/filter/builtins_ffmpeg_filter_parse.ml
@@ -71,7 +71,8 @@ let _ =
        ])
     (fun p ->
       let graph_v = Lang.assoc "" 1 p in
-      let config = get_config graph_v in
+      (* Only to reject a graph variable used outside of its create block. *)
+      ignore (get_config graph_v);
       let graph = Graph.of_value graph_v in
       let description = Lang.to_string (List.assoc "description" p) in
 
@@ -103,139 +104,132 @@ let _ =
 
       let output_format_filters = ref None in
 
-      Queue.push graph.init
-        (Lazy.from_fun (fun () ->
-             let audio_output_formats =
-               List.map
-                 (fun name ->
-                   let aformat_name = uniq_name ("parse_aformat_out_" ^ name) in
-                   let aformat =
-                     Avfilter.attach ~name:aformat_name
-                       (Avfilter.find "aformat") config
-                   in
-                   (name, aformat))
-                 audio_output_names
-             in
+      Queue.push graph.init (fun () ->
+          let config = Builtins_ffmpeg_filters.current_config graph in
+          let audio_output_formats =
+            List.map
+              (fun name ->
+                let aformat_name = uniq_name ("parse_aformat_out_" ^ name) in
+                let aformat =
+                  Avfilter.attach ~name:aformat_name (Avfilter.find "aformat")
+                    config
+                in
+                (name, aformat))
+              audio_output_names
+          in
 
-             let video_output_formats =
-               List.map
-                 (fun name ->
-                   let format_name = uniq_name ("parse_format_out_" ^ name) in
-                   let format_ =
-                     Avfilter.attach ~name:format_name (Avfilter.find "format")
-                       config
-                   in
-                   (name, format_))
-                 video_output_names
-             in
+          let video_output_formats =
+            List.map
+              (fun name ->
+                let format_name = uniq_name ("parse_format_out_" ^ name) in
+                let format_ =
+                  Avfilter.attach ~name:format_name (Avfilter.find "format")
+                    config
+                in
+                (name, format_))
+              video_output_names
+          in
 
-             let audio_output_pads =
-               List.map
-                 (fun (name, pad_v) ->
-                   let caller_output =
-                     match Audio.of_value pad_v with
-                       | `Output lazy_pad -> Lazy.force lazy_pad
-                       | `Input _ ->
-                           failwith
-                             "ffmpeg.filter.parse: input pads must be output \
-                              pads from previous filters"
-                   in
-                   Avfilter.
-                     {
-                       node_name = name;
-                       node_args = None;
-                       node_pad = caller_output;
-                     })
-                 audio_input_pads
-             in
+          let audio_output_pads =
+            List.map
+              (fun (name, pad_v) ->
+                let caller_output =
+                  match Audio.of_value pad_v with
+                    | `Output pad -> pad ()
+                    | `Input _ ->
+                        failwith
+                          "ffmpeg.filter.parse: input pads must be output pads \
+                           from previous filters"
+                in
+                Avfilter.
+                  {
+                    node_name = name;
+                    node_args = None;
+                    node_pad = caller_output;
+                  })
+              audio_input_pads
+          in
 
-             let video_output_pads =
-               List.map
-                 (fun (name, pad_v) ->
-                   let caller_output =
-                     match Video.of_value pad_v with
-                       | `Output lazy_pad -> Lazy.force lazy_pad
-                       | `Input _ ->
-                           failwith
-                             "ffmpeg.filter.parse: input pads must be output \
-                              pads from previous filters"
-                   in
-                   Avfilter.
-                     {
-                       node_name = name;
-                       node_args = None;
-                       node_pad = caller_output;
-                     })
-                 video_input_pads
-             in
+          let video_output_pads =
+            List.map
+              (fun (name, pad_v) ->
+                let caller_output =
+                  match Video.of_value pad_v with
+                    | `Output pad -> pad ()
+                    | `Input _ ->
+                        failwith
+                          "ffmpeg.filter.parse: input pads must be output pads \
+                           from previous filters"
+                in
+                Avfilter.
+                  {
+                    node_name = name;
+                    node_args = None;
+                    node_pad = caller_output;
+                  })
+              video_input_pads
+          in
 
-             let audio_input_pads =
-               List.map
-                 (fun (name, aformat) ->
-                   Avfilter.
-                     {
-                       node_name = name;
-                       node_args = None;
-                       node_pad = List.hd aformat.io.inputs.audio;
-                     })
-                 audio_output_formats
-             in
+          let audio_input_pads =
+            List.map
+              (fun (name, aformat) ->
+                Avfilter.
+                  {
+                    node_name = name;
+                    node_args = None;
+                    node_pad = List.hd aformat.io.inputs.audio;
+                  })
+              audio_output_formats
+          in
 
-             let video_input_pads =
-               List.map
-                 (fun (name, format_) ->
-                   Avfilter.
-                     {
-                       node_name = name;
-                       node_args = None;
-                       node_pad = List.hd format_.io.inputs.video;
-                     })
-                 video_output_formats
-             in
+          let video_input_pads =
+            List.map
+              (fun (name, format_) ->
+                Avfilter.
+                  {
+                    node_name = name;
+                    node_args = None;
+                    node_pad = List.hd format_.io.inputs.video;
+                  })
+              video_output_formats
+          in
 
-             let parse_io =
-               Avfilter.
-                 {
-                   inputs =
-                     { audio = audio_input_pads; video = video_input_pads };
-                   outputs =
-                     { audio = audio_output_pads; video = video_output_pads };
-                 }
-             in
+          let parse_io =
+            Avfilter.
+              {
+                inputs = { audio = audio_input_pads; video = video_input_pads };
+                outputs =
+                  { audio = audio_output_pads; video = video_output_pads };
+              }
+          in
 
-             Avfilter.parse parse_io description config;
+          Avfilter.parse parse_io description config;
 
-             output_format_filters :=
-               Some (audio_output_formats, video_output_formats)));
+          output_format_filters :=
+            Some (audio_output_formats, video_output_formats));
 
       Builtins_ffmpeg_filters.init_graph graph;
 
       let make_audio_output name =
-        let lazy_pad =
-          Lazy.from_fun (fun () ->
-              let audio_formats, _video_formats =
-                Option.get !output_format_filters
-              in
-              let _, aformat =
-                List.find (fun (n, _) -> n = name) audio_formats
-              in
-              List.hd aformat.io.outputs.audio)
+        let pad () =
+          let audio_formats, _video_formats =
+            Option.get !output_format_filters
+          in
+          let _, aformat = List.find (fun (n, _) -> n = name) audio_formats in
+          List.hd aformat.io.outputs.audio
         in
-        Lang.product (Lang.string name) (Audio.to_value (`Output lazy_pad))
+        Lang.product (Lang.string name) (Audio.to_value (`Output pad))
       in
 
       let make_video_output name =
-        let lazy_pad =
-          Lazy.from_fun (fun () ->
-              let _audio_formats, video_formats =
-                Option.get !output_format_filters
-              in
-              let _, format_ =
-                List.find (fun (n, _) -> n = name) video_formats
-              in
-              List.hd format_.io.outputs.video)
+        let pad () =
+          let _audio_formats, video_formats =
+            Option.get !output_format_filters
+          in
+          let _, format_ = List.find (fun (n, _) -> n = name) video_formats in
+          List.hd format_.io.outputs.video
         in
-        Lang.product (Lang.string name) (Video.to_value (`Output lazy_pad))
+        Lang.product (Lang.string name) (Video.to_value (`Output pad))
       in
 
       Lang.record

--- a/src/core/optionals/ffmpeg/filter/builtins_ffmpeg_filters.ml
+++ b/src/core/optionals/ffmpeg/filter/builtins_ffmpeg_filters.ml
@@ -259,6 +259,11 @@ let get_config graph =
                "Graph variables cannot be used outside of ffmpeg.filter.create!",
                [] ))
 
+(* A graph value only means anything inside the [ffmpeg.filter.create] call that
+   made it. Operators that no longer attach anything while the script runs still
+   have to say so. *)
+let check_graph_scope graph_v = ignore (get_config graph_v)
+
 let apply_filter ~args_parser ~filter ~sources_t p =
   Avfilter.(
     let graph_v = Lang.assoc "" 1 p in
@@ -568,7 +573,7 @@ let _ =
          in
          let pass_metadata = Lang.to_bool (List.assoc "pass_metadata" p) in
          let graph_v = Lang.assoc "" 1 p in
-         let config = get_config graph_v in
+         check_graph_scope graph_v;
          let graph = Graph.of_value graph_v in
          let track_val = Lang.assoc "" 2 p in
          let field, source = Lang.to_track track_val in
@@ -595,8 +600,6 @@ let _ =
          s#set_id id;
          Queue.push graph.graph_inputs (s :> Source.source);
          Queue.push graph.input_flushes (fun () -> s#flush_input);
-
-         ignore config;
 
          (* Settled from the first frame of each generation: a source that comes
             back at a different rate gets a buffer that says so. *)
@@ -639,7 +642,7 @@ let _ =
        (fun p ->
          let pass_metadata = Lang.to_bool (List.assoc "pass_metadata" p) in
          let graph_v = Lang.assoc "" 1 p in
-         let config = get_config graph_v in
+         check_graph_scope graph_v;
          let graph = Graph.of_value graph_v in
 
          (* No frame type is built here: [add_track_operator] constrains the
@@ -660,8 +663,6 @@ let _ =
              drain = (fun ~generator -> sink#drain ~generator);
              eof = (fun () -> sink#eof);
            };
-
-         ignore config;
 
          let pad = Audio.of_value (Lang.assoc "" 2 p) in
          let name = uniq_name "abuffersink" in
@@ -703,7 +704,7 @@ let _ =
          in
          let pass_metadata = Lang.to_bool (List.assoc "pass_metadata" p) in
          let graph_v = Lang.assoc "" 1 p in
-         let config = get_config graph_v in
+         check_graph_scope graph_v;
          let graph = Graph.of_value graph_v in
          let track_val = Lang.assoc "" 2 p in
          let field, source = Lang.to_track track_val in
@@ -730,8 +731,6 @@ let _ =
          s#set_id id;
          Queue.push graph.graph_inputs (s :> Source.source);
          Queue.push graph.input_flushes (fun () -> s#flush_input);
-
-         ignore config;
 
          let args = ref None in
          let input_node =
@@ -771,7 +770,7 @@ let _ =
     (fun p ->
       let pass_metadata = Lang.to_bool (List.assoc "pass_metadata" p) in
       let graph_v = Lang.assoc "" 1 p in
-      let config = get_config graph_v in
+      check_graph_scope graph_v;
       let graph = Graph.of_value graph_v in
 
       let s = graph_source graph in
@@ -789,8 +788,6 @@ let _ =
           drain = (fun ~generator -> sink#drain ~generator);
           eof = (fun () -> sink#eof);
         };
-
-      ignore config;
 
       let pad = Video.of_value (Lang.assoc "" 2 p) in
       let name = uniq_name "buffersink" in

--- a/src/core/optionals/ffmpeg/filter/builtins_ffmpeg_filters.ml
+++ b/src/core/optionals/ffmpeg/filter/builtins_ffmpeg_filters.ml
@@ -45,10 +45,11 @@ module Queue = Queues.Queue
     between input and output so we do not look at latency control like we do for
     crossfades. -> When receiving its first frame, the liquidsoap input will
     then initialize the corresponding ffmpeg graph input with full format info.
-    -> When all inputs have been initialized, which is know by checking if all
-    of the graph's lazy values for input pads have been forced (executed), the
-    whole graph is initialized, outputs connected and data can start to flow!
-    This is captured by the call to `initialized` below.
+    -> When all inputs know the parameters of their buffer, the whole graph is
+    built, outputs connected and data can start to flow! This is captured by the
+    call to `init_graph` below. An input that runs dry ends that graph and it is
+    built again, from the same description, when the input comes back: see
+    `cell`.
 
     This is contingent to the inputs being checked for `#is_ready` and the
     outputs only pulling when _all_ inputs are available, to avoid running into
@@ -68,28 +69,77 @@ type outputs =
   ([ `Audio ] output entries, [ `Video ] output entries) Avfilter.av
 
 type graph = {
-  mutable config : Avfilter.config option;
+  (* What the script attaches to while it describes the graph. Only ever used to
+     learn each filter's pad counts, which avfilter reveals on attach and which
+     the script needs before any data flows. Dropped once
+     [ffmpeg.filter.create] returns. *)
+  mutable probe : Avfilter.config option;
+  (* Each generation of the graph gets its own avfilter config. A dry input ends
+     a generation for good -- avfilter has no way back from end of file -- so
+     when the input comes back the graph is described again into a fresh one. *)
+  mutable current : Avfilter.config option;
+  mutable generation : int;
   mutable failed : bool;
+  init : (unit -> unit) Queue.t;
+  resets : (unit -> unit) Queue.t;
   input_inits : (unit -> bool) Queue.t;
   graph_inputs : Source.source Queue.t;
   input_flushes : (unit -> unit) Queue.t;
   mutable graph_source : Ffmpeg_filter_graph.source option;
   mutable audio_outputs : int;
   mutable video_outputs : int;
-  init : unit Lazy.t Queue.t;
   entries : (inputs, outputs) Avfilter.io;
 }
 
+(* A pad belongs to the avfilter graph it was attached to, so nothing built for
+   one generation carries over to the next. A cell holds a piece of the graph
+   the script described and rebuilds it on demand: read it after a teardown and
+   it attaches again, into the new config. This is what lets the wiring stay as
+   plain closures -- reading a pad attaches whatever produces it -- instead of a
+   description we would have to interpret. *)
+type 'a cell = {
+  mutable cell_generation : int;
+  mutable value : 'a option;
+  make : unit -> 'a;
+}
+
+let cell make = { cell_generation = 0; value = None; make }
+
+let read graph c =
+  match c.value with
+    | Some v when c.cell_generation = graph.generation -> v
+    | _ ->
+        let v = c.make () in
+        c.value <- Some v;
+        c.cell_generation <- graph.generation;
+        v
+
+let current_config graph =
+  match graph.current with
+    | Some config -> config
+    | None -> failwith "ffmpeg filter graph read outside of a generation!"
+
+let build graph =
+  graph.generation <- graph.generation + 1;
+  graph.current <- Some (Avfilter.init ());
+  try Queue.iter graph.init (fun f -> f ())
+  with exn ->
+    let bt = Printexc.get_raw_backtrace () in
+    graph.failed <- true;
+    Printexc.raise_with_backtrace exn bt
+
 let init_graph graph =
-  if Queue.fold graph.input_inits (fun v b -> b && v ()) true then (
-    try Queue.iter graph.init Lazy.force
-    with exn ->
-      let bt = Printexc.get_raw_backtrace () in
-      graph.failed <- true;
-      Printexc.raise_with_backtrace exn bt)
+  if Queue.fold graph.input_inits (fun v b -> b && v ()) true then build graph
 
 let initialized graph =
-  Queue.fold graph.init (fun q cur -> cur && Lazy.is_val q) true
+  match graph.current with Some _ -> true | None -> false
+
+(* Called once the graph has handed over everything it was holding. Dropping the
+   config lets it be collected, and the inputs go back to waiting for a first
+   frame, which is what settles the parameters of the next generation. *)
+let reset graph =
+  graph.current <- None;
+  Queue.iter graph.resets (fun f -> f ())
 
 let is_ready graph =
   (match (initialized graph, Queue.peek_opt graph.graph_inputs) with
@@ -130,6 +180,7 @@ let graph_source graph =
             ~pull:(fun () -> pull graph)
             ~is_ready:(fun () -> is_ready graph)
             ~flush_inputs:(fun () -> flush_inputs graph)
+            ~reset:(fun () -> reset graph)
             ~self_sync:(fun source -> self_sync graph source)
             ()
         in
@@ -150,9 +201,12 @@ module Graph = Value.MkCustom (struct
 end)
 
 module Audio = Value.MkCustom (struct
+  (* Pads are read through a thunk rather than held directly: what the script
+     wires together outlives any one generation of the graph, the pads do not.
+     See [cell]. *)
   type content =
-    [ `Input of ([ `Attached ], [ `Audio ], [ `Input ]) Avfilter.pad
-    | `Output of ([ `Attached ], [ `Audio ], [ `Output ]) Avfilter.pad Lazy.t
+    [ `Input of unit -> ([ `Attached ], [ `Audio ], [ `Input ]) Avfilter.pad
+    | `Output of unit -> ([ `Attached ], [ `Audio ], [ `Output ]) Avfilter.pad
     ]
 
   let name = "ffmpeg.filter.audio"
@@ -167,8 +221,8 @@ end)
 
 module Video = Value.MkCustom (struct
   type content =
-    [ `Input of ([ `Attached ], [ `Video ], [ `Input ]) Avfilter.pad
-    | `Output of ([ `Attached ], [ `Video ], [ `Output ]) Avfilter.pad Lazy.t
+    [ `Input of unit -> ([ `Attached ], [ `Video ], [ `Input ]) Avfilter.pad
+    | `Output of unit -> ([ `Attached ], [ `Video ], [ `Output ]) Avfilter.pad
     ]
 
   let name = "ffmpeg.filter.video"
@@ -195,8 +249,8 @@ let uniq_name =
   fun name -> Printf.sprintf "%s_%d" name (name_idx name)
 
 let get_config graph =
-  let { config; _ } = Graph.of_value graph in
-  match config with
+  let { probe; _ } = Graph.of_value graph in
+  match probe with
     | Some config -> config
     | None ->
         raise
@@ -212,7 +266,16 @@ let apply_filter ~args_parser ~filter ~sources_t p =
     let graph = Graph.of_value graph_v in
     let name = uniq_name filter.name in
     let flags = filter.flags in
-    let filter = attach ~args:(args_parser p []) ~name filter config in
+    let args = args_parser p [] in
+    let unattached = filter in
+    (* Attaching once here settles how many pads this instance has -- dynamic
+       filters only say once attached -- and reports bad arguments while the
+       script still has a position to blame. This copy is never run: the cell
+       below attaches the instance the graph actually uses. *)
+    let filter = attach ~args ~name unattached config in
+    let instance =
+      cell (fun () -> attach ~args ~name unattached (current_config graph))
+    in
     let input_set = ref false in
     let meths =
       [
@@ -230,20 +293,30 @@ let apply_filter ~args_parser ~filter ~sources_t p =
               let arg = Lang.to_string (Lang.assoc "" 2 p) in
               if initialized graph then (
                 try
-                  Lang.string (Avfilter.process_command ~flags ~cmd ~arg filter)
+                  Lang.string
+                    (Avfilter.process_command ~flags ~cmd ~arg
+                       (read graph instance))
                 with exn ->
                   let bt = Printexc.get_raw_backtrace () in
                   Lang.raise_as_runtime ~bt ~kind:"ffmpeg.filter" exn)
               else Lang.string "graph not started!") );
         ( "output",
           let audio =
-            List.map
-              (fun p -> Audio.to_value (`Output (Lazy.from_val p)))
+            List.mapi
+              (fun index _ ->
+                Audio.to_value
+                  (`Output
+                     (fun () ->
+                       List.nth (read graph instance).io.outputs.audio index)))
               filter.io.outputs.audio
           in
           let video =
-            List.map
-              (fun p -> Video.to_value (`Output (Lazy.from_val p)))
+            List.mapi
+              (fun index _ ->
+                Video.to_value
+                  (`Output
+                     (fun () ->
+                       List.nth (read graph instance).io.outputs.video index)))
               filter.io.outputs.video
           in
           if List.mem `Dynamic_outputs flags then
@@ -283,9 +356,10 @@ let apply_filter ~args_parser ~filter ~sources_t p =
                 in
                 let output =
                   match of_value output with
-                    | `Output output -> Lazy.force output
+                    | `Output output -> output ()
                     | _ -> assert false
                 in
+                let input = input () in
                 try link output input
                 with exn ->
                   Lang.raise_error ~pos
@@ -297,15 +371,21 @@ let apply_filter ~args_parser ~filter ~sources_t p =
                          (Printexc.to_string exn))
                     "ffmpeg.filter"
               in
-              Queue.push graph.init
-                (Lazy.from_fun (fun () ->
-                     List.iteri
-                       (link ~of_value:Audio.of_value ~mode:`Audio ~ofs:0)
-                       filter.io.inputs.audio;
-                     List.iteri
-                       (link ~of_value:Video.of_value ~mode:`Video
-                          ~ofs:audio_inputs_c)
-                       filter.io.inputs.video));
+              (* Linking reads both ends, which is what attaches them: order
+                 within the queue does not matter. *)
+              Queue.push graph.init (fun () ->
+                  List.iteri
+                    (fun index _ ->
+                      link ~of_value:Audio.of_value ~mode:`Audio ~ofs:0 index
+                        (fun () ->
+                          List.nth (read graph instance).io.inputs.audio index))
+                    filter.io.inputs.audio;
+                  List.iteri
+                    (fun index _ ->
+                      link ~of_value:Video.of_value ~mode:`Video
+                        ~ofs:audio_inputs_c index (fun () ->
+                          List.nth (read graph instance).io.inputs.video index))
+                    filter.io.inputs.video);
               input_set := true;
               Lang.unit) );
       ]
@@ -516,28 +596,32 @@ let _ =
          Queue.push graph.graph_inputs (s :> Source.source);
          Queue.push graph.input_flushes (fun () -> s#flush_input);
 
-         let args = ref None in
+         ignore config;
 
-         let audio =
-           Lazy.from_fun (fun () ->
-               let _abuffer =
-                 Avfilter.attach ~args:(Option.get !args) ~name Avfilter.abuffer
-                   config
-               in
-               Avfilter.(
-                 Hashtbl.replace graph.entries.inputs.audio name s#set_input);
-               List.hd Avfilter.(_abuffer.io.outputs.audio))
+         (* Settled from the first frame of each generation: a source that comes
+            back at a different rate gets a buffer that says so. *)
+         let args = ref None in
+         let input_node =
+           cell (fun () ->
+               Avfilter.attach ~args:(Option.get !args) ~name Avfilter.abuffer
+                 (current_config graph))
          in
 
-         Queue.push graph.input_inits (fun () -> Lazy.is_val audio);
+         Avfilter.(Hashtbl.replace graph.entries.inputs.audio name s#set_input);
+         Queue.push graph.input_inits (fun () -> !args <> None);
+         Queue.push graph.resets (fun () ->
+             args := None;
+             s#reset_graph);
 
          s#set_init (fun frame ->
              if !args = None then (
                args := Some (abuffer_args frame);
-               ignore (Lazy.force audio);
                init_graph graph));
 
-         Audio.to_value (`Output audio)));
+         Audio.to_value
+           (`Output
+              (fun () ->
+                List.hd Avfilter.((read graph input_node).io.outputs.audio)))));
 
   let return_t = Type.make (Format_type.descr raw_audio_format) in
   ignore
@@ -577,22 +661,24 @@ let _ =
              eof = (fun () -> sink#eof);
            };
 
+         ignore config;
+
          let pad = Audio.of_value (Lang.assoc "" 2 p) in
-         Queue.push graph.init
-           (Lazy.from_fun (fun () ->
-                let pad =
-                  match pad with
-                    | `Output pad -> Lazy.force pad
-                    | _ -> assert false
-                in
-                let name = uniq_name "abuffersink" in
-                let _abuffersink =
-                  Avfilter.attach ~name Avfilter.abuffersink config
-                in
-                Avfilter.(link pad (List.hd _abuffersink.io.inputs.audio));
-                Avfilter.(
-                  Hashtbl.replace graph.entries.outputs.audio name
-                    sink#set_output)));
+         let name = uniq_name "abuffersink" in
+         let output_node =
+           cell (fun () ->
+               Avfilter.attach ~name Avfilter.abuffersink (current_config graph))
+         in
+
+         Avfilter.(
+           Hashtbl.replace graph.entries.outputs.audio name sink#set_output);
+         Queue.push graph.resets (fun () -> sink#reset_graph);
+         Queue.push graph.init (fun () ->
+             let pad =
+               match pad with `Output pad -> pad () | _ -> assert false
+             in
+             Avfilter.(
+               link pad (List.hd (read graph output_node).io.inputs.audio)));
 
          (field, (s :> Source.source))));
 
@@ -645,28 +731,31 @@ let _ =
          Queue.push graph.graph_inputs (s :> Source.source);
          Queue.push graph.input_flushes (fun () -> s#flush_input);
 
-         let args = ref None in
+         ignore config;
 
-         let video =
-           Lazy.from_fun (fun () ->
-               let _buffer =
-                 Avfilter.attach ~args:(Option.get !args) ~name Avfilter.buffer
-                   config
-               in
-               Avfilter.(
-                 Hashtbl.replace graph.entries.inputs.video name s#set_input);
-               List.hd Avfilter.(_buffer.io.outputs.video))
+         let args = ref None in
+         let input_node =
+           cell (fun () ->
+               Avfilter.attach ~args:(Option.get !args) ~name Avfilter.buffer
+                 (current_config graph))
          in
 
-         Queue.push graph.input_inits (fun () -> Lazy.is_val video);
+         Avfilter.(Hashtbl.replace graph.entries.inputs.video name s#set_input);
+         Queue.push graph.resets (fun () ->
+             args := None;
+             s#reset_graph);
+
+         Queue.push graph.input_inits (fun () -> !args <> None);
 
          s#set_init (fun frame ->
              if !args = None then (
                args := Some (buffer_args frame);
-               ignore (Lazy.force video);
                init_graph graph));
 
-         Video.to_value (`Output video)));
+         Video.to_value
+           (`Output
+              (fun () ->
+                List.hd Avfilter.((read graph input_node).io.outputs.video)))));
 
   let return_t = Type.make (Format_type.descr raw_video_format) in
   Lang.add_track_operator ~base:ffmpeg_filter_video "output" ~category:`Video
@@ -701,20 +790,23 @@ let _ =
           eof = (fun () -> sink#eof);
         };
 
-      Queue.push graph.init
-        (Lazy.from_fun (fun () ->
-             let pad =
-               match Video.of_value (Lang.assoc "" 2 p) with
-                 | `Output p -> Lazy.force p
-                 | _ -> assert false
-             in
-             let name = uniq_name "buffersink" in
-             let _buffersink =
-               Avfilter.attach ~name Avfilter.buffersink config
-             in
-             Avfilter.(link pad (List.hd _buffersink.io.inputs.video));
-             Avfilter.(
-               Hashtbl.replace graph.entries.outputs.video name sink#set_output)));
+      ignore config;
+
+      let pad = Video.of_value (Lang.assoc "" 2 p) in
+      let name = uniq_name "buffersink" in
+      let output_node =
+        cell (fun () ->
+            Avfilter.attach ~name Avfilter.buffersink (current_config graph))
+      in
+
+      Avfilter.(
+        Hashtbl.replace graph.entries.outputs.video name sink#set_output);
+      Queue.push graph.resets (fun () -> sink#reset_graph);
+      Queue.push graph.init (fun () ->
+          let pad =
+            match pad with `Output pad -> pad () | _ -> assert false
+          in
+          Avfilter.(link pad (List.hd (read graph output_node).io.inputs.video)));
 
       (field, (s :> Source.source)))
 
@@ -734,11 +826,14 @@ let _ =
       let graph =
         Avfilter.
           {
-            config = Some config;
+            probe = Some config;
+            current = None;
+            generation = 0;
             failed = false;
             input_inits = Queue.create ();
             graph_inputs = Queue.create ();
             input_flushes = Queue.create ();
+            resets = Queue.create ();
             graph_source = None;
             audio_outputs = 0;
             video_outputs = 0;
@@ -780,41 +875,39 @@ let _ =
             s#on_sleep (fun () ->
                 Clock.deregister_sub_clock output_clock input_clock));
 
-      Queue.push graph.init
-        (Lazy.from_fun (fun () ->
-             log#info "Initializing graph";
-             let filter = Avfilter.launch config in
-             Avfilter.(
-               List.iter
-                 (fun (name, input) ->
-                   let set_input =
-                     Hashtbl.find graph.entries.inputs.audio name
-                   in
-                   set_input input)
-                 filter.inputs.audio);
-             Avfilter.(
-               List.iter
-                 (fun (name, input) ->
-                   let set_input =
-                     Hashtbl.find graph.entries.inputs.video name
-                   in
-                   set_input input)
-                 filter.inputs.video);
-             Avfilter.(
-               List.iter
-                 (fun (name, output) ->
-                   let set_output =
-                     Hashtbl.find graph.entries.outputs.audio name
-                   in
-                   set_output output)
-                 filter.outputs.audio);
-             Avfilter.(
-               List.iter
-                 (fun (name, output) ->
-                   let set_output =
-                     Hashtbl.find graph.entries.outputs.video name
-                   in
-                   set_output output)
-                 filter.outputs.video)));
-      graph.config <- None;
+      (* Pushed last, so everything the script described is attached and linked
+         by the time it runs. Re-pointing the setters is all a new generation
+         needs: they address the input and sink objects, which outlive it. *)
+      Queue.push graph.init (fun () ->
+          log#info "Initializing graph (generation %d)" graph.generation;
+          let filter = Avfilter.launch (current_config graph) in
+          Avfilter.(
+            List.iter
+              (fun (name, input) ->
+                let set_input = Hashtbl.find graph.entries.inputs.audio name in
+                set_input input)
+              filter.inputs.audio);
+          Avfilter.(
+            List.iter
+              (fun (name, input) ->
+                let set_input = Hashtbl.find graph.entries.inputs.video name in
+                set_input input)
+              filter.inputs.video);
+          Avfilter.(
+            List.iter
+              (fun (name, output) ->
+                let set_output =
+                  Hashtbl.find graph.entries.outputs.audio name
+                in
+                set_output output)
+              filter.outputs.audio);
+          Avfilter.(
+            List.iter
+              (fun (name, output) ->
+                let set_output =
+                  Hashtbl.find graph.entries.outputs.video name
+                in
+                set_output output)
+              filter.outputs.video));
+      graph.probe <- None;
       ret)

--- a/src/core/optionals/ffmpeg/filter/ffmpeg_filter_graph.ml
+++ b/src/core/optionals/ffmpeg/filter/ffmpeg_filter_graph.ml
@@ -47,7 +47,7 @@ type sink = {
   eof : unit -> bool;
 }
 
-class source ~name ~pull ~is_ready ~flush_inputs ~self_sync () =
+class source ~name ~pull ~is_ready ~flush_inputs ~reset ~self_sync () =
   object (self)
     inherit Source.source ~name ()
     val mutable sinks = []
@@ -97,17 +97,23 @@ class source ~name ~pull ~is_ready ~flush_inputs ~self_sync () =
         self#check_buffer
       in
       let done_ () = List.for_all (fun sink -> sink.eof ()) sinks in
+      (* A generation of the graph is over once the inputs have been told so and
+         every sink has handed back what it was holding. Tearing it down here
+         rather than leaving it closed is what lets an input that comes back
+         start a new one: avfilter cannot reopen a graph that has seen end of
+         file, so we build another. *)
+      let end_generation () =
+        flush_inputs ();
+        drain ();
+        if done_ () then reset ()
+      in
       let rec loop () =
         drain ();
         if Generator.length self#buffer < size && not (done_ ()) then
           if is_ready () then (
             pull ();
             loop ())
-          else (
-            (* The inputs have run dry. Telling the graph so is what makes
-               filters holding a tail hand it over. *)
-            flush_inputs ();
-            drain ())
+          else end_generation ()
       in
       (* Ticking the inputs is also what gets the graph launched. *)
       let rec wait_for_launch () =

--- a/src/core/optionals/ffmpeg/filter/ffmpeg_filter_io.ml
+++ b/src/core/optionals/ffmpeg/filter/ffmpeg_filter_io.ml
@@ -250,6 +250,13 @@ class ['a, 'params] base_output ~media ~pass_metadata ~name ~frame_t ~field
 
     val mutable flushed = false
 
+    (* Ready to feed the next generation of the graph. The duration converter is
+       deliberately left alone: its timestamps carry on across the seam, which is
+       what keeps what we push monotonic. *)
+    method reset_graph =
+      flushed <- false;
+      input <- (fun _ -> ())
+
     (* Filters with internal delay only emit their tail once the graph sees end
        of file. Sending it twice is an error, hence the flag. *)
     method flush_input =
@@ -277,12 +284,17 @@ let video_output ~pass_metadata ~name ~frame_t ~field source =
    graph source's generator that this output was given. The graph source owns
    the buffer and does the pulling. *)
 class ['a, 'params] sink ~media ~field ~pass_metadata ~log ~content_type () =
-  let stream_idx = Ffmpeg_content_base.new_stream_idx () in
   object (self)
     inherit ['a] duration_converter
     method log = log
     val mutable output = None
     method connected = output <> None
+
+    (* A rebuilt graph starts its timestamps over. [convert_duration] only lines
+       two runs up when the stream index changes, so each generation has to look
+       like a new stream -- otherwise the restart emits timestamps that go
+       backwards and the content is rejected as non-monotonic. *)
+    val mutable stream_idx = Ffmpeg_content_base.new_stream_idx ()
 
     (* The sink knows the format the graph settled on; give it to the content
        type the script was type-checked against. *)
@@ -395,6 +407,11 @@ class ['a, 'params] sink ~media ~field ~pass_metadata ~log ~content_type () =
 
     (* [true] once the graph has told this sink that nothing more is coming. *)
     method eof = eof
+
+    method reset_graph =
+      output <- None;
+      eof <- false;
+      stream_idx <- Ffmpeg_content_base.new_stream_idx ()
 
     method drain ~generator =
       match output with

--- a/src/core/optionals/ffmpeg/filter/ffmpeg_filter_io.ml
+++ b/src/core/optionals/ffmpeg/filter/ffmpeg_filter_io.ml
@@ -153,8 +153,8 @@ class virtual ['a] duration_converter =
        here. *)
     method flush_duration =
       match duration_converter with
-        | None -> []
-        | Some { converter; _ } -> snd (Ffmpeg_utils.Duration.flush converter)
+        | None -> (0, [])
+        | Some { converter; _ } -> Ffmpeg_utils.Duration.flush converter
   end
 
 class ['a, 'params] base_output ~media ~pass_metadata ~name ~frame_t ~field
@@ -255,7 +255,7 @@ class ['a, 'params] base_output ~media ~pass_metadata ~name ~frame_t ~field
     method flush_input =
       if not flushed then (
         flushed <- true;
-        List.iter (fun (_, frame) -> self#push frame) self#flush_duration;
+        List.iter (fun (_, frame) -> self#push frame) (snd self#flush_duration);
         input `Flush)
 
     initializer self#on_sleep (fun () -> self#flush_input)
@@ -333,6 +333,26 @@ class ['a, 'params] sink ~media ~field ~pass_metadata ~log ~content_type () =
                    chunks = [chunk];
                  })
 
+    method private emit ~generator ~time_base ~length frames =
+      List.iter
+        (fun (pos, frame) ->
+          let metadata = Avutil.Frame.metadata frame in
+          (* Offsets are relative to this field, not to the generator: fields of
+             the same generator can be filled at different rates. *)
+          let pos = Generator.field_length generator field + pos in
+          if List.mem_assoc track_mark_metadata metadata then
+            Generator.add_track_mark ~pos generator;
+          if pass_metadata then (
+            let m =
+              List.filter (fun (k, _) -> k <> track_mark_metadata) metadata
+            in
+            if m <> [] then
+              Generator.add_metadata ~pos generator
+                (Frame.Metadata.from_list
+                   (m @ self#metadata_timestamps ~time_base frame))))
+        frames;
+      self#put_data ~generator ~length frames
+
     method private read_one ~generator output =
       let time_base = Avfilter.(time_base output.context) in
       let frame = output.Avfilter.handler () in
@@ -341,27 +361,33 @@ class ['a, 'params] sink ~media ~field ~pass_metadata ~log ~content_type () =
       with
         | None -> ()
         | Some (length, frames) ->
-            List.iter
-              (fun (pos, frame) ->
-                let metadata = Avutil.Frame.metadata frame in
-                (* Offsets are relative to this field, not to the generator:
-                   fields of the same generator can be filled at different
-                   rates. *)
-                let pos = Generator.field_length generator field + pos in
-                if List.mem_assoc track_mark_metadata metadata then
-                  Generator.add_track_mark ~pos generator;
-                if pass_metadata then (
-                  let m =
-                    List.filter
-                      (fun (k, _) -> k <> track_mark_metadata)
-                      metadata
-                  in
-                  if m <> [] then
-                    Generator.add_metadata ~pos generator
-                      (Frame.Metadata.from_list
-                         (m @ self#metadata_timestamps ~time_base frame))))
-              frames;
-            self#put_data ~generator ~length frames
+            self#emit ~generator ~time_base ~length frames
+
+    (* [Duration] works out how long a frame lasted from the timestamp of the
+       next one, so it is always holding the most recent frames back. At end of
+       stream there is no next one: whatever it still has is the tail of the
+       filters -- everything `loudnorm` and friends were sitting on -- and it
+       only comes out if we ask for it here. *)
+    method private emit_tail ~generator =
+      match (output, self#flush_duration) with
+        | _, (_, []) | None, _ -> ()
+        | Some output, (_, frames) ->
+            let time_base = Avfilter.(time_base output.context) in
+            let dst = Ffmpeg_utils.liq_main_ticks_time_base () in
+            (* [Duration.flush] reports the longest packet, not their total. *)
+            let length =
+              List.fold_left
+                (fun length (_, frame) ->
+                  match Avutil.Frame.duration frame with
+                    | None -> length
+                    | Some d ->
+                        length
+                        + Int64.to_int
+                            (Ffmpeg_utils.convert_time_base ~src:time_base ~dst
+                               d))
+                0 frames
+            in
+            self#emit ~generator ~time_base ~length frames
 
     (* Take everything the sink has ready. Stops on [`Eagain], which means the
        graph needs more input, and on [`Eof], which means it never will. *)
@@ -380,7 +406,9 @@ class ['a, 'params] sink ~media ~field ~pass_metadata ~log ~content_type () =
               done
             with
               | Avutil.Error `Eagain -> ()
-              | Avutil.Error `Eof -> eof <- true)
+              | Avutil.Error `Eof ->
+                  self#emit_tail ~generator;
+                  eof <- true)
   end
 
 let audio_sink ~field ~pass_metadata ~log ~content_type () =

--- a/tests/regression/GH3944.liq
+++ b/tests/regression/GH3944.liq
@@ -1,0 +1,48 @@
+# Regression test for https://github.com/savonet/liquidsoap/issues/3944
+# A filter graph must survive its input running dry. `buffer` is unavailable
+# while it fills, and a filter with a lookahead, `loudnorm` here, cannot fill a
+# frame from what it holds during that window. The graph ends there -- avfilter
+# has no way back from end of file -- and has to be built again when the input
+# comes back, which is what this checks.
+
+%ifdef ffmpeg.filter.loudnorm
+def normalized(s) =
+  def mkfilter(graph) =
+    a = ffmpeg.filter.audio.input(graph, source.tracks(s).audio)
+    a = ffmpeg.filter.loudnorm(i=-14., graph, a)
+    a = ffmpeg.filter.audio.output(graph, a)
+    source({audio = a})
+  end
+  ffmpeg.filter.create(mkfilter)
+end
+
+s = buffer(sine())
+s = ffmpeg.raw.encode.audio(%ffmpeg(%audio.raw), s)
+s = normalized(s)
+s = ffmpeg.raw.decode.audio(s)
+
+frames = ref(0)
+s.on_frame(synchronous=true, fun () -> frames := frames() + 1)
+
+output.dummy(fallible=true, s)
+
+# The buffer runs dry as it fills, well within the first second. Whatever comes
+# out after that is a generation of the graph that was built after it.
+thread.run(
+  delay=5.,
+  fun () ->
+    begin
+      if
+        frames() < 25
+      then
+        test.fail(
+          "graph stopped producing after its input ran dry: #{frames()} frames"
+        )
+      else
+        test.pass()
+      end
+    end
+)
+%else
+test.skip()
+%endif

--- a/tests/regression/dune.inc
+++ b/tests/regression/dune.inc
@@ -724,6 +724,24 @@
   (run %{run_test} GH3881 liquidsoap %{test_liq} GH3881.liq)))
 
 (rule
+ (alias test_GH3944)
+ (package liquidsoap)
+ (deps
+  GH3944.liq
+  (glob_files ../media/**)
+  ../liquidsoap-test-assets
+  ../../src/bin/liquidsoap.exe
+  ../streams/file1.png
+  ../streams/file1.mp3
+  ./theora-test.mp4
+  (package liquidsoap)
+  (source_tree ../../src/libs)
+  (:test_liq ../test.liq)
+  (:run_test ../run_test.exe))
+ (action
+  (run %{run_test} GH3944 liquidsoap %{test_liq} GH3944.liq)))
+
+(rule
  (alias test_GH3960)
  (package liquidsoap)
  (deps
@@ -2433,6 +2451,7 @@
   (alias test_GH3813)
   (alias test_GH3840)
   (alias test_GH3881)
+  (alias test_GH3944)
   (alias test_GH3960)
   (alias test_GH4071)
   (alias test_GH4090)


### PR DESCRIPTION
Fixes #3944.

An input running dry was the end of a filter graph. `fill_buffer` reads "inputs not ready" as end of stream and flushes the buffersrcs, and avfilter has no way back from that: the graph produced nothing ever after, with no error and a zero exit code. On 2.4.x the same script crashed instead, with `Invalid ffmpeg content: non-monotonic PTS`; the graph rewrite turned the crash into a silent stall.

Liquidsoap is synchronous and a source has no way to say it is finished, only that it has nothing right now, so the graph genuinely cannot tell a `buffer` filling up from a stream that is over. This keeps treating both as the end — which is what gets the tail out of filters holding one — and makes it survivable: what the script described is kept, and another graph is built from it when the input comes back. This is the mechanism FFmpeg's own CLI uses to reconfigure (`configure_filtergraph` frees the graph and re-parses from the retained `graph_desc`); it differs only in trigger, since a demuxer tells FFmpeg about EOF explicitly.

The failure only showed with a lookahead in the graph, which is why the reporter saw `loudnorm` behind `buffer()` die while `pan` and `volume` on the same pipeline were fine: those fill a frame from what they already hold and never reach the flush.

## Three commits

**Hand over the tail a graph holds at end of stream.** `Duration` works out how long a frame lasted from the timestamp of the next one, so it always holds the most recent frames back, and the sink never asked for what was left — the input side flushes its converter, the output side did not. Everything a lookahead filter was sitting on was dropped there. A 5.00s source through `loudnorm` produced 2.08s while the sink had received 2.10s of the 4.96s pushed in; it now yields 4.98s, against 5.00s for the same filter through the `ffmpeg` CLI.

**Build the graph again when its input comes back.** The wiring stays as the script wrote it, in closures; only what they hold changes. A pad is read through a cell that remembers which generation built it and attaches its filter again when that generation is gone, so reading a pad rebuilds whatever produces it and the attach-before-link ordering keeps falling out on its own — no description to interpret, and `ffmpeg.filter.parse`, whose subgraph belongs to no node we name, re-parses the same way. Each filter is still attached once while the script runs, which is how dynamic filters report their pad count and how bad arguments still name the line that wrote them; that copy is never used to stream. Each generation announces itself downstream as a new stream, which is what lines its timestamps up with the previous one — rebuilding under the same stream index emits timestamps that go backwards, i.e. the original 2.4.x crash.

**Name the graph-scope check.** Fallout from the above: four operators were left binding a config they no longer use and ignoring it.

## Trade-off

Teardown is immediate, with no grace period, so a stream that hiccups regularly rebuilds each time and loses filter state with it — `loudnorm` measures loudness from zero on each new generation. That is the cost of the finite case getting its tail promptly, and it is documented on the filters page. A flush delay is the knob to add if it bites in practice.

Parameters settling differently across a rebuild are accepted rather than rejected, since a graph is a converter and downstream re-adapts off the new stream index. Not implemented: re-negotiating a content type that a previous generation already pinned. `sink#set_output` still merges into the type declared at startup, so a generation that settles on genuinely different parameters would fail that merge. It does not arise today because liquidsoap normalises content before the graph — 16 rebuilds in the reproducer run below, no merge failure, and the changing-rate test passes — and doing it properly needs a Content-level primitive to un-pin a format, which did not belong in this change.

## Tests

`tests/regression/GH3944.liq` feeds `buffer(sine())` through a `loudnorm` graph and counts frames out after the buffer's initial fill. It fails on `main` with "graph stopped producing after its input ran dry: 2 frames" and passes here.

Measured by hand: the issue's own reproducer goes from 0 bytes to ~19s of audio over a 20s run, across 16 generations, with no `non-monotonic PTS` and no `Content_base.Invalid`; a finite source through a graph still closes its output, now at 4.98s instead of 2.08s; autocue's internal ebur128 analysis is unchanged (`cue_out=5.0`, amplify 7.744 dB before and after).

Existing coverage, all green: `ffmpeg_filter`, `ffmpeg_filter_parse`, `ffmpeg_complex_filter`, `ffmpeg_filter_changing_rate`, `ffmpeg_transparency_filter`, `ffmpeg_filter_array_args`, `ffmpeg_add_text`, `GH4246` — between them audio, video, multi-input `amix`, dynamic outputs via `ebur128`, the parse path, format changes and autocue.
