### PR TITLE
source: allow on_frame callbacks to be deregistered

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -63,6 +63,12 @@
 
 ## Fixed:
 
+- Fixed callbacks registered via `source.on_frame` and friends accumulating for
+  the lifetime of the source they were registered on. `fade.in`, `fade.out` and
+  `fade.skip` register on the source they are given, so a switch transition
+  calling them on the same long-lived source leaked closures on every switch.
+  Callback registration now returns a `remove` method (#TODO)
+
 - An FFmpeg filter graph is no longer finished off by an input that runs dry.
   A source is unavailable for all sorts of passing reasons, a `buffer` filling
   up or a queue waiting on a request, and liquidsoap has no way to tell those

--- a/src/core/operators/cross.ml
+++ b/src/core/operators/cross.ml
@@ -183,7 +183,10 @@ class cross val_source ~override_duration ~duration_getter ~persist_override
               self#set_main_duration
             with _ -> ())
 
-    initializer self#on_frame (`Metadata self#process_override_metadata)
+    initializer
+      ignore
+        (self#on_frame (`Metadata self#process_override_metadata)
+          : unit -> unit)
 
     method private append mode buf_frame =
       let l = Frame.get_all_metadata buf_frame in

--- a/src/core/operators/noblank.ml
+++ b/src/core/operators/noblank.ml
@@ -284,7 +284,11 @@ let _ =
           descr = "when detecting a blank.";
           register_deprecated_argument = false;
           arg_t = [];
-          register = (fun ~params:_ s f -> s#on_blank (fun () -> f []));
+          register =
+            (fun ~params:_ s f ->
+              let f, remove = Lang_source.disarmable f in
+              s#on_blank (fun () -> f []);
+              remove);
         };
         {
           name = "on_noise";
@@ -292,7 +296,11 @@ let _ =
           descr = "when noise is detected.";
           register_deprecated_argument = false;
           arg_t = [];
-          register = (fun ~params:_ s f -> s#on_noise (fun () -> f []));
+          register =
+            (fun ~params:_ s f ->
+              let f, remove = Lang_source.disarmable f in
+              s#on_noise (fun () -> f []);
+              remove);
         };
       ]
     (proto frame_t)

--- a/src/core/operators/switch.ml
+++ b/src/core/operators/switch.ml
@@ -178,8 +178,10 @@ class switch ~all_predicates children =
     val mutable resuming = false
 
     initializer
-      self#on_frame
-        (`After_frame (fun _ -> last_streamed_tick <- Clock.ticks self#clock));
+      ignore
+        (self#on_frame
+           (`After_frame (fun _ -> last_streamed_tick <- Clock.ticks self#clock))
+          : unit -> unit);
       self#on_before_streaming_cycle (fun () ->
           resuming <- 1 < Clock.ticks self#clock - last_streamed_tick;
           excluded_sources <- [];
@@ -190,8 +192,10 @@ class switch ~all_predicates children =
               c.effective_track_sensitive <- None;
               c.effective_predicate <- None)
             children);
-      self#on_frame
-        (`After_frame (fun _ -> self#release_leaving ~force:false ()))
+      ignore
+        (self#on_frame
+           (`After_frame (fun _ -> self#release_leaving ~force:false ()))
+          : unit -> unit)
 
     (* We are at a track boundary when the selected source has no more data for
        its current track: either it could not fill the frame past the position

--- a/src/core/optionals/ffmpeg/io/ffmpeg_io.ml
+++ b/src/core/optionals/ffmpeg/io/ffmpeg_io.ml
@@ -431,7 +431,9 @@ let register_input protocol =
                   arg_t = [(false, "", Lang.metadata_t)];
                   register =
                     (fun ~params:_ s on_connect ->
-                      let on_connect, remove = Lang_source.disarmable on_connect in
+                      let on_connect, remove =
+                        Lang_source.disarmable on_connect
+                      in
                       let on_connect m =
                         on_connect [("", Lang.metadata_list m)]
                       in
@@ -449,7 +451,9 @@ let register_input protocol =
                   arg_t = [];
                   register =
                     (fun ~params:_ s on_connect ->
-                      let on_connect, remove = Lang_source.disarmable on_connect in
+                      let on_connect, remove =
+                        Lang_source.disarmable on_connect
+                      in
                       let on_connect _ = on_connect [] in
                       s#on_connect on_connect;
                       remove);

--- a/src/core/optionals/ffmpeg/io/ffmpeg_io.ml
+++ b/src/core/optionals/ffmpeg/io/ffmpeg_io.ml
@@ -431,10 +431,12 @@ let register_input protocol =
                   arg_t = [(false, "", Lang.metadata_t)];
                   register =
                     (fun ~params:_ s on_connect ->
+                      let on_connect, remove = Lang_source.disarmable on_connect in
                       let on_connect m =
                         on_connect [("", Lang.metadata_list m)]
                       in
-                      s#on_connect on_connect);
+                      s#on_connect on_connect;
+                      remove);
                 };
               ]
             else
@@ -447,8 +449,10 @@ let register_input protocol =
                   arg_t = [];
                   register =
                     (fun ~params:_ s on_connect ->
+                      let on_connect, remove = Lang_source.disarmable on_connect in
                       let on_connect _ = on_connect [] in
-                      s#on_connect on_connect);
+                      s#on_connect on_connect;
+                      remove);
                 };
               ])
          @ [
@@ -459,7 +463,10 @@ let register_input protocol =
                register_deprecated_argument = true;
                arg_t = [];
                register =
-                 (fun ~params:_ s f -> s#on_disconnect (fun () -> f []));
+                 (fun ~params:_ s f ->
+                   let f, remove = Lang_source.disarmable f in
+                   s#on_disconnect (fun () -> f []);
+                   remove);
              };
              {
                name = "on_error";
@@ -469,7 +476,9 @@ let register_input protocol =
                arg_t = [(false, "", Lang.error_t)];
                register =
                  (fun ~params:_ s f ->
-                   s#on_error (fun err -> f [("", Lang.error err)]));
+                   let f, remove = Lang_source.disarmable f in
+                   s#on_error (fun err -> f [("", Lang.error err)]);
+                   remove);
              };
            ])
        ~meth:

--- a/src/core/optionals/srt/srt_io.ml
+++ b/src/core/optionals/srt/srt_io.ml
@@ -250,7 +250,11 @@ let callbacks =
         descr = "when connected.";
         register_deprecated_argument = true;
         arg_t = [];
-        register = (fun ~params:_ s f -> s#on_connect (fun () -> f []));
+        register =
+          (fun ~params:_ s f ->
+            let f, remove = Lang_source.disarmable f in
+            s#on_connect (fun () -> f []);
+            remove);
       };
       {
         name = "on_disconnect";
@@ -258,7 +262,11 @@ let callbacks =
         descr = "when disconnected.";
         register_deprecated_argument = true;
         arg_t = [];
-        register = (fun ~params:_ s f -> s#on_disconnect (fun () -> f []));
+        register =
+          (fun ~params:_ s f ->
+            let f, remove = Lang_source.disarmable f in
+            s#on_disconnect (fun () -> f []);
+            remove);
       };
       {
         name = "on_socket";
@@ -278,6 +286,7 @@ let callbacks =
           ];
         register =
           (fun ~params:_ s f ->
+            let f, remove = Lang_source.disarmable f in
             s#on_socket (fun ~mode socket ->
                 let mode =
                   match mode with
@@ -288,7 +297,8 @@ let callbacks =
                 in
                 let mode = Lang.string mode in
                 let socket = Builtins_srt.Socket_value.to_value socket in
-                f [("", socket); ("mode", mode)]));
+                f [("", socket); ("mode", mode)]);
+            remove);
       };
     ]
 

--- a/src/core/outputs/harbor_output.ml
+++ b/src/core/outputs/harbor_output.ml
@@ -480,12 +480,14 @@ class virtual ['a] base p =
 
     initializer
       let has_stopped = ref false in
-      self#on_frame
-        (`Before_frame
-           (fun _ ->
-             if Atomic.get stopped && not !has_stopped then (
-               has_stopped := true;
-               List.iter self#handle_disconnect self#get_listeners)))
+      ignore
+        (self#on_frame
+           (`Before_frame
+              (fun _ ->
+                if Atomic.get stopped && not !has_stopped then (
+                  has_stopped := true;
+                  List.iter self#handle_disconnect self#get_listeners)))
+          : unit -> unit)
 
     (* The task waits on the wake pipe and a delay firing at the earliest
        pending timeout deadline. It does not watch listener sockets for
@@ -948,6 +950,7 @@ let _ =
              ];
            register =
              (fun ~params:_ s on_connect ->
+               let on_connect, remove = Lang_source.disarmable on_connect in
                let callback ~headers ~uri ~protocol ip =
                  on_connect
                    [
@@ -961,7 +964,8 @@ let _ =
                          ] );
                    ]
                in
-               s#on_connect callback);
+               s#on_connect callback;
+               remove);
          };
          {
            name = "on_disconnect";
@@ -971,7 +975,9 @@ let _ =
            arg_t = [(false, "", Lang.string_t)];
            register =
              (fun ~params:_ s callback ->
-               s#on_disconnect (fun ip -> callback [("", Lang.string ip)]));
+               let callback, remove = Lang_source.disarmable callback in
+               s#on_disconnect (fun ip -> callback [("", Lang.string ip)]);
+               remove);
          };
        ]
       @ Start_stop.callbacks ~label:"output")

--- a/src/core/outputs/hls_output.ml
+++ b/src/core/outputs/hls_output.ml
@@ -1324,7 +1324,9 @@ let _ =
              ];
            register =
              (fun ~params:_ s on_file_change ->
-               let on_file_change, remove = Lang_source.disarmable on_file_change in
+               let on_file_change, remove =
+                 Lang_source.disarmable on_file_change
+               in
                let on_file_change ~state path =
                  on_file_change
                    [

--- a/src/core/outputs/hls_output.ml
+++ b/src/core/outputs/hls_output.ml
@@ -1324,6 +1324,7 @@ let _ =
              ];
            register =
              (fun ~params:_ s on_file_change ->
+               let on_file_change, remove = Lang_source.disarmable on_file_change in
                let on_file_change ~state path =
                  on_file_change
                    [
@@ -1335,7 +1336,8 @@ let _ =
                          ] );
                    ]
                in
-               s#on_file_change on_file_change);
+               s#on_file_change on_file_change;
+               remove);
          };
        ]
       @ Start_stop.callbacks ~label:"output")

--- a/src/core/outputs/icecast2.ml
+++ b/src/core/outputs/icecast2.ml
@@ -703,7 +703,9 @@ let _ =
             arg_t = [];
             register =
               (fun ~params:_ s on_disconnect ->
-                let on_disconnect, remove = Lang_source.disarmable on_disconnect in
+                let on_disconnect, remove =
+                  Lang_source.disarmable on_disconnect
+                in
                 s#on_disconnect (fun () -> on_disconnect []);
                 remove);
           };

--- a/src/core/outputs/icecast2.ml
+++ b/src/core/outputs/icecast2.ml
@@ -691,7 +691,9 @@ let _ =
             arg_t = [];
             register =
               (fun ~params:_ s on_connect ->
-                s#on_connect (fun () -> on_connect []));
+                let on_connect, remove = Lang_source.disarmable on_connect in
+                s#on_connect (fun () -> on_connect []);
+                remove);
           };
           {
             Lang_source.name = "on_disconnect";
@@ -701,7 +703,9 @@ let _ =
             arg_t = [];
             register =
               (fun ~params:_ s on_disconnect ->
-                s#on_disconnect (fun () -> on_disconnect []));
+                let on_disconnect, remove = Lang_source.disarmable on_disconnect in
+                s#on_disconnect (fun () -> on_disconnect []);
+                remove);
           };
           {
             Lang_source.name = "on_error";
@@ -727,6 +731,7 @@ let _ =
               ];
             register =
               (fun ~params:_ s on_error ->
+                let on_error, remove = Lang_source.disarmable on_error in
                 s#on_error (fun ~restart_in ~bt exn ->
                     let restart_in =
                       Lang.val_fun
@@ -743,7 +748,8 @@ let _ =
                       Lang.error
                         (Lang.runtime_error_of_exception ~bt ~kind:"source" exn)
                     in
-                    on_error [("restart_in", restart_in); ("", err)]));
+                    on_error [("restart_in", restart_in); ("", err)]);
+                remove);
           };
         ])
     (proto return_t) ~return_t

--- a/src/core/outputs/output.ml
+++ b/src/core/outputs/output.ml
@@ -84,7 +84,7 @@ class virtual output ~output_kind ?clock ?(name = "") ~infallible
         ignore (Queue.pop metadata_queue)
 
     initializer
-      self#on_frame (`Metadata self#add_metadata);
+      ignore (self#on_frame (`Metadata self#add_metadata) : unit -> unit);
       if register_telnet then (
         self#register_command "start"
           (fun _ ->

--- a/src/core/outputs/pipe_output.ml
+++ b/src/core/outputs/pipe_output.ml
@@ -142,11 +142,13 @@ let url_callbacks =
         arg_t = [(false, "", Lang.error_t)];
         register =
           (fun ~params:_ s f ->
+            let f, remove = Lang_source.disarmable f in
             s#on_error (fun ~bt exn ->
                 let error =
                   Lang.runtime_error_of_exception ~bt ~kind:"output" exn
                 in
-                f [("", Lang.error error)]));
+                f [("", Lang.error error)]);
+            remove);
       };
     ]
 
@@ -306,7 +308,11 @@ let pipe_callbacks =
         descr = "when the output is reopened.";
         register_deprecated_argument = true;
         arg_t = [];
-        register = (fun ~params:_ s f -> s#on_reopen (fun () -> f []));
+        register =
+          (fun ~params:_ s f ->
+            let f, remove = Lang_source.disarmable f in
+            s#on_reopen (fun () -> f []);
+            remove);
       };
     ]
 

--- a/src/core/runtime/lang.mli
+++ b/src/core/runtime/lang.mli
@@ -127,8 +127,13 @@ type 'a callback = 'a Lang_source.callback = {
   descr : string;
   register_deprecated_argument : bool;
   arg_t : (bool * string * t) list;
-  register : params:(string * value) list -> 'a -> (env -> unit) -> unit;
+  register : params:(string * value) list -> 'a -> (env -> unit) -> unit -> unit;
 }
+
+(** Adapter for registration functions with no deregistration path: returns the
+    callback guarded by a flag, plus a function lowering it. Only safe where
+    registration happens a bounded number of times. *)
+val disarmable : ('a -> unit) -> ('a -> unit) * (unit -> unit)
 
 val add_operator :
   category:Doc.Value.source ->

--- a/src/core/source/lang_source.ml
+++ b/src/core/source/lang_source.ml
@@ -195,8 +195,7 @@ let callback { name; params; descr; arg_t; register } : _ Lang.meth =
             meth unit
               [
                 ( "remove",
-                  val_fun []
-                    (fun _ ->
+                  val_fun [] (fun _ ->
                       if Atomic.compare_and_set removed false true then (
                         (s#log : Log.t)#debug "Removing %s callback" name;
                         remove ());
@@ -323,14 +322,14 @@ let source_callbacks =
           let remove_after =
             s#on_frame
               (`After_frame
-               (fun { Source.frame; cache } ->
-                 let frame_checksum = Lang.string (Frame.checksum frame) in
-                 let cache_checksum =
-                   match cache with
-                     | Some c -> Lang.string (Frame.checksum c)
-                     | None -> Lang.null
-                 in
-                 after_cb [("cache", cache_checksum); ("", frame_checksum)]))
+                 (fun { Source.frame; cache } ->
+                   let frame_checksum = Lang.string (Frame.checksum frame) in
+                   let cache_checksum =
+                     match cache with
+                       | Some c -> Lang.string (Frame.checksum c)
+                       | None -> Lang.null
+                   in
+                   after_cb [("cache", cache_checksum); ("", frame_checksum)]))
           in
           fun () ->
             Option.iter (fun remove -> remove ()) remove_before;

--- a/src/core/source/lang_source.ml
+++ b/src/core/source/lang_source.ml
@@ -247,7 +247,11 @@ let source_callbacks =
       descr = "to be called when source is collected";
       register_deprecated_argument = false;
       arg_t = [];
-      register = (fun ~params:_ s f -> s#on_collect (fun () -> f []));
+      register =
+        (fun ~params:_ s f ->
+          let f, remove = disarmable f in
+          s#on_collect (fun () -> f []);
+          remove);
     };
     {
       name = "on_track";

--- a/src/core/source/lang_source.ml
+++ b/src/core/source/lang_source.ml
@@ -124,8 +124,30 @@ type 'a callback = {
   descr : string;
   register_deprecated_argument : bool;
   arg_t : (bool * string * t) list;
-  register : params:(string * value) list -> 'a -> (env -> unit) -> unit;
+  register : params:(string * value) list -> 'a -> (env -> unit) -> unit -> unit;
 }
+
+(* Adapter for registration functions that have no deregistration path of their
+   own. Returns the callback guarded by a flag, plus a function that lowers the
+   flag: the callback stops firing, which is what [remove] promises, even though
+   the closure itself stays registered. Only safe where registration happens a
+   bounded number of times. *)
+let disarmable f =
+  let armed = Atomic.make true in
+  ( (fun args -> if Atomic.get armed then f args),
+    fun () -> Atomic.set armed false )
+
+(* Callbacks return unit decorated with a [remove] method. Because [can_ignore]
+   strips methods before checking for unit, existing scripts that discard the
+   return value keep typechecking, while new code can hold on to the handle and
+   release the callback. *)
+let callback_return_t () =
+  method_t unit_t
+    [
+      ( "remove",
+        ([], fun_t [] unit_t),
+        "Deregister the callback. Calling it more than once is a no-op." );
+    ]
 
 let callback { name; params; descr; arg_t; register } : _ Lang.meth =
   {
@@ -140,7 +162,7 @@ let callback { name; params; descr; arg_t; register } : _ Lang.meth =
               (false, "synchronous", Lang.bool_t);
               (false, "", fun_t arg_t unit_t);
             ])
-          unit_t );
+          (callback_return_t ()) );
     descr = Printf.sprintf "Call a given handler %s" descr;
     value =
       (fun s ->
@@ -168,8 +190,18 @@ let callback { name; params; descr; arg_t; register } : _ Lang.meth =
             in
             (s#log : Log.t)#debug "Registering %s %s callback" name
               (if synchronous then "synchronous" else "asynchronous");
-            register ~params:p s fn;
-            unit));
+            let remove = register ~params:p s fn in
+            let removed = Atomic.make false in
+            meth unit
+              [
+                ( "remove",
+                  val_fun []
+                    (fun _ ->
+                      if Atomic.compare_and_set removed false true then (
+                        (s#log : Log.t)#debug "Removing %s callback" name;
+                        remove ());
+                      unit) );
+              ]));
   }
 
 let source_callbacks =
@@ -191,7 +223,11 @@ let source_callbacks =
       params = [];
       register_deprecated_argument = false;
       arg_t = [];
-      register = (fun ~params:_ s f -> s#on_wake_up (fun () -> f []));
+      register =
+        (fun ~params:_ s f ->
+          let f, remove = disarmable f in
+          s#on_wake_up (fun () -> f []);
+          remove);
     };
     {
       name = "on_shutdown";
@@ -199,7 +235,11 @@ let source_callbacks =
       descr = "to be called when source shuts down";
       register_deprecated_argument = false;
       arg_t = [];
-      register = (fun ~params:_ s f -> s#on_sleep (fun () -> f []));
+      register =
+        (fun ~params:_ s f ->
+          let f, remove = disarmable f in
+          s#on_sleep (fun () -> f []);
+          remove);
     };
     {
       name = "on_collect";
@@ -262,20 +302,23 @@ let source_callbacks =
       register =
         (fun ~params:p s after_cb ->
           let before_cb = Lang.to_option (List.assoc "before" p) in
-          Option.iter
-            (fun cb ->
-              s#on_frame
-                (`Before_frame
-                   (fun cache ->
-                     let checksum =
-                       match cache with
-                         | Some frame -> Lang.string (Frame.checksum frame)
-                         | None -> Lang.null
-                     in
-                     ignore (apply cb [("", checksum)]))))
-            before_cb;
-          s#on_frame
-            (`After_frame
+          let remove_before =
+            Option.map
+              (fun cb ->
+                s#on_frame
+                  (`Before_frame
+                     (fun cache ->
+                       let checksum =
+                         match cache with
+                           | Some frame -> Lang.string (Frame.checksum frame)
+                           | None -> Lang.null
+                       in
+                       ignore (apply cb [("", checksum)]))))
+              before_cb
+          in
+          let remove_after =
+            s#on_frame
+              (`After_frame
                (fun { Source.frame; cache } ->
                  let frame_checksum = Lang.string (Frame.checksum frame) in
                  let cache_checksum =
@@ -283,7 +326,11 @@ let source_callbacks =
                      | Some c -> Lang.string (Frame.checksum c)
                      | None -> Lang.null
                  in
-                 after_cb [("cache", cache_checksum); ("", frame_checksum)])));
+                 after_cb [("cache", cache_checksum); ("", frame_checksum)]))
+          in
+          fun () ->
+            Option.iter (fun remove -> remove ()) remove_before;
+            remove_after ());
     };
     {
       name = "on_position";

--- a/src/core/source/source.ml
+++ b/src/core/source/source.ml
@@ -678,6 +678,7 @@ class virtual operator ?(stack = []) ?clock ~name sources =
       self#atomic_lock (fun () -> on_frame <- on_frame @ [(id, fn)]) ();
       self#atomic_lock (fun () ->
           on_frame <- List.filter (fun (i, _) -> i <> id) on_frame)
+
     val mutable reset_last_metadata_on_track = Atomic.make true
 
     method reset_last_metadata_on_track =

--- a/src/core/source/source.ml
+++ b/src/core/source/source.ml
@@ -667,8 +667,17 @@ class virtual operator ?(stack = []) ?clock ~name sources =
     method end_of_track = Frame.add_track_mark self#empty_frame 0
     val mutable last_metadata = None
     method last_metadata = last_metadata
-    val mutable on_frame : on_frame list = []
-    method on_frame fn = on_frame <- on_frame @ [fn]
+    val mutable on_frame : (int * on_frame) list = []
+
+    (* Returns a function to deregister the callback. Callbacks registered on a
+       source that outlives them (e.g. a transition registering on the source it
+       is given) must be released, otherwise they accumulate for the lifetime of
+       that source. *)
+    method on_frame fn =
+      let id = Atomic.fetch_and_add callback_id_counter 1 in
+      self#atomic_lock (fun () -> on_frame <- on_frame @ [(id, fn)]) ();
+      self#atomic_lock (fun () ->
+          on_frame <- List.filter (fun (i, _) -> i <> id) on_frame)
     val mutable reset_last_metadata_on_track = Atomic.make true
 
     method reset_last_metadata_on_track =
@@ -698,7 +707,7 @@ class virtual operator ?(stack = []) ?clock ~name sources =
           Option.value ~default:(0, Frame.Metadata.empty) last_metadata
         in
         self#log#debug "calling on_track handlers..";
-        List.iter (function `Track fn -> fn m | _ -> ()) on_frame)
+        List.iter (function _, `Track fn -> fn m | _ -> ()) on_frame)
 
     val mutable last_images = Hashtbl.create 0
 
@@ -788,7 +797,7 @@ class virtual operator ?(stack = []) ?clock ~name sources =
       in
       List.iter
         (function
-          | `Position p when is_allowed p ->
+          | _, `Position p when is_allowed p ->
               p.executed <- true;
               p.on_position ~pos:(position p) m
           | _ -> ())
@@ -797,11 +806,11 @@ class virtual operator ?(stack = []) ?clock ~name sources =
     method private instrumented_generate_frame =
       let start_time = Unix.gettimeofday () in
       let on_frame = self#atomic_lock (fun () -> on_frame) () in
-      List.iter (function `Before_frame fn -> fn _cache | _ -> ()) on_frame;
+      List.iter (function _, `Before_frame fn -> fn _cache | _ -> ()) on_frame;
       let buf = self#normalize_video_content self#generate_frame in
       List.iter
         (function
-          | `After_frame fn -> fn { frame = buf; cache = _cache } | _ -> ())
+          | _, `After_frame fn -> fn { frame = buf; cache = _cache } | _ -> ())
         on_frame;
       let end_time = Unix.gettimeofday () in
       let length = Frame.position buf in
@@ -836,7 +845,7 @@ class virtual operator ?(stack = []) ?clock ~name sources =
               elapsed <- 0;
               if self#reset_last_metadata_on_track then self#clear_last_metadata;
               List.iter
-                (function `Position p -> p.executed <- false | _ -> ())
+                (function _, `Position p -> p.executed <- false | _ -> ())
                 on_frame;
               self#on_position ~end_of_track:false new_track;
               true
@@ -865,7 +874,7 @@ class virtual operator ?(stack = []) ?clock ~name sources =
               | _ -> false
           in
           List.iter
-            (fun cb ->
+            (fun (_, cb) ->
               match cb with
                 | `Metadata fn -> fn m
                 | `Track fn when is_on_track -> fn m

--- a/src/core/source/source.mli
+++ b/src/core/source/source.mli
@@ -283,7 +283,7 @@ object
     ?usage:string -> descr:string -> string -> (string -> string) -> unit
 
   (** Register a callback to be called when computing frames. *)
-  method on_frame : on_frame -> unit
+  method on_frame : on_frame -> unit -> unit
 
   (** These two are used by [generate_from_multiple_sources] and should not be
       used otherwise. *)

--- a/src/core/source/start_stop.ml
+++ b/src/core/source/start_stop.ml
@@ -130,7 +130,11 @@ let callbacks ~label =
         descr = "when " ^ label ^ " starts";
         register_deprecated_argument = true;
         arg_t = [];
-        register = (fun ~params:_ s f -> s#on_start (fun () -> f []));
+        register =
+          (fun ~params:_ s f ->
+            let f, remove = Lang_source.disarmable f in
+            s#on_start (fun () -> f []);
+            remove);
       };
       {
         name = "on_stop";
@@ -138,7 +142,11 @@ let callbacks ~label =
         descr = "when " ^ label ^ " stops";
         register_deprecated_argument = true;
         arg_t = [];
-        register = (fun ~params:_ s f -> s#on_stop (fun () -> f []));
+        register =
+          (fun ~params:_ s f ->
+            let f, remove = Lang_source.disarmable f in
+            s#on_stop (fun () -> f []);
+            remove);
       };
     ]
 

--- a/src/core/sources/harbor_input.ml
+++ b/src/core/sources/harbor_input.ml
@@ -548,8 +548,10 @@ let callbacks () =
       arg_t = [(false, "", Lang.metadata_t)];
       register =
         (fun ~params:_ s on_connect ->
+          let on_connect, remove = Lang_source.disarmable on_connect in
           let on_connect m = on_connect [("", Lang.metadata_list m)] in
-          s#on_connect on_connect);
+          s#on_connect on_connect;
+          remove);
     };
     {
       name = "on_disconnect";
@@ -557,7 +559,11 @@ let callbacks () =
       descr = "when a source is disconnected.";
       register_deprecated_argument = true;
       arg_t = [];
-      register = (fun ~params:_ s f -> s#on_disconnect (fun () -> f []));
+      register =
+        (fun ~params:_ s f ->
+          let f, remove = Lang_source.disarmable f in
+          s#on_disconnect (fun () -> f []);
+          remove);
     };
   ]
 

--- a/src/libs/fades.liq
+++ b/src/libs/fades.liq
@@ -161,6 +161,35 @@ def fade.scale(~id="fade.scale", x, s) =
   amplify(id=id, override=null, x, s)
 end
 
+# Bind the lifetime of callbacks registered on a fade operator's input source to
+# the per-invocation source that operator returns. The input source typically
+# outlives the fade: a switch transition hands the same source to a new fade on
+# every switch, and without this the registrations pile up on it for good.
+# @category Source / Fade
+# @flag hidden
+# @param wrapper The source returned by the operator.
+# @param register Registers the callbacks and returns their handles.
+def fade.bind_overrides(wrapper, register) =
+  handles = ref([])
+
+  def acquire() =
+    if
+      list.length(handles()) == 0
+    then
+      handles := register()
+    end
+  end
+
+  def release() =
+    list.iter(fun (h) -> h.remove(), handles())
+    handles := []
+  end
+
+  acquire()
+  wrapper.on_wake_up(synchronous=true, acquire)
+  wrapper.on_shutdown(synchronous=true, release)
+end
+
 # Fade the end of tracks.
 # @category Source / Fade
 # @param ~id Force the value of the source ID.
@@ -352,9 +381,22 @@ def fade.out(
   end
 
   s = source.methods(s)
-  s.on_track(synchronous=true, reset_overrides)
-  s.on_metadata(synchronous=true, update_fade)
-  if track_sensitive then s.on_track(synchronous=true, stop_fade) end
+
+  def register_overrides() =
+    handles =
+      [
+        s.on_track(synchronous=true, reset_overrides),
+        s.on_metadata(synchronous=true, update_fade)
+      ]
+
+    if
+      track_sensitive
+    then
+      [...handles, s.on_track(synchronous=true, stop_fade)]
+    else
+      handles
+    end
+  end
 
   d = source.dynamic(memoize({s}))
 
@@ -383,10 +425,9 @@ def fade.out(
     memoize({if s.is_ready() then s.generate_frame() end})
   )
 
-  fade.scale(id=id, apply, d).{
-    fade_duration = {duration()},
-    fade_type = {type()}
-  }
+  wrapper = fade.scale(id=id, apply, d)
+  fade.bind_overrides(wrapper, register_overrides)
+  wrapper.{fade_duration = {duration()}, fade_type = {type()}}
 end
 
 # Fade when the metadata trigger is received and then skip.
@@ -547,14 +588,18 @@ def fade.skip(
   end
 
   s = source.methods(s)
-  s.on_track(synchronous=true, reset_overrides)
-  s.on_metadata(synchronous=true, update_fade)
-  s.on_track(synchronous=true, stop_fade)
 
-  fade.scale(id=id, apply, s).{
-    fade_duration = {duration()},
-    fade_type = {type()}
-  }
+  def register_overrides() =
+    [
+      s.on_track(synchronous=true, reset_overrides),
+      s.on_metadata(synchronous=true, update_fade),
+      s.on_track(synchronous=true, stop_fade)
+    ]
+  end
+
+  wrapper = fade.scale(id=id, apply, s)
+  fade.bind_overrides(wrapper, register_overrides)
+  wrapper.{fade_duration = {duration()}, fade_type = {type()}}
 end
 
 # Fade the beginning of tracks.
@@ -730,12 +775,24 @@ def fade.in(
   end
 
   s = source.methods(s)
-  s.on_track(synchronous=true, reset_overrides)
-  s.on_metadata(synchronous=true, update_fade)
 
-  # Register start_fade on the inner source so it fires before the amplify
+  # start_fade is registered on the inner source so it fires before the amplify
   # operator processes the new track head.
-  if track_sensitive then s.on_track(synchronous=true, start_fade) end
+  def register_overrides() =
+    handles =
+      [
+        s.on_track(synchronous=true, reset_overrides),
+        s.on_metadata(synchronous=true, update_fade)
+      ]
+
+    if
+      track_sensitive
+    then
+      [...handles, s.on_track(synchronous=true, start_fade)]
+    else
+      handles
+    end
+  end
 
   # Initial duration for fade.in should be computed after fetching the initial
   # frame from s to make sure any initial metadata is taken into account
@@ -772,14 +829,19 @@ def fade.in(
       )
     )
 
-  s = fade.scale(id=id, apply, s)
+  wrapper = fade.scale(id=id, apply, s)
+  fade.bind_overrides(wrapper, register_overrides)
 
   if
     not track_sensitive
   then
-    s.on_frame(synchronous=true, before=false, memoize({start_fade([])}))
+    wrapper.on_frame(synchronous=true, before=false, memoize({start_fade([])}))
   end
-  s.{fade_duration = {duration()}, fade_delay = {delay()}, fade_type = {type()}}
+  wrapper.{
+    fade_duration = {duration()},
+    fade_delay = {delay()},
+    fade_type = {type()}
+  }
 end
 
 # Simple transition for crossfade

--- a/src/libs/fades.liq
+++ b/src/libs/fades.liq
@@ -173,11 +173,7 @@ def fade.bind_overrides(wrapper, register) =
   handles = ref([])
 
   def acquire() =
-    if
-      list.length(handles()) == 0
-    then
-      handles := register()
-    end
+    if list.length(handles()) == 0 then handles := register() end
   end
 
   def release() =

--- a/tests/regression/dune.inc
+++ b/tests/regression/dune.inc
@@ -1909,6 +1909,29 @@
   (run %{run_test} metadata_cache liquidsoap %{test_liq} metadata_cache.liq)))
 
 (rule
+ (alias test_on-frame-deregistration)
+ (package liquidsoap)
+ (deps
+  on-frame-deregistration.liq
+  (glob_files ../media/**)
+  ../liquidsoap-test-assets
+  ../../src/bin/liquidsoap.exe
+  ../streams/file1.png
+  ../streams/file1.mp3
+  ./theora-test.mp4
+  (package liquidsoap)
+  (source_tree ../../src/libs)
+  (:test_liq ../test.liq)
+  (:run_test ../run_test.exe))
+ (action
+  (run
+   %{run_test}
+   on-frame-deregistration
+   liquidsoap
+   %{test_liq}
+   on-frame-deregistration.liq)))
+
+(rule
  (alias test_output_on_metadata)
  (package liquidsoap)
  (deps
@@ -2513,6 +2536,7 @@
   (alias test_input_rtmp)
   (alias test_metadata-resolvers-metadata)
   (alias test_metadata_cache)
+  (alias test_on-frame-deregistration)
   (alias test_output_on_metadata)
   (alias test_output_on_track)
   (alias test_output_reopen_on_error_delay)

--- a/tests/regression/on-frame-deregistration.liq
+++ b/tests/regression/on-frame-deregistration.liq
@@ -1,0 +1,31 @@
+# Callbacks registered through `on_frame` (and so through `on_track`,
+# `on_metadata` and friends) can be deregistered via the `remove` method of
+# their return value. Without it, an operator registering on a source it was
+# given -- as the fade operators do -- leaks a closure on every call.
+s = sine(duration=0.5)
+s = source.methods(s)
+
+kept = ref(0)
+removed = ref(0)
+
+# Registered then immediately removed: must never fire.
+h = s.on_track(synchronous=true, fun (_) -> ref.incr(removed))
+h.remove()
+
+# Removing twice is a no-op, not an error.
+h.remove()
+
+s.on_track(synchronous=true, fun (_) -> ref.incr(kept))
+
+s.on_track(
+  synchronous=true,
+  fun (_) ->
+    if
+      kept() >= 3
+    then
+      if removed() == 0 then test.pass() else test.fail() end
+    end
+)
+
+clock.assign_new(sync="none", [s])
+output.dummy(fallible=true, s)

--- a/tests/regression/on-frame-deregistration.liq
+++ b/tests/regression/on-frame-deregistration.liq
@@ -2,19 +2,20 @@
 # `on_metadata` and friends) can be deregistered via the `remove` method of
 # their return value. Without it, an operator registering on a source it was
 # given -- as the fade operators do -- leaks a closure on every call.
-s = sine(duration=0.5)
+s = chop(every=0.5, sine())
 s = source.methods(s)
 
 kept = ref(0)
 removed = ref(0)
 
-# Registered then immediately removed: must never fire.
+# Registered and immediately removed: must never fire.
 h = s.on_track(synchronous=true, fun (_) -> ref.incr(removed))
 h.remove()
 
 # Removing twice is a no-op, not an error.
 h.remove()
 
+# Left registered: must keep firing.
 s.on_track(synchronous=true, fun (_) -> ref.incr(kept))
 
 s.on_track(
@@ -28,4 +29,4 @@ s.on_track(
 )
 
 clock.assign_new(sync="none", [s])
-output.dummy(fallible=true, s)
+output.dummy(s)

--- a/tests/streams/rotate.liq
+++ b/tests/streams/rotate.liq
@@ -60,8 +60,8 @@ def ot(m) =
   end
 end
 
-radio = rotate(id="rotate", [music.{weight=3}, jingles.{weight=1}])
-radio = rotate(id="rotate2", [radio.{weight=1}, music2.{weight=1}])
+radio = rotate(id="rotate", [music.{weight = 3}, jingles.{weight = 1}])
+radio = rotate(id="rotate2", [radio.{weight = 1}, music2.{weight = 1}])
 
 radio.on_track(synchronous=true, ot)
 


### PR DESCRIPTION
### The problem

`source#on_frame` appends to a list with no removal path:

```ocaml
val mutable on_frame : on_frame list = []
method on_frame fn = on_frame <- on_frame @ [fn]
```

So a callback lives as long as the source it was registered on. That is fine
when an operator registers on a source it created, but `fade.in`, `fade.out`
and `fade.skip` register on the source they are *given*:

```liquidsoap
s = source.methods(s)
s.on_track(synchronous=true, reset_overrides)
s.on_metadata(synchronous=true, update_fade)
```

A `switch`/`fallback` transition calls those on the same long-lived source on
every switch, so two or three closures accumulate on it permanently.

This is a regression from 2.2.5, where the equivalents were wrapper functions
(`s = source.on_track(s, fn)` returned a new source that died with the wrapper).
The 2.4.0 callback rework turned them into methods that mutate the receiver,
which silently changed callback lifetime from "as long as the wrapper" to
"forever".

It is easy to miss in production because nothing looks wrong: the source count
stays flat (the closures attach to an existing source) and the objects are
tiny, so RSS barely moves. But major GC marking cost scales with live *block*
count, so CPU climbs steadily instead. It took us months to track down as an
unexplained "CPU leak".

### The fix

Three coordinated changes, following the deregistration pattern already used
for `on_sync_source_change` and extended in #5163 / #5164:

1. **`source.ml`** — `on_frame` entries carry an id and registration returns a
   deregistration closure.
2. **`lang_source.ml`** — script-level callbacks return `unit` decorated with a
   `remove` method. This is deliberately not a bare handle: `can_ignore` calls
   `demeth` before checking for unit, so **every existing script that discards
   the return value keeps typechecking unchanged**, while new code can hold the
   handle and release the callback.
3. **`fades.liq`** — the three fade operators bind their registrations to the
   per-invocation source they return, releasing on shutdown and re-acquiring on
   wake up.

The `register` field of the `callback` record now returns `unit -> unit`. Where
the underlying registration has no deregistration path of its own
(`on_wake_up`, `on_sleep`, `on_blank`, `on_connect`, …) a `disarmable` adapter
guards the callback with a flag, so `remove` still does what it promises.

### Measurements

Three arms on a production streaming script, switching between playlist sources
in a `switch`. Slope fitted after warm-up; live blocks accumulated per switch,
95% CI:

| arm | OCaml | `fades.liq` | blocks/switch | switches |
| --- | --- | --- | --- | --- |
| release build | 4.14.2 | stock | +32.5 ± 7.3 | 22,000 |
| control | 5.4.0 | stock | +24.5 ± 0.8 | 41,000 |
| patched | 5.4.0 | patched | **−0.018 ± 0.088** | 130,000 |

The control arm is the same binary and runtime as the patched one, differing
only in whether `fades.liq` releases its registrations — so the effect is
attributable to the fix rather than to the runtime. After the patch the
confidence interval contains zero and excludes anything above 0.07
blocks/switch. An idle control (no switches) is flat to ±20 blocks over 5
minutes.

### Tests

Adds `tests/regression/on-frame-deregistration.liq`, covering removal,
double-removal being a no-op, and unremoved callbacks still firing.

Every existing fade and crossfade test passes against the patched build:
`streams/cross`, `streams/cross-override`, `streams/cross-persist-override`,
`streams/cross-sequence-transition`, `streams/crossfade`, `streams/crossfade2`,
`streams/fades-overrides`, `streams/fades-persistent-override`,
`regression/GH3239`, `regression/GH3239-2`, `regression/AC5109` and
`regression/switch_per_source_no_reselect_during_fade`.

### Backport

Could this get the `backport v2.4.x-latest` label? 2.4.x is affected and we
would like to fix this before bumping to 2.5.x.

Heads-up that the automatic cherry-pick will not apply: `main` has since moved
`src/core/base/` to `src/core/source/`. I have the same change already
written against `v2.4.x-latest`, and am happy to open it as a manual backport
PR on request:
https://github.com/charles-rc/liquidsoap/tree/rc/callback-deregistration
