### PR TITLE
lang: add the source(_) type

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,7 +26,7 @@ repos:
         exclude: (dune.inc|fixtures/)
 
   - repo: https://github.com/savonet/pre-commit-liquidsoap
-    rev: 6c5b79e26d81a71f38f1f32a39e2cb71db6e3e77
+    rev: f1f288ad551c8b4c01d1943c7b55854ad77ba9b5
     hooks:
       - id: liquidsoap-prettier
       - id: prettier

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,6 +24,19 @@
   `crossfade` or `stretch` may buffer from its child source. Operators sharing a child
   source must consume it at converging rates; past this value, an error names the operator
   that fell behind instead of letting the buffer grow without bound (#5267).
+- Source callbacks (`on_track`, `on_metadata`, `on_frame`, `on_connect`, ...) now return a
+  `release` method taking the callback back. A function registering on a source it is given
+  keeps the callback alive for as long as that source lives, so one that runs more than once
+  needs to release what it registered. Past five callbacks on the same source, a log message
+  says so. Existing scripts are unaffected: the returned value is still ignorable.
+- Callbacks a script registers on the sources `switch` and `cross` hand to `on_select`,
+  `on_leave` and transition functions are now released when the selection or the crossing
+  ends, instead of accumulating on those sources for as long as they live.
+- Added the `source(_)` type: a source whose content is unknown. Any source can be used where
+  one is expected, so sources of different content can be held together, for instance in a
+  list, without their content types being unified into one. The converse is rejected: nothing
+  can be assumed about what a `source(_)` streams. `source` and `source(...)` are unchanged
+  and still mean a source whose content is inferred.
 
 ## Changed:
 

--- a/src/core/runtime/hooks_implementations.ml
+++ b/src/core/runtime/hooks_implementations.ml
@@ -116,26 +116,30 @@ let () =
         ?pos:(Option.map Liquidsoap_lang_prelude.Pos.of_lexing_pos pos)
         Lang_clock.ClockValue.base_t.Type.descr
 
-let mk_source_ty ?pos name { Parsed_term.extensible; tracks } =
+let mk_source_ty ?pos name annotation =
   if name <> "source" then (
     let pos = Option.value ~default:(Lexing.dummy_pos, Lexing.dummy_pos) pos in
     raise (Term.Parse_error (pos, "Unknown type constructor: " ^ name ^ ".")));
 
-  match tracks with
-    | [] -> Lang_source.source_t ?pos (Lang.univ_t ())
-    | tracks ->
-        let fields =
-          List.fold_left
-            (fun fields { Parsed_term.track_name; track_type; track_params } ->
-              Frame.Fields.add
-                (Frame.Fields.field_of_string track_name)
-                (mk_field_t ?pos track_type track_params)
-                fields)
-            Frame.Fields.empty tracks
-        in
-        let base = if extensible then Lang.univ_t () else Lang.unit_t in
+  match annotation with
+    | `Abstract -> Lang_source.abstract_source_t ?pos ()
+    | `Tracks { Parsed_term.extensible; tracks } -> (
+        match tracks with
+          | [] -> Lang_source.source_t ?pos (Lang.univ_t ())
+          | tracks ->
+              let fields =
+                List.fold_left
+                  (fun fields
+                       { Parsed_term.track_name; track_type; track_params } ->
+                    Frame.Fields.add
+                      (Frame.Fields.field_of_string track_name)
+                      (mk_field_t ?pos track_type track_params)
+                      fields)
+                  Frame.Fields.empty tracks
+              in
+              let base = if extensible then Lang.univ_t () else Lang.unit_t in
 
-        Lang_source.source_t ?pos (Frame_type.make base fields)
+              Lang_source.source_t ?pos (Frame_type.make base fields))
 
 let register () =
   Hooks.liq_libs_dir := Configure.liq_libs_dir;

--- a/src/core/runtime/lang.ml
+++ b/src/core/runtime/lang.ml
@@ -5,6 +5,7 @@ module Flags = Liquidsoap_lang_data.Flags
 module Http = Liq_http
 
 let source_t = source_t ?pos:None
+let abstract_source_t = abstract_source_t ?pos:None
 let () = Hooks_implementations.register ()
 
 (** Helpers for defining protocols. *)

--- a/src/core/runtime/lang.mli
+++ b/src/core/runtime/lang.mli
@@ -219,6 +219,11 @@ val nullable_t : t -> t
 val ref_t : t -> t
 val error_t : t
 val source_t : ?methods:bool -> t -> t
+
+(** The type of a source whose content is unknown: any source can be used where
+    one is expected, but not the other way around. *)
+val abstract_source_t : unit -> t
+
 val of_source_t : t -> t
 val format_t : t -> t
 val metadata_track_t : t

--- a/src/core/source/lang_source.ml
+++ b/src/core/source/lang_source.ml
@@ -936,6 +936,9 @@ let source_t ?(pos : Term.parsed_pos option) ?(methods = false) frame_t =
   in
   if methods then source_methods_t t else t
 
+let abstract_source_t ?(pos : Term.parsed_pos option) () =
+  make_t ?pos (Type.Constr { Type.constructor = "source"; params = [] })
+
 let of_source_t t =
   match (Type.demeth t).Type.descr with
     | Type.Constr { Type.constructor = "source"; params = [(_, t)] } -> t

--- a/src/lang/ast/parsed_term.ml
+++ b/src/lang/ast/parsed_term.ml
@@ -188,11 +188,9 @@ and source_track_annotation = {
   track_params : track_annotation list;
 }
 
-and source_annotation = {
-  extensible : bool;
-  tracks : source_track_annotation list;
-}
-
+(* [`Abstract] is [source(_)], whose content is unknown. *)
+and source_annotation = [ `Abstract | `Tracks of source_tracks ]
+and source_tracks = { extensible : bool; tracks : source_track_annotation list }
 and argument = bool * string * type_annotation
 
 and type_annotation =

--- a/src/lang/parser/parser.mly
+++ b/src/lang/parser/parser.mly
@@ -402,9 +402,12 @@ meth_ty:
                             { { optional_meth = true; name = $3; typ = $6; json_name = Some (render_string ~pos:$loc($1) $1) } }
 
 ty_source_tracks:
-  | VAR GETS ty_content { { extensible = false; tracks = [{track_name = $1; track_type = fst $3; track_params = snd $3}] } }
-  | DOTDOTDOT { { extensible = true; tracks = [] } }
-  | VAR GETS ty_content COMMA ty_source_tracks { { $5 with tracks = { track_name = $1; track_type = fst $3; track_params = snd $3}::$5.tracks } }
+  | VAR GETS ty_content { `Tracks { extensible = false; tracks = [{track_name = $1; track_type = fst $3; track_params = snd $3}] } }
+  | DOTDOTDOT { `Tracks { extensible = true; tracks = [] } }
+  | VAR GETS ty_content COMMA ty_source_tracks {
+      match $5 with
+        | `Abstract -> raise (Term.Parse_error ($loc, "Invalid source type: _ cannot be mixed with tracks"))
+        | `Tracks t -> `Tracks { t with tracks = { track_name = $1; track_type = fst $3; track_params = snd $3}::t.tracks } }
 
 ty_content:
   | VAR                           { $1, [] }

--- a/src/lang/parser/parser_helper.ml
+++ b/src/lang/parser/parser_helper.ml
@@ -248,15 +248,19 @@ let mk_named_ty ~pos name ty =
                Printf.sprintf
                  "Type constructor %s takes a type parameter, as in `%s(int)`."
                  name name ))
+    (* [source(_)] reaches us here rather than through [ty_source_tracks]:
+       [_] parses as a type of its own. *)
+    | Some `Source, Some (`Named "_") -> mk_source_ty ~pos name `Abstract
     | Some `Source, None ->
-        mk_source_ty ~pos name { Parsed_term.extensible = false; tracks = [] }
+        mk_source_ty ~pos name
+          (`Tracks { Parsed_term.extensible = false; tracks = [] })
     | Some `Source, Some _ ->
         raise
           (Term.Parse_error
              ( pos,
                "`source(...)` takes track declarations, as in \
-                `source(audio=pcm)`. Write `source` on its own for a source \
-                with any tracks." ))
+                `source(audio=pcm)`, or `_` for a source of unknown content. \
+                Write `source` on its own for a source with any tracks." ))
 
 type let_opt_el = string * Parsed_term.t
 

--- a/src/lang/reducer/term_reducer_ty.ml
+++ b/src/lang/reducer/term_reducer_ty.ml
@@ -36,7 +36,8 @@ let mk_named_ty ?pos = function
   | "string" -> Type.make ?pos:(Option.map Pos.of_lexing_pos pos) Type.String
   | "ref" -> Type.reference (Type.var ())
   | "clock" -> mk_clock_ty ?pos ()
-  | "source" -> mk_source_ty ?pos "source" { extensible = true; tracks = [] }
+  | "source" ->
+      mk_source_ty ?pos "source" (`Tracks { extensible = true; tracks = [] })
   | "source_methods" -> !Hooks.source_methods_t ()
   | name -> (
       match Type.find_opt_typ name with

--- a/src/lang/tooling/parsed_json.ml
+++ b/src/lang/tooling/parsed_json.ml
@@ -177,10 +177,15 @@ and json_of_meth_annotation { optional_meth; name; typ; json_name } =
       ]
     (json_of_type_annotation typ)
 
-and json_of_source_annotation { extensible; tracks } =
-  type_node ~typ:"source_annotation"
-    ~extra:[("extensible", `Bool extensible)]
-    (`Tuple (List.map json_of_source_track_annotation tracks))
+and json_of_source_annotation = function
+  | `Abstract ->
+      type_node ~typ:"source_annotation"
+        ~extra:[("abstract", `Bool true)]
+        (`Tuple [])
+  | `Tracks { extensible; tracks } ->
+      type_node ~typ:"source_annotation"
+        ~extra:[("extensible", `Bool extensible)]
+        (`Tuple (List.map json_of_source_track_annotation tracks))
 
 and json_of_source_track_annotation { track_name; track_type; track_params } =
   type_node ~typ:"source_track_annotation"

--- a/src/lang/types/repr.ml
+++ b/src/lang/types/repr.ml
@@ -250,6 +250,11 @@ let print f t =
         Format.fprintf f ")";
         Format.close_box ();
         vars
+    (* The source constructor with no content parameter is [source(_)]: print it
+       the way it is written. *)
+    | `Constr ("source", []) ->
+        Format.fprintf f "source(_)";
+        vars
     | `Constr (name, []) ->
         Format.fprintf f "%s" name;
         vars

--- a/src/lang/types/typing.ml
+++ b/src/lang/types/typing.ml
@@ -403,6 +403,15 @@ and ( <: ) a b =
           a <: b
       | _, Var { contents = Link (_, b) } -> a <: b
       | Var { contents = Link (_, a) }, _ -> a <: b
+      (* A source can be streamed without knowing what it streams, so any
+         source is a source of unknown content. The converse would let a
+         caller assume content the source may not have. *)
+      | ( Constr { constructor = "source"; params = _ :: _ },
+          Constr { constructor = "source"; params = [] } ) ->
+          ()
+      | ( Constr { constructor = "source"; params = [] },
+          Constr { constructor = "source"; params = _ :: _ } ) ->
+          raise (Error (Repr.make a, Repr.make b))
       | Constr c1, Constr c2 when c1.constructor = c2.constructor ->
           let rec aux pre p1 p2 =
             match (p1, p2) with

--- a/tests/failures/test_abstract_source.liq
+++ b/tests/failures/test_abstract_source.liq
@@ -1,0 +1,12 @@
+# A source of unknown content cannot be used as a source of any given content:
+# nothing is known about what it streams. The other direction is fine and is
+# covered by tests/language/abstract_source.liq.
+#
+# Expected:
+# Error 5: this value has type
+#   source(_) (inferred at line 11, char 4-24)
+# but it should be a subtype of
+#   source('A)
+
+s = (sine() : source(_))
+output.dummy(s)

--- a/tests/language/abstract_source.liq
+++ b/tests/language/abstract_source.liq
@@ -15,16 +15,15 @@ sources = [(audio_source : source(_)), (video_source : source(_))]
 def check() =
   audio_content = source.content(audio_source)
   video_content = source.content(video_source)
-  log.important("audio: #{audio_content}, video: #{video_content}")
+  log.important(
+    "audio: #{audio_content}, video: #{video_content}"
+  )
 
   if
     list.length(sources) == 2
-  and
-    list.assoc.mem("audio", audio_content)
-  and
-    not list.assoc.mem("video", audio_content)
-  and
-    list.assoc.mem("video", video_content)
+    and list.assoc.mem("audio", audio_content)
+    and not list.assoc.mem("video", audio_content)
+    and list.assoc.mem("video", video_content)
   then
     test.pass()
   else

--- a/tests/language/abstract_source.liq
+++ b/tests/language/abstract_source.liq
@@ -1,0 +1,41 @@
+log.level.set(4)
+
+# `source(_)` is a source whose content is unknown. Any source can be used where
+# one is expected, so sources of different content can sit in the same list
+# without their content types being unified into one.
+
+audio_source = source.methods((sine(id="audio") : source(audio=pcm)))
+video_source =
+  source.methods((video.testsrc(id="video") : source(video=yuv420p)))
+
+# Each element is coerced on its own: a list literal unifies its elements'
+# types before the list type is checked.
+sources = [(audio_source : source(_)), (video_source : source(_))]
+
+def check() =
+  audio_content = source.content(audio_source)
+  video_content = source.content(video_source)
+  log.important("audio: #{audio_content}, video: #{video_content}")
+
+  if
+    list.length(sources) == 2
+  and
+    list.assoc.mem("audio", audio_content)
+  and
+    not list.assoc.mem("video", audio_content)
+  and
+    list.assoc.mem("video", video_content)
+  then
+    test.pass()
+  else
+    test.fail()
+  end
+end
+
+output.dummy(fallible=true, audio_source)
+output.dummy(fallible=true, video_source)
+
+clock.assign_new(sync="none", [audio_source])
+clock.assign_new(sync="none", [video_source])
+
+thread.run(delay=1., check)

--- a/tests/language/dune.inc
+++ b/tests/language/dune.inc
@@ -1,4 +1,23 @@
 (rule
+ (alias test_abstract_source)
+ (package liquidsoap)
+ (deps
+  abstract_source.liq
+  ../../src/bin/liquidsoap.exe
+  (package liquidsoap)
+  (source_tree ../../src/libs)
+  crontab_test_cases.json
+  (:test_liq ../test.liq)
+  (:run_test ../run_test.exe))
+ (action
+  (run
+   %{run_test}
+   abstract_source.liq
+   liquidsoap
+   %{test_liq}
+   abstract_source.liq)))
+
+(rule
  (alias test_argsof)
  (package liquidsoap)
  (deps
@@ -763,6 +782,7 @@
 (alias
  (name citest)
  (deps
+  (alias test_abstract_source)
   (alias test_argsof)
   (alias test_bool)
   (alias test_comments)


### PR DESCRIPTION
Adds `source(_)`, a source whose content is unknown: any source can be used where one is expected, since streaming a source needs nothing from its content, but nothing can be assumed about what it streams, so the converse is rejected.

This makes it possible to hold sources of different content together, which `source('a)` cannot do: a list unifies its elements' types, so passing a video source alongside an audio one silently turns it into an audio source rather than failing.

## The problem

```liquidsoap
audio = (sine() : source(audio=pcm))
video = (video.testsrc() : source(video=yuv420p))

ignore([audio, video])
```

This typechecks today, and `video` ends up streaming `{audio: pcm(stereo)}`: the list forced both element types together and the video source lost its content. Nothing warns about it.

## The type

```liquidsoap
sources = [(audio : source(_)), (video : source(_))]
```

Each element is coerced on its own — a list literal unifies its elements' types before the list type is checked, so the annotation goes on the elements rather than on the list.

The other direction is a type error:

```liquidsoap
s = (sine() : source(_))
output.dummy(s)
```

```
Error 5: this value has type
  source(_) (inferred at line 1, char 4-24)
but it should be a subtype of
  source('A)
```

`source` and `source(...)` are unchanged and still mean a source whose content is inferred.

## Implementation

`source(_)` is `Constr { constructor = "source"; params = [] }`, i.e. the source constructor with no content parameter, so the two are told apart by arity. Subtyping gets one rule in each direction in `typing.ml`, ahead of the generic `Constr` case, which asserts equal arity:

```ocaml
| ( Constr { constructor = "source"; params = _ :: _ },
    Constr { constructor = "source"; params = [] } ) ->
    ()
| ( Constr { constructor = "source"; params = [] },
    Constr { constructor = "source"; params = _ :: _ } ) ->
    raise (Error (Repr.make a, Repr.make b))
```

`Parsed_term.source_annotation` becomes `` `Abstract | `Tracks of source_tracks ``, since the two are alternatives rather than a record with an extra flag. `source(_)` is routed in `mk_named_ty`, not in `ty_source_tracks`: `_` parses as a type of its own, so it reaches the parser through `VARLPAR ty RPAR`. Adding it to `ty_source_tracks` as well produces a reduce/reduce conflict, which `--strict` catches.

## Tests

`tests/language/abstract_source.liq` builds a list holding an audio and a video source and checks that each keeps its own content type after startup. It fails if the subtyping rule is removed.

`tests/failures/test_abstract_source.liq` records the rejected direction. The test harness has no expected-failure mode, so this one is not automated; it is checked by running `liquidsoap --check` on it.

## Note on tooling

The tree-sitter and lezer grammars already parse `source(_)`: both have `source(TYPE)` productions and `_` is a type, verified by parsing. `liquidsoap-prettier` needs the companion change in savonet/liquidsoap-prettier#10 — until then its parser, which predates this syntax, parses `source(_)` and prints it back as `source`, silently changing the annotation's meaning.
