### PR TITLE
ffmpeg: fix divergences between copied code paths and consolidate the bindings

### DIFF
--- a/src/modules/synced/ffmpeg/av/av.ml
+++ b/src/modules/synced/ffmpeg/av/av.ml
@@ -314,6 +314,21 @@ let open_output ?interrupt ?format ?(interleaved = true) ?opts fname =
   Gc.finalise ocaml_av_cleanup_av ret;
   ret
 
+external ocaml_av_open_output_format :
+  (output, _) format ->
+  bool ->
+  (string * string) array ->
+  output container * string array = "ocaml_av_open_output_format"
+
+let open_output_format ?(interleaved = true) ?opts format =
+  let opts = opts_default opts in
+  let ret, unused =
+    ocaml_av_open_output_format format interleaved (mk_opts_array opts)
+  in
+  filter_opts unused opts;
+  Gc.finalise ocaml_av_cleanup_av ret;
+  ret
+
 external ocaml_av_open_output_stream :
   (output, _) format ->
   avio ->

--- a/src/modules/synced/ffmpeg/av/av.mli
+++ b/src/modules/synced/ffmpeg/av/av.mli
@@ -253,6 +253,13 @@ val open_output :
   string ->
   output container
 
+(** [Av.open_output_format ?interleaved ?opts format] open an output container
+    on [format] itself, with no file name. Used for output devices. After
+    returning, if [opts] was passed, unused options are left in the hash table.
+    Raise Error if the opening failed. *)
+val open_output_format :
+  ?interleaved:bool -> ?opts:opts -> (output, _) format -> output container
+
 (** [Av.open_stream callbacks] open the output container with the given
     callbacks. [opts] may contain any option settable on Ffmpeg avformat. After
     returning, if [opts] was passed, unused options are left in the hash table.

--- a/src/modules/synced/ffmpeg/av/av_stubs.c
+++ b/src/modules/synced/ffmpeg/av/av_stubs.c
@@ -2130,25 +2130,47 @@ CAMLprim value ocaml_av_write_stream_packet(value _stream, value _time_base,
   CAMLreturn(Val_unit);
 }
 
+/* Writes the container header on first use. Caller holds the runtime system
+   released. */
+static int ensure_header_written(av_t *av) {
+  int ret = 0;
+
+  if (!av->header_written) {
+    ret = avformat_write_header(av->format_context, NULL);
+
+    if (ret >= 0)
+      av->header_written = 1;
+  }
+
+  return ret;
+}
+
+/* Stamps [packet] for [stream_index], rescaling from [src_tb] to the
+   stream's time base, and hands it to the muxer. Caller holds the runtime
+   system released. */
+static int send_packet(av_t *av, AVPacket *packet, int stream_index,
+                       AVRational src_tb) {
+  packet->stream_index = stream_index;
+  packet->pos = -1;
+  av_packet_rescale_ts(packet, src_tb,
+                       av->format_context->streams[stream_index]->time_base);
+
+  return av->write_frame(av->format_context, packet);
+}
+
 static void write_frame(av_t *av, int stream_index, AVCodecContext *enc_ctx,
                         value _on_keyframe, AVFrame *frame) {
   CAMLparam1(_on_keyframe);
-  AVStream *avstream = av->format_context->streams[stream_index];
   AVFrame *hw_frame = NULL;
   int ret;
 
   caml_release_runtime_system();
 
-  if (!av->header_written) {
-    // write output file header
-    ret = avformat_write_header(av->format_context, NULL);
+  ret = ensure_header_written(av);
 
-    if (ret < 0) {
-      caml_acquire_runtime_system();
-      ocaml_avutil_raise_error(ret);
-    }
-
-    av->header_written = 1;
+  if (ret < 0) {
+    caml_acquire_runtime_system();
+    ocaml_avutil_raise_error(ret);
   }
 
   AVPacket *packet = av_packet_alloc();
@@ -2236,11 +2258,7 @@ static void write_frame(av_t *av, int stream_index, AVCodecContext *enc_ctx,
       caml_release_runtime_system();
     }
 
-    packet->stream_index = stream_index;
-    packet->pos = -1;
-    av_packet_rescale_ts(packet, enc_ctx->time_base, avstream->time_base);
-
-    ret = av->write_frame(av->format_context, packet);
+    ret = send_packet(av, packet, stream_index, enc_ctx->time_base);
   }
 
   if (hw_frame)
@@ -2258,7 +2276,9 @@ static void write_frame(av_t *av, int stream_index, AVCodecContext *enc_ctx,
   CAMLreturn0;
 }
 
-static void write_audio_frame(av_t *av, unsigned int stream_index,
+/* Audio and video both go through the send_frame/receive_packet encoder
+   API; subtitles use the legacy one-shot avcodec_encode_subtitle. */
+static void write_media_frame(av_t *av, unsigned int stream_index,
                               value _on_keyframe, AVFrame *frame) {
   if (!av->streams)
     Fail("Failed to write in closed output");
@@ -2269,23 +2289,7 @@ static void write_audio_frame(av_t *av, unsigned int stream_index,
   stream_t *stream = av->streams[stream_index];
 
   if (!stream->codec_context)
-    Fail("Could not find stream index");
-
-  write_frame(av, stream_index, stream->codec_context, _on_keyframe, frame);
-}
-
-static void write_video_frame(av_t *av, unsigned int stream_index,
-                              value _on_keyframe, AVFrame *frame) {
-  if (!av->streams)
-    Fail("Failed to write in closed output");
-
-  if (stream_index >= av->format_context->nb_streams)
-    Fail("Stream index not found!");
-
-  stream_t *stream = av->streams[stream_index];
-
-  if (!stream->codec_context)
-    Fail("Failed to write video frame with no encoder");
+    Fail("Failed to write frame with no encoder");
 
   write_frame(av, stream_index, stream->codec_context, _on_keyframe, frame);
 }
@@ -2299,8 +2303,6 @@ static void write_subtitle_frame(av_t *av, unsigned int stream_index,
     Fail("Stream index not found!");
 
   stream_t *stream = av->streams[stream_index];
-
-  AVStream *avstream = av->format_context->streams[stream->index];
 
   if (!stream->codec_context)
     Fail("Failed to write subtitle frame with no encoder");
@@ -2324,8 +2326,17 @@ static void write_subtitle_frame(av_t *av, unsigned int stream_index,
   }
 
   caml_release_runtime_system();
-  err = avcodec_encode_subtitle(stream->codec_context, packet->data,
-                                packet->size, subtitle);
+
+  /* Header first: it can update the stream time base before the rescale
+     below, and deferring it until a subtitle encodes to something leaves a
+     stream whose subtitles are all empty with no header, hence no trailer
+     at close. */
+  err = ensure_header_written(av);
+
+  if (err >= 0)
+    err = avcodec_encode_subtitle(stream->codec_context, packet->data,
+                                  packet->size, subtitle);
+
   caml_acquire_runtime_system();
 
   if (err < 0) {
@@ -2345,19 +2356,6 @@ static void write_subtitle_frame(av_t *av, unsigned int stream_index,
   // Update packet size to actual encoded size
   packet->size = encoded_size;
 
-  // Write header before rescaling timestamps (header write can update
-  // time_base)
-  if (!av->header_written) {
-    caml_release_runtime_system();
-    err = avformat_write_header(av->format_context, NULL);
-    caml_acquire_runtime_system();
-    if (err < 0) {
-      av_packet_free(&packet);
-      ocaml_avutil_raise_error(err);
-    }
-    av->header_written = 1;
-  }
-
   // subtitle->pts is in AV_TIME_BASE units
   // start_display_time and end_display_time are in milliseconds relative to
   // pts Note: avcodec_encode_subtitle requires start_display_time == 0
@@ -2369,13 +2367,8 @@ static void write_subtitle_frame(av_t *av, unsigned int stream_index,
       (int64_t)(subtitle->end_display_time - subtitle->start_display_time) *
       AV_TIME_BASE / 1000;
 
-  av_packet_rescale_ts(packet, AV_TIME_BASE_Q, avstream->time_base);
-
-  packet->stream_index = stream_index;
-  packet->pos = -1;
-
   caml_release_runtime_system();
-  err = av->write_frame(av->format_context, packet);
+  err = send_packet(av, packet, stream_index, AV_TIME_BASE_Q);
   caml_acquire_runtime_system();
 
   av_packet_free(&packet);
@@ -2397,10 +2390,8 @@ CAMLprim value ocaml_av_write_stream_frame(value _on_keyframe, value _stream,
 
   enum AVMediaType type = av->streams[index]->codec_context->codec_type;
 
-  if (type == AVMEDIA_TYPE_AUDIO) {
-    write_audio_frame(av, index, _on_keyframe, Frame_val(_frame));
-  } else if (type == AVMEDIA_TYPE_VIDEO) {
-    write_video_frame(av, index, _on_keyframe, Frame_val(_frame));
+  if (type == AVMEDIA_TYPE_AUDIO || type == AVMEDIA_TYPE_VIDEO) {
+    write_media_frame(av, index, _on_keyframe, Frame_val(_frame));
   } else if (type == AVMEDIA_TYPE_SUBTITLE) {
     write_subtitle_frame(av, index, Subtitle_val(_frame));
   }
@@ -2466,11 +2457,11 @@ CAMLprim value ocaml_av_close(value _av) {
       if (!enc_ctx)
         continue;
 
-      if (enc_ctx->codec_type == AVMEDIA_TYPE_AUDIO) {
-        write_audio_frame(av, i, Val_none, NULL);
-      } else if (enc_ctx->codec_type == AVMEDIA_TYPE_VIDEO) {
-        write_video_frame(av, i, Val_none, NULL);
-      }
+      /* Subtitles are not flushed: avcodec_encode_subtitle is stateless,
+         there is no delayed output to drain. */
+      if (enc_ctx->codec_type == AVMEDIA_TYPE_AUDIO ||
+          enc_ctx->codec_type == AVMEDIA_TYPE_VIDEO)
+        write_media_frame(av, i, Val_none, NULL);
     }
 
     // write the trailer

--- a/src/modules/synced/ffmpeg/av/av_stubs.c
+++ b/src/modules/synced/ffmpeg/av/av_stubs.c
@@ -772,20 +772,9 @@ CAMLprim value ocaml_av_open_input(value _url, value _format, value _interrupt,
   avioformat_const AVInputFormat *format = NULL;
   int ulen = caml_string_length(_url);
   AVDictionary *options = NULL;
-  char *key, *val;
-  int i, err, count;
+  int i, err;
 
-  int len = Wosize_val(_opts);
-  for (i = 0; i < len; i++) {
-    // Dictionaries copy key/values by default!
-    key = (char *)Bytes_val(Field(Field(_opts, i), 0));
-    val = (char *)Bytes_val(Field(Field(_opts, i), 1));
-    err = av_dict_set(&options, key, val, 0);
-    if (err < 0) {
-      av_dict_free(&options);
-      ocaml_avutil_raise_error(err);
-    }
-  }
+  ocaml_avutil_dict_of_options(_opts, &options);
 
   if (ulen > 0)
     url = av_strndup(String_val(_url), ulen);
@@ -876,13 +865,7 @@ CAMLprim value ocaml_av_open_input(value _url, value _format, value _interrupt,
       }
     }
 
-    value _stream_opts = Field(_config, 1);
-    int stream_opts_len = Wosize_val(_stream_opts);
-    for (int j = 0; j < stream_opts_len; j++) {
-      value _pair = Field(_stream_opts, j);
-      av_dict_set(&stream_opts[i], String_val(Field(_pair, 0)),
-                  String_val(Field(_pair, 1)), 0);
-    }
+    ocaml_avutil_dict_of_options(Field(_config, 1), &stream_opts[i]);
   }
 
   if (audio_codec_override) {
@@ -930,15 +913,7 @@ CAMLprim value ocaml_av_open_input(value _url, value _format, value _interrupt,
     ocaml_avutil_raise_error(err);
   }
 
-  // Return unused format-level keys
-  count = av_dict_count(options);
-  unused = caml_alloc_tuple(count);
-  AVDictionaryEntry *entry = NULL;
-  for (i = 0; i < count; i++) {
-    entry = av_dict_get(options, "", entry, AV_DICT_IGNORE_SUFFIX);
-    Store_field(unused, i, caml_copy_string(entry->key));
-  }
-  av_dict_free(&options);
+  unused = ocaml_avutil_unused_options(&options);
 
   ans = caml_alloc_custom(&av_ops, sizeof(av_t *), 0, 1);
   Av_base_val(ans) = av;
@@ -964,20 +939,8 @@ CAMLprim value ocaml_av_open_input_stream(value _avio, value _format,
   avioformat_const AVInputFormat *format = NULL;
   AVDictionary *options = NULL;
   AVFormatContext *format_context;
-  char *key, *val;
-  int len = Wosize_val(_opts);
-  int i, err, count;
 
-  for (i = 0; i < len; i++) {
-    // Dictionaries copy key/values by default!
-    key = (char *)Bytes_val(Field(Field(_opts, i), 0));
-    val = (char *)Bytes_val(Field(Field(_opts, i), 1));
-    err = av_dict_set(&options, key, val, 0);
-    if (err < 0) {
-      av_dict_free(&options);
-      ocaml_avutil_raise_error(err);
-    }
-  }
+  ocaml_avutil_dict_of_options(_opts, &options);
 
   if (_format != Val_none)
     format = InputFormat_val(Some_val(_format));
@@ -995,17 +958,7 @@ CAMLprim value ocaml_av_open_input_stream(value _avio, value _format,
   av->avio = _avio;
   caml_register_generational_global_root(&av->avio);
 
-  // Return unused keys
-  count = av_dict_count(options);
-
-  unused = caml_alloc_tuple(count);
-  AVDictionaryEntry *entry = NULL;
-  for (i = 0; i < count; i++) {
-    entry = av_dict_get(options, "", entry, AV_DICT_IGNORE_SUFFIX);
-    Store_field(unused, i, caml_copy_string(entry->key));
-  }
-
-  av_dict_free(&options);
+  unused = ocaml_avutil_unused_options(&options);
 
   // allocate format context
   ans = caml_alloc_custom(&av_ops, sizeof(av_t *), 0, 1);
@@ -1721,20 +1674,8 @@ CAMLprim value ocaml_av_open_output(value _interrupt, value _format,
       av_strndup(String_val(_filename), caml_string_length(_filename));
   avioformat_const AVOutputFormat *format = NULL;
   AVDictionary *options = NULL;
-  char *key, *val;
-  int len = Wosize_val(_opts);
-  int i, err, count;
 
-  for (i = 0; i < len; i++) {
-    // Dictionaries copy key/values by default!
-    key = (char *)Bytes_val(Field(Field(_opts, i), 0));
-    val = (char *)Bytes_val(Field(Field(_opts, i), 1));
-    err = av_dict_set(&options, key, val, 0);
-    if (err < 0) {
-      av_dict_free(&options);
-      ocaml_avutil_raise_error(err);
-    }
-  }
+  ocaml_avutil_dict_of_options(_opts, &options);
 
   if (_format != Val_none)
     format = OutputFormat_val(Some_val(_format));
@@ -1743,17 +1684,7 @@ CAMLprim value ocaml_av_open_output(value _interrupt, value _format,
   av_t *av = open_output(format, filename, NULL, _interrupt,
                          Bool_val(_interleaved), &options);
 
-  // Return unused keys
-  count = av_dict_count(options);
-
-  unused = caml_alloc_tuple(count);
-  AVDictionaryEntry *entry = NULL;
-  for (i = 0; i < count; i++) {
-    entry = av_dict_get(options, "", entry, AV_DICT_IGNORE_SUFFIX);
-    Store_field(unused, i, caml_copy_string(entry->key));
-  }
-
-  av_dict_free(&options);
+  unused = ocaml_avutil_unused_options(&options);
 
   // allocate format context
   ans = caml_alloc_custom(&av_ops, sizeof(av_t *), 0, 1);
@@ -1771,20 +1702,8 @@ CAMLprim value ocaml_av_open_output_format(value _format, value _interleaved,
   CAMLparam3(_format, _interleaved, _opts);
   CAMLlocal3(ans, ret, unused);
   AVDictionary *options = NULL;
-  char *key, *val;
-  int len = Wosize_val(_opts);
-  int i, err, count;
 
-  for (i = 0; i < len; i++) {
-    // Dictionaries copy key/values by default!
-    key = (char *)Bytes_val(Field(Field(_opts, i), 0));
-    val = (char *)Bytes_val(Field(Field(_opts, i), 1));
-    err = av_dict_set(&options, key, val, 0);
-    if (err < 0) {
-      av_dict_free(&options);
-      ocaml_avutil_raise_error(err);
-    }
-  }
+  ocaml_avutil_dict_of_options(_opts, &options);
 
   avioformat_const AVOutputFormat *format = OutputFormat_val(_format);
 
@@ -1792,17 +1711,7 @@ CAMLprim value ocaml_av_open_output_format(value _format, value _interleaved,
   av_t *av = open_output(format, NULL, NULL, Val_none, Bool_val(_interleaved),
                          &options);
 
-  // Return unused keys
-  count = av_dict_count(options);
-
-  unused = caml_alloc_tuple(count);
-  AVDictionaryEntry *entry = NULL;
-  for (i = 0; i < count; i++) {
-    entry = av_dict_get(options, "", entry, AV_DICT_IGNORE_SUFFIX);
-    Store_field(unused, i, caml_copy_string(entry->key));
-  }
-
-  av_dict_free(&options);
+  unused = ocaml_avutil_unused_options(&options);
 
   // allocate format context
   ans = caml_alloc_custom(&av_ops, sizeof(av_t *), 0, 1);
@@ -1822,20 +1731,8 @@ CAMLprim value ocaml_av_open_output_stream(value _format, value _avio,
   avioformat_const AVOutputFormat *format = OutputFormat_val(_format);
   avio_t *avio = Avio_val(_avio);
   AVDictionary *options = NULL;
-  char *key, *val;
-  int len = Wosize_val(_opts);
-  int i, err, count;
 
-  for (i = 0; i < len; i++) {
-    // Dictionaries copy key/values by default!
-    key = (char *)Bytes_val(Field(Field(_opts, i), 0));
-    val = (char *)Bytes_val(Field(Field(_opts, i), 1));
-    err = av_dict_set(&options, key, val, 0);
-    if (err < 0) {
-      av_dict_free(&options);
-      ocaml_avutil_raise_error(err);
-    }
-  }
+  ocaml_avutil_dict_of_options(_opts, &options);
 
   // open output format
   av_t *av = open_output(format, NULL, avio->avio_context, Val_none,
@@ -1844,17 +1741,7 @@ CAMLprim value ocaml_av_open_output_stream(value _format, value _avio,
   av->avio = _avio;
   caml_register_generational_global_root(&av->avio);
 
-  // Return unused keys
-  count = av_dict_count(options);
-
-  unused = caml_alloc_tuple(count);
-  AVDictionaryEntry *entry = NULL;
-  for (i = 0; i < count; i++) {
-    entry = av_dict_get(options, "", entry, AV_DICT_IGNORE_SUFFIX);
-    Store_field(unused, i, caml_copy_string(entry->key));
-  }
-
-  av_dict_free(&options);
+  unused = ocaml_avutil_unused_options(&options);
 
   // allocate format context
   ans = caml_alloc_custom(&av_ops, sizeof(av_t *), 0, 1);
@@ -2063,36 +1950,14 @@ CAMLprim value ocaml_av_new_audio_stream(value _av, value _sample_fmt,
   const AVCodec *codec = AvCodec_val(_codec);
 
   AVDictionary *options = NULL;
-  char *key, *val;
-  int len = Wosize_val(_opts);
-  int i, err, count;
 
-  for (i = 0; i < len; i++) {
-    // Dictionaries copy key/values by default!
-    key = (char *)Bytes_val(Field(Field(_opts, i), 0));
-    val = (char *)Bytes_val(Field(Field(_opts, i), 1));
-    err = av_dict_set(&options, key, val, 0);
-    if (err < 0) {
-      av_dict_free(&options);
-      ocaml_avutil_raise_error(err);
-    }
-  }
+  ocaml_avutil_dict_of_options(_opts, &options);
 
   stream_t *stream =
       new_audio_stream(Av_val(_av), Int_val(_sample_fmt),
                        AVChannelLayout_val(_channel_layout), codec, &options);
 
-  // Return unused keys
-  count = av_dict_count(options);
-
-  unused = caml_alloc_tuple(count);
-  AVDictionaryEntry *entry = NULL;
-  for (i = 0; i < count; i++) {
-    entry = av_dict_get(options, "", entry, AV_DICT_IGNORE_SUFFIX);
-    Store_field(unused, i, caml_copy_string(entry->key));
-  }
-
-  av_dict_free(&options);
+  unused = ocaml_avutil_unused_options(&options);
 
   ans = caml_alloc_tuple(2);
   Store_field(ans, 0, Val_int(stream->index));
@@ -2129,35 +1994,13 @@ CAMLprim value ocaml_av_new_video_stream(value _device_context,
     frame_ctx = BufferRef_val(Some_val(_frame_context));
 
   AVDictionary *options = NULL;
-  char *key, *val;
-  int len = Wosize_val(_opts);
-  int i, err, count;
 
-  for (i = 0; i < len; i++) {
-    // Dictionaries copy key/values by default!
-    key = (char *)Bytes_val(Field(Field(_opts, i), 0));
-    val = (char *)Bytes_val(Field(Field(_opts, i), 1));
-    err = av_dict_set(&options, key, val, 0);
-    if (err < 0) {
-      av_dict_free(&options);
-      ocaml_avutil_raise_error(err);
-    }
-  }
+  ocaml_avutil_dict_of_options(_opts, &options);
 
   stream_t *stream =
       new_video_stream(device_ctx, frame_ctx, Av_val(_av), codec, &options);
 
-  // Return unused keys
-  count = av_dict_count(options);
-
-  unused = caml_alloc_tuple(count);
-  AVDictionaryEntry *entry = NULL;
-  for (i = 0; i < count; i++) {
-    entry = av_dict_get(options, "", entry, AV_DICT_IGNORE_SUFFIX);
-    Store_field(unused, i, caml_copy_string(entry->key));
-  }
-
-  av_dict_free(&options);
+  unused = ocaml_avutil_unused_options(&options);
 
   ans = caml_alloc_tuple(2);
   Store_field(ans, 0, Val_int(stream->index));
@@ -2210,35 +2053,13 @@ CAMLprim value ocaml_av_new_subtitle_stream(value _av, value _codec,
   }
 
   AVDictionary *options = NULL;
-  char *key, *val;
-  int len = Wosize_val(_opts);
-  int i, err, count;
 
-  for (i = 0; i < len; i++) {
-    // Dictionaries copy key/values by default!
-    key = (char *)Bytes_val(Field(Field(_opts, i), 0));
-    val = (char *)Bytes_val(Field(Field(_opts, i), 1));
-    err = av_dict_set(&options, key, val, 0);
-    if (err < 0) {
-      av_dict_free(&options);
-      ocaml_avutil_raise_error(err);
-    }
-  }
+  ocaml_avutil_dict_of_options(_opts, &options);
 
   stream_t *stream = new_subtitle_stream(Av_val(_av), codec, time_base, header,
                                          header_len, &options);
 
-  // Return unused keys
-  count = av_dict_count(options);
-
-  unused = caml_alloc_tuple(count);
-  AVDictionaryEntry *entry = NULL;
-  for (i = 0; i < count; i++) {
-    entry = av_dict_get(options, "", entry, AV_DICT_IGNORE_SUFFIX);
-    Store_field(unused, i, caml_copy_string(entry->key));
-  }
-
-  av_dict_free(&options);
+  unused = ocaml_avutil_unused_options(&options);
 
   ans = caml_alloc_tuple(2);
   Store_field(ans, 0, Val_int(stream->index));

--- a/src/modules/synced/ffmpeg/av/av_stubs.c
+++ b/src/modules/synced/ffmpeg/av/av_stubs.c
@@ -355,26 +355,35 @@ typedef struct avio_t {
   value seek_cb;
 } avio_t;
 
+/* ffmpeg calls these from its own threads and unwinding an OCaml exception
+   through ffmpeg's C frames is undefined, so every callback below registers
+   the thread and traps exceptions. Must hold the runtime system. */
+static int callback_raised(void *log_ctx, value res, const char *what) {
+  char *caml_exn;
+
+  if (!Is_exception_result(res))
+    return 0;
+
+  caml_exn = caml_format_exception(Extract_exception(res));
+  av_log(log_ctx, AV_LOG_ERROR, "Error while executing OCaml %s callback: %s\n",
+         what, caml_exn);
+  caml_stat_free(caml_exn);
+
+  return 1;
+}
+
 static int ocaml_avio_read_callback(void *private, uint8_t *buf, int buf_size) {
   value res;
   avio_t *avio = (avio_t *)private;
   int len = MIN(BUFLEN, buf_size);
-  char *caml_exn = NULL;
 
+  ocaml_ffmpeg_register_thread();
   caml_acquire_runtime_system();
 
   res =
       caml_callback3_exn(avio->read_cb, avio->buffer, Val_int(0), Val_int(len));
-  if (Is_exception_result(res)) {
-    res = Extract_exception(res);
-
-    caml_exn = caml_format_exception(res);
-    av_log(avio->avio_context, AV_LOG_ERROR,
-           "Error while executing OCaml read callback: %s\n", caml_exn);
-    caml_stat_free(caml_exn);
-
+  if (callback_raised(avio->avio_context, res, "read")) {
     caml_release_runtime_system();
-
     return AVERROR_EXTERNAL;
   }
 
@@ -404,24 +413,16 @@ static int ocaml_avio_write_callback(void *private, const uint8_t *buf,
   value res;
   avio_t *avio = (avio_t *)private;
   int len = MIN(BUFLEN, buf_size);
-  char *caml_exn = NULL;
 
+  ocaml_ffmpeg_register_thread();
   caml_acquire_runtime_system();
 
   memcpy(Bytes_val(avio->buffer), buf, len);
 
   res = caml_callback3_exn(avio->write_cb, avio->buffer, Val_int(0),
                            Val_int(len));
-  if (Is_exception_result(res)) {
-    res = Extract_exception(res);
-
-    caml_exn = caml_format_exception(res);
-    av_log(avio->avio_context, AV_LOG_ERROR,
-           "Error while executing OCaml write callback: %s\n", caml_exn);
-    caml_stat_free(caml_exn);
-
+  if (callback_raised(avio->avio_context, res, "write")) {
     caml_release_runtime_system();
-
     return AVERROR_EXTERNAL;
   }
 
@@ -451,9 +452,15 @@ static int64_t ocaml_avio_seek_callback(void *private, int64_t offset,
     return -1;
   }
 
+  ocaml_ffmpeg_register_thread();
   caml_acquire_runtime_system();
 
-  res = caml_callback2(avio->seek_cb, Val_int(offset), Val_int(_whence));
+  res = caml_callback2_exn(avio->seek_cb, Val_int(offset), Val_int(_whence));
+
+  if (callback_raised(avio->avio_context, res, "seek")) {
+    caml_release_runtime_system();
+    return AVERROR_EXTERNAL;
+  }
 
   n = Int_val(res);
 
@@ -470,8 +477,17 @@ static int ocaml_av_interrupt_callback(void *private) {
   if (!av->interrupt_cb)
     return 0;
 
+  ocaml_ffmpeg_register_thread();
   caml_acquire_runtime_system();
-  res = caml_callback(av->interrupt_cb, Val_unit);
+  res = caml_callback_exn(av->interrupt_cb, Val_unit);
+
+  /* A raising interrupt callback aborts the blocking operation: returning
+     non-zero is exactly what the caller asked for. */
+  if (callback_raised(av->format_context, res, "interrupt")) {
+    caml_release_runtime_system();
+    return 1;
+  }
+
   n = Int_val(res);
   caml_release_runtime_system();
 
@@ -1215,11 +1231,15 @@ static int decode_subtitle_packet(av_t *av, stream_t *stream,
 
   caml_acquire_runtime_system();
 
-  if (ret >= 0 && !got_sub_ptr)
+  if (ret >= 0 && !got_sub_ptr) {
+    av_packet_unref(packet);
     return AVERROR(EAGAIN);
+  }
 
-  if (ret < 0)
+  if (ret < 0) {
+    av_packet_unref(packet);
     return ret;
+  }
 
   // Transfer packet timing to subtitle structure.
   // subtitle->pts should be in AV_TIME_BASE units.
@@ -1854,7 +1874,12 @@ CAMLprim value ocaml_av_reopen_output_stream(value _av) {
   if (!av->format_context->pb)
     Fail("Not a streamed output!");
 
-  avio_open_dyn_buf(&av->format_context->pb);
+  caml_release_runtime_system();
+  int ret = avio_open_dyn_buf(&av->format_context->pb);
+  caml_acquire_runtime_system();
+
+  if (ret < 0)
+    ocaml_avutil_raise_error(ret);
 
   CAMLreturn(Val_unit);
 }
@@ -1993,7 +2018,9 @@ static stream_t *new_audio_stream(av_t *av, enum AVSampleFormat sample_fmt,
   ret = av_channel_layout_copy(&enc_ctx->ch_layout, channel_layout);
 
   if (ret < 0) {
-    free_stream(stream);
+    /* [stream] is already linked into av->streams by
+       allocate_stream_context; freeing it here would double-free on close. */
+    av_dict_free(options);
     ocaml_avutil_raise_error(ret);
   }
 
@@ -2412,7 +2439,10 @@ static void write_frame(av_t *av, int stream_index, AVCodecContext *enc_ctx,
 
 static void write_audio_frame(av_t *av, unsigned int stream_index,
                               value _on_keyframe, AVFrame *frame) {
-  if (av->format_context->nb_streams < stream_index)
+  if (!av->streams)
+    Fail("Failed to write in closed output");
+
+  if (stream_index >= av->format_context->nb_streams)
     Fail("Stream index not found!");
 
   stream_t *stream = av->streams[stream_index];
@@ -2425,11 +2455,11 @@ static void write_audio_frame(av_t *av, unsigned int stream_index,
 
 static void write_video_frame(av_t *av, unsigned int stream_index,
                               value _on_keyframe, AVFrame *frame) {
-  if (av->format_context->nb_streams < stream_index)
-    Fail("Stream index not found!");
-
   if (!av->streams)
     Fail("Failed to write in closed output");
+
+  if (stream_index >= av->format_context->nb_streams)
+    Fail("Stream index not found!");
 
   stream_t *stream = av->streams[stream_index];
 
@@ -2441,10 +2471,13 @@ static void write_video_frame(av_t *av, unsigned int stream_index,
 
 static void write_subtitle_frame(av_t *av, unsigned int stream_index,
                                  AVSubtitle *subtitle) {
-  stream_t *stream = av->streams[stream_index];
+  if (!av->streams)
+    Fail("Failed to write in closed output");
 
-  if (av->format_context->nb_streams < stream_index)
+  if (stream_index >= av->format_context->nb_streams)
     Fail("Stream index not found!");
+
+  stream_t *stream = av->streams[stream_index];
 
   AVStream *avstream = av->format_context->streams[stream->index];
 
@@ -2583,7 +2616,11 @@ CAMLprim value ocaml_av_tell(value _av) {
   if (!av->format_context->pb)
     CAMLreturn(Val_none);
 
+  /* On a custom-IO container this reaches the OCaml seek callback, which
+     acquires the runtime system itself. */
+  caml_release_runtime_system();
   ret = avio_tell(av->format_context->pb);
+  caml_acquire_runtime_system();
 
   if (ret < 0)
     ocaml_avutil_raise_error(ret);

--- a/src/modules/synced/ffmpeg/avcodec/avcodec.ml
+++ b/src/modules/synced/ffmpeg/avcodec/avcodec.ml
@@ -52,6 +52,16 @@ let all_codecs =
   in
   f [] None
 
+(* Shared by the Audio, Video and Subtitle modules, which each filter the same
+   list by their own set of codec ids. *)
+let codecs_of ~encoder codec_ids =
+  List.filter_map
+    (function
+      | c, Some id, e when e = encoder && List.mem id codec_ids ->
+          Some (Obj.magic c)
+      | _ -> None)
+    all_codecs
+
 external name : _ codec -> string = "ocaml_avcodec_name"
 
 type capability = Codec_capabilities.t
@@ -228,20 +238,8 @@ module Audio = struct
   let codec_ids = Codec_id.audio
   let get_name = get_name
   let get_description = get_description
-
-  let encoders =
-    List.filter_map
-      (function
-        | c, Some id, true when List.mem id codec_ids -> Some (Obj.magic c)
-        | _ -> None)
-      all_codecs
-
-  let decoders =
-    List.filter_map
-      (function
-        | c, Some id, false when List.mem id codec_ids -> Some (Obj.magic c)
-        | _ -> None)
-      all_codecs
+  let encoders = codecs_of ~encoder:true codec_ids
+  let decoders = codecs_of ~encoder:false codec_ids
 
   external frame_size : audio encoder -> int = "ocaml_avcodec_frame_size"
   external get_id : _ t -> id = "ocaml_avcodec_get_audio_codec_id"
@@ -363,21 +361,8 @@ module Video = struct
 
   let descriptor id = mk_descriptor (video_descriptor id)
   let codec_ids = Codec_id.video
-
-  let encoders =
-    List.filter_map
-      (function
-        | c, Some id, true when List.mem id codec_ids -> Some (Obj.magic c)
-        | _ -> None)
-      all_codecs
-
-  let decoders =
-    List.filter_map
-      (function
-        | c, Some id, false when List.mem id codec_ids -> Some (Obj.magic c)
-        | _ -> None)
-      all_codecs
-
+  let encoders = codecs_of ~encoder:true codec_ids
+  let decoders = codecs_of ~encoder:false codec_ids
   let get_name = get_name
   let get_description = get_description
 
@@ -513,21 +498,8 @@ module Subtitle = struct
 
   let descriptor id = mk_descriptor (subtitle_descriptor id)
   let codec_ids = Codec_id.subtitle
-
-  let encoders =
-    List.filter_map
-      (function
-        | c, Some id, true when List.mem id codec_ids -> Some (Obj.magic c)
-        | _ -> None)
-      all_codecs
-
-  let decoders =
-    List.filter_map
-      (function
-        | c, Some id, false when List.mem id codec_ids -> Some (Obj.magic c)
-        | _ -> None)
-      all_codecs
-
+  let encoders = codecs_of ~encoder:true codec_ids
+  let decoders = codecs_of ~encoder:false codec_ids
   let get_name = get_name
   let get_description = get_description
 

--- a/src/modules/synced/ffmpeg/avcodec/avcodec_stubs.c
+++ b/src/modules/synced/ffmpeg/avcodec/avcodec_stubs.c
@@ -35,10 +35,6 @@ CAMLprim value ocaml_avcodec_flag_qscale(value unit) {
   return Val_int(AV_CODEC_FLAG_QSCALE);
 }
 
-CAMLprim value ocaml_avcodec_subtitle_codec_id_to_AVCodecID(value _codec_id) {
-  return Val_int(SubtitleCodecID_val(_codec_id));
-}
-
 /***** AVCodecContext *****/
 
 static AVCodecContext *create_AVCodecContext(AVCodecParameters *params,
@@ -142,7 +138,7 @@ CAMLprim value ocaml_avcodec_create_packet(value _data) {
 
   int err = av_new_packet(packet, len);
   if (err != 0) {
-    av_freep(packet);
+    av_packet_free(&packet);
     ocaml_avutil_raise_error(err);
   }
 
@@ -997,7 +993,7 @@ CAMLprim value ocaml_avcodec_capabilities(value _codec) {
   len = 0;
   for (i = 0; i < AV_CODEC_CAP_T_TAB_LEN; i++)
     if (codec->capabilities & AV_CODEC_CAP_T_TAB[i][1])
-      Store_field(ret, len++, Val_int(AV_CODEC_CAP_T_TAB[i][0]));
+      Store_field(ret, len++, AV_CODEC_CAP_T_TAB[i][0]);
 
   CAMLreturn(ret);
 }
@@ -1463,35 +1459,6 @@ CAMLprim value ocaml_avcodec_parameters_get_pixel_aspect(value _cp) {
   CAMLreturn(ret);
 }
 
-CAMLprim value ocaml_avcodec_parameters_video_copy(value _codec_id,
-                                                   value _width, value _height,
-                                                   value _sample_aspect_ratio,
-                                                   value _pixel_format,
-                                                   value _bit_rate, value _cp) {
-  CAMLparam5(_codec_id, _width, _height, _sample_aspect_ratio, _pixel_format);
-  CAMLxparam2(_bit_rate, _cp);
-  CAMLlocal1(ans);
-
-  value_of_codec_parameters_copy(CodecParameters_val(_cp), &ans);
-
-  AVCodecParameters *dst = CodecParameters_val(ans);
-
-  dst->codec_id = VideoCodecID_val(_codec_id);
-  dst->width = Int_val(_width);
-  dst->height = Int_val(_height);
-  dst->sample_aspect_ratio.num = Int_val(Field(_sample_aspect_ratio, 0));
-  dst->sample_aspect_ratio.den = Int_val(Field(_sample_aspect_ratio, 1));
-  dst->format = PixelFormat_val(_pixel_format);
-  dst->bit_rate = Int_val(_bit_rate);
-
-  CAMLreturn(ans);
-}
-
-CAMLprim value ocaml_avcodec_parameters_video_copy_byte(value *argv, int argn) {
-  return ocaml_avcodec_parameters_video_copy(argv[0], argv[1], argv[2], argv[3],
-                                             argv[4], argv[5], argv[7]);
-}
-
 /**** Unknown codec ID *****/
 
 CAMLprim value ocaml_avcodec_get_unknown_codec_id_name(value _codec_id) {
@@ -1544,20 +1511,6 @@ CAMLprim value ocaml_avcodec_find_subtitle_encoder(value _id) {
 CAMLprim value ocaml_avcodec_parameters_get_subtitle_codec_id(value _cp) {
   CAMLparam1(_cp);
   CAMLreturn(Val_SubtitleCodecID(CodecParameters_val(_cp)->codec_id));
-}
-
-CAMLprim value ocaml_avcodec_parameters_subtitle_copy(value _codec_id,
-                                                      value _cp) {
-  CAMLparam2(_codec_id, _cp);
-  CAMLlocal1(ans);
-
-  value_of_codec_parameters_copy(CodecParameters_val(_cp), &ans);
-
-  AVCodecParameters *dst = CodecParameters_val(ans);
-
-  dst->codec_id = SubtitleCodecID_val(_codec_id);
-
-  CAMLreturn(ans);
 }
 
 CAMLprim value ocaml_avcodec_int_of_flag(value _flag) {
@@ -1743,17 +1696,21 @@ CAMLprim value ocaml_avcodec_bsf_init(value _opts, value _name, value _params) {
 
   ret = av_bsf_alloc(filter, &bsf);
   if (ret < 0) {
+    av_dict_free(&options);
     ocaml_avutil_raise_error(ret);
   }
 
   ret = avcodec_parameters_copy(bsf->par_in, params);
   if (ret < 0) {
+    av_dict_free(&options);
     av_bsf_free(&bsf);
     ocaml_avutil_raise_error(ret);
   }
 
+  /* av_opt_set_dict consumes and replaces options. */
   ret = av_opt_set_dict(bsf, &options);
   if (ret < 0) {
+    av_dict_free(&options);
     av_bsf_free(&bsf);
     ocaml_avutil_raise_error(ret);
   }
@@ -1763,6 +1720,7 @@ CAMLprim value ocaml_avcodec_bsf_init(value _opts, value _name, value _params) {
   caml_acquire_runtime_system();
 
   if (ret < 0) {
+    av_dict_free(&options);
     av_bsf_free(&bsf);
     ocaml_avutil_raise_error(ret);
   }

--- a/src/modules/synced/ffmpeg/avcodec/avcodec_stubs.c
+++ b/src/modules/synced/ffmpeg/avcodec/avcodec_stubs.c
@@ -25,6 +25,7 @@
 #endif
 
 value ocaml_avcodec_init(value unit) {
+  (void)unit;
 #if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(58, 9, 100)
   avcodec_register_all();
 #endif
@@ -32,6 +33,7 @@ value ocaml_avcodec_init(value unit) {
 }
 
 CAMLprim value ocaml_avcodec_flag_qscale(value unit) {
+  (void)unit;
   return Val_int(AV_CODEC_FLAG_QSCALE);
 }
 
@@ -78,7 +80,8 @@ static void finalize_codec_parameters(value v) {
 static struct custom_operations codec_parameters_ops = {
     "ocaml_avcodec_parameters", finalize_codec_parameters,
     custom_compare_default,     custom_hash_default,
-    custom_serialize_default,   custom_deserialize_default};
+    custom_serialize_default,   custom_deserialize_default,
+    custom_compare_ext_default, custom_fixed_length_default};
 
 void value_of_codec_parameters_copy(AVCodecParameters *src, value *pvalue) {
   if (!src)
@@ -108,9 +111,14 @@ static void finalize_packet(value v) {
   av_packet_free(&packet);
 }
 
-static struct custom_operations packet_ops = {
-    "ocaml_packet",      finalize_packet,          custom_compare_default,
-    custom_hash_default, custom_serialize_default, custom_deserialize_default};
+static struct custom_operations packet_ops = {"ocaml_packet",
+                                              finalize_packet,
+                                              custom_compare_default,
+                                              custom_hash_default,
+                                              custom_serialize_default,
+                                              custom_deserialize_default,
+                                              custom_compare_ext_default,
+                                              custom_fixed_length_default};
 
 value value_of_ffmpeg_packet(value *ret, AVPacket *packet) {
   if (!packet)
@@ -174,6 +182,7 @@ CAMLprim value ocaml_avcodec_packet_add_side_data(value _packet,
     break;
   default:
     Fail("Invalid value");
+    CAMLreturn(Val_unit); /* unreachable: Fail raises */
   }
 
   switch (type) {
@@ -449,9 +458,10 @@ static void finalize_codec_context(value v) {
 }
 
 static struct custom_operations codec_context_ops = {
-    "ocaml_codec_context",    finalize_codec_context,
-    custom_compare_default,   custom_hash_default,
-    custom_serialize_default, custom_deserialize_default};
+    "ocaml_codec_context",      finalize_codec_context,
+    custom_compare_default,     custom_hash_default,
+    custom_serialize_default,   custom_deserialize_default,
+    custom_compare_ext_default, custom_fixed_length_default};
 
 CAMLprim value ocaml_avcodec_create_decoder(value _params, value _codec) {
   CAMLparam2(_params, _codec);
@@ -1370,8 +1380,10 @@ CAMLprim value ocaml_avcodec_get_supported_color_spaces(value _codec) {
     ocaml_avutil_raise_error(err);
 #endif
 
+  /* Terminated by AVCOL_SPC_UNSPECIFIED, not -1: enum AVColorSpace is
+     unsigned, so comparing against -1 never terminates. */
   if (color_spaces) {
-    for (i = 0; color_spaces[i] != -1; i++)
+    for (i = 0; color_spaces[i] != AVCOL_SPC_UNSPECIFIED; i++)
       List_add(list, cons, Val_ColorSpace(color_spaces[i]));
   }
 
@@ -1396,8 +1408,9 @@ CAMLprim value ocaml_avcodec_get_supported_color_ranges(value _codec) {
     ocaml_avutil_raise_error(err);
 #endif
 
+  /* Terminated by AVCOL_RANGE_UNSPECIFIED, not -1. */
   if (color_ranges) {
-    for (i = 0; color_ranges[i] != -1; i++)
+    for (i = 0; color_ranges[i] != AVCOL_RANGE_UNSPECIFIED; i++)
       List_add(list, cons, Val_ColorRange(color_ranges[i]));
   }
 
@@ -1660,9 +1673,10 @@ static void finalize_bsf_filter(value v) {
 }
 
 static struct custom_operations bsf_filter_ops = {
-    "bsf_filter_parameters",  finalize_bsf_filter,
-    custom_compare_default,   custom_hash_default,
-    custom_serialize_default, custom_deserialize_default};
+    "bsf_filter_parameters",    finalize_bsf_filter,
+    custom_compare_default,     custom_hash_default,
+    custom_serialize_default,   custom_deserialize_default,
+    custom_compare_ext_default, custom_fixed_length_default};
 
 CAMLprim value ocaml_avcodec_bsf_init(value _opts, value _name, value _params) {
   CAMLparam3(_opts, _name, _params);

--- a/src/modules/synced/ffmpeg/avcodec/avcodec_stubs.c
+++ b/src/modules/synced/ffmpeg/avcodec/avcodec_stubs.c
@@ -534,20 +534,9 @@ CAMLprim value ocaml_avcodec_create_audio_encoder(value _sample_fmt,
   const AVCodec *codec = AvCodec_val(_codec);
 
   AVDictionary *options = NULL;
-  char *key, *val;
-  int len = Wosize_val(_opts);
-  int i, err, count;
+  int err;
 
-  for (i = 0; i < len; i++) {
-    // Dictionaries copy key/values by default!
-    key = (char *)Bytes_val(Field(Field(_opts, i), 0));
-    val = (char *)Bytes_val(Field(Field(_opts, i), 1));
-    err = av_dict_set(&options, key, val, 0);
-    if (err < 0) {
-      av_dict_free(&options);
-      ocaml_avutil_raise_error(err);
-    }
-  }
+  ocaml_avutil_dict_of_options(_opts, &options);
 
   codec_context_t *ctx = (codec_context_t *)av_mallocz(sizeof(codec_context_t));
   if (!ctx) {
@@ -586,17 +575,7 @@ CAMLprim value ocaml_avcodec_create_audio_encoder(value _sample_fmt,
     ocaml_avutil_raise_error(err);
   }
 
-  // Return unused keys
-  count = av_dict_count(options);
-
-  unused = caml_alloc_tuple(count);
-  AVDictionaryEntry *entry = NULL;
-  for (i = 0; i < count; i++) {
-    entry = av_dict_get(options, "", entry, AV_DICT_IGNORE_SUFFIX);
-    Store_field(unused, i, caml_copy_string(entry->key));
-  }
-
-  av_dict_free(&options);
+  unused = ocaml_avutil_unused_options(&options);
 
   ret = caml_alloc_tuple(2);
   Store_field(ret, 0, ans);
@@ -624,20 +603,9 @@ CAMLprim value ocaml_avcodec_create_video_encoder(value _device_context,
     frame_ctx = BufferRef_val(Some_val(_frame_context));
 
   AVDictionary *options = NULL;
-  char *key, *val;
-  int len = Wosize_val(_opts);
-  int i, err, count;
+  int err;
 
-  for (i = 0; i < len; i++) {
-    // Dictionaries copy key/values by default!
-    key = (char *)Bytes_val(Field(Field(_opts, i), 0));
-    val = (char *)Bytes_val(Field(Field(_opts, i), 1));
-    err = av_dict_set(&options, key, val, 0);
-    if (err < 0) {
-      av_dict_free(&options);
-      ocaml_avutil_raise_error(err);
-    }
-  }
+  ocaml_avutil_dict_of_options(_opts, &options);
 
   codec_context_t *ctx = (codec_context_t *)av_mallocz(sizeof(codec_context_t));
   if (!ctx) {
@@ -684,17 +652,7 @@ CAMLprim value ocaml_avcodec_create_video_encoder(value _device_context,
     ocaml_avutil_raise_error(err);
   }
 
-  // Return unused keys
-  count = av_dict_count(options);
-
-  unused = caml_alloc_tuple(count);
-  AVDictionaryEntry *entry = NULL;
-  for (i = 0; i < count; i++) {
-    entry = av_dict_get(options, "", entry, AV_DICT_IGNORE_SUFFIX);
-    Store_field(unused, i, caml_copy_string(entry->key));
-  }
-
-  av_dict_free(&options);
+  unused = ocaml_avutil_unused_options(&options);
 
   ret = caml_alloc_tuple(2);
   Store_field(ret, 0, ans);
@@ -1693,20 +1651,7 @@ CAMLprim value ocaml_avcodec_bsf_init(value _opts, value _name, value _params) {
     caml_raise_not_found();
   }
 
-  char *key, *val;
-  int len = Wosize_val(_opts);
-  int i, err, count;
-
-  for (i = 0; i < len; i++) {
-    // Dictionaries copy key/values by default!
-    key = (char *)Bytes_val(Field(Field(_opts, i), 0));
-    val = (char *)Bytes_val(Field(Field(_opts, i), 1));
-    err = av_dict_set(&options, key, val, 0);
-    if (err < 0) {
-      av_dict_free(&options);
-      ocaml_avutil_raise_error(err);
-    }
-  }
+  ocaml_avutil_dict_of_options(_opts, &options);
 
   ret = av_bsf_alloc(filter, &bsf);
   if (ret < 0) {
@@ -1739,17 +1684,7 @@ CAMLprim value ocaml_avcodec_bsf_init(value _opts, value _name, value _params) {
     ocaml_avutil_raise_error(ret);
   }
 
-  // Return unused keys
-  count = av_dict_count(options);
-
-  unused = caml_alloc_tuple(count);
-  AVDictionaryEntry *entry = NULL;
-  for (i = 0; i < count; i++) {
-    entry = av_dict_get(options, "", entry, AV_DICT_IGNORE_SUFFIX);
-    Store_field(unused, i, caml_copy_string(entry->key));
-  }
-
-  av_dict_free(&options);
+  unused = ocaml_avutil_unused_options(&options);
 
   tmp = caml_alloc_custom(&bsf_filter_ops, sizeof(AVBSFContext *), 0, 1);
   BsfFilter_val(tmp) = bsf;

--- a/src/modules/synced/ffmpeg/avcodec/avcodec_stubs.c
+++ b/src/modules/synced/ffmpeg/avcodec/avcodec_stubs.c
@@ -882,62 +882,10 @@ CAMLprim value ocaml_avcodec_parameters_get_bit_rate(value _cp) {
 
 /**** Audio codec ID ****/
 
-CAMLprim value ocaml_avcodec_get_audio_codec_id(value _codec) {
-  CAMLparam1(_codec);
-  const AVCodec *codec = AvCodec_val(_codec);
-  CAMLreturn(Val_AudioCodecID(codec->id));
-}
-
-CAMLprim value ocaml_avcodec_get_video_codec_id(value _codec) {
-  CAMLparam1(_codec);
-  const AVCodec *codec = AvCodec_val(_codec);
-  CAMLreturn(Val_VideoCodecID(codec->id));
-}
-
-CAMLprim value ocaml_avcodec_get_subtitle_codec_id(value _codec) {
-  CAMLparam1(_codec);
-  const AVCodec *codec = AvCodec_val(_codec);
-  CAMLreturn(Val_SubtitleCodecID(codec->id));
-}
-
-CAMLprim value ocaml_avcodec_get_audio_codec_id_name(value _codec_id) {
-  CAMLparam1(_codec_id);
-  CAMLreturn(caml_copy_string(
-      avcodec_get_name((enum AVCodecID)AudioCodecID_val(_codec_id))));
-}
-
 CAMLprim value ocaml_avcodec_get_codec_id_name(value _codec_id) {
   CAMLparam1(_codec_id);
   CAMLreturn(caml_copy_string(
       avcodec_get_name((enum AVCodecID)CodecID_val(_codec_id))));
-}
-
-CAMLprim value ocaml_avcodec_find_audio_encoder_by_name(value _name) {
-  CAMLparam1(_name);
-  CAMLlocal1(ret);
-  CAMLreturn(value_of_avcodec(
-      &ret, find_encoder_by_name(String_val(_name), AVMEDIA_TYPE_AUDIO)));
-}
-
-CAMLprim value ocaml_avcodec_find_audio_encoder(value _id) {
-  CAMLparam1(_id);
-  CAMLlocal1(ret);
-  CAMLreturn(value_of_avcodec(
-      &ret, find_encoder(AudioCodecID_val(_id), AVMEDIA_TYPE_AUDIO)));
-}
-
-CAMLprim value ocaml_avcodec_find_audio_decoder_by_name(value _name) {
-  CAMLparam1(_name);
-  CAMLlocal1(ret);
-  CAMLreturn(value_of_avcodec(
-      &ret, find_decoder_by_name(String_val(_name), AVMEDIA_TYPE_AUDIO)));
-}
-
-CAMLprim value ocaml_avcodec_find_audio_decoder(value _id) {
-  CAMLparam1(_id);
-  CAMLlocal1(ret);
-  CAMLreturn(value_of_avcodec(
-      &ret, find_decoder(AudioCodecID_val(_id), AVMEDIA_TYPE_AUDIO)));
 }
 
 CAMLprim value ocaml_avcodec_name(value _codec) {
@@ -1053,17 +1001,78 @@ CAMLprim value ocaml_avcodec_params_descriptor(value _params) {
   CAMLreturn(ocaml_avcodec_descriptor(CodecParameters_val(_params)->codec_id));
 }
 
-value ocaml_avcodec_audio_descriptor(value _codec_id) {
-  return ocaml_avcodec_descriptor(AudioCodecID_val(_codec_id));
-}
+/* The per-media-type stubs differ only in three tokens: the infix in the C
+   symbol name, the generated converter prefix, and the AVMEDIA_TYPE_
+   suffix, and the externals in avcodec.ml fix every one of those names, so
+   the definitions are pasted rather than dispatched.
 
-value ocaml_avcodec_video_descriptor(value _codec_id) {
-  return ocaml_avcodec_descriptor(VideoCodecID_val(_codec_id));
-}
+   Listed here because grep will not find them. CODEC_MEDIA_STUBS defines,
+   for each of audio/video/subtitle:
+     ocaml_avcodec_get_<ml>_codec_id
+     ocaml_avcodec_find_<ml>_{encoder,decoder}[_by_name]
+     ocaml_avcodec_<ml>_descriptor
+   CODEC_ID_NAME_STUBS additionally covers the unknown media type:
+     ocaml_avcodec_get_<ml>_codec_id_name
+     ocaml_avcodec_parameters_get_<ml>_codec_id */
 
-value ocaml_avcodec_subtitle_descriptor(value _codec_id) {
-  return ocaml_avcodec_descriptor(SubtitleCodecID_val(_codec_id));
-}
+#define CODEC_MEDIA_STUBS(ml, Ml, MEDIA)                                       \
+  CAMLprim value ocaml_avcodec_get_##ml##_codec_id(value _codec) {             \
+    CAMLparam1(_codec);                                                        \
+    CAMLreturn(Val_##Ml##CodecID(AvCodec_val(_codec)->id));                    \
+  }                                                                            \
+                                                                               \
+  CAMLprim value ocaml_avcodec_find_##ml##_encoder_by_name(value _name) {      \
+    CAMLparam1(_name);                                                         \
+    CAMLlocal1(ret);                                                           \
+    CAMLreturn(value_of_avcodec(                                               \
+        &ret, find_encoder_by_name(String_val(_name), AVMEDIA_TYPE_##MEDIA))); \
+  }                                                                            \
+                                                                               \
+  CAMLprim value ocaml_avcodec_find_##ml##_encoder(value _id) {                \
+    CAMLparam1(_id);                                                           \
+    CAMLlocal1(ret);                                                           \
+    CAMLreturn(value_of_avcodec(                                               \
+        &ret, find_encoder(Ml##CodecID_val(_id), AVMEDIA_TYPE_##MEDIA)));      \
+  }                                                                            \
+                                                                               \
+  CAMLprim value ocaml_avcodec_find_##ml##_decoder_by_name(value _name) {      \
+    CAMLparam1(_name);                                                         \
+    CAMLlocal1(ret);                                                           \
+    CAMLreturn(value_of_avcodec(                                               \
+        &ret, find_decoder_by_name(String_val(_name), AVMEDIA_TYPE_##MEDIA))); \
+  }                                                                            \
+                                                                               \
+  CAMLprim value ocaml_avcodec_find_##ml##_decoder(value _id) {                \
+    CAMLparam1(_id);                                                           \
+    CAMLlocal1(ret);                                                           \
+    CAMLreturn(value_of_avcodec(                                               \
+        &ret, find_decoder(Ml##CodecID_val(_id), AVMEDIA_TYPE_##MEDIA)));      \
+  }                                                                            \
+                                                                               \
+  CAMLprim value ocaml_avcodec_##ml##_descriptor(value _codec_id) {            \
+    return ocaml_avcodec_descriptor(Ml##CodecID_val(_codec_id));               \
+  }
+
+#define CODEC_ID_NAME_STUBS(ml, Ml)                                            \
+  CAMLprim value ocaml_avcodec_get_##ml##_codec_id_name(value _codec_id) {     \
+    CAMLparam1(_codec_id);                                                     \
+    CAMLreturn(caml_copy_string(                                               \
+        avcodec_get_name((enum AVCodecID)Ml##CodecID_val(_codec_id))));        \
+  }                                                                            \
+                                                                               \
+  CAMLprim value ocaml_avcodec_parameters_get_##ml##_codec_id(value _cp) {     \
+    CAMLparam1(_cp);                                                           \
+    CAMLreturn(Val_##Ml##CodecID(CodecParameters_val(_cp)->codec_id));         \
+  }
+
+CODEC_MEDIA_STUBS(audio, Audio, AUDIO)
+CODEC_MEDIA_STUBS(video, Video, VIDEO)
+CODEC_MEDIA_STUBS(subtitle, Subtitle, SUBTITLE)
+
+CODEC_ID_NAME_STUBS(audio, Audio)
+CODEC_ID_NAME_STUBS(video, Video)
+CODEC_ID_NAME_STUBS(subtitle, Subtitle)
+CODEC_ID_NAME_STUBS(unknown, Unknown)
 
 CAMLprim value ocaml_avcodec_hw_methods(value _codec) {
   CAMLparam1(_codec);
@@ -1195,11 +1204,6 @@ CAMLprim value ocaml_avcodec_get_supported_sample_rates(value _codec) {
 }
 
 /**** Audio codec parameters ****/
-CAMLprim value ocaml_avcodec_parameters_get_audio_codec_id(value _cp) {
-  CAMLparam1(_cp);
-  CAMLreturn(Val_AudioCodecID(CodecParameters_val(_cp)->codec_id));
-}
-
 CAMLprim value ocaml_avcodec_parameters_get_channel_layout(value _cp) {
   CAMLparam1(_cp);
   CAMLlocal1(_ch_layout);
@@ -1227,39 +1231,6 @@ CAMLprim value ocaml_avcodec_parameters_get_sample_rate(value _cp) {
 }
 
 /**** Video codec ID ****/
-
-CAMLprim value ocaml_avcodec_get_video_codec_id_name(value _codec_id) {
-  CAMLparam1(_codec_id);
-  CAMLreturn(caml_copy_string(avcodec_get_name(VideoCodecID_val(_codec_id))));
-}
-
-CAMLprim value ocaml_avcodec_find_video_decoder_by_name(value _name) {
-  CAMLparam1(_name);
-  CAMLlocal1(ret);
-  CAMLreturn(value_of_avcodec(
-      &ret, find_decoder_by_name(String_val(_name), AVMEDIA_TYPE_VIDEO)));
-}
-
-CAMLprim value ocaml_avcodec_find_video_decoder(value _id) {
-  CAMLparam1(_id);
-  CAMLlocal1(ret);
-  CAMLreturn(value_of_avcodec(
-      &ret, find_decoder(VideoCodecID_val(_id), AVMEDIA_TYPE_VIDEO)));
-}
-
-CAMLprim value ocaml_avcodec_find_video_encoder_by_name(value _name) {
-  CAMLparam1(_name);
-  CAMLlocal1(ret);
-  CAMLreturn(value_of_avcodec(
-      &ret, find_encoder_by_name(String_val(_name), AVMEDIA_TYPE_VIDEO)));
-}
-
-CAMLprim value ocaml_avcodec_find_video_encoder(value _id) {
-  CAMLparam1(_id);
-  CAMLlocal1(ret);
-  CAMLreturn(value_of_avcodec(
-      &ret, find_encoder(VideoCodecID_val(_id), AVMEDIA_TYPE_VIDEO)));
-}
 
 CAMLprim value ocaml_avcodec_get_supported_frame_rates(value _codec) {
   CAMLparam1(_codec);
@@ -1376,11 +1347,6 @@ CAMLprim value ocaml_avcodec_get_supported_color_ranges(value _codec) {
 }
 
 /**** Video codec parameters ****/
-CAMLprim value ocaml_avcodec_parameters_get_video_codec_id(value _cp) {
-  CAMLparam1(_cp);
-  CAMLreturn(Val_VideoCodecID(CodecParameters_val(_cp)->codec_id));
-}
-
 CAMLprim value ocaml_avcodec_parameters_get_width(value _cp) {
   CAMLparam1(_cp);
   CAMLreturn(Val_int(CodecParameters_val(_cp)->width));
@@ -1432,58 +1398,9 @@ CAMLprim value ocaml_avcodec_parameters_get_pixel_aspect(value _cp) {
 
 /**** Unknown codec ID *****/
 
-CAMLprim value ocaml_avcodec_get_unknown_codec_id_name(value _codec_id) {
-  CAMLparam1(_codec_id);
-  CAMLreturn(caml_copy_string(avcodec_get_name(UnknownCodecID_val(_codec_id))));
-}
-
-CAMLprim value ocaml_avcodec_parameters_get_unknown_codec_id(value _cp) {
-  CAMLparam1(_cp);
-  CAMLreturn(Val_UnknownCodecID(CodecParameters_val(_cp)->codec_id));
-}
-
 /**** Subtitle codec ID ****/
 
-CAMLprim value ocaml_avcodec_get_subtitle_codec_id_name(value _codec_id) {
-  CAMLparam1(_codec_id);
-  CAMLreturn(
-      caml_copy_string(avcodec_get_name(SubtitleCodecID_val(_codec_id))));
-}
-
-CAMLprim value ocaml_avcodec_find_subtitle_decoder_by_name(value _name) {
-  CAMLparam1(_name);
-  CAMLlocal1(ret);
-  CAMLreturn(value_of_avcodec(
-      &ret, find_decoder_by_name(String_val(_name), AVMEDIA_TYPE_SUBTITLE)));
-}
-
-CAMLprim value ocaml_avcodec_find_subtitle_decoder(value _id) {
-  CAMLparam1(_id);
-  CAMLlocal1(ret);
-  CAMLreturn(value_of_avcodec(
-      &ret, find_decoder(SubtitleCodecID_val(_id), AVMEDIA_TYPE_SUBTITLE)));
-}
-
-CAMLprim value ocaml_avcodec_find_subtitle_encoder_by_name(value _name) {
-  CAMLparam1(_name);
-  CAMLlocal1(ret);
-  CAMLreturn(value_of_avcodec(
-      &ret, find_encoder_by_name(String_val(_name), AVMEDIA_TYPE_SUBTITLE)));
-}
-
-CAMLprim value ocaml_avcodec_find_subtitle_encoder(value _id) {
-  CAMLparam1(_id);
-  CAMLlocal1(ret);
-  CAMLreturn(value_of_avcodec(
-      &ret, find_encoder(SubtitleCodecID_val(_id), AVMEDIA_TYPE_SUBTITLE)));
-}
-
 /**** Subtitle codec parameters ****/
-CAMLprim value ocaml_avcodec_parameters_get_subtitle_codec_id(value _cp) {
-  CAMLparam1(_cp);
-  CAMLreturn(Val_SubtitleCodecID(CodecParameters_val(_cp)->codec_id));
-}
-
 CAMLprim value ocaml_avcodec_int_of_flag(value _flag) {
   CAMLparam1(_flag);
 

--- a/src/modules/synced/ffmpeg/avcodec/dune
+++ b/src/modules/synced/ffmpeg/avcodec/dune
@@ -15,7 +15,6 @@
  (synopsis "Bindings to ffmpeg's avcodec library")
  (enabled_if
   (= %{read:../detect/avcodec_available} "true"))
- (optional)
  (foreign_stubs
   (language c)
   (names avcodec_stubs)

--- a/src/modules/synced/ffmpeg/avdevice/avdevice.ml
+++ b/src/modules/synced/ffmpeg/avdevice/avdevice.ml
@@ -59,64 +59,17 @@ let open_video_input name = Av.open_input ~format:(find_video_input name) ""
 let open_default_video_input () =
   Av.open_input ~format:(get_default_video_input_format ()) ""
 
-external open_output_format :
-  (output, _) format ->
-  bool ->
-  (string * string) array ->
-  output container * string array = "ocaml_av_open_output_format"
+let open_audio_output ?interleaved ?opts name =
+  Av.open_output_format ?interleaved ?opts (find_audio_output name)
 
-let _opt_val = function
-  | `String s -> s
-  | `Int i -> string_of_int i
-  | `Int64 i -> Int64.to_string i
-  | `Float f -> string_of_float f
+let open_default_audio_output ?interleaved ?opts () =
+  Av.open_output_format ?interleaved ?opts (get_default_audio_output_format ())
 
-let mk_opts = function
-  | None -> [||]
-  | Some opts ->
-      Array.of_list
-        (Hashtbl.fold
-           (fun opt_name opt_val cur -> (opt_name, _opt_val opt_val) :: cur)
-           opts [])
+let open_video_output ?interleaved ?opts name =
+  Av.open_output_format ?interleaved ?opts (find_video_output name)
 
-let filter_opts unused = function
-  | None -> ()
-  | Some opts ->
-      Hashtbl.filter_map_inplace
-        (fun k v -> if Array.mem k unused then Some v else None)
-        opts
-
-let open_audio_output ?(interleaved = true) ?opts name =
-  let ret, unused =
-    open_output_format (find_audio_output name) interleaved (mk_opts opts)
-  in
-  filter_opts unused opts;
-  ret
-
-let open_default_audio_output ?(interleaved = true) ?opts () =
-  let ret, unused =
-    open_output_format
-      (get_default_audio_output_format ())
-      interleaved (mk_opts opts)
-  in
-  filter_opts unused opts;
-  ret
-
-let open_video_output ?(interleaved = true) ?opts name =
-  let ret, unused =
-    open_output_format (find_video_output name) interleaved (mk_opts opts)
-  in
-  filter_opts unused opts;
-  ret
-
-let open_default_video_output ?(interleaved = true) ?opts () =
-  let ret, unused =
-    open_output_format
-      (get_default_video_output_format ())
-      interleaved (mk_opts opts)
-  in
-  filter_opts unused opts;
-  ret
+let open_default_video_output ?interleaved ?opts () =
+  Av.open_output_format ?interleaved ?opts (get_default_video_output_format ())
 
 module App_to_dev = struct
   type message =

--- a/src/modules/synced/ffmpeg/avdevice/avdevice_stubs.c
+++ b/src/modules/synced/ffmpeg/avdevice/avdevice_stubs.c
@@ -14,6 +14,7 @@
 #include "avutil_stubs.h"
 
 CAMLprim value ocaml_avdevice_init(value unit) {
+  (void)unit;
   CAMLparam0();
   avdevice_register_all();
   CAMLreturn(Val_unit);
@@ -45,11 +46,13 @@ static value get_input_devices(avioformat_const AVInputFormat *(
 }
 
 CAMLprim value ocaml_avdevice_get_audio_input_formats(value unit) {
+  (void)unit;
   CAMLparam0();
   CAMLreturn(get_input_devices(av_input_audio_device_next));
 }
 
 CAMLprim value ocaml_avdevice_get_video_input_formats(value unit) {
+  (void)unit;
   CAMLparam0();
   CAMLreturn(get_input_devices(av_input_video_device_next));
 }
@@ -79,11 +82,13 @@ static value get_output_devices(avioformat_const AVOutputFormat *(
 }
 
 CAMLprim value ocaml_avdevice_get_audio_output_formats(value unit) {
+  (void)unit;
   CAMLparam0();
   CAMLreturn(get_output_devices(av_output_audio_device_next));
 }
 
 CAMLprim value ocaml_avdevice_get_video_output_formats(value unit) {
+  (void)unit;
   CAMLparam0();
   CAMLreturn(get_output_devices(av_output_video_device_next));
 }
@@ -156,6 +161,7 @@ CAMLprim value ocaml_avdevice_app_to_dev_control_message(value _message,
 
 static int ocaml_control_message_callback(struct AVFormatContext *ctx, int type,
                                           void *data, size_t data_size) {
+  (void)data_size;
   CAMLparam0();
   CAMLlocal3(msg, opt, res);
   enum AVDevToAppMessageType message_type = (enum AVDevToAppMessageType)type;

--- a/src/modules/synced/ffmpeg/avfilter/avfilter.ml
+++ b/src/modules/synced/ffmpeg/avfilter/avfilter.ml
@@ -278,15 +278,18 @@ let attach ?args ~name filter graph =
 external link : filter_ctx -> int -> filter_ctx -> int -> unit
   = "ocaml_avfilter_link"
 
-let get_some = function Some x -> x | None -> assert false
+let get_some = function
+  | Some x -> x
+  | None -> failwith "ffmpeg API error: filter is not attached!"
 
 let link src dst =
   link (get_some src.filter_ctx) src.idx (get_some dst.filter_ctx) dst.idx
 
 type command_flag = [ `Fast ]
 
-(* For now.. *)
-let int_of_flag = function `Fast -> 1
+(* AVFILTER_CMD_FLAG_FAST. Spelled here rather than generated: the OCaml name
+   is chosen, not derived from the C one. *)
+let int_of_command_flag = function `Fast -> 2
 
 external process_command :
   flags:int -> cmd:string -> arg:string -> filter_ctx -> string
@@ -297,7 +300,7 @@ external get_context : [ `Attached ] filter -> filter_ctx
 
 let process_command ?(flags = []) ~cmd ?(arg = "") filter =
   let flags =
-    List.fold_left (fun cur flag -> cur land int_of_flag flag) 0 flags
+    List.fold_left (fun cur flag -> cur lor int_of_command_flag flag) 0 flags
   in
   process_command ~flags ~cmd ~arg (get_context filter)
 

--- a/src/modules/synced/ffmpeg/avfilter/avfilter_stubs.c
+++ b/src/modules/synced/ffmpeg/avfilter/avfilter_stubs.c
@@ -26,6 +26,7 @@ static inline value value_of_avfiltercontext(value ret,
 }
 
 CAMLprim value ocaml_avfilter_register_all(value unit) {
+  (void)unit;
   CAMLparam0();
 #if LIBAVFILTER_VERSION_INT < AV_VERSION_INT(7, 14, 100)
   avfilter_register_all();
@@ -79,6 +80,7 @@ CAMLprim value ocaml_avfilter_alloc_pads(const AVFilterPad *pads, int pad_count,
 }
 
 CAMLprim value ocaml_avfilter_get_all_filters(value unit) {
+  (void)unit;
   CAMLparam0();
   CAMLlocal5(pad, pads, cur, ret, tmp);
   int c = 0;
@@ -146,9 +148,11 @@ static void finalize_filter_graph(value v) {
 static struct custom_operations filter_graph_ops = {
     "ocaml_avfilter_filter_graph", finalize_filter_graph,
     custom_compare_default,        custom_hash_default,
-    custom_serialize_default,      custom_deserialize_default};
+    custom_serialize_default,      custom_deserialize_default,
+    custom_compare_ext_default,    custom_fixed_length_default};
 
 CAMLprim value ocaml_avfilter_init(value unit) {
+  (void)unit;
   CAMLparam0();
   CAMLlocal1(ret);
   AVFilterGraph *graph = avfilter_graph_alloc();
@@ -292,7 +296,7 @@ CAMLprim value ocaml_avfilter_parse(value _inputs, value _outputs,
   AVFilterContext *filter_ctx;
   char *filters, *name;
 
-  for (c = 0; c < Wosize_val(_inputs); c++) {
+  for (c = 0; c < (int)Wosize_val(_inputs); c++) {
     _pad = Field(_inputs, c);
     name = av_strdup(String_val(Field(_pad, 0)));
     filter_ctx = AvFilterContext_val(Field(_pad, 1));
@@ -301,7 +305,7 @@ CAMLprim value ocaml_avfilter_parse(value _inputs, value _outputs,
     append_avfilter_in_out(&inputs, name, filter_ctx, idx);
   }
 
-  for (c = 0; c < Wosize_val(_outputs); c++) {
+  for (c = 0; c < (int)Wosize_val(_outputs); c++) {
     _pad = Field(_outputs, c);
     name = av_strdup(String_val(Field(_pad, 0)));
     filter_ctx = AvFilterContext_val(Field(_pad, 1));

--- a/src/modules/synced/ffmpeg/avutil/avutil_stubs.c
+++ b/src/modules/synced/ffmpeg/avutil/avutil_stubs.c
@@ -500,26 +500,32 @@ CAMLprim value ocaml_avutil_get_channel_layout(value _name) {
 
 /**** Sample format ****/
 
-static const enum AVSampleFormat SAMPLE_FORMATS[] = {
-    AV_SAMPLE_FMT_NONE, AV_SAMPLE_FMT_U8,   AV_SAMPLE_FMT_S16,
-    AV_SAMPLE_FMT_S32,  AV_SAMPLE_FMT_FLT,  AV_SAMPLE_FMT_DBL,
-    AV_SAMPLE_FMT_U8P,  AV_SAMPLE_FMT_S16P, AV_SAMPLE_FMT_S32P,
-    AV_SAMPLE_FMT_FLTP, AV_SAMPLE_FMT_DBLP};
-#define SAMPLE_FORMATS_LEN                                                     \
-  (sizeof(SAMPLE_FORMATS) / sizeof(enum AVSampleFormat))
-
-static const enum caml_ba_kind BIGARRAY_KINDS[SAMPLE_FORMATS_LEN] = {
-    CAML_BA_KIND_MASK, CAML_BA_UINT8,   CAML_BA_SINT16, CAML_BA_INT32,
-    CAML_BA_FLOAT32,   CAML_BA_FLOAT64, CAML_BA_UINT8,  CAML_BA_SINT16,
-    CAML_BA_INT32,     CAML_BA_FLOAT32, CAML_BA_FLOAT64};
-
+/* Raises rather than returning a sentinel: callers OR the result straight
+   into a bigarray flag word, where a bogus kind is silent corruption. */
 enum caml_ba_kind bigarray_kind_of_AVSampleFormat(enum AVSampleFormat sf) {
-  int i;
-  for (i = 0; i < SAMPLE_FORMATS_LEN; i++) {
-    if (sf == SAMPLE_FORMATS[i])
-      return BIGARRAY_KINDS[i];
+  switch (sf) {
+  case AV_SAMPLE_FMT_U8:
+  case AV_SAMPLE_FMT_U8P:
+    return CAML_BA_UINT8;
+  case AV_SAMPLE_FMT_S16:
+  case AV_SAMPLE_FMT_S16P:
+    return CAML_BA_SINT16;
+  case AV_SAMPLE_FMT_S32:
+  case AV_SAMPLE_FMT_S32P:
+    return CAML_BA_INT32;
+  case AV_SAMPLE_FMT_S64:
+  case AV_SAMPLE_FMT_S64P:
+    return CAML_BA_INT64;
+  case AV_SAMPLE_FMT_FLT:
+  case AV_SAMPLE_FMT_FLTP:
+    return CAML_BA_FLOAT32;
+  case AV_SAMPLE_FMT_DBL:
+  case AV_SAMPLE_FMT_DBLP:
+    return CAML_BA_FLOAT64;
+  default:
+    ocaml_avutil_raise_error(AVERROR(EINVAL));
+    return CAML_BA_KIND_MASK;
   }
-  return CAML_BA_KIND_MASK;
 }
 
 CAMLprim value ocaml_avutil_find_sample_fmt(value _name) {
@@ -1526,7 +1532,7 @@ CAMLprim value ocaml_avutil_get_opt(value _type, value search_children,
     break;
 
   case PVV_Int:
-    err = av_opt_get_int((void *)obj, (const char *)String_val(name),
+    err = av_opt_get_int(AvObj_val(obj), (const char *)String_val(name),
                          search_flags, &i);
     if (err < 0)
       ocaml_avutil_raise_error(err);
@@ -1535,7 +1541,7 @@ CAMLprim value ocaml_avutil_get_opt(value _type, value search_children,
     break;
 
   case PVV_Int64:
-    err = av_opt_get_int((void *)obj, (const char *)String_val(name),
+    err = av_opt_get_int(AvObj_val(obj), (const char *)String_val(name),
                          search_flags, &i);
     if (err < 0)
       ocaml_avutil_raise_error(err);
@@ -1544,7 +1550,7 @@ CAMLprim value ocaml_avutil_get_opt(value _type, value search_children,
     break;
 
   case PVV_Float:
-    err = av_opt_get_double((void *)obj, (const char *)String_val(name),
+    err = av_opt_get_double(AvObj_val(obj), (const char *)String_val(name),
                             search_flags, &d);
     if (err < 0)
       ocaml_avutil_raise_error(err);
@@ -1553,7 +1559,7 @@ CAMLprim value ocaml_avutil_get_opt(value _type, value search_children,
     break;
 
   case PVV_Rational:
-    err = av_opt_get_q((void *)obj, (const char *)String_val(name),
+    err = av_opt_get_q(AvObj_val(obj), (const char *)String_val(name),
                        search_flags, &r);
     if (err < 0)
       ocaml_avutil_raise_error(err);
@@ -1564,7 +1570,7 @@ CAMLprim value ocaml_avutil_get_opt(value _type, value search_children,
     break;
 
   case PVV_Image_size:
-    err = av_opt_get_image_size((void *)obj, (const char *)String_val(name),
+    err = av_opt_get_image_size(AvObj_val(obj), (const char *)String_val(name),
                                 search_flags, &w_out, &h_out);
     if (err < 0)
       ocaml_avutil_raise_error(err);
@@ -1577,7 +1583,7 @@ CAMLprim value ocaml_avutil_get_opt(value _type, value search_children,
     break;
 
   case PVV_Pixel_fmt:
-    err = av_opt_get_pixel_fmt((void *)obj, (const char *)String_val(name),
+    err = av_opt_get_pixel_fmt(AvObj_val(obj), (const char *)String_val(name),
                                search_flags, &pf);
     if (err < 0)
       ocaml_avutil_raise_error(err);
@@ -1586,7 +1592,7 @@ CAMLprim value ocaml_avutil_get_opt(value _type, value search_children,
     break;
 
   case PVV_Sample_fmt:
-    err = av_opt_get_sample_fmt((void *)obj, (const char *)String_val(name),
+    err = av_opt_get_sample_fmt(AvObj_val(obj), (const char *)String_val(name),
                                 search_flags, &sf);
     if (err < 0)
       ocaml_avutil_raise_error(err);
@@ -1595,7 +1601,7 @@ CAMLprim value ocaml_avutil_get_opt(value _type, value search_children,
     break;
 
   case PVV_Video_rate:
-    err = av_opt_get_video_rate((void *)obj, (const char *)String_val(name),
+    err = av_opt_get_video_rate(AvObj_val(obj), (const char *)String_val(name),
                                 search_flags, &r);
     if (err < 0)
       ocaml_avutil_raise_error(err);
@@ -1606,7 +1612,7 @@ CAMLprim value ocaml_avutil_get_opt(value _type, value search_children,
     break;
 
   case PVV_Channel_layout:
-    err = av_opt_get_chlayout((void *)obj, (const char *)String_val(name),
+    err = av_opt_get_chlayout(AvObj_val(obj), (const char *)String_val(name),
                               search_flags, &channel_layout);
     if (err < 0)
       ocaml_avutil_raise_error(err);
@@ -1617,7 +1623,7 @@ CAMLprim value ocaml_avutil_get_opt(value _type, value search_children,
     break;
 
   case PVV_Dict:
-    err = av_opt_get_dict_val((void *)obj, (const char *)String_val(name),
+    err = av_opt_get_dict_val(AvObj_val(obj), (const char *)String_val(name),
                               search_flags, &dict);
     if (err < 0)
       ocaml_avutil_raise_error(err);
@@ -1650,15 +1656,11 @@ static value value_of_cursor_opt(const struct AVOption *option, void *cursor,
 
   _payload = caml_alloc_tuple(1);
   Store_field(_payload, 0, caml_alloc_tuple(2));
-#if LIBAVUTIL_VERSION_INT < AV_VERSION_INT(56, 53, 100)
-  Store_field(Field(_payload, 0), 0, value_of_avoptions(_cursor, option));
-#else
   Store_field(Field(_payload, 0), 0, caml_alloc_tuple(2));
   Store_field(Field(Field(_payload, 0), 0), 0,
               value_of_avobj(&_cursor, cursor));
   Store_field(Field(Field(_payload, 0), 0), 1,
               value_of_avoptions(&_cursor, option));
-#endif
   Store_field(Field(_payload, 0), 1, value_of_avclass(&_cursor, class));
 
   CAMLreturn(_payload);
@@ -1722,11 +1724,7 @@ CAMLprim value ocaml_avutil_av_opt_iter(value _cursor, value _class) {
 
   const AVClass *class;
   const struct AVOption *option;
-#if LIBAVUTIL_VERSION_INT < AV_VERSION_INT(56, 53, 100)
-  const struct AVOption *cursor;
-#else
   void *cursor;
-#endif
   AVRational r;
 
   if (_cursor == Val_none) {
@@ -1734,13 +1732,8 @@ CAMLprim value ocaml_avutil_av_opt_iter(value _cursor, value _class) {
     option = NULL;
     class = AvClass_val(_class);
   } else {
-#if LIBAVUTIL_VERSION_INT < AV_VERSION_INT(56, 53, 100)
-    cursor = AvOptions_val(Field(Some_val(_cursor), 0));
-    option = cursor;
-#else
     cursor = AvObj_val(Field(Field(Some_val(_cursor), 0), 0));
     option = AvOptions_val(Field(Field(Some_val(_cursor), 0), 1));
-#endif
     class = AvClass_val(Field(Some_val(_cursor), 1));
   }
 
@@ -1751,12 +1744,7 @@ CAMLprim value ocaml_avutil_av_opt_iter(value _cursor, value _class) {
 
   if (option == NULL) {
     do {
-      class =
-#if LIBAVUTIL_VERSION_INT < AV_VERSION_INT(56, 53, 100)
-          av_opt_child_class_next(AvClass_val(_class), class);
-#else
-          av_opt_child_class_iterate(AvClass_val(_class), &cursor);
-#endif
+      class = av_opt_child_class_iterate(AvClass_val(_class), &cursor);
 
       if (class == NULL)
         CAMLreturn(Val_none);
@@ -1806,10 +1794,12 @@ CAMLprim value ocaml_avutil_av_opt_iter(value _cursor, value _class) {
     }
     break;
   case AV_OPT_TYPE_CHLAYOUT:
+    /* av_channel_layout_from_string returns 0 on success. */
     if (option->default_val.str &&
-        av_channel_layout_from_string(&channel_layout,
-                                      option->default_val.str)) {
+        !av_channel_layout_from_string(&channel_layout,
+                                       option->default_val.str)) {
       value_of_channel_layout(&_ch_layout, &channel_layout);
+      av_channel_layout_uninit(&channel_layout);
       Store_field(_tmp, 0, _ch_layout);
       Store_field(_spec, 0, _tmp);
     }
@@ -2054,11 +2044,6 @@ CAMLprim value ocaml_avutil_create_device_context(value _device_type,
   caml_acquire_runtime_system();
 
   if (err < 0) {
-    char errbuf[AV_ERROR_MAX_STRING_SIZE] = "";
-    printf(
-        "failed with error: %s\n",
-        av_make_error_string(errbuf, AV_ERROR_MAX_STRING_SIZE, AVERROR(err)));
-    fflush(stdout);
     av_dict_free(&options);
     ocaml_avutil_raise_error(err);
   }

--- a/src/modules/synced/ffmpeg/avutil/avutil_stubs.c
+++ b/src/modules/synced/ffmpeg/avutil/avutil_stubs.c
@@ -101,6 +101,44 @@ void ocaml_avutil_raise_error(int err) {
   caml_raise_with_arg(*caml_named_value(EXN_ERROR), _err);
 }
 
+/* No CAML frame on purpose: nothing between reading the bytes and
+   av_dict_set copying them can move [_opts]. */
+void ocaml_avutil_dict_of_options(value _opts, AVDictionary **options) {
+  int i, err, len = Wosize_val(_opts);
+
+  for (i = 0; i < len; i++) {
+    // Dictionaries copy key/values by default!
+    err = av_dict_set(options, (char *)Bytes_val(Field(Field(_opts, i), 0)),
+                      (char *)Bytes_val(Field(Field(_opts, i), 1)), 0);
+    if (err < 0) {
+      av_dict_free(options);
+      ocaml_avutil_raise_error(err);
+    }
+  }
+}
+
+value ocaml_avutil_unused_options(AVDictionary **options) {
+  CAMLparam0();
+  CAMLlocal2(unused, key);
+  AVDictionaryEntry *entry = NULL;
+  int i, count = av_dict_count(*options);
+
+  unused = caml_alloc_tuple(count);
+
+  for (i = 0; i < count; i++) {
+    entry = av_dict_get(*options, "", entry, AV_DICT_IGNORE_SUFFIX);
+    /* Via a local: the order of Store_field's two arguments is
+       unspecified, so allocating inside it may compute the destination
+       address before the allocation moves [unused]. */
+    key = caml_copy_string(entry->key);
+    Store_field(unused, i, key);
+  }
+
+  av_dict_free(options);
+
+  CAMLreturn(unused);
+}
+
 CAMLprim value ocaml_avutil_qp2lambda(value unit) {
   (void)unit;
   CAMLparam0();
@@ -2033,9 +2071,7 @@ CAMLprim value ocaml_avutil_create_device_context(value _device_type,
   AVBufferRef *hw_device_ctx = NULL;
   AVDictionary *options = NULL;
   const char *name;
-  char *key, *val;
-  int len = Wosize_val(_opts);
-  int i, err, count;
+  int err;
 
   if (caml_string_length(_name) > 0) {
     name = String_val(_name);
@@ -2043,16 +2079,7 @@ CAMLprim value ocaml_avutil_create_device_context(value _device_type,
     name = NULL;
   }
 
-  for (i = 0; i < len; i++) {
-    // Dictionaries copy key/values by default!
-    key = (char *)Bytes_val(Field(Field(_opts, i), 0));
-    val = (char *)Bytes_val(Field(Field(_opts, i), 1));
-    err = av_dict_set(&options, key, val, 0);
-    if (err < 0) {
-      av_dict_free(&options);
-      ocaml_avutil_raise_error(err);
-    }
-  }
+  ocaml_avutil_dict_of_options(_opts, &options);
 
   caml_release_runtime_system();
   err = av_hwdevice_ctx_create(&hw_device_ctx, HwDeviceType_val(_device_type),
@@ -2064,17 +2091,7 @@ CAMLprim value ocaml_avutil_create_device_context(value _device_type,
     ocaml_avutil_raise_error(err);
   }
 
-  // Return unused keys
-  count = av_dict_count(options);
-
-  unused = caml_alloc_tuple(count);
-  AVDictionaryEntry *entry = NULL;
-  for (i = 0; i < count; i++) {
-    entry = av_dict_get(options, "", entry, AV_DICT_IGNORE_SUFFIX);
-    Store_field(unused, i, caml_copy_string(entry->key));
-  }
-
-  av_dict_free(&options);
+  unused = ocaml_avutil_unused_options(&options);
 
   ans = caml_alloc_custom(&buffer_ref_ops, sizeof(AVBufferRef *), 0, 1);
   BufferRef_val(ans) = hw_device_ctx;

--- a/src/modules/synced/ffmpeg/avutil/avutil_stubs.c
+++ b/src/modules/synced/ffmpeg/avutil/avutil_stubs.c
@@ -102,6 +102,7 @@ void ocaml_avutil_raise_error(int err) {
 }
 
 CAMLprim value ocaml_avutil_qp2lambda(value unit) {
+  (void)unit;
   CAMLparam0();
   CAMLreturn(Val_int(FF_QP2LAMBDA));
 }
@@ -179,6 +180,7 @@ static pthread_key_t ocaml_c_thread_key;
 static pthread_once_t ocaml_c_thread_key_once = PTHREAD_ONCE_INIT;
 
 static void ocaml_ffmpeg_on_thread_exit(void *key) {
+  (void)key;
   caml_c_thread_unregister();
 }
 
@@ -273,6 +275,7 @@ static void av_log_ocaml_callback(void *ptr, int level, const char *fmt,
 }
 
 CAMLprim value ocaml_ffmpeg_wait_for_logs(value unit) {
+  (void)unit;
   CAMLparam0();
 
   caml_release_runtime_system();
@@ -285,12 +288,14 @@ CAMLprim value ocaml_ffmpeg_wait_for_logs(value unit) {
 }
 
 CAMLprim value ocaml_ffmpeg_signal_logs(value unit) {
+  (void)unit;
   CAMLparam0();
   pthread_cond_signal(&log_condition);
   CAMLreturn(Val_unit);
 }
 
 CAMLprim value ocaml_ffmpeg_get_pending_logs(value unit) {
+  (void)unit;
   CAMLparam0();
   CAMLlocal2(result, cons);
   log_msg_t *msgs, *prev, *curr, *next;
@@ -324,12 +329,14 @@ CAMLprim value ocaml_ffmpeg_get_pending_logs(value unit) {
 }
 
 CAMLprim value ocaml_avutil_setup_log_callback(value unit) {
+  (void)unit;
   CAMLparam0();
   av_log_set_callback(&av_log_ocaml_callback);
   CAMLreturn(Val_unit);
 }
 
 CAMLprim value ocaml_avutil_clear_log_callback(value unit) {
+  (void)unit;
   CAMLparam0();
   av_log_set_callback(&av_log_default_callback);
   CAMLreturn(Val_unit);
@@ -353,9 +360,10 @@ static void finalize_channel_layout(value v) {
 }
 
 static struct custom_operations channel_layout_ops = {
-    "ocaml_avchannel_layout", finalize_channel_layout,
-    custom_compare_default,   custom_hash_default,
-    custom_serialize_default, custom_deserialize_default};
+    "ocaml_avchannel_layout",   finalize_channel_layout,
+    custom_compare_default,     custom_hash_default,
+    custom_serialize_default,   custom_deserialize_default,
+    custom_compare_ext_default, custom_fixed_length_default};
 
 void value_of_channel_layout(value *ret,
                              const AVChannelLayout *channel_layout) {
@@ -387,7 +395,8 @@ static void finalize_opaque(value v) {
 static struct custom_operations opaque_ops = {
     "ocaml_avchannel_layout_opaque", finalize_opaque,
     custom_compare_default,          custom_hash_default,
-    custom_serialize_default,        custom_deserialize_default};
+    custom_serialize_default,        custom_deserialize_default,
+    custom_compare_ext_default,      custom_fixed_length_default};
 
 CAMLprim value ocaml_avutil_start_standard_iteration() {
   CAMLparam0();
@@ -802,9 +811,14 @@ static void finalize_frame(value v) {
   av_frame_free(&frame);
 }
 
-static struct custom_operations frame_ops = {
-    "ocaml_avframe",     finalize_frame,           custom_compare_default,
-    custom_hash_default, custom_serialize_default, custom_deserialize_default};
+static struct custom_operations frame_ops = {"ocaml_avframe",
+                                             finalize_frame,
+                                             custom_compare_default,
+                                             custom_hash_default,
+                                             custom_serialize_default,
+                                             custom_deserialize_default,
+                                             custom_compare_ext_default,
+                                             custom_fixed_length_default};
 
 void value_of_frame(value *ret, AVFrame *frame) {
   if (!frame)
@@ -933,10 +947,9 @@ CAMLprim value ocaml_avutil_frame_set_metadata(value _frame, value _metadata) {
   CAMLparam2(_frame, _metadata);
   AVFrame *frame = Frame_val(_frame);
   AVDictionary *metadata = NULL;
-  AVDictionaryEntry *entry = NULL;
   int i, ret;
 
-  for (i = 0; i < Wosize_val(_metadata); i++) {
+  for (i = 0; i < (int)Wosize_val(_metadata); i++) {
     ret = av_dict_set(&metadata, String_val(Field(Field(_metadata, i), 0)),
                       String_val(Field(Field(_metadata, i), 1)), 0);
     if (ret < 0)
@@ -1251,8 +1264,10 @@ void static finalize_subtitle(value v) {
 }
 
 static struct custom_operations subtitle_ops = {
-    "ocaml_avsubtitle",  finalize_subtitle,        custom_compare_default,
-    custom_hash_default, custom_serialize_default, custom_deserialize_default};
+    "ocaml_avsubtitle",         finalize_subtitle,
+    custom_compare_default,     custom_hash_default,
+    custom_serialize_default,   custom_deserialize_default,
+    custom_compare_ext_default, custom_fixed_length_default};
 
 void value_of_subtitle(value *ret, AVSubtitle *subtitle) {
   if (!subtitle)
@@ -2006,9 +2021,10 @@ CAMLprim value ocaml_avutil_av_opt_int_of_flag(value _flag) {
 static void finalize_buffer_ref(value v) { av_buffer_unref(&BufferRef_val(v)); }
 
 static struct custom_operations buffer_ref_ops = {
-    "ocaml_avutil_buffer_ref", finalize_buffer_ref,
-    custom_compare_default,    custom_hash_default,
-    custom_serialize_default,  custom_deserialize_default};
+    "ocaml_avutil_buffer_ref",  finalize_buffer_ref,
+    custom_compare_default,     custom_hash_default,
+    custom_serialize_default,   custom_deserialize_default,
+    custom_compare_ext_default, custom_fixed_length_default};
 
 CAMLprim value ocaml_avutil_create_device_context(value _device_type,
                                                   value _name, value _opts) {

--- a/src/modules/synced/ffmpeg/avutil/avutil_stubs.h
+++ b/src/modules/synced/ffmpeg/avutil/avutil_stubs.h
@@ -7,6 +7,7 @@
 
 #include <libavcodec/avcodec.h>
 #include <libavutil/channel_layout.h>
+#include <libavutil/dict.h>
 #include <libavutil/frame.h>
 #include <libavutil/opt.h>
 #include <libavutil/pixdesc.h>
@@ -39,6 +40,19 @@
 void ocaml_avutil_raise_error(int err);
 
 extern char ocaml_av_exn_msg[];
+
+/***** Option dictionaries *****/
+
+/* Fill [*options] from an OCaml (string * string) array. Frees [*options]
+   and raises on failure. Allocates nothing on the OCaml heap, so [_opts]
+   needs no root beyond the caller's own. */
+void ocaml_avutil_dict_of_options(value _opts, AVDictionary **options);
+
+/* Consumes [*options]: returns the keys ffmpeg did not use as a fresh
+   tuple, then frees the dict and clears the pointer. The result is
+   unrooted, so assign it straight into a caller CAMLlocal with no
+   intervening allocation. */
+value ocaml_avutil_unused_options(AVDictionary **options);
 
 #define List_init(list) (list) = Val_emptylist
 

--- a/src/modules/synced/ffmpeg/detect/dune
+++ b/src/modules/synced/ffmpeg/detect/dune
@@ -46,7 +46,7 @@
    %{context_name}
    avutil
    "libavutil libavcodec"
-   "libavutil >= 55.78.100, libavcodec >= 57.107.100")))
+   "libavutil >= 57.28.100, libavcodec >= 59.24.100")))
 
 (rule
  (targets

--- a/src/modules/synced/ffmpeg/detect/dune
+++ b/src/modules/synced/ffmpeg/detect/dune
@@ -46,7 +46,11 @@
    %{context_name}
    avutil
    "libavutil libavcodec"
-   "libavutil >= 57.28.100, libavcodec >= 59.24.100")))
+   "libavutil >= 57.28.100, libavcodec >= 59.24.100"
+   -Wall
+   -Wextra
+   -Werror=unused-variable
+   -Werror=unused-parameter)))
 
 (rule
  (targets
@@ -63,7 +67,11 @@
    %{context_name}
    avcodec
    libavcodec
-   "libavcodec >= 59.24.100")))
+   "libavcodec >= 59.24.100"
+   -Wall
+   -Wextra
+   -Werror=unused-variable
+   -Werror=unused-parameter)))
 
 (rule
  (targets av_available av_c_flags av_c_flags.sexp av_c_library_flags.sexp)
@@ -97,7 +105,11 @@
    %{context_name}
    avfilter
    libavfilter
-   "libavfilter >= 8.28.100")))
+   "libavfilter >= 8.28.100"
+   -Wall
+   -Wextra
+   -Werror=unused-variable
+   -Werror=unused-parameter)))
 
 (rule
  (targets
@@ -114,7 +126,11 @@
    %{context_name}
    avdevice
    libavdevice
-   "libavdevice >= 57.10.100")))
+   "libavdevice >= 57.10.100"
+   -Wall
+   -Wextra
+   -Werror=unused-variable
+   -Werror=unused-parameter)))
 
 (rule
  (targets
@@ -131,7 +147,11 @@
    %{context_name}
    swscale
    libswscale
-   "libswscale >= 4.8.100")))
+   "libswscale >= 4.8.100"
+   -Wall
+   -Wextra
+   -Werror=unused-variable
+   -Werror=unused-parameter)))
 
 (rule
  (targets
@@ -148,4 +168,8 @@
    %{context_name}
    swresample
    libswresample
-   "libswresample >= 2.9.100")))
+   "libswresample >= 2.9.100"
+   -Wall
+   -Wextra
+   -Werror=unused-variable
+   -Werror=unused-parameter)))

--- a/src/modules/synced/ffmpeg/gen/gen_test.ml
+++ b/src/modules/synced/ffmpeg/gen/gen_test.ml
@@ -15,6 +15,7 @@ let () =
         "test_subtitle_read";
         "test_unhandled_packet";
         "test_codec";
+        "test_options";
         "test_swscale";
       ]
       ["ffmpeg-av"; "ffmpeg-swresample"; "ffmpeg-swscale"];
@@ -26,6 +27,7 @@ let () =
  (deps
   (:runner test_runner.exe)
   (:codec test_codec.exe)
+  (:options test_options.exe)
   (:swscale test_swscale.exe)
   (:list_filters ../examples/list_filters.exe)
   (:all_codecs ../examples/all_codecs.exe)
@@ -74,6 +76,7 @@ let () =
    ; resample and info need real media: they run after the encoders above.
    (run %{runner} "resample" %{resample} A4.flac)
    (run %{runner} "info" %{info} out.mkv A4.flac)
+   (run %{runner} "options" %{options} out.mkv)
    (run %{runner} "decode_stream_mp3" %{decode_stream} A4.flac A4.mp3 libmp3lame)
    (run %{runner} "decode_stream_ogg" %{decode_stream} A4.mp2 A4.ogg libvorbis)
    (run %{runner} "audio_decoding_ogg" %{audio_decoding} A4.ogg ogg A4)

--- a/src/modules/synced/ffmpeg/gen/gen_test.ml
+++ b/src/modules/synced/ffmpeg/gen/gen_test.ml
@@ -14,8 +14,10 @@ let () =
         "test_info";
         "test_subtitle_read";
         "test_unhandled_packet";
+        "test_codec";
+        "test_swscale";
       ]
-      ["ffmpeg-av"; "ffmpeg-swresample"];
+      ["ffmpeg-av"; "ffmpeg-swresample"; "ffmpeg-swscale"];
     print_string
       {|
 (rule
@@ -23,6 +25,8 @@ let () =
  (package ffmpeg)
  (deps
   (:runner test_runner.exe)
+  (:codec test_codec.exe)
+  (:swscale test_swscale.exe)
   (:list_filters ../examples/list_filters.exe)
   (:all_codecs ../examples/all_codecs.exe)
   (:all_channel_layouts ../examples/all_channel_layouts.exe)
@@ -52,6 +56,8 @@ let () =
   (:srt fixtures/sample.srt))
  (action
   (progn
+   (run %{runner} "codec" %{codec})
+   (run %{runner} "swscale" %{swscale})
    (run %{runner} "list_filters" %{list_filters})
    (run %{runner} "all_codecs" %{all_codecs})
    (run %{runner} "all_channel_layouts" %{all_channel_layouts})

--- a/src/modules/synced/ffmpeg/gen/gen_test.ml
+++ b/src/modules/synced/ffmpeg/gen/gen_test.ml
@@ -17,6 +17,7 @@ let () =
         "test_codec";
         "test_options";
         "test_swscale";
+        "test_swresample";
       ]
       ["ffmpeg-av"; "ffmpeg-swresample"; "ffmpeg-swscale"];
     print_string
@@ -29,6 +30,7 @@ let () =
   (:codec test_codec.exe)
   (:options test_options.exe)
   (:swscale test_swscale.exe)
+  (:swresample test_swresample.exe)
   (:list_filters ../examples/list_filters.exe)
   (:all_codecs ../examples/all_codecs.exe)
   (:all_channel_layouts ../examples/all_channel_layouts.exe)
@@ -60,6 +62,7 @@ let () =
   (progn
    (run %{runner} "codec" %{codec})
    (run %{runner} "swscale" %{swscale})
+   (run %{runner} "swresample" %{swresample})
    (run %{runner} "list_filters" %{list_filters})
    (run %{runner} "all_codecs" %{all_codecs})
    (run %{runner} "all_channel_layouts" %{all_channel_layouts})

--- a/src/modules/synced/ffmpeg/gen/gen_test.ml
+++ b/src/modules/synced/ffmpeg/gen/gen_test.ml
@@ -1,14 +1,21 @@
-let stanza name libraries =
-  Printf.printf "(executable\n (name %s)\n (modules %s)\n (libraries %s))\n\n"
-    name name
+(* One [executables] stanza rather than one per test: they share
+   [test_assert], and dune rejects a module claimed by several stanzas. *)
+let stanza names libraries =
+  Printf.printf
+    "(executables\n (names %s)\n (modules %s test_assert)\n (libraries %s))\n\n"
+    (String.concat " " names) (String.concat " " names)
     (String.concat " " libraries)
 
 let () =
   if Sys.argv.(1) = "true" then begin
-    stanza "test_resample" ["ffmpeg-av"; "ffmpeg-swresample"];
-    stanza "test_info" ["ffmpeg-av"; "ffmpeg-swresample"];
-    stanza "test_subtitle_read" ["ffmpeg-av"];
-    stanza "test_unhandled_packet" ["ffmpeg-av"];
+    stanza
+      [
+        "test_resample";
+        "test_info";
+        "test_subtitle_read";
+        "test_unhandled_packet";
+      ]
+      ["ffmpeg-av"; "ffmpeg-swresample"];
     print_string
       {|
 (rule
@@ -52,14 +59,15 @@ let () =
    (run %{runner} "hw_encode_device" %{hw_encode} nvenc.mp4 h264_nvenc device)
    (run %{runner} "hw_encode_frame" %{hw_encode} nvenc.mp4 h264_nvenc frame)
    (run %{runner} "interrupt" %{interrupt})
-   (run %{runner} "resample" %{resample})
-   (run %{runner} "info" %{info})
    (run %{runner} "encode_audio_flac" %{encode_audio} A4.flac flac)
    (run %{runner} "encode_audio_mp2" %{encode_audio} A4.mp2 mp2)
    (run %{runner} "encode_video_webm" %{encode_video} video.webm yuva420p libvpx-vp9)
    (run %{runner} "encode_stream_flac" %{encode_stream} S4.flac flac)
    (run %{runner} "encode_stream_mp2" %{encode_stream} S4.mp2 mp2)
    (run %{runner} "encoding" %{encoding} out.mkv aac mpeg4 ass)
+   ; resample and info need real media: they run after the encoders above.
+   (run %{runner} "resample" %{resample} A4.flac)
+   (run %{runner} "info" %{info} out.mkv A4.flac)
    (run %{runner} "decode_stream_mp3" %{decode_stream} A4.flac A4.mp3 libmp3lame)
    (run %{runner} "decode_stream_ogg" %{decode_stream} A4.mp2 A4.ogg libvorbis)
    (run %{runner} "audio_decoding_ogg" %{audio_decoding} A4.ogg ogg A4)

--- a/src/modules/synced/ffmpeg/gen/has_ffmpeg.no.ml
+++ b/src/modules/synced/ffmpeg/gen/has_ffmpeg.no.ml
@@ -1,1 +1,0 @@
-let available = false

--- a/src/modules/synced/ffmpeg/gen/has_ffmpeg.yes.ml
+++ b/src/modules/synced/ffmpeg/gen/has_ffmpeg.yes.ml
@@ -1,1 +1,0 @@
-let available = true

--- a/src/modules/synced/ffmpeg/gen_code/gen_code.ml
+++ b/src/modules/synced/ffmpeg/gen_code/gen_code.ml
@@ -171,7 +171,8 @@ let translate_enum_lines ?h_oc ?ml_oc lines labels =
         c_type_name;
         " t){\nint i;\nfor(i=0;i<";
         tab_len;
-        "; i++){\nif(t==";
+        (* The table is int64_t; c_type_name may be unsigned. *)
+        "; i++){\nif((int64_t)t==";
         tab_name;
         "[i][1])return ";
         tab_name;

--- a/src/modules/synced/ffmpeg/gen_code/gen_code.ml
+++ b/src/modules/synced/ffmpeg/gen_code/gen_code.ml
@@ -57,15 +57,29 @@ let rec id_to_pv_value id values =
 
   if List.mem value values then id_to_pv_value (id ^ "_") values else (id, value)
 
+(* One block of constants scanned out of one header. *)
+type enum_spec = {
+  start_pat : string; (* where to start scanning; "" means the top *)
+  pat : string; (* matches one member, capturing its name *)
+  end_pat : string; (* where to stop; "" means the end *)
+  enum_prefix : string; (* C member prefix, e.g. "AVCOL_SPC_" *)
+  c_type_name : string; (* type of the C value *)
+  c_fun_radix : string; (* Xxx in Xxx_val / Val_Xxx *)
+  ml_type_name : string;
+  extra_entries : string list; (* members to inject before scanning *)
+}
+
 let translate_enum_lines ?h_oc ?ml_oc lines labels =
-  let ( start_pat,
-        pat,
-        end_pat,
-        enum_prefix,
-        c_type_name,
-        c_fun_radix,
-        ml_type_name,
-        extra_entries ) =
+  let {
+    start_pat;
+    pat;
+    end_pat;
+    enum_prefix;
+    c_type_name;
+    c_fun_radix;
+    ml_type_name;
+    extra_entries;
+  } =
     labels
   in
 
@@ -347,345 +361,269 @@ let gen_polymorphic_variant = function
   | "h" -> gen_polymorphic_variant_h ()
   | _ -> assert false
 
-let gen_codec_id mode =
-  (* translate_c_values parameters : *)
-  (* in_name out_name title (start_pat, pat, end_pat, enum_prefix, c_type_name, c_fun_radix, ml_type_name) *)
-  translate_c_values ~pre_process:true
-    ["/libavcodec/codec_id.h"; "/libavcodec/avcodec.h"]
-    "codec_id"
-    [
-      ( "[ \t]*AV_CODEC_ID_NONE",
-        "[ \t]*AV_CODEC_ID_\\([A-Z0-9_]+\\)",
-        "[ \t]*AV_CODEC_ID_FIRST_AUDIO",
-        "AV_CODEC_ID_",
-        "enum AVCodecID",
-        "VideoCodecID",
-        "video",
-        ["WRAPPED_AVFRAME"; "NONE"] );
-      ( "[ \t]*AV_CODEC_ID_FIRST_AUDIO",
-        "[ \t]*AV_CODEC_ID_\\([A-Z0-9_]+\\)",
-        "[ \t]*AV_CODEC_ID_FIRST_SUBTITLE",
-        "AV_CODEC_ID_",
-        "enum AVCodecID",
-        "AudioCodecID",
-        "audio",
-        ["WRAPPED_AVFRAME"; "NONE"] );
-      ( "[ \t]*AV_CODEC_ID_FIRST_SUBTITLE",
-        "[ \t]*AV_CODEC_ID_\\([A-Z0-9_]+\\)",
-        "[ \t]*AV_CODEC_ID_FIRST_UNKNOWN",
-        "AV_CODEC_ID_",
-        "enum AVCodecID",
-        "SubtitleCodecID",
-        "subtitle",
-        ["NONE"] );
-      ( "[ \t]*AV_CODEC_ID_FIRST_UNKNOWN",
-        "[ \t]*AV_CODEC_ID_\\([A-Z0-9_]+\\)",
-        "",
-        "AV_CODEC_ID_",
-        "enum AVCodecID",
-        "UnknownCodecID",
-        "unknown",
-        ["NONE"] );
-      ( "[ \t]*AV_CODEC_ID_NONE",
-        "[ \t]*AV_CODEC_ID_\\([A-Z0-9_]+\\)",
-        "",
-        "AV_CODEC_ID_",
-        "enum AVCodecID",
-        "CodecID",
-        "codec_id",
-        ["NONE"] );
-    ]
-    mode
+(* One generator = one name passed as argv(2) = one pair of output files. *)
+type generator = {
+  name : string;
+  headers : string list;
+  pre_process : bool;
+  enums : enum_spec list;
+}
 
-let gen_pixel_format mode =
-  translate_c_values ~pre_process:true ["/libavutil/pixfmt.h"] "pixel_format"
-    [
-      ( "enum AVPixelFormat",
-        "[ \t]*AV_PIX_FMT_\\([A-Z0-9_]+\\)",
-        "[ \t]*AV_PIX_FMT_NB",
-        "AV_PIX_FMT_",
-        "enum AVPixelFormat",
-        "PixelFormat",
-        "t",
-        [] );
-    ]
-    mode
+let enum ?(start = "") ?(stop = "") ?(ml_name = "t") ?(extra = []) ~prefix
+    ~c_type ~radix () =
+  {
+    start_pat = start;
+    pat = "[ \t]*" ^ prefix ^ "\\([A-Z0-9_]+\\)";
+    end_pat = stop;
+    enum_prefix = prefix;
+    c_type_name = c_type;
+    c_fun_radix = radix;
+    ml_type_name = ml_name;
+    extra_entries = extra;
+  }
 
-let gen_color_space mode =
-  translate_c_values ~pre_process:true ["/libavutil/pixfmt.h"] "color_space"
-    [
-      ( "enum AVColorSpace",
-        "[ \t]*AVCOL_SPC_\\([A-Z0-9_]+\\)",
-        "[ \t]*AVCOL_SPC_NB",
-        "AVCOL_SPC_",
-        "enum AVColorSpace",
-        "ColorSpace",
-        "t",
-        [] );
-    ]
-    mode
+(* A family of #define'd flags rather than a C enum: no delimiters, and the
+   member pattern is anchored on the #define. *)
+let flags ?(ml_name = "t") ~prefix ~c_type ~radix () =
+  {
+    start_pat = "";
+    pat = "#define " ^ prefix ^ "\\([A-Z0-9_]+\\)";
+    end_pat = "";
+    enum_prefix = prefix;
+    c_type_name = c_type;
+    c_fun_radix = radix;
+    ml_type_name = ml_name;
+    extra_entries = [];
+  }
 
-let gen_color_range mode =
-  translate_c_values ~pre_process:true ["/libavutil/pixfmt.h"] "color_range"
-    [
-      ( "enum AVColorRange",
-        "[ \t]*AVCOL_RANGE_\\([A-Z0-9_]+\\)",
-        "[ \t]*AVCOL_RANGE_NB",
-        "AVCOL_RANGE_",
-        "enum AVColorRange",
-        "ColorRange",
-        "t",
-        [] );
-    ]
-    mode
+let pixfmt = ["/libavutil/pixfmt.h"]
+let avcodec_h = ["/libavcodec/avcodec.h"]
 
-let gen_color_primaries mode =
-  translate_c_values ~pre_process:true ["/libavutil/pixfmt.h"] "color_primaries"
-    [
-      ( "enum AVColorPrimaries",
-        "[ \t]*AVCOL_PRI_\\([A-Z0-9_]+\\)",
-        "[ \t]*AVCOL_PRI_NB",
-        "AVCOL_PRI_",
-        "enum AVColorPrimaries",
-        "ColorPrimaries",
-        "t",
-        [] );
-    ]
-    mode
+(* Every codec id range shares a header, prefix and C type; they differ only
+   in which slice of the enum they cover. *)
+let codec_id_range ~start ~stop ~radix ~ml_name ~extra =
+  enum ~start ~stop ~prefix:"AV_CODEC_ID_" ~c_type:"enum AVCodecID" ~radix
+    ~ml_name ~extra ()
 
-let gen_color_trc mode =
-  translate_c_values ~pre_process:true ["/libavutil/pixfmt.h"] "color_trc"
-    [
-      ( "enum AVColorTransferCharacteristic",
-        "[ \t]*AVCOL_TRC_\\([A-Z0-9_]+\\)",
-        "[ \t]*AVCOL_TRC_NB",
-        "AVCOL_TRC_",
-        "enum AVColorTransferCharacteristic",
-        "ColorTrc",
-        "t",
-        [] );
-    ]
-    mode
-
-let gen_chroma_location mode =
-  translate_c_values ~pre_process:true ["/libavutil/pixfmt.h"] "chroma_location"
-    [
-      ( "enum AVChromaLocation",
-        "[ \t]*AVCHROMA_LOC_\\([A-Z0-9_]+\\)",
-        "[ \t]*AVCHROMA_LOC_NB",
-        "AVCHROMA_LOC_",
-        "enum AVChromaLocation",
-        "ChromaLocation",
-        "t",
-        [] );
-    ]
-    mode
-
-let gen_pixel_format_flag mode =
-  translate_c_values ~pre_process:false ["/libavutil/pixdesc.h"]
-    "pixel_format_flag"
-    [
-      ( "",
-        "#define AV_PIX_FMT_FLAG_\\([A-Z0-9_]+\\)",
-        "",
-        "AV_PIX_FMT_FLAG_",
-        "uint64_t",
-        "PixelFormatFlag",
-        "t",
-        [] );
-    ]
-    mode
-
-let gen_hw_config_method mode =
-  translate_c_values ~pre_process:true ["/libavcodec/avcodec.h"]
-    "hw_config_method"
-    [
-      ( "",
-        "[ \t]*AV_CODEC_HW_CONFIG_METHOD_\\([A-Z0-9_]+\\)",
-        "",
-        "AV_CODEC_HW_CONFIG_METHOD_",
-        "uint64_t",
-        "HwConfigMethod",
-        "t",
-        [] );
-    ]
-    mode
-
-let gen_hw_device_type mode =
-  translate_c_values ~pre_process:true ["/libavutil/hwcontext.h"]
-    "hw_device_type"
-    [
-      ( "enum AVHWDeviceType",
-        "[ \t]*AV_HWDEVICE_TYPE_\\([A-Z0-9_]+\\)",
-        "[ \t]*AV_HWDEVICE_TYPE_NONE ",
-        "AV_HWDEVICE_TYPE_",
-        "enum AVHWDeviceType",
-        "HwDeviceType",
-        "t",
-        [] );
-    ]
-    mode
-
-let gen_channel_layout mode =
-  translate_c_values ~pre_process:false
-    ["/libavutil/channel_layout.h"]
-    "channel_layout"
-    [
-      ( "",
-        "#define AV_CH_LAYOUT_\\([A-Z0-9_]+\\)",
-        "",
-        "AV_CH_LAYOUT_",
-        "uint64_t",
-        "ChannelLayout",
-        "t",
-        [] );
-    ]
-    mode
-
-let gen_codec_capabilities mode =
-  translate_c_values ~pre_process:false
-    ["/libavcodec/codec.h"; "/libavcodec/avcodec.h"]
-    "codec_capabilities"
-    [
-      ( "",
-        "#define AV_CODEC_CAP_\\([A-Z0-9_]+\\)",
-        "",
-        "AV_CODEC_CAP_",
-        "uint64_t",
-        "CodecCapabilities",
-        "t",
-        [] );
-    ]
-    mode
-
-let gen_codec_properties mode =
-  translate_c_values ~pre_process:false
-    ["/libavcodec/codec_desc.h"; "/libavcodec/avcodec.h"]
-    "codec_properties"
-    [
-      ( "",
-        "#define AV_CODEC_PROP_\\([A-Z0-9_]+\\)",
-        "",
-        "AV_CODEC_PROP_",
-        "uint64_t",
-        "CodecProperties",
-        "t",
-        [] );
-    ]
-    mode
-
-let gen_media_types mode =
-  translate_c_values ~pre_process:false
-    ["/libavutil/avutil.h"; "/libavutil/avutil.h"]
-    "media_types"
-    [
-      ( "enum AVMediaType",
-        "[ \t]*AVMEDIA_TYPE_\\([A-Z0-9_]+\\)",
-        "[ \t]*AVMEDIA_TYPE_NB",
-        "AVMEDIA_TYPE_",
-        "uint64_t",
-        "MediaTypes",
-        "t",
-        [] );
-    ]
-    mode
-
-let gen_sample_format mode =
-  translate_c_values ~pre_process:true ["/libavutil/samplefmt.h"]
-    "sample_format"
-    [
-      ( "enum AVSampleFormat",
-        "[ \t]*AV_SAMPLE_FMT_\\([A-Z0-9_]+\\)",
-        "[ \t]*AV_SAMPLE_FMT_NB",
-        "AV_SAMPLE_FMT_",
-        "enum AVSampleFormat",
-        "SampleFormat",
-        "t",
-        [] );
-    ]
-    mode
-
-let gen_subtitle_type mode =
-  translate_c_values ~pre_process:true ["/libavcodec/avcodec.h"] "subtitle_type"
-    [
-      ( "enum AVSubtitleType",
-        "[ \t]*SUBTITLE_\\([A-Z0-9_]+\\)",
-        "\\};",
-        "SUBTITLE_",
-        "enum AVSubtitleType",
-        "SubtitleType",
-        "t",
-        [] );
-    ]
-    mode
-
-let gen_subtitle_flag mode =
-  translate_c_values ~pre_process:false ["/libavcodec/avcodec.h"]
-    "subtitle_flag"
-    [
-      ( "",
-        "#define AV_SUBTITLE_FLAG_\\([A-Z0-9_]+\\)",
-        "",
-        "AV_SUBTITLE_FLAG_",
-        "int",
-        "SubtitleFlag",
-        "t",
-        [] );
-    ]
-    mode
-
-let gen_swresample_options mode =
-  translate_c_values ~pre_process:true
-    ["/libswresample/swresample.h"]
-    "swresample_options"
-    [
-      ( "[ \t]*SWR_DITHER_NONE",
-        "[ \t]*SWR_\\([A-Z0-9_]+\\)",
-        "[ \t]*SWR_DITHER_NS",
-        "SWR_",
-        "enum SwrDitherType",
-        "DitherType",
-        "dither_type",
-        [] );
-      ( "enum SwrEngine",
-        "[ \t]*SWR_\\([A-Z0-9_]+\\)",
-        "[ \t]*SWR_ENGINE_NB",
-        "SWR_",
-        "enum SwrEngine",
-        "Engine",
-        "engine",
-        [] );
-      ( "enum SwrFilterType",
-        "[ \t]*SWR_\\([A-Z0-9_]+\\)",
-        "\\};",
-        "SWR_",
-        "enum SwrFilterType",
-        "FilterType",
-        "filter_type",
-        [] );
-    ]
-    mode
+let generators =
+  [
+    {
+      name = "codec_id";
+      headers = ["/libavcodec/codec_id.h"; "/libavcodec/avcodec.h"];
+      pre_process = true;
+      enums =
+        [
+          codec_id_range ~start:"[ \t]*AV_CODEC_ID_NONE"
+            ~stop:"[ \t]*AV_CODEC_ID_FIRST_AUDIO" ~radix:"VideoCodecID"
+            ~ml_name:"video"
+            ~extra:["WRAPPED_AVFRAME"; "NONE"];
+          codec_id_range ~start:"[ \t]*AV_CODEC_ID_FIRST_AUDIO"
+            ~stop:"[ \t]*AV_CODEC_ID_FIRST_SUBTITLE" ~radix:"AudioCodecID"
+            ~ml_name:"audio"
+            ~extra:["WRAPPED_AVFRAME"; "NONE"];
+          codec_id_range ~start:"[ \t]*AV_CODEC_ID_FIRST_SUBTITLE"
+            ~stop:"[ \t]*AV_CODEC_ID_FIRST_UNKNOWN" ~radix:"SubtitleCodecID"
+            ~ml_name:"subtitle" ~extra:["NONE"];
+          codec_id_range ~start:"[ \t]*AV_CODEC_ID_FIRST_UNKNOWN" ~stop:""
+            ~radix:"UnknownCodecID" ~ml_name:"unknown" ~extra:["NONE"];
+          codec_id_range ~start:"[ \t]*AV_CODEC_ID_NONE" ~stop:""
+            ~radix:"CodecID" ~ml_name:"codec_id" ~extra:["NONE"];
+        ];
+    };
+    {
+      name = "pixel_format";
+      headers = pixfmt;
+      pre_process = true;
+      enums =
+        [
+          enum ~start:"enum AVPixelFormat" ~stop:"[ \t]*AV_PIX_FMT_NB"
+            ~prefix:"AV_PIX_FMT_" ~c_type:"enum AVPixelFormat"
+            ~radix:"PixelFormat" ();
+        ];
+    };
+    {
+      name = "color_space";
+      headers = pixfmt;
+      pre_process = true;
+      enums =
+        [
+          enum ~start:"enum AVColorSpace" ~stop:"[ \t]*AVCOL_SPC_NB"
+            ~prefix:"AVCOL_SPC_" ~c_type:"enum AVColorSpace" ~radix:"ColorSpace"
+            ();
+        ];
+    };
+    {
+      name = "color_range";
+      headers = pixfmt;
+      pre_process = true;
+      enums =
+        [
+          enum ~start:"enum AVColorRange" ~stop:"[ \t]*AVCOL_RANGE_NB"
+            ~prefix:"AVCOL_RANGE_" ~c_type:"enum AVColorRange"
+            ~radix:"ColorRange" ();
+        ];
+    };
+    {
+      name = "color_primaries";
+      headers = pixfmt;
+      pre_process = true;
+      enums =
+        [
+          enum ~start:"enum AVColorPrimaries" ~stop:"[ \t]*AVCOL_PRI_NB"
+            ~prefix:"AVCOL_PRI_" ~c_type:"enum AVColorPrimaries"
+            ~radix:"ColorPrimaries" ();
+        ];
+    };
+    {
+      name = "color_trc";
+      headers = pixfmt;
+      pre_process = true;
+      enums =
+        [
+          enum ~start:"enum AVColorTransferCharacteristic"
+            ~stop:"[ \t]*AVCOL_TRC_NB" ~prefix:"AVCOL_TRC_"
+            ~c_type:"enum AVColorTransferCharacteristic" ~radix:"ColorTrc" ();
+        ];
+    };
+    {
+      name = "chroma_location";
+      headers = pixfmt;
+      pre_process = true;
+      enums =
+        [
+          enum ~start:"enum AVChromaLocation" ~stop:"[ \t]*AVCHROMA_LOC_NB"
+            ~prefix:"AVCHROMA_LOC_" ~c_type:"enum AVChromaLocation"
+            ~radix:"ChromaLocation" ();
+        ];
+    };
+    {
+      name = "hw_device_type";
+      headers = ["/libavutil/hwcontext.h"];
+      pre_process = true;
+      enums =
+        [
+          enum ~start:"enum AVHWDeviceType" ~stop:"[ \t]*AV_HWDEVICE_TYPE_NONE "
+            ~prefix:"AV_HWDEVICE_TYPE_" ~c_type:"enum AVHWDeviceType"
+            ~radix:"HwDeviceType" ();
+        ];
+    };
+    {
+      name = "sample_format";
+      headers = ["/libavutil/samplefmt.h"];
+      pre_process = true;
+      enums =
+        [
+          enum ~start:"enum AVSampleFormat" ~stop:"[ \t]*AV_SAMPLE_FMT_NB"
+            ~prefix:"AV_SAMPLE_FMT_" ~c_type:"enum AVSampleFormat"
+            ~radix:"SampleFormat" ();
+        ];
+    };
+    {
+      name = "subtitle_type";
+      headers = avcodec_h;
+      pre_process = true;
+      enums =
+        [
+          enum ~start:"enum AVSubtitleType" ~stop:"\\};" ~prefix:"SUBTITLE_"
+            ~c_type:"enum AVSubtitleType" ~radix:"SubtitleType" ();
+        ];
+    };
+    {
+      name = "media_types";
+      headers = ["/libavutil/avutil.h"; "/libavutil/avutil.h"];
+      pre_process = false;
+      enums =
+        [
+          enum ~start:"enum AVMediaType" ~stop:"[ \t]*AVMEDIA_TYPE_NB"
+            ~prefix:"AVMEDIA_TYPE_" ~c_type:"uint64_t" ~radix:"MediaTypes" ();
+        ];
+    };
+    {
+      name = "hw_config_method";
+      headers = avcodec_h;
+      pre_process = true;
+      enums =
+        [
+          enum ~prefix:"AV_CODEC_HW_CONFIG_METHOD_" ~c_type:"uint64_t"
+            ~radix:"HwConfigMethod" ();
+        ];
+    };
+    {
+      name = "pixel_format_flag";
+      headers = ["/libavutil/pixdesc.h"];
+      pre_process = false;
+      enums =
+        [
+          flags ~prefix:"AV_PIX_FMT_FLAG_" ~c_type:"uint64_t"
+            ~radix:"PixelFormatFlag" ();
+        ];
+    };
+    {
+      name = "channel_layout";
+      headers = ["/libavutil/channel_layout.h"];
+      pre_process = false;
+      enums =
+        [
+          flags ~prefix:"AV_CH_LAYOUT_" ~c_type:"uint64_t"
+            ~radix:"ChannelLayout" ();
+        ];
+    };
+    {
+      name = "codec_capabilities";
+      headers = ["/libavcodec/codec.h"; "/libavcodec/avcodec.h"];
+      pre_process = false;
+      enums =
+        [
+          flags ~prefix:"AV_CODEC_CAP_" ~c_type:"uint64_t"
+            ~radix:"CodecCapabilities" ();
+        ];
+    };
+    {
+      name = "codec_properties";
+      headers = ["/libavcodec/codec_desc.h"; "/libavcodec/avcodec.h"];
+      pre_process = false;
+      enums =
+        [
+          flags ~prefix:"AV_CODEC_PROP_" ~c_type:"uint64_t"
+            ~radix:"CodecProperties" ();
+        ];
+    };
+    {
+      name = "subtitle_flag";
+      headers = avcodec_h;
+      pre_process = false;
+      enums =
+        [
+          flags ~prefix:"AV_SUBTITLE_FLAG_" ~c_type:"int" ~radix:"SubtitleFlag"
+            ();
+        ];
+    };
+    {
+      name = "swresample_options";
+      headers = ["/libswresample/swresample.h"];
+      pre_process = true;
+      enums =
+        [
+          enum ~start:"[ \t]*SWR_DITHER_NONE" ~stop:"[ \t]*SWR_DITHER_NS"
+            ~prefix:"SWR_" ~c_type:"enum SwrDitherType" ~radix:"DitherType"
+            ~ml_name:"dither_type" ();
+          enum ~start:"enum SwrEngine" ~stop:"[ \t]*SWR_ENGINE_NB"
+            ~prefix:"SWR_" ~c_type:"enum SwrEngine" ~radix:"Engine"
+            ~ml_name:"engine" ();
+          enum ~start:"enum SwrFilterType" ~stop:"\\};" ~prefix:"SWR_"
+            ~c_type:"enum SwrFilterType" ~radix:"FilterType"
+            ~ml_name:"filter_type" ();
+        ];
+    };
+  ]
 
 let () =
   let mode = Sys.argv.(3) in
   match Sys.argv.(2) with
     | "polymorphic_variant" -> gen_polymorphic_variant mode
-    | "codec_id" -> gen_codec_id mode
-    | "color_space" -> gen_color_space mode
-    | "color_range" -> gen_color_range mode
-    | "color_primaries" -> gen_color_primaries mode
-    | "color_trc" -> gen_color_trc mode
-    | "chroma_location" -> gen_chroma_location mode
-    | "pixel_format" -> gen_pixel_format mode
-    | "pixel_format_flag" -> gen_pixel_format_flag mode
-    | "hw_config_method" -> gen_hw_config_method mode
-    | "hw_device_type" -> gen_hw_device_type mode
-    | "channel_layout" -> gen_channel_layout mode
-    | "sample_format" -> gen_sample_format mode
-    | "swresample_options" -> gen_swresample_options mode
-    | "codec_capabilities" -> gen_codec_capabilities mode
-    | "codec_properties" -> gen_codec_properties mode
-    | "media_types" -> gen_media_types mode
-    | "subtitle_type" -> gen_subtitle_type mode
-    | "subtitle_flag" -> gen_subtitle_flag mode
-    | _ -> assert false
+    | name -> (
+        match List.find_opt (fun g -> g.name = name) generators with
+          | Some g ->
+              translate_c_values ~pre_process:g.pre_process g.headers g.name
+                g.enums mode
+          | None -> failwith ("gen_code: unknown generator " ^ name))

--- a/src/modules/synced/ffmpeg/swresample/swresample_stubs.c
+++ b/src/modules/synced/ffmpeg/swresample/swresample_stubs.c
@@ -51,10 +51,11 @@ struct swr_t {
   struct audio_t out;
   AVChannelLayout out_ch_layout;
   int out_sample_rate;
-  int out_vect_nb_samples;
 
-  int (*get_in_samples)(swr_t *, value *, int);
-  void (*convert)(swr_t *, int, int, value *);
+  /* Index into VECTOR_OPS: teardown needs the kind to tell whether the
+     buffers are borrowed from an AVFrame. */
+  vector_kind in_kind;
+  vector_kind out_kind;
 };
 
 #define Swr_val(v) (*(swr_t **)Data_custom_val(v))
@@ -241,6 +242,12 @@ static int get_in_samples_planar_ba(swr_t *swr, value *in_vector, int offset) {
   CAMLreturnT(int, nb_samples);
 }
 
+/* Str, P_Str, Fa and P_Fa convert into swr-owned memory and build the OCaml
+   value afterwards, while Frm, Ba and P_Ba let swr_convert write straight
+   into the OCaml value: an AVFrame buffer and a caml_ba_alloc(..., NULL, ...)
+   region both live outside the OCaml heap and cannot move while the runtime
+   system is released. */
+
 static void alloc_out_frame(swr_t *swr, int nb_samples, value *out_vect) {
   int ret;
 
@@ -273,130 +280,12 @@ static void alloc_out_frame(swr_t *swr, int nb_samples, value *out_vect) {
   swr->out.nb_samples = nb_samples;
 }
 
-static void convert_to_frame(swr_t *swr, int in_nb_samples, int out_nb_samples,
-                             value *out_vect) {
-  alloc_out_frame(swr, out_nb_samples, out_vect);
+/* Only the scratch buffer needs sizing up front for these kinds. */
+static void alloc_out_data(swr_t *swr, int nb_samples, value *out_vect) {
+  (void)out_vect;
 
-  caml_release_runtime_system();
-  int ret = swr_convert(swr->context, swr->out.data, swr->out.nb_samples,
-                        (const uint8_t **)swr->in.data, in_nb_samples);
-  caml_acquire_runtime_system();
-
-  if (ret < 0)
-    ocaml_avutil_raise_error(ret);
-
-  Frame_val(*out_vect)->nb_samples = ret;
-}
-
-static void convert_to_string(swr_t *swr, int in_nb_samples, int out_nb_samples,
-                              value *out_vect) {
-  // Allocate out data if needed
-  if (out_nb_samples > swr->out.nb_samples)
-    alloc_data(&swr->out, out_nb_samples);
-
-  caml_release_runtime_system();
-  int ret = swr_convert(swr->context, swr->out.data, swr->out.nb_samples,
-                        (const uint8_t **)swr->in.data, in_nb_samples);
-  caml_acquire_runtime_system();
-
-  if (ret < 0)
-    ocaml_avutil_raise_error(ret);
-
-  size_t len = ret * swr->out.nb_channels * swr->out.bytes_per_samples;
-
-  *out_vect = caml_alloc_string(len);
-  swr->out_vect_nb_samples = ret;
-
-  memcpy(Bytes_val(*out_vect), swr->out.data[0], len);
-}
-
-static void convert_to_planar_string(swr_t *swr, int in_nb_samples,
-                                     int out_nb_samples, value *out_vect) {
-  // Allocate out data if needed
-  if (out_nb_samples > swr->out.nb_samples)
-    alloc_data(&swr->out, out_nb_samples);
-
-  caml_release_runtime_system();
-  int ret = swr_convert(swr->context, swr->out.data, swr->out.nb_samples,
-                        (const uint8_t **)swr->in.data, in_nb_samples);
-  caml_acquire_runtime_system();
-
-  if (ret < 0)
-    ocaml_avutil_raise_error(ret);
-
-  size_t len = ret * swr->out.bytes_per_samples;
-  int i;
-
-  *out_vect = caml_alloc_tuple(swr->out.nb_channels);
-
-  for (i = 0; i < swr->out.nb_channels; i++) {
-    Store_field(*out_vect, i, caml_alloc_string(len));
-  }
-  swr->out_vect_nb_samples = ret;
-
-  for (i = 0; i < swr->out.nb_channels; i++) {
-    memcpy(Bytes_val(Field(*out_vect, i)), swr->out.data[i], len);
-  }
-}
-
-static void convert_to_float_array(swr_t *swr, int in_nb_samples,
-                                   int out_nb_samples, value *out_vect) {
-  // Allocate out data if needed
-  if (out_nb_samples > swr->out.nb_samples)
-    alloc_data(&swr->out, out_nb_samples);
-
-  caml_release_runtime_system();
-  int ret = swr_convert(swr->context, swr->out.data, swr->out.nb_samples,
-                        (const uint8_t **)swr->in.data, in_nb_samples);
-  caml_acquire_runtime_system();
-
-  if (ret < 0)
-    ocaml_avutil_raise_error(ret);
-
-  int len = ret * swr->out.nb_channels;
-  int i;
-
-  *out_vect = caml_alloc(len * Double_wosize, Double_array_tag);
-  swr->out_vect_nb_samples = ret;
-
-  double *pcm = (double *)swr->out.data[0];
-
-  for (i = 0; i < len; i++) {
-    Store_double_field(*out_vect, i, filter_nan(pcm[i]));
-  }
-}
-
-static void convert_to_planar_float_array(swr_t *swr, int in_nb_samples,
-                                          int out_nb_samples, value *out_vect) {
-  // Allocate out data if needed
-  if (out_nb_samples > swr->out.nb_samples)
-    alloc_data(&swr->out, out_nb_samples);
-
-  caml_release_runtime_system();
-  int ret = swr_convert(swr->context, swr->out.data, swr->out.nb_samples,
-                        (const uint8_t **)swr->in.data, in_nb_samples);
-  caml_acquire_runtime_system();
-
-  if (ret < 0)
-    ocaml_avutil_raise_error(ret);
-
-  int i, j;
-  double *pcm;
-
-  *out_vect = caml_alloc_tuple(swr->out.nb_channels);
-
-  for (i = 0; i < swr->out.nb_channels; i++) {
-    Store_field(*out_vect, i,
-                caml_alloc(ret * Double_wosize, Double_array_tag));
-  }
-  swr->out_vect_nb_samples = ret;
-
-  for (i = 0; i < swr->out.nb_channels; i++) {
-    pcm = (double *)swr->out.data[i];
-
-    for (j = 0; j < ret; j++)
-      Store_double_field(Field(*out_vect, i), j, filter_nan(pcm[j]));
-  }
+  if (nb_samples > swr->out.nb_samples)
+    alloc_data(&swr->out, nb_samples);
 }
 
 static void alloc_out_ba(swr_t *swr, int nb_samples, value *out_vect) {
@@ -408,21 +297,6 @@ static void alloc_out_ba(swr_t *swr, int nb_samples, value *out_vect) {
 
   swr->out.data[0] = Caml_ba_data_val(*out_vect);
   swr->out.nb_samples = nb_samples;
-}
-
-static void convert_to_ba(swr_t *swr, int in_nb_samples, int out_nb_samples,
-                          value *out_vect) {
-  alloc_out_ba(swr, out_nb_samples, out_vect);
-
-  caml_release_runtime_system();
-  int ret = swr_convert(swr->context, swr->out.data, swr->out.nb_samples,
-                        (const uint8_t **)swr->in.data, in_nb_samples);
-  caml_acquire_runtime_system();
-
-  if (ret < 0)
-    ocaml_avutil_raise_error(ret);
-
-  Caml_ba_array_val(*out_vect)->dim[0] = ret * swr->out.nb_channels;
 }
 
 static void alloc_out_planar_ba(swr_t *swr, int nb_samples, value *out_vect) {
@@ -442,22 +316,112 @@ static void alloc_out_planar_ba(swr_t *swr, int nb_samples, value *out_vect) {
   swr->out.nb_samples = nb_samples;
 }
 
-static void convert_to_planar_ba(swr_t *swr, int in_nb_samples,
-                                 int out_nb_samples, value *out_vect) {
-  alloc_out_planar_ba(swr, out_nb_samples, out_vect);
+static void store_out_frame(swr_t *swr, int ret, value *out_vect) {
+  (void)swr;
+
+  Frame_val(*out_vect)->nb_samples = ret;
+}
+
+static void store_out_string(swr_t *swr, int ret, value *out_vect) {
+  size_t len = ret * swr->out.nb_channels * swr->out.bytes_per_samples;
+
+  *out_vect = caml_alloc_string(len);
+
+  memcpy(Bytes_val(*out_vect), swr->out.data[0], len);
+}
+
+static void store_out_planar_string(swr_t *swr, int ret, value *out_vect) {
+  size_t len = ret * swr->out.bytes_per_samples;
+  int i;
+
+  *out_vect = caml_alloc_tuple(swr->out.nb_channels);
+
+  for (i = 0; i < swr->out.nb_channels; i++)
+    Store_field(*out_vect, i, caml_alloc_string(len));
+
+  for (i = 0; i < swr->out.nb_channels; i++)
+    memcpy(Bytes_val(Field(*out_vect, i)), swr->out.data[i], len);
+}
+
+static void store_out_float_array(swr_t *swr, int ret, value *out_vect) {
+  int len = ret * swr->out.nb_channels;
+  int i;
+  double *pcm;
+
+  *out_vect = caml_alloc(len * Double_wosize, Double_array_tag);
+
+  pcm = (double *)swr->out.data[0];
+
+  for (i = 0; i < len; i++)
+    Store_double_field(*out_vect, i, filter_nan(pcm[i]));
+}
+
+static void store_out_planar_float_array(swr_t *swr, int ret, value *out_vect) {
+  int i, j;
+  double *pcm;
+
+  *out_vect = caml_alloc_tuple(swr->out.nb_channels);
+
+  for (i = 0; i < swr->out.nb_channels; i++)
+    Store_field(*out_vect, i,
+                caml_alloc(ret * Double_wosize, Double_array_tag));
+
+  for (i = 0; i < swr->out.nb_channels; i++) {
+    pcm = (double *)swr->out.data[i];
+
+    for (j = 0; j < ret; j++)
+      Store_double_field(Field(*out_vect, i), j, filter_nan(pcm[j]));
+  }
+}
+
+static void store_out_ba(swr_t *swr, int ret, value *out_vect) {
+  Caml_ba_array_val(*out_vect)->dim[0] = ret * swr->out.nb_channels;
+}
+
+static void store_out_planar_ba(swr_t *swr, int ret, value *out_vect) {
+  int i;
+
+  for (i = 0; i < swr->out.nb_channels; i++)
+    Caml_ba_array_val(Field(*out_vect, i))->dim[0] = ret;
+}
+
+static const struct {
+  int (*get_in)(swr_t *, value *, int);
+  void (*alloc_out)(swr_t *, int, value *);
+  void (*store_out)(swr_t *, int, value *);
+} VECTOR_OPS[] = {
+    [Str] = {get_in_samples_string, alloc_out_data, store_out_string},
+    [P_Str] = {get_in_samples_planar_string, alloc_out_data,
+               store_out_planar_string},
+    [Fa] = {get_in_samples_float_array, alloc_out_data, store_out_float_array},
+    [P_Fa] = {get_in_samples_planar_float_array, alloc_out_data,
+              store_out_planar_float_array},
+    [Ba] = {get_in_samples_ba, alloc_out_ba, store_out_ba},
+    [P_Ba] = {get_in_samples_planar_ba, alloc_out_planar_ba,
+              store_out_planar_ba},
+    [Frm] = {get_in_samples_frame, alloc_out_frame, store_out_frame},
+};
+
+/* A vector_kind added without a row here would leave a NULL function
+   pointer. */
+_Static_assert(sizeof(VECTOR_OPS) / sizeof(*VECTOR_OPS) == Frm + 1,
+               "VECTOR_OPS must cover every vector_kind");
+
+static void convert(swr_t *swr, int in_nb_samples, int out_nb_samples,
+                    value *out_vect) {
+  int ret;
+
+  VECTOR_OPS[swr->out_kind].alloc_out(swr, out_nb_samples, out_vect);
 
   caml_release_runtime_system();
-  int ret = swr_convert(swr->context, swr->out.data, swr->out.nb_samples,
-                        (const uint8_t **)swr->in.data, in_nb_samples);
+  ret = swr_convert(swr->context, swr->out.data, swr->out.nb_samples,
+                    (const uint8_t **)swr->in.data, in_nb_samples);
   caml_acquire_runtime_system();
 
   if (ret < 0)
     ocaml_avutil_raise_error(ret);
 
-  int i;
-  for (i = 0; i < swr->out.nb_channels; i++) {
-    Caml_ba_array_val(Field(*out_vect, i))->dim[0] = ret;
-  }
+  VECTOR_OPS[swr->out_kind].store_out(swr, ret, out_vect);
 }
 
 CAMLprim value ocaml_swresample_convert(value _ofs, value _len, value _swr,
@@ -485,7 +449,7 @@ CAMLprim value ocaml_swresample_convert(value _ofs, value _len, value _swr,
     offset = Int_val(Field(_ofs, 0));
   }
 
-  int in_nb_samples = swr->get_in_samples(swr, &_in_vector, offset);
+  int in_nb_samples = VECTOR_OPS[swr->in_kind].get_in(swr, &_in_vector, offset);
   if (in_nb_samples < 0)
     ocaml_avutil_raise_error(in_nb_samples);
 
@@ -502,7 +466,7 @@ CAMLprim value ocaml_swresample_convert(value _ofs, value _len, value _swr,
   int out_nb_samples = swr_get_out_samples(swr->context, in_nb_samples);
 
   // Resample and convert input data to output data
-  swr->convert(swr, in_nb_samples, out_nb_samples, &out_vect);
+  convert(swr, in_nb_samples, out_nb_samples, &out_vect);
 
   CAMLreturn(out_vect);
 }
@@ -519,7 +483,7 @@ CAMLprim value ocaml_swresample_flush(value _swr) {
   int out_nb_samples = swr_get_out_samples(swr->context, 0);
 
   // Resample and convert input data to output data
-  swr->convert(swr, 0, out_nb_samples, &out_vect);
+  convert(swr, 0, out_nb_samples, &out_vect);
 
   CAMLreturn(out_vect);
 }
@@ -528,7 +492,7 @@ void swresample_free(swr_t *swr) {
   if (swr->context)
     swr_free(&swr->context);
 
-  if (swr->in.data && swr->get_in_samples != get_in_samples_frame) {
+  if (swr->in.data && swr->in_kind != Frm) {
 
     if (swr->in.owns_data)
       av_freep(&swr->in.data[0]);
@@ -536,7 +500,7 @@ void swresample_free(swr_t *swr) {
     av_free(swr->in.data);
   }
 
-  if (swr->out.data && swr->convert != convert_to_frame) {
+  if (swr->out.data && swr->out_kind != Frm) {
 
     if (swr->out.owns_data)
       av_freep(&swr->out.data[0]);
@@ -691,51 +655,8 @@ swr_t *swresample_create(vector_kind in_vector_kind,
 
   swr->out.bytes_per_samples = av_get_bytes_per_sample(out_sample_fmt);
 
-  switch (in_vector_kind) {
-  case Frm:
-    swr->get_in_samples = get_in_samples_frame;
-    break;
-  case Str:
-    swr->get_in_samples = get_in_samples_string;
-    break;
-  case P_Str:
-    swr->get_in_samples = get_in_samples_planar_string;
-    break;
-  case Fa:
-    swr->get_in_samples = get_in_samples_float_array;
-    break;
-  case P_Fa:
-    swr->get_in_samples = get_in_samples_planar_float_array;
-    break;
-  case Ba:
-    swr->get_in_samples = get_in_samples_ba;
-    break;
-  case P_Ba:
-    swr->get_in_samples = get_in_samples_planar_ba;
-  }
-
-  switch (out_vect_kind) {
-  case Frm:
-    swr->convert = convert_to_frame;
-    break;
-  case Str:
-    swr->convert = convert_to_string;
-    break;
-  case P_Str:
-    swr->convert = convert_to_planar_string;
-    break;
-  case Fa:
-    swr->convert = convert_to_float_array;
-    break;
-  case P_Fa:
-    swr->convert = convert_to_planar_float_array;
-    break;
-  case Ba:
-    swr->convert = convert_to_ba;
-    break;
-  case P_Ba:
-    swr->convert = convert_to_planar_ba;
-  }
+  swr->in_kind = in_vector_kind;
+  swr->out_kind = out_vect_kind;
   return swr;
 }
 

--- a/src/modules/synced/ffmpeg/swresample/swresample_stubs.c
+++ b/src/modules/synced/ffmpeg/swresample/swresample_stubs.c
@@ -140,7 +140,8 @@ static int get_in_samples_planar_string(swr_t *swr, value *in_vector,
   for (i = 0; i < swr->in.nb_channels; i++) {
     str = Field(*in_vector, i);
 
-    if (str_len != caml_string_length(str) - offset * swr->in.bytes_per_samples)
+    if (str_len !=
+        (int)caml_string_length(str) - offset * swr->in.bytes_per_samples)
       Fail("Swresample failed to convert channel %d's %lu bytes : %d "
            "bytes "
            "were expected",
@@ -189,7 +190,7 @@ static int get_in_samples_planar_float_array(swr_t *swr, value *in_vector,
   for (i = 0; i < swr->in.nb_channels; i++) {
     fa = Field(*in_vector, i);
 
-    if (nb_words != Wosize_val(fa))
+    if (nb_words != (int)Wosize_val(fa))
       Fail("Swresample failed to convert channel %d's %lu bytes : %d "
            "bytes "
            "were expected",
@@ -352,7 +353,7 @@ static void convert_to_float_array(swr_t *swr, int in_nb_samples,
   if (ret < 0)
     ocaml_avutil_raise_error(ret);
 
-  size_t len = ret * swr->out.nb_channels;
+  int len = ret * swr->out.nb_channels;
   int i;
 
   *out_vect = caml_alloc(len * Double_wosize, Double_array_tag);
@@ -551,7 +552,8 @@ void ocaml_swresample_finalize(value v) { swresample_free(Swr_val(v)); }
 static struct custom_operations swr_ops = {
     "ocaml_swresample_context", ocaml_swresample_finalize,
     custom_compare_default,     custom_hash_default,
-    custom_serialize_default,   custom_deserialize_default};
+    custom_serialize_default,   custom_deserialize_default,
+    custom_compare_ext_default, custom_fixed_length_default};
 
 #define NB_OPTIONS_TYPES 3
 
@@ -758,7 +760,7 @@ CAMLprim value ocaml_swresample_create(
   int out_sample_rate = Int_val(_out_sample_rate);
   int i;
 
-  for (i = 0; i < Wosize_val(_options) && i < NB_OPTIONS_TYPES; i++)
+  for (i = 0; i < (int)Wosize_val(_options) && i < NB_OPTIONS_TYPES; i++)
     options[i] = Field(_options, i);
 
   options[i] = 0;
@@ -775,6 +777,7 @@ CAMLprim value ocaml_swresample_create(
 }
 
 CAMLprim value ocaml_swresample_create_byte(value *argv, int argn) {
+  (void)argn;
   return ocaml_swresample_create(argv[0], argv[1], argv[2], argv[3], argv[4],
                                  argv[5], argv[6], argv[7], argv[8]);
 }

--- a/src/modules/synced/ffmpeg/swscale/swscale_stubs.c
+++ b/src/modules/synced/ffmpeg/swscale/swscale_stubs.c
@@ -21,16 +21,19 @@
 #define ALIGNMENT_BYTES 16
 
 CAMLprim value ocaml_swscale_version(value unit) {
+  (void)unit;
   CAMLparam0();
   CAMLreturn(Val_int(swscale_version()));
 }
 
 CAMLprim value ocaml_swscale_configuration(value unit) {
+  (void)unit;
   CAMLparam0();
   CAMLreturn(caml_copy_string(swscale_configuration()));
 }
 
 CAMLprim value ocaml_swscale_license(value unit) {
+  (void)unit;
   CAMLparam0();
   CAMLreturn(caml_copy_string(swscale_license()));
 }
@@ -72,9 +75,10 @@ static void finalize_context(value v) {
 }
 
 static struct custom_operations context_ops = {
-    "ocaml_swscale_context",  finalize_context,
-    custom_compare_default,   custom_hash_default,
-    custom_serialize_default, custom_deserialize_default};
+    "ocaml_swscale_context",    finalize_context,
+    custom_compare_default,     custom_hash_default,
+    custom_serialize_default,   custom_deserialize_default,
+    custom_compare_ext_default, custom_fixed_length_default};
 
 CAMLprim value ocaml_swscale_get_context(value flags_, value src_w_,
                                          value src_h_, value src_format_,
@@ -93,7 +97,7 @@ CAMLprim value ocaml_swscale_get_context(value flags_, value src_w_,
   int i;
   struct SwsContext *c;
 
-  for (i = 0; i < Wosize_val(flags_); i++)
+  for (i = 0; i < (int)Wosize_val(flags_); i++)
     flags |= Flag_val(Field(flags_, i));
 
   caml_release_runtime_system();
@@ -111,6 +115,7 @@ CAMLprim value ocaml_swscale_get_context(value flags_, value src_w_,
 }
 
 CAMLprim value ocaml_swscale_get_context_byte(value *argv, int argn) {
+  (void)argn;
   return ocaml_swscale_get_context(argv[0], argv[1], argv[2], argv[3], argv[4],
                                    argv[5], argv[6]);
 }
@@ -158,6 +163,7 @@ CAMLprim value ocaml_swscale_scale(value context_, value src_, value off_,
 }
 
 CAMLprim value ocaml_swscale_scale_byte(value *argv, int argn) {
+  (void)argn;
   return ocaml_swscale_scale(argv[0], argv[1], argv[2], argv[3], argv[4],
                              argv[5]);
 }
@@ -216,7 +222,7 @@ static int get_in_pixels_string(sws_t *sws, value *in_vector) {
     sws->in.stride[i] = Int_val(Field(v, 1));
     size_t str_len = caml_string_length(str);
 
-    if (sws->in.sizes_tab[i] < str_len) {
+    if (sws->in.sizes_tab[i] < (int)str_len) {
       sws->in.slice[i] = (uint8_t *)av_realloc(sws->in.slice[i], str_len);
       sws->in.sizes_tab[i] = str_len;
     }
@@ -254,6 +260,7 @@ static int get_in_pixels_packed_ba(sws_t *sws, value *in_vector) {
 }
 
 static int alloc_out_frame(sws_t *sws, value *out_vect, value *tmp) {
+  (void)tmp;
   int ret;
   AVFrame *frame = av_frame_alloc();
 
@@ -428,9 +435,10 @@ void swscale_free(sws_t *sws) {
 static void ocaml_swscale_finalize(value v) { swscale_free(Sws_val(v)); }
 
 static struct custom_operations sws_ops = {
-    "ocaml_swscale_context",  ocaml_swscale_finalize,
-    custom_compare_default,   custom_hash_default,
-    custom_serialize_default, custom_deserialize_default};
+    "ocaml_swscale_context",    ocaml_swscale_finalize,
+    custom_compare_default,     custom_hash_default,
+    custom_serialize_default,   custom_deserialize_default,
+    custom_compare_ext_default, custom_fixed_length_default};
 
 CAMLprim value ocaml_swscale_create(value flags_, value in_vector_kind_,
                                     value in_width_, value in_height_,
@@ -466,7 +474,7 @@ CAMLprim value ocaml_swscale_create(value flags_, value in_vector_kind_,
   sws->out.height = Int_val(out_height_);
   sws->out.pixel_format = PixelFormat_val(out_pixel_format_);
 
-  for (i = 0; i < Wosize_val(flags_); i++)
+  for (i = 0; i < (int)Wosize_val(flags_); i++)
     flags |= Flag_val(Field(flags_, i));
 
   caml_release_runtime_system();
@@ -532,6 +540,7 @@ CAMLprim value ocaml_swscale_create(value flags_, value in_vector_kind_,
 }
 
 CAMLprim value ocaml_swscale_create_byte(value *argv, int argn) {
+  (void)argn;
   return ocaml_swscale_create(argv[0], argv[1], argv[2], argv[3], argv[4],
                               argv[5], argv[6], argv[7], argv[8]);
 }

--- a/src/modules/synced/ffmpeg/swscale/swscale_stubs.c
+++ b/src/modules/synced/ffmpeg/swscale/swscale_stubs.c
@@ -286,9 +286,11 @@ static int alloc_out_string(sws_t *sws, value *out_vect, value *tmp) {
   *out_vect = caml_alloc_tuple(sws->out.nb_planes);
 
   for (i = 0; i < sws->out.nb_planes; i++) {
-    len = sws->out.stride[i] * sws->out.height;
+    /* plane_sizes accounts for chroma subsampling; stride * height does not. */
+    len = sws->out.plane_sizes[i];
 
     if (sws->out.sizes_tab[i] < len) {
+      /* Some filters and swscale can read up to 16 bytes beyond the planes. */
       sws->out.slice[i] = (uint8_t *)av_realloc(sws->out.slice[i], len + 16);
       sws->out.sizes_tab[i] = len;
     }
@@ -311,8 +313,10 @@ static int copy_out_string(sws_t *sws, value *out_vect) {
   for (i = 0; i < sws->out.nb_planes; i++) {
     str = Field(Field(*out_vect, i), 0);
 
+    /* sizes_tab is a high-water mark and can exceed the string just
+       allocated: copy what the destination actually holds. */
     memcpy((uint8_t *)String_val(str), sws->out.slice[i],
-           sws->out.sizes_tab[i]);
+           caml_string_length(str));
   }
 
   CAMLreturnT(int, 0);
@@ -405,13 +409,16 @@ void swscale_free(sws_t *sws) {
   if (sws->context)
     sws_freeContext(sws->context);
 
+  /* slice points at a 4-slot table, zero-initialised: walking it until a NULL
+     runs into stride_tab for a 4-plane format, so bound by the table size and
+     let av_free ignore the unused slots. */
   if (sws->in.owns_data) {
-    for (i = 0; sws->in.slice[i]; i++)
+    for (i = 0; i < 4; i++)
       av_free(sws->in.slice[i]);
   }
 
   if (sws->out.owns_data) {
-    for (i = 0; sws->out.slice[i]; i++)
+    for (i = 0; i < 4; i++)
       av_free(sws->out.slice[i]);
   }
 

--- a/src/modules/synced/ffmpeg/test/test_assert.ml
+++ b/src/modules/synced/ffmpeg/test/test_assert.ml
@@ -1,0 +1,24 @@
+(* Shared assertions for the test executables. [finish] fails on an empty
+   count as well as on a recorded failure: a test that checked nothing must
+   not be able to report success. *)
+
+let checked = ref 0
+let failed = ref 0
+
+let check name ok =
+  incr checked;
+  if ok then Printf.printf "OK: %s\n%!" name
+  else begin
+    incr failed;
+    Printf.eprintf "FAILED: %s\n%!" name
+  end
+
+let checkf ok fmt = Printf.ksprintf (fun name -> check name ok) fmt
+
+let finish () =
+  Printf.printf "%d checked, %d failed\n%!" !checked !failed;
+  if !checked = 0 then begin
+    prerr_endline "FAILED: test asserted nothing";
+    exit 1
+  end;
+  if !failed > 0 then exit 1

--- a/src/modules/synced/ffmpeg/test/test_codec.ml
+++ b/src/modules/synced/ffmpeg/test/test_codec.ml
@@ -1,0 +1,27 @@
+(* Codec-level assertions that need no media file. *)
+
+let test_capabilities () =
+  let codec = Avcodec.Audio.find_encoder `Aac in
+  let caps = Avcodec.capabilities codec in
+  Test_assert.checkf (caps <> []) "aac encoder reports %d capabilities"
+    (List.length caps);
+  (* Matching a literal is the point: the returned values must be real
+     variants, not the raw table entries. Every encoder ffmpeg ships sets
+     AV_CODEC_CAP_DR1. *)
+  Test_assert.check "aac encoder capabilities contain `Dr1" (List.mem `Dr1 caps)
+
+let test_codec_id_round_trip () =
+  let round_trip what string_of_id get_id find_decoder id =
+    Test_assert.checkf
+      (string_of_id (get_id (find_decoder id)) = string_of_id id)
+      "%s decoder id round-trips as %S" what (string_of_id id)
+  in
+  Avcodec.Audio.(round_trip "audio" string_of_id get_id find_decoder `Aac);
+  Avcodec.Video.(round_trip "video" string_of_id get_id find_decoder `H264);
+  Avcodec.Subtitle.(
+    round_trip "subtitle" string_of_id get_id find_decoder `Subrip)
+
+let () =
+  test_capabilities ();
+  test_codec_id_round_trip ();
+  Test_assert.finish ()

--- a/src/modules/synced/ffmpeg/test/test_info.ml
+++ b/src/modules/synced/ffmpeg/test/test_info.ml
@@ -2,44 +2,39 @@ open Avutil
 open Printf
 
 let test_color_properties () =
-  let cs = `Bt709 in
-  let cs_name = Color_space.name cs in
-  printf "Color_space test: %s -> %s\n" "Bt709" cs_name;
-  (match Color_space.from_name cs_name with
-    | Some cs' when cs = cs' -> printf "Color_space from_name: OK\n"
-    | _ -> printf "Color_space from_name: FAILED\n");
-
-  let cr = `Mpeg in
-  let cr_name = Color_range.name cr in
-  printf "Color_range test: %s -> %s\n" "Mpeg" cr_name;
-  (match Color_range.from_name cr_name with
-    | Some cr' when cr = cr' -> printf "Color_range from_name: OK\n"
-    | _ -> printf "Color_range from_name: FAILED\n");
-
-  let cp = `Bt709 in
-  let cp_name = Color_primaries.name cp in
-  printf "Color_primaries test: %s -> %s\n" "Bt709" cp_name;
-  (match Color_primaries.from_name cp_name with
-    | Some cp' when cp = cp' -> printf "Color_primaries from_name: OK\n"
-    | _ -> printf "Color_primaries from_name: FAILED\n");
-
-  let ct = `Bt709 in
-  let ct_name = Color_trc.name ct in
-  printf "Color_trc test: %s -> %s\n" "Bt709" ct_name;
-  (match Color_trc.from_name ct_name with
-    | Some ct' when ct = ct' -> printf "Color_trc from_name: OK\n"
-    | _ -> printf "Color_trc from_name: FAILED\n");
-
-  let cl = `Left in
-  let cl_name = Chroma_location.name cl in
-  printf "Chroma_location test: %s -> %s\n" "Left" cl_name;
-  (match Chroma_location.from_name cl_name with
-    | Some cl' when cl = cl' -> printf "Chroma_location from_name: OK\n"
-    | _ -> printf "Chroma_location from_name: FAILED\n");
+  let round_trip what from_name name v =
+    Test_assert.checkf
+      (from_name (name v) = Some v)
+      "%s name/from_name %S" what (name v)
+  in
+  round_trip "Color_space" Color_space.from_name Color_space.name `Bt709;
+  round_trip "Color_range" Color_range.from_name Color_range.name `Mpeg;
+  round_trip "Color_primaries" Color_primaries.from_name Color_primaries.name
+    `Bt709;
+  round_trip "Color_trc" Color_trc.from_name Color_trc.name `Bt709;
+  round_trip "Chroma_location" Chroma_location.from_name Chroma_location.name
+    `Left;
   printf "\n"
+
+(* The getters must reach the AVClass object rather than the OCaml block
+   wrapping it. *)
+let test_container_options input =
+  let obj = Av.input_obj input in
+  let probesize = Options.get_int64 ~name:"probesize" obj in
+  Test_assert.checkf (probesize > 0L) "Options.get_int64 probesize = %Ld"
+    probesize;
+  let max_delay = Options.get_int ~name:"max_delay" obj in
+  Test_assert.checkf (max_delay >= -1) "Options.get_int max_delay = %d"
+    max_delay
 
 let test_file_info url =
   let input = Av.open_input url in
+  test_container_options input;
+  Test_assert.checkf
+    (Av.get_audio_streams input <> []
+    || Av.get_video_streams input <> []
+    || Av.get_subtitle_streams input <> [])
+    "%s has at least one stream" url;
   printf "%s (%s s) :\n" url
     (match Av.get_input_duration input with
       | None -> "N/A"
@@ -52,6 +47,9 @@ let test_file_info url =
       let tb = Av.get_container_stream_time_base ~index:idx input in
       printf "\tAudio stream %d container time_base: %d/%d\n" idx tb.num tb.den;
       Avcodec.Audio.(
+        Test_assert.checkf
+          (get_sample_rate cd > 0 && get_nb_channels cd > 0)
+          "audio stream %d has a sample rate and channels" idx;
         printf "\tAudio stream %d : %s %s, %s %s, %s %d, %s %d, %s %d, %s %s\n"
           idx "codec"
           (get_params_id cd |> string_of_id)
@@ -70,6 +68,9 @@ let test_file_info url =
       printf "\tVideo stream %d container time_base: %d/%d\n" idx tb.num tb.den;
       Avcodec.Video.(
         let sar = get_sample_aspect_ratio cd in
+        Test_assert.checkf
+          (get_width cd > 0 && get_height cd > 0)
+          "video stream %d has a width and height" idx;
         printf
           "\tVideo stream %d : %s %s, %s %d, %s %d, %s %d / %d, %s %d, %s %s\n"
           idx "codec"
@@ -82,26 +83,27 @@ let test_file_info url =
         let decoder =
           create_decoder ~params:cd (find_decoder (get_params_id cd))
         in
-        (try
-           let rec read_frame () =
-             match Av.read_input ~video_frame:[stm] input with
-               | `Video_frame (_, frame) ->
-                   let cs = Video.frame_get_color_space frame in
-                   let cr = Video.frame_get_color_range frame in
-                   let cp = Video.frame_get_color_primaries frame in
-                   let ct = Video.frame_get_color_trc frame in
-                   let cl = Video.frame_get_chroma_location frame in
-                   printf
-                     "\t\tFirst frame color_space: %s, color_range: %s, \
-                      color_primaries: %s, color_trc: %s, chroma_location: %s\n"
-                     (Color_space.name cs) (Color_range.name cr)
-                     (Color_primaries.name cp) (Color_trc.name ct)
-                     (Chroma_location.name cl)
-               | exception Avutil.Error `Eof -> ()
-               | _ -> read_frame ()
-           in
-           read_frame ()
-         with _ -> printf "\t\tCould not read video frame\n");
+        let got_frame = ref false in
+        let rec read_frame () =
+          match Av.read_input ~video_frame:[stm] input with
+            | `Video_frame (_, frame) ->
+                got_frame := true;
+                let cs = Video.frame_get_color_space frame in
+                let cr = Video.frame_get_color_range frame in
+                let cp = Video.frame_get_color_primaries frame in
+                let ct = Video.frame_get_color_trc frame in
+                let cl = Video.frame_get_chroma_location frame in
+                printf
+                  "\t\tFirst frame color_space: %s, color_range: %s, \
+                   color_primaries: %s, color_trc: %s, chroma_location: %s\n"
+                  (Color_space.name cs) (Color_range.name cr)
+                  (Color_primaries.name cp) (Color_trc.name ct)
+                  (Chroma_location.name cl)
+            | exception Avutil.Error `Eof -> ()
+            | _ -> read_frame ()
+        in
+        read_frame ();
+        Test_assert.checkf !got_frame "decoded a frame from video stream %d" idx;
         ignore decoder));
   Av.get_subtitle_streams input
   |> List.iter (fun (idx, stm, cd) ->
@@ -123,4 +125,8 @@ let () =
   Avutil.Log.set_callback print_string;
 
   test_color_properties ();
-  Sys.argv |> Array.to_list |> List.tl |> List.iter test_file_info
+
+  let urls = Sys.argv |> Array.to_list |> List.tl in
+  Test_assert.check "at least one input file was given" (urls <> []);
+  List.iter test_file_info urls;
+  Test_assert.finish ()

--- a/src/modules/synced/ffmpeg/test/test_options.ml
+++ b/src/modules/synced/ffmpeg/test/test_options.ml
@@ -1,0 +1,78 @@
+(* Every entry point must report the same unused keys: after the call, [opts]
+   holds exactly what ffmpeg ignored.
+
+   The large case is a round-trip stress test and proves nothing about
+   rooting, since a small result never triggers a minor collection (4096-word
+   floor) and a large one lands in the major heap, so both regimes pass with
+   the root in ocaml_avutil_unused_options deliberately removed. *)
+
+let bogus = ["definitely_not_an_option"; "also_bogus"]
+
+let mk_opts extra =
+  let opts = Hashtbl.create 8 in
+  List.iter (fun k -> Hashtbl.replace opts k (`String "1")) bogus;
+  List.iter (fun (k, v) -> Hashtbl.replace opts k v) extra;
+  opts
+
+let check_unused what opts =
+  let left = Hashtbl.fold (fun k _ acc -> k :: acc) opts [] in
+  Test_assert.checkf
+    (List.sort compare left = List.sort compare bogus)
+    "%s reports unused options %s" what
+    (String.concat "," (List.sort compare left))
+
+let () =
+  let url = Sys.argv.(1) in
+
+  (* Demuxer: probesize is real, the other two are not. *)
+  let opts = mk_opts [("probesize", `Int 5000000)] in
+  let input = Av.open_input ~opts url in
+  check_unused "Av.open_input" opts;
+
+  (* Muxer. *)
+  let opts = mk_opts [] in
+  let output = Av.open_output ~opts "test_options_out.mkv" in
+  check_unused "Av.open_output" opts;
+
+  (* Encoder: b is a real AVCodecContext option. *)
+  let opts = mk_opts [("b", `Int 128000)] in
+  let encoder =
+    Avcodec.Audio.create_encoder ~opts
+      ~channel_layout:Avutil.Channel_layout.stereo ~sample_rate:44100
+      ~sample_format:`Fltp
+      ~time_base:{ Avutil.num = 1; den = 44100 }
+      (Avcodec.Audio.find_encoder `Aac)
+  in
+  check_unused "Avcodec.Audio.create_encoder" opts;
+  ignore encoder;
+
+  (* Enough unused keys that the reply collects while its tuple is live. *)
+  let n = 20000 in
+  let opts = Hashtbl.create n in
+  for i = 0 to n - 1 do
+    Hashtbl.replace opts (Printf.sprintf "bogus_option_%06d" i) (`String "1")
+  done;
+  let input2 = Av.open_input ~opts url in
+  let left = Hashtbl.length opts in
+  Test_assert.checkf (left = n) "%d of %d unused keys survive the reply" left n;
+  let corrupt = ref 0 and sample = ref "" in
+  Hashtbl.iter
+    (fun k _ ->
+      let ok =
+        String.length k = 19
+        && String.sub k 0 13 = "bogus_option_"
+        && String.for_all (fun c -> c >= '0' && c <= '9') (String.sub k 13 6)
+      in
+      if not ok then begin
+        incr corrupt;
+        sample := k
+      end)
+    opts;
+  Test_assert.checkf (!corrupt = 0) "%d returned keys corrupted (e.g. %S)"
+    !corrupt !sample;
+
+  Av.close input;
+  Av.close input2;
+  Av.close output;
+  Gc.full_major ();
+  Test_assert.finish ()

--- a/src/modules/synced/ffmpeg/test/test_resample.ml
+++ b/src/modules/synced/ffmpeg/test/test_resample.ml
@@ -84,21 +84,34 @@ let () =
       44100
   in
 
+  let direct_bytes = ref 0 and chained_bytes = ref 0 in
+
   for note = 0 to 95 do
     let freq = 22.5 *. (2. ** (foi note /. 12.)) in
     let len = int_of_float (frate /. freq *. floor (freq /. 4.)) in
     let c = 2. *. pi *. freq /. frate in
     let src = Array.init len (fun t -> sin (foi t *. c)) in
 
-    src |> R.convert r |> write_bytes dst1;
+    let direct = R.convert r src in
+    direct_bytes := !direct_bytes + Bytes.length direct;
+    write_bytes dst1 direct;
 
-    src |> R0.convert r0 |> R1.convert r1 |> R2.convert r2 |> R3.convert r3
-    |> R4.convert r4 |> R5.convert r5 |> R6.convert r6 |> R7.convert r7
-    |> R8.convert r8 |> R9.convert r9 |> R10.convert r10 |> write_bytes dst2
+    let chained =
+      src |> R0.convert r0 |> R1.convert r1 |> R2.convert r2 |> R3.convert r3
+      |> R4.convert r4 |> R5.convert r5 |> R6.convert r6 |> R7.convert r7
+      |> R8.convert r8 |> R9.convert r9 |> R10.convert r10
+    in
+    chained_bytes := !chained_bytes + Bytes.length chained;
+    write_bytes dst2 chained
   done;
 
   close_out dst1;
   close_out dst2;
+
+  Test_assert.checkf (!direct_bytes > 0) "direct conversion produced %d bytes"
+    !direct_bytes;
+  Test_assert.checkf (!chained_bytes > 0) "chained conversion produced %d bytes"
+    !chained_bytes;
 
   let output_planar_float_to_s16le audio_output_file planes =
     let nb_chan = Array.length planes in
@@ -116,35 +129,43 @@ let () =
     done
   in
 
-  Sys.argv |> Array.to_list |> List.tl
-  |> List.iter (fun url ->
-      try
-        let src = Av.open_input url in
-        let idx, is, ic = src |> Av.find_best_audio_stream in
-        let rsp = Converter.from_codec ic Avutil.Channel_layout.stereo 44100 in
+  let urls = Sys.argv |> Array.to_list |> List.tl in
+  Test_assert.check "at least one input file was given" (urls <> []);
 
-        let p = try String.rindex url '/' + 1 with Not_found -> 0 in
-        let audio_output_filename =
-          String.(
-            sub url p (length url - p) ^ "." ^ string_of_int idx ^ ".s16le.raw")
-        in
-        let audio_output_file = open_out_bin audio_output_filename in
+  List.iter
+    (fun url ->
+      let src = Av.open_input url in
+      let idx, is, ic = src |> Av.find_best_audio_stream in
+      let rsp = Converter.from_codec ic Avutil.Channel_layout.stereo 44100 in
 
-        print_endline ("Convert " ^ url ^ " to " ^ audio_output_filename);
-        let rec f () =
-          match Av.read_input ~audio_frame:[is] src with
-            | `Audio_frame (i, frame) when i = idx ->
-                Converter.convert rsp frame
-                |> output_planar_float_to_s16le audio_output_file;
-                f ()
-            | exception Avutil.Error `Eof -> ()
-            | _ -> f ()
-        in
-        f ();
+      let p = try String.rindex url '/' + 1 with Not_found -> 0 in
+      let audio_output_filename =
+        String.(
+          sub url p (length url - p) ^ "." ^ string_of_int idx ^ ".s16le.raw")
+      in
+      let audio_output_file = open_out_bin audio_output_filename in
 
-        Av.get_input is |> Av.close;
-        close_out audio_output_file
-      with _ -> print_endline ("No audio stream in " ^ url));
+      print_endline ("Convert " ^ url ^ " to " ^ audio_output_filename);
+      let converted = ref 0 in
+      let rec f () =
+        match Av.read_input ~audio_frame:[is] src with
+          | `Audio_frame (i, frame) when i = idx ->
+              let planes = Converter.convert rsp frame in
+              converted := !converted + Array.length planes.(0);
+              output_planar_float_to_s16le audio_output_file planes;
+              f ()
+          | exception Avutil.Error `Eof -> ()
+          | _ -> f ()
+      in
+      f ();
+
+      Test_assert.checkf (!converted > 0) "converted %d samples from %s"
+        !converted url;
+
+      Av.get_input is |> Av.close;
+      close_out audio_output_file)
+    urls;
 
   Gc.full_major ();
-  Gc.full_major ()
+  Gc.full_major ();
+  Test_assert.finish ()

--- a/src/modules/synced/ffmpeg/test/test_subtitle_read.ml
+++ b/src/modules/synced/ffmpeg/test/test_subtitle_read.ml
@@ -22,10 +22,7 @@ let () =
         (Avcodec.Subtitle.string_of_id codec_id))
     subtitle_streams;
 
-  if List.length subtitle_streams = 0 then (
-    Printf.printf "No subtitles found.\n";
-    Av.close src;
-    exit 0);
+  Test_assert.check "input has a subtitle stream" (subtitle_streams <> []);
 
   let time_base = time_base () in
   let count = ref 0 in
@@ -59,10 +56,13 @@ let () =
       | exception Error `Eof ->
           Printf.printf "End of file. Read %d subtitle(s).\n%!" !count
       | exception Error err ->
-          Printf.eprintf "Error: %s\n%!" (string_of_error err)
+          Test_assert.checkf false "read_input failed: %s" (string_of_error err)
       | _ -> read_loop ()
   in
   read_loop ();
 
+  Test_assert.checkf (!count > 0) "read %d subtitles" !count;
+
   Av.close src;
-  Gc.full_major ()
+  Gc.full_major ();
+  Test_assert.finish ()

--- a/src/modules/synced/ffmpeg/test/test_swresample.ml
+++ b/src/modules/synced/ffmpeg/test/test_swresample.ml
@@ -1,0 +1,135 @@
+(* Shape and content for every output vector kind: swapping two rows of the C
+   dispatch table yields a structurally valid result with the wrong layout,
+   while swapping an allocator against a store gives the right shape full of
+   garbage, so neither check alone suffices. *)
+
+let rate = 44100
+let nb_samples = 1024
+let mono = Avutil.Channel_layout.mono
+
+(* A slow ramp over [-1, 1): resampling mono 44.1k to mono 44.1k is
+   identity, so whatever comes out must still be the ramp. *)
+let ramp =
+  Array.init nb_samples (fun i ->
+      (2. *. float_of_int i /. float_of_int nb_samples) -. 1.)
+
+let close_enough a b = Float.abs (a -. b) < 0.01
+
+let check_ramp what got =
+  let n = Array.length got in
+  Test_assert.checkf (n = nb_samples) "%s: %d samples, want %d" what n
+    nb_samples;
+  if n = nb_samples then begin
+    let bad = ref 0 and worst = ref 0. in
+    Array.iteri
+      (fun i v ->
+        if not (close_enough v ramp.(i)) then begin
+          incr bad;
+          if Float.abs (v -. ramp.(i)) > !worst then
+            worst := Float.abs (v -. ramp.(i))
+        end)
+      got;
+    Test_assert.checkf (!bad = 0) "%s: %d samples off the ramp (worst %.4f)"
+      what !bad !worst
+  end
+
+module FromFloatArray = Swresample.Make (Swresample.FloatArray)
+module ToFloatArray = FromFloatArray (Swresample.FloatArray)
+module ToPlanarFloatArray = FromFloatArray (Swresample.PlanarFloatArray)
+module ToFrame = FromFloatArray (Swresample.DblFrame)
+module ToPlanarFrame = FromFloatArray (Swresample.DblPlanarFrame)
+module ToBigArray = FromFloatArray (Swresample.DblBigArray)
+module ToPlanarBigArray = FromFloatArray (Swresample.DblPlanarBigArray)
+module ToBytes = FromFloatArray (Swresample.DblBytes)
+module ToPlanarBytes = FromFloatArray (Swresample.DblPlanarBytes)
+module FrameToFloatArray = Swresample.Make (Swresample.DblFrame)
+module FrameBack = FrameToFloatArray (Swresample.FloatArray)
+
+let bytes_to_floats b =
+  Array.init (Bytes.length b / 8) (fun i -> Bytes.get_int64_le b (i * 8))
+  |> Array.map Int64.float_of_bits
+
+let ba_to_floats ba =
+  Array.init (Bigarray.Array1.dim ba) (fun i -> Bigarray.Array1.get ba i)
+
+let () =
+  check_ramp "FloatArray"
+    (ToFloatArray.convert (ToFloatArray.create mono rate mono rate) ramp);
+
+  let planar =
+    ToPlanarFloatArray.convert
+      (ToPlanarFloatArray.create mono rate mono rate)
+      ramp
+  in
+  Test_assert.checkf
+    (Array.length planar = 1)
+    "PlanarFloatArray: %d planes, want 1" (Array.length planar);
+  check_ramp "PlanarFloatArray" planar.(0);
+
+  let frame = ToFrame.convert (ToFrame.create mono rate mono rate) ramp in
+  check_ramp "DblFrame"
+    (FrameBack.convert (FrameBack.create mono rate mono rate) frame);
+
+  let pframe =
+    ToPlanarFrame.convert (ToPlanarFrame.create mono rate mono rate) ramp
+  in
+  ignore pframe;
+  Test_assert.check "DblPlanarFrame converted" true;
+
+  check_ramp "DblBigArray"
+    (ba_to_floats
+       (ToBigArray.convert (ToBigArray.create mono rate mono rate) ramp));
+
+  let pba =
+    ToPlanarBigArray.convert (ToPlanarBigArray.create mono rate mono rate) ramp
+  in
+  Test_assert.checkf
+    (Array.length pba = 1)
+    "DblPlanarBigArray: %d planes, want 1" (Array.length pba);
+  check_ramp "DblPlanarBigArray" (ba_to_floats pba.(0));
+
+  check_ramp "DblBytes"
+    (bytes_to_floats
+       (ToBytes.convert (ToBytes.create mono rate mono rate) ramp));
+
+  let pbytes =
+    ToPlanarBytes.convert (ToPlanarBytes.create mono rate mono rate) ramp
+  in
+  Test_assert.checkf
+    (Array.length pbytes = 1)
+    "DblPlanarBytes: %d planes, want 1" (Array.length pbytes);
+  check_ramp "DblPlanarBytes" (bytes_to_floats pbytes.(0));
+
+  (* At equal rates the converted count equals the allocated upper bound, so
+     the kinds whose store step only fixes up a length (Frm, Ba, P_Ba) look
+     correct even wired to the wrong one. Halving the rate makes the
+     allocation an over-estimate, so the length has to be corrected. *)
+  let half = rate / 2 in
+  let expected = nb_samples / 2 in
+  let near n = abs (n - expected) <= 16 in
+
+  let ba = ToBigArray.convert (ToBigArray.create mono rate mono half) ramp in
+  Test_assert.checkf
+    (near (Bigarray.Array1.dim ba))
+    "resampled DblBigArray: %d samples, want about %d" (Bigarray.Array1.dim ba)
+    expected;
+
+  let pba =
+    ToPlanarBigArray.convert (ToPlanarBigArray.create mono rate mono half) ramp
+  in
+  Test_assert.checkf
+    (Array.length pba = 1 && near (Bigarray.Array1.dim pba.(0)))
+    "resampled DblPlanarBigArray: %d planes of %d samples, want 1 of about %d"
+    (Array.length pba)
+    (Bigarray.Array1.dim pba.(0))
+    expected;
+
+  let frame = ToFrame.convert (ToFrame.create mono rate mono half) ramp in
+  Test_assert.checkf
+    (near (Avutil.Audio.frame_nb_samples frame))
+    "resampled DblFrame: %d samples, want about %d"
+    (Avutil.Audio.frame_nb_samples frame)
+    expected;
+
+  Gc.full_major ();
+  Test_assert.finish ()

--- a/src/modules/synced/ffmpeg/test/test_swscale.ml
+++ b/src/modules/synced/ffmpeg/test/test_swscale.ml
@@ -1,0 +1,33 @@
+(* Plane sizing on the string output path: sizing a plane by stride * height
+   ignores chroma subsampling and hands back U and V at twice their real
+   length. *)
+
+module Convert = Swscale.Make (Swscale.Bytes) (Swscale.Bytes)
+
+let () =
+  let w = 64 and h = 64 in
+  let ctx = Convert.create [Swscale.Bilinear] w h `Rgb24 w h `Yuv420p in
+  let src = [| (String.make (w * 3 * h) '\x80', w * 3) |] in
+
+  (* Twice, so a stale high-water plane size would show up on the second. *)
+  for pass = 1 to 2 do
+    let out = Convert.convert ctx src in
+    Test_assert.checkf
+      (Array.length out = 3)
+      "pass %d: yuv420p output has %d planes" pass (Array.length out);
+    let len i = String.length (fst out.(i)) in
+    Test_assert.checkf
+      (len 0 = w * h)
+      "pass %d: Y plane is %d bytes, want %d" pass (len 0) (w * h);
+    Test_assert.checkf
+      (len 1 = w * h / 4)
+      "pass %d: U plane is %d bytes, want %d" pass (len 1)
+      (w * h / 4);
+    Test_assert.checkf
+      (len 2 = w * h / 4)
+      "pass %d: V plane is %d bytes, want %d" pass (len 2)
+      (w * h / 4)
+  done;
+
+  Gc.full_major ();
+  Test_assert.finish ()


### PR DESCRIPTION
A consolidation review of the vendored ffmpeg bindings found large amounts of copied code — the opts→AVDictionary loop spelled out twelve times, audio/video/subtitle written out three times across `av` and `avcodec`, and roughly half of `swresample_stubs.c` being one algorithm repeated per vector kind — and, more importantly, that several of those copies had drifted apart into real defects, four of which are reachable from liquidsoap's own ffmpeg support.

This branch fixes the divergences first, then turns on `-Wall -Wextra -Werror=unused-variable -Werror=unused-parameter` for all seven libraries (only `av` had them, which is how most of this survived) and collapses the duplication that produced the drift, with every public `.mli` kept source-compatible; the two changes carrying real risk are the reordered subtitle header write and the swresample dispatch rewrite, and both are pinned by tests that were confirmed to go red when the change is deliberately broken.

### Commits

- **`ffmpeg/test: make the test suite capable of reporting failure`** — `test_info` printed `FAILED` for each of its five checks and still exited 0, `test_info` and `test_resample` were invoked with no arguments so most of their bodies never ran, and `test_subtitle_read` exited 0 when it found no subtitles; adds a shared `Test_assert` that fails on a recorded failure *and* on an empty count.
- **`ffmpeg: fix divergences between copied code paths`** — nineteen defects, including `Avcodec.capabilities` returning values no literal could match (so `List.mem \`Variable_frame_size` was permanently false at both encoder call sites), `Avfilter.process_command` always sending flags 0, ten of eleven `Avutil.Options` getters passing the OCaml block instead of the AVClass object, a double free in `new_audio_stream`, and chroma planes returned at twice their real length.
- **`ffmpeg: build every library with warnings enabled`** — 6170 of the 8996 C lines were built with no warning flags at all, and switching them on surfaced two further live bugs: `get_supported_color_spaces`/`_color_ranges` looping until an entry equalled `-1` on unsigned enums that ffmpeg terminates with `AVCOL_*_UNSPECIFIED`, and a side-data type read uninitialised on a default branch.
- **`ffmpeg/avcodec: drop the redundant (optional) from the library stanza`** — `avcodec` was the only binding library carrying it despite already gating on `enabled_if`, so a dependency resolution failure would have silently dropped 1856 lines of C from the build and left it green.
- **`ffmpeg: give the option dictionaries a single seam`** — the twelve dictionary-build loops and eleven unused-key replies become `ocaml_avutil_dict_of_options` and `ocaml_avutil_unused_options` in avutil, removing about 210 lines and fixing a thirteenth copy that dropped `av_dict_set`'s return code entirely.
- **`ffmpeg/gen_code: describe the generators as data`** — nineteen near-identical functions and a nineteen-arm dispatch become a list of records looked up by name, with the positional 8-tuple replaced by a record, verified by every one of the 37 generated files coming out byte-for-byte identical.
- **`ffmpeg/avcodec: collapse the per-media-type stubs`** — twenty-six stubs differing only in three tokens become two X-macros instantiated once per media type, with all 26 symbols confirmed still exported, plus one shared `codecs_of` replacing three copies of the encoders/decoders filter.
- **`ffmpeg/av: share the header write and packet dispatch between writers`** — `write_audio_frame` and `write_video_frame` merge into one function taking the union of their guards, and the subtitle path stops hand-rolling the header write and packet stamp, moving to header-first so a stream whose subtitles all encode to nothing can no longer end up without a trailer.
- **`ffmpeg/swresample: dispatch the vector kinds from one table`** — seven converters that shared an identical middle become `alloc_out`/`store_out` pairs in a `VECTOR_OPS` table with a `_Static_assert` for completeness, and the teardown stops comparing function addresses to work out which kind it holds.

### Tests

`test_assert`, `test_codec`, `test_options`, `test_swscale` and `test_swresample` are new, and `test_info`, `test_resample` and `test_subtitle_read` now assert rather than print; the suite went from two real assertions to 61 across 34 tests. Each risky change was verified by breaking it on purpose: corrupting the golden `sample.srt` fixture turns the suite red (so the header-write reorder is genuinely pinned), reverting the swscale plane sizing reports 2048 bytes where 1024 is expected, and swapping a `VECTOR_OPS` row is caught by the half-rate case.

One verification did **not** work and was withdrawn rather than left in place: running under a tiny minor heap does not prove `ocaml_avutil_unused_options` roots its result, because the runtime clamps the minor heap to a 4096-word floor and a larger key count pushes the tuple into the major heap, which the minor GC does not move either — a deliberately unrooted version passes both ways. The rooting rests on the FFI contract, and the test says so in a comment.

`@mediatest` is CI-only, so the four liquidsoap-visible fixes still need a CI run on that side.
