### PR TITLE
source: release script callbacks instead of piling them up

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -28,7 +28,8 @@
   `release` method taking the callback back. A function registering on a source it is given
   keeps the callback alive for as long as that source lives, so one that runs more than once
   needs to release what it registered. Past five callbacks on the same source, a log message
-  says so. Existing scripts are unaffected: the returned value is still ignorable.
+  says so. Existing scripts are unaffected: the returned value is still ignorable. See the
+  new [source callbacks](doc/content/callbacks.md) page.
 - Callbacks a script registers on the sources `switch` and `cross` hand to `on_select`,
   `on_leave` and transition functions are now released when the selection or the crossing
   ends, instead of accumulating on those sources for as long as they live.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -32,6 +32,9 @@
 - Callbacks a script registers on the sources `switch` and `cross` hand to `on_select`,
   `on_leave` and transition functions are now released when the selection or the crossing
   ends, instead of accumulating on those sources for as long as they live.
+- Added `source.collect_callback_releases`, which runs a function and gathers the callbacks
+  it registered on a given list of sources into a single `release`. This is what `switch` and
+  `cross` use, available to scripts calling their own functions more than once.
 - Added the `source(_)` type: a source whose content is unknown. Any source can be used where
   one is expected, so sources of different content can be held together, for instance in a
   list, without their content types being unified into one. The converse is rejected: nothing

--- a/doc/content/callbacks.md
+++ b/doc/content/callbacks.md
@@ -12,9 +12,42 @@ A callback attached this way belongs to the source. It fires every time the
 event happens, for as long as that source is alive — which, for a source defined
 at the top level of a script, means until liquidsoap shuts down.
 
-That is what most scripts want, and if all your callbacks are registered once at
-startup there is nothing else to know here. The rest of this page is about the
-case where they are not.
+That is what most scripts want. Two things are still worth deciding: which
+thread the callback runs in, and what happens when a registration is not meant
+to last as long as the source.
+
+## Synchronous or not
+
+`synchronous` has no default: every registration has to say which of the two
+behaviours it wants.
+
+With `synchronous=true` the callback runs where the event happened, which for
+stream events — `on_track`, `on_metadata`, `on_frame` — is the streaming thread.
+The stream waits for it. That is what you want when the callback has to take
+effect before the stream moves on, and it means the callback must be quick:
+no HTTP request, no database query, no `thread.pause`, nothing that waits on
+something else. A callback that takes too long makes the streaming loop fall
+behind and produces [catchup errors](./latency_control.md).
+
+With `synchronous=false` the callback is handed to liquidsoap's scheduler and
+runs on one of its generic queues instead. Blocking is fine there, so this is
+the setting for posting to an API, writing to a database or calling out to an
+external program. In exchange you give up three things:
+
+- **Timing.** The callback runs shortly after the event, not at it. By then the
+  source may have moved on, so use what the callback is handed rather than
+  asking the source what it is doing now.
+- **Ordering.** Firings are queued independently and the queues run in parallel,
+  so they can overlap and complete out of order. With the default five generic
+  queues, five copies of a slow callback can be running at once.
+- **Room for other work.** Those queues also resolve requests — downloads,
+  playlist reloads. A callback slower than the events feeding it builds a
+  backlog and crowds them out. `settings.scheduler.generic_queues` and
+  `settings.scheduler.fast_queues` control how many queues there are.
+
+When in doubt, ask what the callback does: if it only reads its arguments and
+sets a variable, `synchronous=true`; if it talks to anything outside
+liquidsoap, `synchronous=false`.
 
 ## Taking a callback back
 
@@ -26,6 +59,11 @@ Registering returns a value with a `release` method that detaches the callback:
 
 Once released, the callback stops firing and the function it wrapped is
 forgotten. Releasing twice is harmless.
+
+Releasing takes the callback off the source; it does not cancel work already in
+flight. An asynchronous firing that the scheduler has already queued still runs,
+so code that releases a callback and then tears down what that callback touches
+should be able to cope with one last call.
 
 The returned value is otherwise `unit`, so you can keep ignoring it: a
 registration whose result you drop is still valid liquidsoap.

--- a/doc/content/callbacks.md
+++ b/doc/content/callbacks.md
@@ -1,0 +1,102 @@
+# Source callbacks
+
+Sources tell you what they are doing through callbacks: `on_metadata` when they
+send new metadata, `on_track` at track boundaries, `on_connect` when a client
+shows up, and so on. You attach one by calling the method on the source:
+
+```liquidsoap
+music.on_metadata(synchronous=true, print_title)
+```
+
+A callback attached this way belongs to the source. It fires every time the
+event happens, for as long as that source is alive — which, for a source defined
+at the top level of a script, means until liquidsoap shuts down.
+
+That is what most scripts want, and if all your callbacks are registered once at
+startup there is nothing else to know here. The rest of this page is about the
+case where they are not.
+
+## Taking a callback back
+
+Registering returns a value with a `release` method that detaches the callback:
+
+```{.liquidsoap include="callback-release.liq"}
+
+```
+
+Once released, the callback stops firing and the function it wrapped is
+forgotten. Releasing twice is harmless.
+
+The returned value is otherwise `unit`, so you can keep ignoring it: a
+registration whose result you drop is still valid liquidsoap.
+
+## When you need to release
+
+The question to ask is: **does the callback outlive whatever registered it?**
+
+A function that registers on a source it is given, and that runs more than once,
+answers yes. Each call leaves another callback on that source, and they all keep
+firing. Common shapes:
+
+- a telnet or HTTP command that builds something out of a long-lived source,
+- a handler that decorates the current track and is itself called on every
+  track,
+- code that creates and destroys sources or outputs while the script runs, as in
+  [dynamic source creation](./dynamic_sources.md).
+
+In those cases the caller keeps the release and uses it when it tears down what
+it built:
+
+```{.liquidsoap include="callback-release-per-call.liq"}
+
+```
+
+Callbacks registered on a source the function created itself need nothing: they
+are collected along with the source they are attached to.
+
+Liquidsoap tells you when this goes wrong. Past five callbacks of the same kind
+on the same source, it logs:
+
+```
+[music:3] 6 on_metadata callbacks registered on music. If you are registering
+from a function that runs more than once, keep the value it returns and call
+its release() method.
+```
+
+The count is per source _and_ per callback, so the message names what is piling
+up: six `on_metadata` warns, three `on_metadata` alongside three `on_track` does
+not. A script that registers and releases in step never reaches the threshold.
+
+## Callbacks registered on your behalf
+
+Plenty of operators register on the source you hand them: `fade.in` watches its
+input for track marks and metadata, and it is not alone. Call one of them once
+per stream, on a source that outlives the stream, and you have the same pile-up
+with no registration of your own to hold onto.
+
+`source.collect_callback_releases` runs a function and gathers everything it
+registered on the sources you name into a single release:
+
+```{.liquidsoap include="callback-collect.liq" from="BEGIN" to="END"}
+
+```
+
+It returns `result`, whatever the function returned, and `release`, which takes
+back every callback the function registered on any of the listed sources.
+Callbacks registered on other sources are left alone, and so is liquidsoap's own
+internal wiring: only callbacks registered from a script are collected.
+
+The sources are passed as a list of `source(_)`, so sources carrying different
+content can be watched together.
+
+## What the operators already do
+
+`switch` (and `fallback`, `rotate`, `random`) hands sources to `on_select` and
+`on_leave`, and `cross` hands them to its transition. Those functions run on
+every selection and every crossing, so the operators collect what they register
+and release it once the selection or the crossing is over. Writing [your own
+transition](./composition.md) needs no bookkeeping on your part.
+
+`source.dynamic` is the exception: its `next` function takes no source
+arguments, so there is nothing for the operator to watch. If `next` registers on
+a source from the enclosing script, release it yourself.

--- a/doc/content/composition.md
+++ b/doc/content/composition.md
@@ -203,6 +203,11 @@ would never run.
 it is created and started right there, then torn down when the handoff is over.
 Keep it cheap: no blocking calls, no file or network access.
 
+It also runs on every selection, so any callback it registers on `ending` or
+`starting` would pile up on sources that live much longer than the handoff. The
+switch releases those for you when the selection ends, and `cross` does the same
+for its transition — see [source callbacks](./callbacks.md).
+
 To keep the previous behaviour, where switching mid-track cut straight over with
 no fade, there is a ready-made transition:
 

--- a/doc/content/documentation.md
+++ b/doc/content/documentation.md
@@ -42,6 +42,7 @@ If you are migrating from a previous version, you might want to checkout
 
 - Basic concepts: [sources](./sources.md), [clocks](./clocks.md) and [requests](./requests.md).
 - [Source composition](./composition.md): how `fallback`, `switch`, `rotate` and `random` hand over from one source to another.
+- [Source callbacks](./callbacks.md): how long `on_track`, `on_metadata` and friends stay attached, and how to release them.
 - [Stream contents](./stream_content.md): what kind of streams are supported, and how.
 - [Script loading](./script_loading.md): load several scripts, learn about the script library.
 - [Execution phases](./phases.md)

--- a/doc/content/dynamic_sources.md
+++ b/doc/content/dynamic_sources.md
@@ -24,3 +24,8 @@ After executing this script, you should see two telnet commands:
 - `restream.stop <uri>`
 
 which you can use to create/destroy dynamically your sources.
+
+Note that `create_stream` reuses `s`, which lives for as long as the script
+does. Any callback it registers on `s` — directly, or through an operator such
+as `fade.in` — stays there once the stream is deleted, and one is added on every
+call. See [source callbacks](./callbacks.md) for how to release them.

--- a/doc/content/latency_control.md
+++ b/doc/content/latency_control.md
@@ -110,7 +110,7 @@ If timing is CPU-controlled, then Liquidsoap needs to generate chunks fast enoug
 - 💽 Disk access is slow—especially with network-based filesystems like NFS.
 - 🔄 Blocking code inside the streaming loop.
 
-💡 **Pro Tip:** Before version 2.4.0, all callbacks in Liquidsoap were synchronous (blocking). Since 2.4.0, most callbacks are **asynchronous** by default.
+💡 **Pro Tip:** Before version 2.4.0, all callbacks in Liquidsoap were synchronous (blocking). Since 2.4.0, source callbacks take a mandatory `synchronous` parameter: pass `synchronous=false` and the callback runs off the streaming loop. See [source callbacks](./callbacks.md).
 
 #### ✅ 4. Are other processes slowing things down?
 

--- a/doc/content/liq/callback-collect.liq
+++ b/doc/content/liq/callback-collect.liq
@@ -1,0 +1,73 @@
+settings.init.force_start := true
+settings.server.telnet := true
+
+s = playlist("/path/to/files")
+
+streams = ref([])
+count = ref(0)
+
+enc = %mp3
+
+# BEGIN
+def create_stream(url) =
+  if
+    list.assoc.mem(url, streams())
+  then
+    "Stream for url #{url} already exists!"
+  else
+    # `fade.in` registers callbacks on `s`, which lives for as long as the
+    # script does.
+    stream =
+      source.collect_callback_releases(
+        [s],
+        {
+          output.url(
+            id="restream-#{count()}",
+            fallible=true,
+            url=url,
+            enc,
+            fade.in(duration=2., s)
+          )
+        }
+      )
+
+    def stop() =
+      stream.result.shutdown()
+      stream.release()
+    end
+
+    count := count() + 1
+    streams := [...streams(), (url, stop)]
+    "OK!"
+  end
+end
+
+# END
+
+def delete_stream(url) =
+  if
+    not list.assoc.mem(url, streams())
+  then
+    "Stream for url #{url} does not exists!"
+  else
+    stop = list.assoc(url, streams())
+    stop()
+    streams := list.filter((fun (el) -> fst(el) != url), streams())
+    "OK!"
+  end
+end
+
+server.register(
+  namespace="restream",
+  description="Redirect a stream.",
+  usage="start <url>",
+  "start",
+  create_stream
+)
+server.register(
+  namespace="restream",
+  description="Stop a dynamic playlist.",
+  usage="stop <url>",
+  "stop",
+  delete_stream
+)

--- a/doc/content/liq/callback-release-per-call.liq
+++ b/doc/content/liq/callback-release-per-call.liq
@@ -1,0 +1,35 @@
+music = playlist("~/Music")
+
+# Registers on the source it is given, so each call leaves one more callback
+# on `music`.
+def announce(s) =
+  s.on_metadata(
+    synchronous=true,
+    fun (m) ->
+      log(
+        "Now playing: #{m["title"]}"
+      )
+  )
+end
+
+announcement = ref(null)
+
+def start_announcing() =
+  if
+    null.defined(announcement())
+  then
+    "already announcing"
+  else
+    announcement := announce(music)
+    "announcing"
+  end
+end
+
+def stop_announcing() =
+  if null.defined(announcement()) then null.get(announcement()).release() end
+  announcement := null
+  "stopped"
+end
+
+server.register("announce.start", fun (_) -> start_announcing())
+server.register("announce.stop", fun (_) -> stop_announcing())

--- a/doc/content/liq/callback-release-per-call.liq
+++ b/doc/content/liq/callback-release-per-call.liq
@@ -1,15 +1,15 @@
 music = playlist("~/Music")
 
-# Registers on the source it is given, so each call leaves one more callback
-# on `music`.
-def announce(s) =
-  s.on_metadata(
-    synchronous=true,
-    fun (m) ->
-      log(
-        "Now playing: #{m["title"]}"
-      )
+def print_title(m) =
+  log(
+    "Now playing: #{m["title"]}"
   )
+end
+
+# Registers on the source it is given, so each call leaves one more callback on
+# that source.
+def announce(s) =
+  s.on_metadata(synchronous=true, print_title)
 end
 
 announcement = ref(null)

--- a/doc/content/liq/callback-release.liq
+++ b/doc/content/liq/callback-release.liq
@@ -1,0 +1,13 @@
+music = playlist("~/Music")
+
+announce =
+  music.on_metadata(
+    synchronous=true,
+    fun (m) ->
+      log(
+        "Now playing: #{m["title"]}"
+      )
+  )
+
+# Takes the callback back off `music`.
+announce.release()

--- a/doc/content/liq/callback-release.liq
+++ b/doc/content/liq/callback-release.liq
@@ -1,13 +1,12 @@
 music = playlist("~/Music")
 
-announce =
-  music.on_metadata(
-    synchronous=true,
-    fun (m) ->
-      log(
-        "Now playing: #{m["title"]}"
-      )
+def print_title(m) =
+  log(
+    "Now playing: #{m["title"]}"
   )
+end
+
+announce = music.on_metadata(synchronous=true, print_title)
 
 # Takes the callback back off `music`.
 announce.release()

--- a/doc/content/migrating.md
+++ b/doc/content/migrating.md
@@ -286,6 +286,35 @@ Several operators are built on top of `fallback` and used to pass a fixed `track
 
 The deprecated `mkavailable` lost its `track_sensitive` parameter with no replacement; use `source.available` instead, as the deprecation warning already suggests.
 
+### Source callbacks return a release
+
+Registering a callback on a source — `on_track`, `on_metadata`, `on_frame`, `on_connect`, `on_start`, `on_blank`, and the rest — now returns a value carrying a `release` method:
+
+```liquidsoap
+announce = s.on_metadata(synchronous=true, fn)
+announce.release()
+```
+
+The value is still `unit` underneath, so nothing needs to change in existing scripts: dropping the result, or annotating it as `unit`, both remain valid.
+
+What this is for is the case where a callback outlives whatever registered it. A callback belongs to the source it is registered on and fires for as long as that source lives, so a function that registers on a source it is given and runs more than once leaves one more callback behind on every call. That shows up as a script that gets slower and noisier over time rather than as an error. See [source callbacks](./callbacks.md) for the full picture, including `source.collect_callback_releases` for the callbacks operators such as `fade.in` register on your behalf.
+
+Liquidsoap also reports the pile-up. Past five callbacks of the same kind on the same source, it logs:
+
+```
+[music:3] 6 on_metadata callbacks registered on music. If you are registering
+from a function that runs more than once, keep the value it returns and call
+its release() method.
+```
+
+If you see this and the registrations are deliberate — five `on_track` handlers set up once at startup is fine — nothing needs fixing.
+
+### Callbacks registered in transitions are released
+
+`switch` (and `fallback`, `rotate`, `random`) now releases the callbacks that `on_select` and `on_leave` register on the sources they are handed, once the selection ends. `cross` does the same for its transition, once the crossing ends. Both also cover the callbacks those functions register on their own children.
+
+This is what keeps a custom transition building `fade.in`/`fade.out` on the sources it receives from piling callbacks up on them for the lifetime of the stream. It only affects transitions that register callbacks: if one of yours registered a callback on `ending` or `starting` and relied on it still firing after the handoff was over, it will not any more. Register from outside the transition instead.
+
 ## From 2.3.x to 2.4.x
 
 See our [2.4.0 blog post](https://www.liquidsoap.info/blog/2025-08-11-liquidsoap-2.4.0/) for a detailed presentation

--- a/doc/content/sources.md
+++ b/doc/content/sources.md
@@ -122,4 +122,5 @@ Want to go deeper?
 
 - Explore the [scripting API reference](reference.html)
 - Learn about [clocks](./clocks.md)
+- See how [source callbacks](./callbacks.md) hook into what a source is doing
 - Experiment with your own custom source graphs

--- a/doc/dune.inc
+++ b/doc/dune.inc
@@ -214,6 +214,20 @@
    content/liq/blank-sorry.liq)))
 
 (rule
+ (alias test-doc-callback-collect)
+ (package liquidsoap)
+ (deps
+  (alias_rec ../install)
+  (source_tree ../src/libs)
+  (:test_liq content/liq/callback-collect.liq))
+ (action
+  (run
+   %{bin:liquidsoap}
+   --check
+   --no-fallible-check
+   content/liq/callback-collect.liq)))
+
+(rule
  (alias test-doc-callback-release-per-call)
  (package liquidsoap)
  (deps
@@ -2173,6 +2187,7 @@
   (alias test-doc-beets-source)
   (alias test-doc-blank-detect)
   (alias test-doc-blank-sorry)
+  (alias test-doc-callback-collect)
   (alias test-doc-callback-release)
   (alias test-doc-callback-release-per-call)
   (alias test-doc-clock-alsa-file)

--- a/doc/dune.inc
+++ b/doc/dune.inc
@@ -214,6 +214,34 @@
    content/liq/blank-sorry.liq)))
 
 (rule
+ (alias test-doc-callback-release-per-call)
+ (package liquidsoap)
+ (deps
+  (alias_rec ../install)
+  (source_tree ../src/libs)
+  (:test_liq content/liq/callback-release-per-call.liq))
+ (action
+  (run
+   %{bin:liquidsoap}
+   --check
+   --no-fallible-check
+   content/liq/callback-release-per-call.liq)))
+
+(rule
+ (alias test-doc-callback-release)
+ (package liquidsoap)
+ (deps
+  (alias_rec ../install)
+  (source_tree ../src/libs)
+  (:test_liq content/liq/callback-release.liq))
+ (action
+  (run
+   %{bin:liquidsoap}
+   --check
+   --no-fallible-check
+   content/liq/callback-release.liq)))
+
+(rule
  (alias test-doc-clock-alsa-file)
  (package liquidsoap)
  (deps
@@ -2145,6 +2173,8 @@
   (alias test-doc-beets-source)
   (alias test-doc-blank-detect)
   (alias test-doc-blank-sorry)
+  (alias test-doc-callback-release)
+  (alias test-doc-callback-release-per-call)
   (alias test-doc-clock-alsa-file)
   (alias test-doc-clock-alsa-pulseaudio-buffer)
   (alias test-doc-clock-alsa-pulseaudio-conflict)

--- a/src/core/builtins/builtins_source.ml
+++ b/src/core/builtins/builtins_source.ml
@@ -153,6 +153,39 @@ let _ =
       Lang.float frame_position)
 
 let _ =
+  let univ = Lang.univ_t () in
+  Lang.add_builtin ~base:source "collect_callback_releases"
+    ~category:(`Source `Liquidsoap)
+    [
+      ("", Lang.list_t (Lang.abstract_source_t ()), None, None);
+      ("", Lang.fun_t [] univ, None, None);
+    ]
+    (Lang.record_t [("release", Lang.fun_t [] Lang.unit_t); ("result", univ)])
+    ~descr:
+      "Run the given function, collecting the callbacks it registers on any of \
+       the given sources into a single `release`. Use this when calling a \
+       function more than once with the same sources: the callbacks it \
+       registers on them live as long as those sources do, so they pile up \
+       unless they are released."
+    (fun p ->
+      let sources =
+        List.map Lang.to_source (Lang.to_list (Lang.assoc "" 1 p))
+      in
+      let fn = Lang.assoc "" 2 p in
+      let { Lang_source.release; result } =
+        Lang_source.collect_callback_releases sources (fun () ->
+            Lang.apply fn [])
+      in
+      Lang.record
+        [
+          ( "release",
+            Lang.val_fun [] (fun _ ->
+                release ();
+                Lang.unit) );
+          ("result", result);
+        ])
+
+let _ =
   Lang.add_builtin ~base:source "on_shutdown" ~category:(`Source `Liquidsoap)
     [
       ("", Lang.source_t (Lang.univ_t ()), None, None);

--- a/src/core/liquidsoap_core.ml
+++ b/src/core/liquidsoap_core.ml
@@ -74,6 +74,7 @@ module Generator = Generator
 
 (* Sources and clocks *)
 module Source = Source
+module Callbacks = Callbacks
 module Clock = Clock
 module Clock_utils = Clock_utils
 module Output = Output

--- a/src/core/liquidsoap_core.mli
+++ b/src/core/liquidsoap_core.mli
@@ -93,6 +93,9 @@ module Generator = Generator
     The streaming model: sources produce frames, clocks animate them. *)
 module Source = Source
 
+(** Ordered callback lists a callback can be removed from. *)
+module Callbacks = Callbacks
+
 module Clock = Clock
 module Clock_utils = Clock_utils
 module Output = Output

--- a/src/core/operators/cross.ml
+++ b/src/core/operators/cross.ml
@@ -144,10 +144,15 @@ class cross val_source ~override_duration ~duration_getter ~persist_override
           | `After of Clock.activation * Source.source ] =
       `Idle
 
+    (* Releases what the transition registered, if we are holding one. *)
+    val mutable release_transition = fun () -> ()
+
     method set_status v =
       (match status with
         | `Idle -> ()
         | `Before (a, s) | `After (a, s) -> s#sleep a);
+      release_transition ();
+      release_transition <- (fun () -> ());
       status <- v
 
     method! child_clock_controller =
@@ -353,7 +358,7 @@ class cross val_source ~override_duration ~duration_getter ~persist_override
       let buffered_seconds = Frame.seconds_of_main buffered in
       self#fade_out_adjustements buffered_seconds;
       self#fade_in_adjustements buffered_seconds;
-      let compound =
+      let compound, release_callbacks =
         let metadata = function None -> Frame.Metadata.empty | Some m -> m in
         let before_metadata = metadata before_metadata in
         let after_metadata = metadata after_metadata in
@@ -413,7 +418,10 @@ class cross val_source ~override_duration ~duration_getter ~persist_override
           db_after
           (Frame.seconds_of_main buffered_before)
           (Frame.seconds_of_main buffered_after);
-        let compound =
+        (* The transition runs on every crossing, so what it registers on the
+           sources it can reach — the two we hand it, and the source we cross,
+           which it may well have captured — is released with the crossing. *)
+        let { Lang_source.release = release_callbacks; result = compound } =
           let params =
             [
               ( "",
@@ -432,7 +440,9 @@ class cross val_source ~override_duration ~duration_getter ~persist_override
                   ] );
             ]
           in
-          Lang.to_source (Lang.apply transition params)
+          Lang_source.collect_callback_releases
+            [(before :> Source.source); (after :> Source.source); s]
+            (fun () -> Lang.to_source (Lang.apply transition params))
         in
         Typing.(compound#frame_type <: self#frame_type);
         let compound =
@@ -451,11 +461,12 @@ class cross val_source ~override_duration ~duration_getter ~persist_override
             | Some _, Some _ -> assert false
         in
         Typing.(compound#frame_type <: self#frame_type);
-        compound
+        (compound, release_callbacks)
       in
       let a = self#prepare_source compound in
       self#reset_analysis;
-      self#set_status (`After (a, compound))
+      self#set_status (`After (a, compound));
+      release_transition <- release_callbacks
 
     method remaining =
       match status with

--- a/src/core/operators/noblank.ml
+++ b/src/core/operators/noblank.ml
@@ -288,7 +288,7 @@ let _ =
           descr = "when detecting a blank.";
           register_deprecated_argument = false;
           arg_t = [];
-          register = (fun ~params:_ s f -> s#on_blank (fun () -> f []));
+          register = (fun ~params:_ s f -> s#register_on_blank (fun () -> f []));
         };
         {
           name = "on_noise";
@@ -296,7 +296,7 @@ let _ =
           descr = "when noise is detected.";
           register_deprecated_argument = false;
           arg_t = [];
-          register = (fun ~params:_ s f -> s#on_noise (fun () -> f []));
+          register = (fun ~params:_ s f -> s#register_on_noise (fun () -> f []));
         };
       ]
     (proto frame_t)

--- a/src/core/operators/noblank.ml
+++ b/src/core/operators/noblank.ml
@@ -97,10 +97,12 @@ class detect ~start_blank ~max_blank ~min_noise ~threshold ~track_sensitive
     method remaining = source#remaining
     method effective_source = source#effective_source
     method self_sync = source#self_sync
-    val mutable on_blank = []
-    method on_blank fn = on_blank <- on_blank @ [fn]
-    val mutable on_noise = []
-    method on_noise fn = on_noise <- on_noise @ [fn]
+    val on_blank = Callbacks.create ()
+    method register_on_blank fn = Callbacks.register on_blank fn
+    method on_blank fn = Callbacks.add on_blank fn
+    val on_noise = Callbacks.create ()
+    method register_on_noise fn = Callbacks.register on_noise fn
+    method on_noise fn = Callbacks.add on_noise fn
 
     method private generate_frame =
       let buf = source#get_frame in
@@ -110,8 +112,10 @@ class detect ~start_blank ~max_blank ~min_noise ~threshold ~track_sensitive
         self#is_blank
       in
       (match (was_blank, is_blank) with
-        | true, false -> List.iter (fun fn -> fn ()) on_noise
-        | false, true -> List.iter (fun fn -> fn ()) on_blank
+        | true, false ->
+            List.iter (fun fn -> fn ()) (Callbacks.elements on_noise)
+        | false, true ->
+            List.iter (fun fn -> fn ()) (Callbacks.elements on_blank)
         | _ -> ());
       buf
   end

--- a/src/core/operators/switch.ml
+++ b/src/core/operators/switch.ml
@@ -247,13 +247,25 @@ class switch ~all_predicates children =
       in
       Typing.(starting#frame_type <: self#frame_type);
 
-      let effective_source = child.on_select ending starting in
+      (* [on_select] runs on every selection, so what it registers on the
+         sources it can reach — the ones we hand it, and our own children, which
+         it may well have captured — would otherwise pile up on them for good.
+         They only need to be around for as long as this selection. *)
+      let { Lang_source.release = release_callbacks; result = effective_source }
+          =
+        Lang_source.collect_callback_releases
+          (sources @ ((starting :> Source.source) :: Option.to_list ending))
+          (fun () -> child.on_select ending starting)
+      in
       Typing.(effective_source#frame_type <: self#frame_type);
 
       (* Wake the new graph before putting the previous selection to sleep: when
          it holds [previous.proxy] this keeps that source continuously up. *)
       let a = effective_source#wake_up (self :> Clock.source) in
-      let sleep () = effective_source#sleep a in
+      let sleep () =
+        effective_source#sleep a;
+        release_callbacks ()
+      in
 
       Option.iter
         (self#push_leaving ~track_sensitive:(Option.is_none ending))

--- a/src/core/optionals/ffmpeg/io/ffmpeg_io.ml
+++ b/src/core/optionals/ffmpeg/io/ffmpeg_io.ml
@@ -82,13 +82,16 @@ class input ?(name = "input.ffmpeg") ~autostart ~self_sync ~poll_delay ~debug
     method self_sync =
       (`Dynamic, self#source_sync (self#get_self_sync && self#is_connected))
 
-    val mutable on_connect = []
-    method on_connect fn = on_connect <- on_connect @ [fn]
+    val on_connect = Callbacks.create ()
+    method register_on_connect fn = Callbacks.register on_connect fn
+    method on_connect fn = Callbacks.add on_connect fn
     method on_connect_metadata_map _ : (string * string) list = []
-    val mutable on_disconnect = []
-    method on_disconnect fn = on_disconnect <- on_disconnect @ [fn]
-    val mutable on_error = []
-    method on_error fn = on_error <- on_error @ [fn]
+    val on_disconnect = Callbacks.create ()
+    method register_on_disconnect fn = Callbacks.register on_disconnect fn
+    method on_disconnect fn = Callbacks.add on_disconnect fn
+    val on_error = Callbacks.create ()
+    method register_on_error fn = Callbacks.register on_error fn
+    method on_error fn = Callbacks.add on_error fn
     method private start = self#connect
     method private stop = self#disconnect
     val mutable url = url
@@ -136,7 +139,7 @@ class input ?(name = "input.ffmpeg") ~autostart ~self_sync ~poll_delay ~debug
         in
         let buffer = Decoder.mk_buffer ~ctype:self#content_type self#buffer in
         let m = self#on_connect_metadata_map container in
-        List.iter (fun fn -> fn m) on_connect;
+        List.iter (fun fn -> fn m) (Callbacks.elements on_connect);
         Generator.add_track_mark self#buffer;
         let container = { decoder; remaining; buffer; closed } in
         Atomic.set source_status (`Connected (url, container));
@@ -151,7 +154,7 @@ class input ?(name = "input.ffmpeg") ~autostart ~self_sync ~poll_delay ~debug
               ~bt:(Printexc.raw_backtrace_to_string bt)
               (Printf.sprintf "Decoding failed: %s" (Printexc.to_string e));
             let err = Lang.runtime_error_of_exception ~bt ~kind:"ffmpeg" e in
-            List.iter (fun fn -> fn err) on_error;
+            List.iter (fun fn -> fn err) (Callbacks.elements on_error);
             if debug then Printexc.raise_with_backtrace e bt;
             Atomic.set source_status `Starting;
             poll_delay
@@ -190,7 +193,7 @@ class input ?(name = "input.ffmpeg") ~autostart ~self_sync ~poll_delay ~debug
                Utils.log_exception ~log:self#log ~bt
                  (Printf.sprintf "Error while disconnecting: %s"
                     (Printexc.to_string exn)));
-            List.iter (fun fn -> fn ()) on_disconnect;
+            List.iter (fun fn -> fn ()) (Callbacks.elements on_disconnect);
             stop_task ()
 
     method private reconnect =
@@ -237,7 +240,7 @@ class input ?(name = "input.ffmpeg") ~autostart ~self_sync ~poll_delay ~debug
           ~bt:(Printexc.raw_backtrace_to_string bt)
           (Printf.sprintf "Feeding failed: %s" (Printexc.to_string exn));
         let err = Lang.runtime_error_of_exception ~bt ~kind:"ffmpeg" exn in
-        List.iter (fun fn -> fn err) on_error;
+        List.iter (fun fn -> fn err) (Callbacks.elements on_error);
         self#reconnect;
         Frame.append (Generator.slice self#buffer size) self#end_of_track
   end
@@ -294,7 +297,7 @@ class http_input ~autostart ~self_sync ~poll_delay ~debug ~max_buffer ?format
             (Printf.sprintf "Error while fetching icy headers: %s"
                (Printexc.to_string exn));
           let err = Lang.runtime_error_of_exception ~bt ~kind:"ffmpeg" exn in
-          List.iter (fun fn -> fn err) on_error;
+          List.iter (fun fn -> fn err) (Callbacks.elements on_error);
           []
       in
       Atomic.set is_icy (icy_headers <> []);

--- a/src/core/optionals/ffmpeg/io/ffmpeg_io.ml
+++ b/src/core/optionals/ffmpeg/io/ffmpeg_io.ml
@@ -437,7 +437,7 @@ let register_input protocol =
                       let on_connect m =
                         on_connect [("", Lang.metadata_list m)]
                       in
-                      s#on_connect on_connect);
+                      s#register_on_connect on_connect);
                 };
               ]
             else
@@ -451,7 +451,7 @@ let register_input protocol =
                   register =
                     (fun ~params:_ s on_connect ->
                       let on_connect _ = on_connect [] in
-                      s#on_connect on_connect);
+                      s#register_on_connect on_connect);
                 };
               ])
          @ [
@@ -462,7 +462,8 @@ let register_input protocol =
                register_deprecated_argument = true;
                arg_t = [];
                register =
-                 (fun ~params:_ s f -> s#on_disconnect (fun () -> f []));
+                 (fun ~params:_ s f ->
+                   s#register_on_disconnect (fun () -> f []));
              };
              {
                name = "on_error";
@@ -472,7 +473,7 @@ let register_input protocol =
                arg_t = [(false, "", Lang.error_t)];
                register =
                  (fun ~params:_ s f ->
-                   s#on_error (fun err -> f [("", Lang.error err)]));
+                   s#register_on_error (fun err -> f [("", Lang.error err)]));
              };
            ])
        ~meth:

--- a/src/core/optionals/srt/srt_io.ml
+++ b/src/core/optionals/srt/srt_io.ml
@@ -33,8 +33,12 @@ type input =
   ; get_sockets : (Unix.sockaddr * Srt.socket) list
   ; set_should_stop : bool -> unit
   ; on_socket : (mode:socket_mode -> Srt.socket -> unit) -> unit
+  ; register_on_socket :
+      (mode:socket_mode -> Srt.socket -> unit) -> unit -> unit
   ; on_connect : (unit -> unit) -> unit
+  ; register_on_connect : (unit -> unit) -> unit -> unit
   ; on_disconnect : (unit -> unit) -> unit
+  ; register_on_disconnect : (unit -> unit) -> unit -> unit
   ; connect : unit
   ; disconnect : unit >
 
@@ -43,8 +47,12 @@ type output =
   ; get_sockets : (Unix.sockaddr * Srt.socket) list
   ; set_should_stop : bool -> unit
   ; on_socket : (mode:socket_mode -> Srt.socket -> unit) -> unit
+  ; register_on_socket :
+      (mode:socket_mode -> Srt.socket -> unit) -> unit -> unit
   ; on_connect : (unit -> unit) -> unit
+  ; register_on_connect : (unit -> unit) -> unit -> unit
   ; on_disconnect : (unit -> unit) -> unit
+  ; register_on_disconnect : (unit -> unit) -> unit -> unit
   ; connect : unit
   ; disconnect : unit >
 
@@ -589,18 +597,26 @@ class virtual base () =
     method private should_stop = Atomic.get shutdown || Atomic.get should_stop
     method set_should_stop v = Atomic.set should_stop v
     method srt_id = id
-    val mutable on_socket = []
-    method on_socket fn = on_socket <- on_socket @ [fn]
+    val on_socket = Callbacks.create ()
+    method register_on_socket fn = Callbacks.register on_socket fn
+    method on_socket fn = Callbacks.add on_socket fn
 
     method apply_on_socket ~(mode : socket_mode) (s : Srt.socket) =
-      List.iter (fun fn -> fn ~mode s) on_socket
+      List.iter (fun fn -> fn ~mode s) (Callbacks.elements on_socket)
 
-    val mutable on_connect = []
-    method on_connect fn = on_connect <- on_connect @ [fn]
-    method apply_on_connect = List.iter (fun fn -> fn ()) on_connect
-    val mutable on_disconnect = []
-    method on_disconnect fn = on_disconnect <- on_disconnect @ [fn]
-    method apply_on_disconnect = List.iter (fun fn -> fn ()) on_disconnect
+    val on_connect = Callbacks.create ()
+    method register_on_connect fn = Callbacks.register on_connect fn
+    method on_connect fn = Callbacks.add on_connect fn
+
+    method apply_on_connect =
+      List.iter (fun fn -> fn ()) (Callbacks.elements on_connect)
+
+    val on_disconnect = Callbacks.create ()
+    method register_on_disconnect fn = Callbacks.register on_disconnect fn
+    method on_disconnect fn = Callbacks.add on_disconnect fn
+
+    method apply_on_disconnect =
+      List.iter (fun fn -> fn ()) (Callbacks.elements on_disconnect)
   end
 
 class virtual networking_agent =

--- a/src/core/optionals/srt/srt_io.ml
+++ b/src/core/optionals/srt/srt_io.ml
@@ -258,7 +258,7 @@ let callbacks =
         descr = "when connected.";
         register_deprecated_argument = true;
         arg_t = [];
-        register = (fun ~params:_ s f -> s#on_connect (fun () -> f []));
+        register = (fun ~params:_ s f -> s#register_on_connect (fun () -> f []));
       };
       {
         name = "on_disconnect";
@@ -266,7 +266,8 @@ let callbacks =
         descr = "when disconnected.";
         register_deprecated_argument = true;
         arg_t = [];
-        register = (fun ~params:_ s f -> s#on_disconnect (fun () -> f []));
+        register =
+          (fun ~params:_ s f -> s#register_on_disconnect (fun () -> f []));
       };
       {
         name = "on_socket";
@@ -286,7 +287,7 @@ let callbacks =
           ];
         register =
           (fun ~params:_ s f ->
-            s#on_socket (fun ~mode socket ->
+            s#register_on_socket (fun ~mode socket ->
                 let mode =
                   match mode with
                     | `Connect -> "connect"

--- a/src/core/outputs/harbor_output.ml
+++ b/src/core/outputs/harbor_output.ml
@@ -402,14 +402,16 @@ class virtual ['a] base p =
     val burst_buffer = Strings.Mutable.empty ()
     val shared_metadata : Frame.metadata option Atomic.t = Atomic.make None
     val mutable dump_channel : out_channel option = None
-    val mutable on_connect_callbacks = []
-    val mutable on_disconnect_callbacks = []
+    val on_connect_callbacks = Callbacks.create ()
+    val on_disconnect_callbacks = Callbacks.create ()
     val start_stop_mutex = Mutex.create ()
-    method on_connect fn = on_connect_callbacks <- fn :: on_connect_callbacks
+    method register_on_connect fn = Callbacks.register on_connect_callbacks fn
+    method on_connect fn = Callbacks.add on_connect_callbacks fn
 
-    method on_disconnect fn =
-      on_disconnect_callbacks <- fn :: on_disconnect_callbacks
+    method register_on_disconnect fn =
+      Callbacks.register on_disconnect_callbacks fn
 
+    method on_disconnect fn = Callbacks.add on_disconnect_callbacks fn
     method self_sync = source#self_sync
     method private get_metadata = Atomic.get shared_metadata
 
@@ -451,7 +453,9 @@ class virtual ['a] base p =
             handler =
               (fun _ ->
                 self#stop_listener_encoder listener;
-                List.iter (fun fn -> fn listener.id) on_disconnect_callbacks;
+                List.iter
+                  (fun fn -> fn listener.id)
+                  (Callbacks.elements on_disconnect_callbacks);
                 []);
           }
       end
@@ -696,7 +700,7 @@ class virtual ['a] base p =
       self#log#info "Listener %s connected" client_id;
       List.iter
         (fun fn -> fn ~headers ~uri:request_uri ~protocol client_id)
-        on_connect_callbacks;
+        (Callbacks.elements on_connect_callbacks);
       Duppy.Monad.Io.exec ~priority:`Maybe_blocking handler (Harbor.custom ())
 
     method private register_http_handler =

--- a/src/core/outputs/harbor_output.ml
+++ b/src/core/outputs/harbor_output.ml
@@ -965,7 +965,7 @@ let _ =
                          ] );
                    ]
                in
-               s#on_connect callback);
+               s#register_on_connect callback);
          };
          {
            name = "on_disconnect";
@@ -975,7 +975,8 @@ let _ =
            arg_t = [(false, "", Lang.string_t)];
            register =
              (fun ~params:_ s callback ->
-               s#on_disconnect (fun ip -> callback [("", Lang.string ip)]));
+               s#register_on_disconnect (fun ip ->
+                   callback [("", Lang.string ip)]));
          };
        ]
       @ Start_stop.callbacks ~label:"output")

--- a/src/core/outputs/hls_output.ml
+++ b/src/core/outputs/hls_output.ml
@@ -1343,7 +1343,7 @@ let _ =
                          ] );
                    ]
                in
-               s#on_file_change on_file_change);
+               s#register_on_file_change on_file_change);
          };
        ]
       @ Start_stop.callbacks ~label:"output")

--- a/src/core/outputs/hls_output.ml
+++ b/src/core/outputs/hls_output.ml
@@ -656,8 +656,12 @@ class hls_output p =
     val mutable current_position = (0, 0)
     val mutable stopped = false
     method self_sync = source#self_sync
-    val mutable on_file_change : (state:file_state -> string -> unit) list = []
-    method on_file_change fn = on_file_change <- on_file_change @ [fn]
+
+    val on_file_change : (state:file_state -> string -> unit) Callbacks.t =
+      Callbacks.create ()
+
+    method register_on_file_change fn = Callbacks.register on_file_change fn
+    method on_file_change fn = Callbacks.add on_file_change fn
 
     method private open_out filename =
       let temp_dir = Option.value ~default:hls_directory temp_dir in
@@ -724,12 +728,16 @@ class hls_output p =
                    ~mode:[Open_creat; Open_trunc; Open_binary]
                    ~perms tmp_file fname;
                  Sys.remove tmp_file);
-              List.iter (fun fn -> fn ~state fname) on_file_change)
+              List.iter
+                (fun fn -> fn ~state fname)
+                (Callbacks.elements on_file_change))
       end
 
     method private unlink filename =
       self#log#debug "Cleaning up %s.." filename;
-      List.iter (fun fn -> fn ~state:`Deleted filename) on_file_change;
+      List.iter
+        (fun fn -> fn ~state:`Deleted filename)
+        (Callbacks.elements on_file_change);
       try Unix.unlink filename
       with Unix.Unix_error (e, _, _) ->
         self#log#important "Could not remove file %s: %s" filename

--- a/src/core/outputs/icecast2.ml
+++ b/src/core/outputs/icecast2.ml
@@ -499,10 +499,12 @@ class output p =
 
     val mutable encoder = None
     method self_sync = source#self_sync
-    val mutable on_connect = []
-    method on_connect fn = on_connect <- on_connect @ [fn]
-    val mutable on_disconnect = []
-    method on_disconnect fn = on_disconnect <- on_disconnect @ [fn]
+    val on_connect = Callbacks.create ()
+    method register_on_connect fn = Callbacks.register on_connect fn
+    method on_connect fn = Callbacks.add on_connect fn
+    val on_disconnect = Callbacks.create ()
+    method register_on_disconnect fn = Callbacks.register on_disconnect fn
+    method on_disconnect fn = Callbacks.add on_disconnect fn
 
     val mutable on_error
         : restart_in:(float option -> unit) ->
@@ -512,6 +514,13 @@ class output p =
       fun ~restart_in:_ ~bt:_ _ -> ()
 
     method on_error fn = on_error <- fn
+
+    (* A single handler decides how long to wait before restarting, so this one
+       replaces rather than appends: releasing puts the previous one back. *)
+    method register_on_error fn =
+      let previous = on_error in
+      on_error <- fn;
+      fun () -> if on_error == fn then on_error <- previous
 
     method call_on_error ~bt exn =
       let delay = ref (Some 3.) in
@@ -642,7 +651,7 @@ class output p =
               with _ -> ())
           | _ -> ());
 
-        List.iter (fun fn -> fn ()) on_connect
+        List.iter (fun fn -> fn ()) (Callbacks.elements on_connect)
       with
       (* In restart mode, no_connect and no_login are not fatal.
          The output will just try to reconnect later. *)
@@ -670,7 +679,7 @@ class output p =
                Utils.log_exception ~log:self#log ~bt
                  (Printf.sprintf "Error while closing connection: %s"
                     (Printexc.to_string exn)));
-            List.iter (fun fn -> fn ()) on_disconnect
+            List.iter (fun fn -> fn ()) (Callbacks.elements on_disconnect)
       end;
       match dump with Some f -> close_out f | None -> ()
   end

--- a/src/core/outputs/icecast2.ml
+++ b/src/core/outputs/icecast2.ml
@@ -700,7 +700,7 @@ let _ =
             arg_t = [];
             register =
               (fun ~params:_ s on_connect ->
-                s#on_connect (fun () -> on_connect []));
+                s#register_on_connect (fun () -> on_connect []));
           };
           {
             Lang_source.name = "on_disconnect";
@@ -710,7 +710,7 @@ let _ =
             arg_t = [];
             register =
               (fun ~params:_ s on_disconnect ->
-                s#on_disconnect (fun () -> on_disconnect []));
+                s#register_on_disconnect (fun () -> on_disconnect []));
           };
           {
             Lang_source.name = "on_error";
@@ -736,7 +736,7 @@ let _ =
               ];
             register =
               (fun ~params:_ s on_error ->
-                s#on_error (fun ~restart_in ~bt exn ->
+                s#register_on_error (fun ~restart_in ~bt exn ->
                     let restart_in =
                       Lang.val_fun
                         [("", "", None)]

--- a/src/core/outputs/output.mli
+++ b/src/core/outputs/output.mli
@@ -48,7 +48,9 @@ object
   method effective_source : Source.source
   method output : unit
   method on_start : (unit -> unit) -> unit
+  method register_on_start : (unit -> unit) -> unit -> unit
   method on_stop : (unit -> unit) -> unit
+  method register_on_stop : (unit -> unit) -> unit -> unit
   method private video_dimensions : int * int
   method private reset : unit
   method virtual private send_frame : Frame.t -> unit

--- a/src/core/outputs/pipe_output.ml
+++ b/src/core/outputs/pipe_output.ml
@@ -172,15 +172,16 @@ class url_output p =
     method private encoder_factory = encoder_factory ~format format_val
     val mutable restart_time = 0.
     method can_connect = restart_time <= Unix.gettimeofday ()
-    val mutable on_error = []
-    method on_error fn = on_error <- on_error @ [fn]
+    val on_error = Callbacks.create ()
+    method register_on_error fn = Callbacks.register on_error fn
+    method on_error fn = Callbacks.add on_error fn
 
     method apply_on_error ~bt exn =
       (try ignore self#close_encoder with _ -> ());
       Utils.log_exception ~log:self#log
         ~bt:(Printexc.raw_backtrace_to_string bt)
         (Printf.sprintf "Error while connecting: %s" (Printexc.to_string exn));
-      List.iter (fun fn -> fn ~bt exn) on_error;
+      List.iter (fun fn -> fn ~bt exn) (Callbacks.elements on_error);
       match restart_delay with
         | None -> Printexc.raise_with_backtrace exn bt
         | Some delay ->
@@ -366,8 +367,9 @@ class virtual piped_output ?clock ~name p =
         (try base#send self#close_encoder with _ -> ());
         self#close_pipe)
 
-    val mutable on_reopen = []
-    method on_reopen fn = on_reopen <- on_reopen @ [fn]
+    val on_reopen = Callbacks.create ()
+    method register_on_reopen fn = Callbacks.register on_reopen fn
+    method on_reopen fn = Callbacks.add on_reopen fn
     method start = self#prepare_pipe
     method stop = self#cleanup_pipe
 
@@ -375,7 +377,7 @@ class virtual piped_output ?clock ~name p =
       self#log#important "Re-opening output pipe.";
       self#cleanup_pipe;
       self#prepare_pipe;
-      List.iter (fun fn -> fn ()) on_reopen
+      List.iter (fun fn -> fn ()) (Callbacks.elements on_reopen)
 
     method private reopen_on_error ~bt exn =
       open_date <- reopen_time_on_error ~log:self#log reopen_on_error ~bt exn

--- a/src/core/outputs/pipe_output.ml
+++ b/src/core/outputs/pipe_output.ml
@@ -142,7 +142,7 @@ let url_callbacks =
         arg_t = [(false, "", Lang.error_t)];
         register =
           (fun ~params:_ s f ->
-            s#on_error (fun ~bt exn ->
+            s#register_on_error (fun ~bt exn ->
                 let error =
                   Lang.runtime_error_of_exception ~bt ~kind:"output" exn
                 in
@@ -307,7 +307,7 @@ let pipe_callbacks =
         descr = "when the output is reopened.";
         register_deprecated_argument = true;
         arg_t = [];
-        register = (fun ~params:_ s f -> s#on_reopen (fun () -> f []));
+        register = (fun ~params:_ s f -> s#register_on_reopen (fun () -> f []));
       };
     ]
 

--- a/src/core/runtime/lang.mli
+++ b/src/core/runtime/lang.mli
@@ -127,7 +127,7 @@ type 'a callback = 'a Lang_source.callback = {
   descr : string;
   register_deprecated_argument : bool;
   arg_t : (bool * string * t) list;
-  register : params:(string * value) list -> 'a -> (env -> unit) -> unit;
+  register : params:(string * value) list -> 'a -> (env -> unit) -> unit -> unit;
 }
 
 val add_operator :

--- a/src/core/source/callbacks.ml
+++ b/src/core/source/callbacks.ml
@@ -20,13 +20,21 @@
 
  *****************************************************************************)
 
-(** Sources. *)
+module Queue = Queues.Queue
 
-module Callbacks = Callbacks
-module External_input = External_input
-module Lang_clock = Lang_clock
-module Lang_source = Lang_source
-module Source = Source
-module Source_tracks = Source_tracks
-module Start_stop = Start_stop
-module Track = Track
+(* [Queues.Queue] preserves order, locks internally and iterates over a
+   snapshot, so a callback can be released while the list is being iterated. *)
+type 'a t = { ids : int Atomic.t; entries : (int * 'a) Queue.t }
+
+let create () = { ids = Atomic.make 0; entries = Queue.create () }
+let elements { entries } = List.map snd (Queue.elements entries)
+let count { entries } = Queue.length entries
+
+let register t fn =
+  let id = Atomic.fetch_and_add t.ids 1 in
+  Queue.push t.entries (id, fn);
+  fun () -> Queue.filter_out t.entries (fun (id', _) -> id' = id)
+
+let add t fn =
+  let _release = register t fn in
+  ()

--- a/src/core/source/callbacks.mli
+++ b/src/core/source/callbacks.mli
@@ -20,13 +20,24 @@
 
  *****************************************************************************)
 
-(** Sources. *)
+(** An ordered list of callbacks that a callback can be removed from.
 
-module Callbacks = Callbacks
-module External_input = External_input
-module Lang_clock = Lang_clock
-module Lang_source = Lang_source
-module Source = Source
-module Source_tracks = Source_tracks
-module Start_stop = Start_stop
-module Track = Track
+    Callbacks a source holds live as long as it does, so anything registering on
+    a source that outlives it has to be able to take its callbacks back. *)
+
+type 'a t
+
+val create : unit -> 'a t
+
+(** Callbacks in registration order. Iteration is over a snapshot, so a callback
+    may be released while the list is being iterated. *)
+val elements : 'a t -> 'a list
+
+val count : 'a t -> int
+
+(** Register a callback and return the function releasing it. Calling that
+    function more than once is a no-op. *)
+val register : 'a t -> 'a -> unit -> unit
+
+(** Register a callback that its registrant will never release. *)
+val add : 'a t -> 'a -> unit

--- a/src/core/source/lang_source.ml
+++ b/src/core/source/lang_source.ml
@@ -124,8 +124,97 @@ type 'a callback = {
   descr : string;
   register_deprecated_argument : bool;
   arg_t : (bool * string * t) list;
-  register : params:(string * value) list -> 'a -> (env -> unit) -> unit;
+  register : params:(string * value) list -> 'a -> (env -> unit) -> unit -> unit;
 }
+
+(* Performed for every callback a script registers, carrying what releases it.
+   Registering is the only way a script can add a callback to a source, so an
+   operator handing sources to a script function can take back everything that
+   function registered on them, and nothing else: the engine's own wiring does
+   not go through here. *)
+type _ Effect.t +=
+  | Callback_registered : {
+      owner : int;
+      release : unit -> unit;
+    }
+      -> unit Effect.t
+
+type 'a collected = { release : unit -> unit; result : 'a }
+
+(* Sources are identified by [Oo.id]: callbacks are registered on outputs and
+   other objects too, and this is the one identity they all share. *)
+let collect_callback_releases sources fn =
+  let owners = List.map Oo.id sources in
+  let releases = ref [] in
+  let result =
+    Effect.Deep.try_with fn ()
+      {
+        Effect.Deep.effc =
+          (fun (type a) (eff : a Effect.t) ->
+            match eff with
+              | Callback_registered { owner; release }
+                when List.mem owner owners ->
+                  Some
+                    (fun (k : (a, _) Effect.Deep.continuation) ->
+                      releases := release :: !releases;
+                      Effect.Deep.continue k ())
+              | _ -> None);
+      }
+  in
+  let release () =
+    List.iter (fun release -> release ()) !releases;
+    releases := []
+  in
+  { release; result }
+
+(* Callbacks are registered from every thread that runs script code, and effects
+   do not cross thread boundaries. Rather than install a default handler at each
+   thread entry, where a missed one would raise at runtime, registration outside
+   any collector is simply not observed. *)
+let notify_callback_registered ~owner release =
+  try Effect.perform (Callback_registered { owner; release })
+  with Effect.Unhandled _ -> ()
+
+let max_script_callbacks = 5
+
+(* Script callbacks currently registered, per source and callback: naming the
+   callback that is piling up is what makes it findable. Counting the callback
+   lists themselves would not do: they also hold the engine's own wiring, of
+   which a handful is normal. What is not normal is a script piling them up,
+   which is what a function registering on a source it is given does every time
+   it runs. *)
+let script_callbacks : (int * string, int) Hashtbl.t = Hashtbl.create 10
+let script_callbacks_m = Mutex.create ()
+
+let count_script_callback ~log ~id ~name ~owner release =
+  let key = (owner, name) in
+  let count =
+    Mutex_utils.mutexify script_callbacks_m
+      (fun () ->
+        let count =
+          1 + Option.value ~default:0 (Hashtbl.find_opt script_callbacks key)
+        in
+        Hashtbl.replace script_callbacks key count;
+        count)
+      ()
+  in
+  if count = max_script_callbacks + 1 then
+    (log : Log.t)#important
+      "%d %s callbacks registered on %s. If you are registering from a \
+       function that runs more than once, keep the value it returns and call \
+       its release() method."
+      count name id;
+  let released = Atomic.make false in
+  fun () ->
+    if Atomic.compare_and_set released false true then (
+      Mutex_utils.mutexify script_callbacks_m
+        (fun () ->
+          match Hashtbl.find_opt script_callbacks key with
+            | Some count when count <= 1 -> Hashtbl.remove script_callbacks key
+            | Some count -> Hashtbl.replace script_callbacks key (count - 1)
+            | None -> ())
+        ();
+      release ())
 
 let callback { name; params; descr; arg_t; register } : _ Lang.meth =
   {
@@ -140,7 +229,13 @@ let callback { name; params; descr; arg_t; register } : _ Lang.meth =
               (false, "synchronous", Lang.bool_t);
               (false, "", fun_t arg_t unit_t);
             ])
-          unit_t );
+          (method_t unit_t
+             [
+               ( "release",
+                 ([], fun_t [] unit_t),
+                 "Release the callback. Calling it more than once is a no-op."
+               );
+             ]) );
     descr = Printf.sprintf "Call a given handler %s" descr;
     value =
       (fun s ->
@@ -168,8 +263,19 @@ let callback { name; params; descr; arg_t; register } : _ Lang.meth =
             in
             (s#log : Log.t)#debug "Registering %s %s callback" name
               (if synchronous then "synchronous" else "asynchronous");
-            register ~params:p s fn;
-            unit));
+            let owner = Oo.id s in
+            let release =
+              count_script_callback ~log:s#log ~id:s#id ~name ~owner
+                (register ~params:p s fn)
+            in
+            notify_callback_registered ~owner release;
+            meth unit
+              [
+                ( "release",
+                  val_fun [] (fun _ ->
+                      release ();
+                      unit) );
+              ]));
   }
 
 let source_callbacks =
@@ -183,7 +289,7 @@ let source_callbacks =
       register =
         (fun ~params:_ s f ->
           let f m = f [("", metadata m)] in
-          s#on_frame (`Metadata f));
+          s#register_on_frame (`Metadata f));
     };
     {
       name = "on_wake_up";
@@ -191,7 +297,7 @@ let source_callbacks =
       params = [];
       register_deprecated_argument = false;
       arg_t = [];
-      register = (fun ~params:_ s f -> s#on_wake_up (fun () -> f []));
+      register = (fun ~params:_ s f -> s#register_on_wake_up (fun () -> f []));
     };
     {
       name = "on_shutdown";
@@ -199,7 +305,7 @@ let source_callbacks =
       descr = "to be called when source shuts down";
       register_deprecated_argument = false;
       arg_t = [];
-      register = (fun ~params:_ s f -> s#on_sleep (fun () -> f []));
+      register = (fun ~params:_ s f -> s#register_on_sleep (fun () -> f []));
     };
     {
       name = "on_collect";
@@ -207,7 +313,7 @@ let source_callbacks =
       descr = "to be called when source is collected";
       register_deprecated_argument = false;
       arg_t = [];
-      register = (fun ~params:_ s f -> s#on_collect (fun () -> f []));
+      register = (fun ~params:_ s f -> s#register_on_collect (fun () -> f []));
     };
     {
       name = "on_track";
@@ -218,7 +324,7 @@ let source_callbacks =
       register =
         (fun ~params:_ s f ->
           let f m = f [("", metadata m)] in
-          s#on_frame (`Track f));
+          s#register_on_frame (`Track f));
     };
     {
       name = "on_frame";
@@ -235,8 +341,8 @@ let source_callbacks =
         (fun ~params:p s on_frame ->
           let on_frame _ = on_frame [] in
           let before = Lang.to_bool (List.assoc "before" p) in
-          if before then s#on_frame (`Before_frame on_frame)
-          else s#on_frame (`After_frame (fun _ -> on_frame ())));
+          if before then s#register_on_frame (`Before_frame on_frame)
+          else s#register_on_frame (`After_frame (fun _ -> on_frame ())));
     };
     {
       name = "on_frame_checksum";
@@ -262,28 +368,35 @@ let source_callbacks =
       register =
         (fun ~params:p s after_cb ->
           let before_cb = Lang.to_option (List.assoc "before" p) in
-          Option.iter
-            (fun cb ->
-              s#on_frame
-                (`Before_frame
-                   (fun cache ->
-                     let checksum =
-                       match cache with
-                         | Some frame -> Lang.string (Frame.checksum frame)
-                         | None -> Lang.null
-                     in
-                     ignore (apply cb [("", checksum)]))))
-            before_cb;
-          s#on_frame
-            (`After_frame
-               (fun { Source.frame; cache } ->
-                 let frame_checksum = Lang.string (Frame.checksum frame) in
-                 let cache_checksum =
-                   match cache with
-                     | Some c -> Lang.string (Frame.checksum c)
-                     | None -> Lang.null
-                 in
-                 after_cb [("cache", cache_checksum); ("", frame_checksum)])));
+          let release_before =
+            Option.map
+              (fun cb ->
+                s#register_on_frame
+                  (`Before_frame
+                     (fun cache ->
+                       let checksum =
+                         match cache with
+                           | Some frame -> Lang.string (Frame.checksum frame)
+                           | None -> Lang.null
+                       in
+                       ignore (apply cb [("", checksum)]))))
+              before_cb
+          in
+          let release_after =
+            s#register_on_frame
+              (`After_frame
+                 (fun { Source.frame; cache } ->
+                   let frame_checksum = Lang.string (Frame.checksum frame) in
+                   let cache_checksum =
+                     match cache with
+                       | Some c -> Lang.string (Frame.checksum c)
+                       | None -> Lang.null
+                   in
+                   after_cb [("cache", cache_checksum); ("", frame_checksum)]))
+          in
+          fun () ->
+            Option.iter (fun release -> release ()) release_before;
+            release_after ());
     };
     {
       name = "on_position";
@@ -322,7 +435,7 @@ let source_callbacks =
           let mode = if remaining then `Remaining else `Elapsed in
           let position = Lang.to_float_getter (List.assoc "position" p) in
           let position () = Frame.main_of_seconds (position ()) in
-          s#on_frame
+          s#register_on_frame
             (`Position
                {
                  Source.allow_partial;

--- a/src/core/source/liquidsoap_core_source.ml
+++ b/src/core/source/liquidsoap_core_source.ml
@@ -22,6 +22,7 @@
 
 (* See liquidsoap_core_source.mli. *)
 
+module Callbacks = Callbacks
 module External_input = External_input
 module Lang_clock = Lang_clock
 module Lang_source = Lang_source

--- a/src/core/source/source.ml
+++ b/src/core/source/source.ml
@@ -102,14 +102,14 @@ let check_sleep ~activations ~s =
 
 let on_finalize ~on_collect id =
  fun () ->
-  List.iter (fun fn -> fn ()) !on_collect;
+  List.iter (fun fn -> fn ()) (Callbacks.elements on_collect);
   source_log#info "Source %s is collected." !id
 
 class virtual operator ?(stack = []) ?clock ~name sources =
   let frame_type = Type.var () in
   let clock = match clock with Some c -> c | None -> Clock.create ~stack () in
   let id = ref (Lang_string.generate_id ~category:"source" name) in
-  let on_collect = ref [] in
+  let on_collect = Callbacks.create () in
   object (self)
     (** Monitoring *)
     val mutable watchers = []
@@ -249,23 +249,19 @@ class virtual operator ?(stack = []) ?clock ~name sources =
     method source_state = source_state
 
     val state_callbacks
-        : (int
-          * (old:Clock.sync_source option -> Clock.sync_source option -> unit))
-          Queue.t =
-      Queue.create ()
+        : (old:Clock.sync_source option -> Clock.sync_source option -> unit)
+          Callbacks.t =
+      Callbacks.create ()
 
-    val callback_id_counter = Atomic.make 0
-
-    method on_sync_source_change fn =
-      let id = Atomic.fetch_and_add callback_id_counter 1 in
-      Queue.push state_callbacks (id, fn);
-      fun () -> Queue.filter_out state_callbacks (fun (i, _) -> i = id)
+    method on_sync_source_change fn = Callbacks.register state_callbacks fn
 
     method private notify_sync_source new_state =
       if sync_source_changed new_state source_state then (
         let old = source_state in
         source_state <- new_state;
-        Queue.iter state_callbacks (fun (_, fn) -> fn ~old new_state))
+        List.iter
+          (fun fn -> fn ~old new_state)
+          (Callbacks.elements state_callbacks))
 
     method private on_child_state_change ~child:_ ~old:_ _ =
       self#notify_sync_source (snd self#self_sync)
@@ -354,8 +350,9 @@ class virtual operator ?(stack = []) ?clock ~name sources =
             dim
         | Some dim -> dim
 
-    val mutable on_wake_up = []
-    method on_wake_up fn = on_wake_up <- on_wake_up @ [fn]
+    val on_wake_up : (unit -> unit) Callbacks.t = Callbacks.create ()
+    method register_on_wake_up fn = Callbacks.register on_wake_up fn
+    method on_wake_up fn = Callbacks.add on_wake_up fn
     val mutable on_activation = []
     method on_activation fn = on_activation <- on_activation @ [fn]
 
@@ -400,7 +397,7 @@ class virtual operator ?(stack = []) ?clock ~name sources =
           self#log#debug "Clock is %s." (Clock.id self#clock);
           self#log#important "Content type is %s."
             (Frame.string_of_content_type self#content_type);
-          List.iter (fun fn -> fn ()) on_wake_up
+          List.iter (fun fn -> fn ()) (Callbacks.elements on_wake_up)
         with exn ->
           Atomic.set is_up `Error;
           let bt = Printexc.get_raw_backtrace () in
@@ -412,8 +409,9 @@ class virtual operator ?(stack = []) ?clock ~name sources =
       List.iter (fun fn -> fn ()) on_activation;
       activation
 
-    val mutable on_sleep = []
-    method on_sleep fn = on_sleep <- on_sleep @ [fn]
+    val on_sleep : (unit -> unit) Callbacks.t = Callbacks.create ()
+    method register_on_sleep fn = Callbacks.register on_sleep fn
+    method on_sleep fn = Callbacks.add on_sleep fn
 
     method private actual_sleep =
       if Atomic.compare_and_set is_up `True `False then (
@@ -434,7 +432,7 @@ class virtual operator ?(stack = []) ?clock ~name sources =
                 ~bt:(Printexc.raw_backtrace_to_string bt)
                 (Printf.sprintf "Error while shutting down source %s: %s!"
                    self#id (Printexc.to_string exn)))
-          on_sleep)
+          (Callbacks.elements on_sleep))
 
     method sleep (src : Clock.activation) =
       if not (WeakQueue.exists activations (fun a -> a == src)) then (
@@ -458,7 +456,8 @@ class virtual operator ?(stack = []) ?clock ~name sources =
         | 0, _, _ -> self#actual_sleep
         | _ -> ()
 
-    method on_collect fn = on_collect := fn :: !on_collect
+    method register_on_collect fn = Callbacks.register on_collect fn
+    method on_collect fn = Callbacks.add on_collect fn
 
     initializer
       Gc.finalise_last (on_finalize ~on_collect id) self;
@@ -667,8 +666,9 @@ class virtual operator ?(stack = []) ?clock ~name sources =
     method end_of_track = Frame.add_track_mark self#empty_frame 0
     val mutable last_metadata = None
     method last_metadata = last_metadata
-    val mutable on_frame : on_frame list = []
-    method on_frame fn = on_frame <- on_frame @ [fn]
+    val on_frame : on_frame Callbacks.t = Callbacks.create ()
+    method register_on_frame fn = Callbacks.register on_frame fn
+    method on_frame fn = Callbacks.add on_frame fn
     val mutable reset_last_metadata_on_track = Atomic.make true
 
     method reset_last_metadata_on_track =
@@ -698,7 +698,9 @@ class virtual operator ?(stack = []) ?clock ~name sources =
           Option.value ~default:(0, Frame.Metadata.empty) last_metadata
         in
         self#log#debug "calling on_track handlers..";
-        List.iter (function `Track fn -> fn m | _ -> ()) on_frame)
+        List.iter
+          (function `Track fn -> fn m | _ -> ())
+          (Callbacks.elements on_frame))
 
     val mutable last_images = Hashtbl.create 0
 
@@ -792,11 +794,11 @@ class virtual operator ?(stack = []) ?clock ~name sources =
               p.executed <- true;
               p.on_position ~pos:(position p) m
           | _ -> ())
-        on_frame
+        (Callbacks.elements on_frame)
 
     method private instrumented_generate_frame =
       let start_time = Unix.gettimeofday () in
-      let on_frame = self#atomic_lock (fun () -> on_frame) () in
+      let on_frame = Callbacks.elements on_frame in
       List.iter (function `Before_frame fn -> fn _cache | _ -> ()) on_frame;
       let buf = self#normalize_video_content self#generate_frame in
       List.iter

--- a/src/core/source/source.mli
+++ b/src/core/source/source.mli
@@ -152,6 +152,11 @@ object
   (** Register a callback to be executed when the source is collected. *)
   method on_collect : (unit -> unit) -> unit
 
+  (** Same, returning the function that releases the callback. Registrations
+      that outlive their registrant have to be released, otherwise they pile up
+      on the source for as long as it lives. *)
+  method register_on_collect : (unit -> unit) -> unit -> unit
+
   (** The clock under which the source will run. *)
   method clock : Clock.t
 
@@ -184,6 +189,9 @@ object
   (** Register a callback when wake_up is called. *)
   method on_wake_up : (unit -> unit) -> unit
 
+  (** Same, returning the function that releases the callback. *)
+  method register_on_wake_up : (unit -> unit) -> unit -> unit
+
   (** Register a callback called on every activation, i.e. each time [wake_up]
       is called, not just the first one. *)
   method on_activation : (unit -> unit) -> unit
@@ -196,6 +204,9 @@ object
 
   (** Register a callback when sleep is called. *)
   method on_sleep : (unit -> unit) -> unit
+
+  (** Same, returning the function that releases the callback. *)
+  method register_on_sleep : (unit -> unit) -> unit -> unit
 
   (** Called when the source can release all its resources. Can be called
       concurrently and multiple times. *)
@@ -284,6 +295,9 @@ object
 
   (** Register a callback to be called when computing frames. *)
   method on_frame : on_frame -> unit
+
+  (** Same, returning the function that releases the callback. *)
+  method register_on_frame : on_frame -> unit -> unit
 
   (** These two are used by [generate_from_multiple_sources] and should not be
       used otherwise. *)

--- a/src/core/source/start_stop.ml
+++ b/src/core/source/start_stop.ml
@@ -41,10 +41,12 @@ class virtual base =
     method virtual private start : unit
     method virtual private stop : unit
     method virtual on_before_streaming_cycle : (unit -> unit) -> unit
-    val mutable on_start = []
-    val mutable on_stop = []
-    method on_start fn = on_start <- on_start @ [fn]
-    method on_stop fn = on_stop <- on_stop @ [fn]
+    val on_start = Callbacks.create ()
+    val on_stop = Callbacks.create ()
+    method register_on_start fn = Callbacks.register on_start fn
+    method on_start fn = Callbacks.add on_start fn
+    method register_on_stop fn = Callbacks.register on_stop fn
+    method on_stop fn = Callbacks.add on_stop fn
 
     (* Default [reset] method. Can be overridden if necessary. *)
     method reset =
@@ -60,18 +62,18 @@ class virtual base =
       match (s, self#state) with
         | `Started, `Stopped | `Started, `Idle ->
             self#start;
-            List.iter (fun fn -> fn ()) on_start;
+            List.iter (fun fn -> fn ()) (Callbacks.elements on_start);
             state <- `Started
         | `Started, `Started -> ()
         | `Stopped, `Started ->
             self#stop;
-            List.iter (fun fn -> fn ()) on_stop;
+            List.iter (fun fn -> fn ()) (Callbacks.elements on_stop);
             state <- `Stopped
         | `Stopped, `Idle -> state <- `Stopped
         | `Stopped, `Stopped -> ()
         | `Idle, `Started ->
             self#stop;
-            List.iter (fun fn -> fn ()) on_stop;
+            List.iter (fun fn -> fn ()) (Callbacks.elements on_stop);
             state <- `Idle
         | `Idle, `Stopped | `Idle, `Idle -> ()
 

--- a/src/core/source/start_stop.ml
+++ b/src/core/source/start_stop.ml
@@ -132,7 +132,7 @@ let callbacks ~label =
         descr = "when " ^ label ^ " starts";
         register_deprecated_argument = true;
         arg_t = [];
-        register = (fun ~params:_ s f -> s#on_start (fun () -> f []));
+        register = (fun ~params:_ s f -> s#register_on_start (fun () -> f []));
       };
       {
         name = "on_stop";
@@ -140,7 +140,7 @@ let callbacks ~label =
         descr = "when " ^ label ^ " stops";
         register_deprecated_argument = true;
         arg_t = [];
-        register = (fun ~params:_ s f -> s#on_stop (fun () -> f []));
+        register = (fun ~params:_ s f -> s#register_on_stop (fun () -> f []));
       };
     ]
 

--- a/src/core/sources/harbor_input.ml
+++ b/src/core/sources/harbor_input.ml
@@ -553,7 +553,7 @@ let callbacks () =
       register =
         (fun ~params:_ s on_connect ->
           let on_connect m = on_connect [("", Lang.metadata_list m)] in
-          s#on_connect on_connect);
+          s#register_on_connect on_connect);
     };
     {
       name = "on_disconnect";
@@ -561,7 +561,8 @@ let callbacks () =
       descr = "when a source is disconnected.";
       register_deprecated_argument = true;
       arg_t = [];
-      register = (fun ~params:_ s f -> s#on_disconnect (fun () -> f []));
+      register =
+        (fun ~params:_ s f -> s#register_on_disconnect (fun () -> f []));
     };
   ]
 

--- a/src/core/sources/harbor_input.ml
+++ b/src/core/sources/harbor_input.ml
@@ -64,7 +64,9 @@ class virtual http_input_base ~dumpfile ~logfile ~bufferize ~max ~replay_meta
     val mime_type : string option Atomic.t = Atomic.make None
     val mutable dump = None
     val mutable logf = None
-    val mutable on_connect : ((string * string) list -> unit) list = []
+
+    val on_connect : ((string * string) list -> unit) Callbacks.t =
+      Callbacks.create ()
 
     initializer
       self#on_wake_up (fun () ->
@@ -72,9 +74,11 @@ class virtual http_input_base ~dumpfile ~logfile ~bufferize ~max ~replay_meta
             (Some (Frame.main_of_seconds max)));
       self#on_sleep (fun () -> self#disconnect)
 
-    method on_connect fn = on_connect <- on_connect @ [fn]
-    val mutable on_disconnect = []
-    method on_disconnect fn = on_disconnect <- on_disconnect @ [fn]
+    method register_on_connect fn = Callbacks.register on_connect fn
+    method on_connect fn = Callbacks.add on_connect fn
+    val on_disconnect = Callbacks.create ()
+    method register_on_disconnect fn = Callbacks.register on_disconnect fn
+    method on_disconnect fn = Callbacks.add on_disconnect fn
     val mutable on_relay : (unit -> unit) option = None
     method on_relay fn = on_relay <- Some fn
 
@@ -183,7 +187,7 @@ class virtual http_input_base ~dumpfile ~logfile ~bufferize ~max ~replay_meta
       self#register_decoder (Option.get (Atomic.get mime_type));
       Option.iter (Generator.add_metadata self#buffer) pending_metadata;
       pending_metadata <- None;
-      List.iter (fun fn -> fn pending_headers) on_connect;
+      List.iter (fun fn -> fn pending_headers) (Callbacks.elements on_connect);
       begin match dumpfile with
         | Some f -> (
             try dump <- Some (open_out_bin (Lang_string.home_unrelate f))
@@ -242,7 +246,7 @@ class virtual http_input_base ~dumpfile ~logfile ~bufferize ~max ~replay_meta
                   close_out f;
                   logf <- None
               | None -> ());
-            List.iter (fun fn -> fn ()) on_disconnect
+            List.iter (fun fn -> fn ()) (Callbacks.elements on_disconnect)
   end
 
 class http_input_server ~pos ~transport ~dumpfile ~logfile ~bufferize ~max ~icy

--- a/tests/regression/callback_release.liq
+++ b/tests/regression/callback_release.liq
@@ -1,0 +1,98 @@
+log.level.set(4)
+
+# Callbacks a script registers do not pile up on the sources they are
+# registered on.
+#
+# `release()` takes a callback back, and an operator handing sources to a
+# script function takes back what that function registered on them: `on_select`
+# runs on every selection and registers on `base`, which is a child of the
+# switch and outlives all of them. If those registrations were kept, one frame
+# of `base` would fire the callback once per past selection instead of once.
+
+released_hits = ref(0)
+released = sine(id="released")
+c =
+  released.on_frame(
+    synchronous=true,
+    before=false,
+    fun () -> ref.incr(released_hits)
+  )
+c.release()
+c.release()
+
+base = sine(id="base")
+other = sine(id="other")
+
+# Registered once, never released: tells us how many frames `base` produced.
+base_frames = ref(0)
+base.on_frame(synchronous=true, before=false, fun () -> ref.incr(base_frames))
+
+hits = ref(0)
+selections = ref(0)
+
+def on_select(
+  ({starting}:{starting: source, ending: source?, replay_metadata: bool})
+) =
+  ref.incr(selections)
+  base.on_frame(synchronous=true, before=false, fun () -> ref.incr(hits))
+  starting
+end
+
+use_other = ref(false)
+
+s =
+  switch(
+    [
+      ({use_other()}, other.{track_sensitive = false}),
+      ({true}, base.{track_sensitive = false, on_select = on_select})
+    ]
+  )
+
+frames = ref(0)
+
+s.on_frame(
+  synchronous=true,
+  before=false,
+  fun () ->
+    begin
+      ref.incr(frames)
+
+      # Flip every 10 frames, so `base` is selected again and again.
+      if frames() mod 10 == 0 then use_other := not use_other() end
+
+      if
+        selections() >= 5 and frames() > 100
+      then
+        if
+          released_hits() > 0
+        then
+          log.important(
+            "released callback still fired!"
+          )
+          test.fail()
+        elsif
+          hits() == 0 or base_frames() == 0
+        then
+          log.important(
+            "callbacks never fired, test proves nothing"
+          )
+          test.fail()
+        elsif
+          # One live registration per frame of `base`, whatever the number of
+          # selections. Leaked ones would multiply this by `selections()`.
+          hits() > base_frames()
+        then
+          log.important(
+            "#{hits()} hits for #{base_frames()} frames after #{selections()} \
+             selections: callbacks piled up"
+          )
+          test.fail()
+        else
+          test.pass()
+        end
+      end
+    end
+)
+
+clock.assign_new(sync="none", [s])
+output.dummy(fallible=true, s)

--- a/tests/regression/callback_release.liq
+++ b/tests/regression/callback_release.liq
@@ -20,6 +20,36 @@ c =
 c.release()
 c.release()
 
+# Same, through the collector a script can use around its own functions. It
+# takes several sources, and hands back what the function returned.
+collected_hits = ref(0)
+collected = sine(id="collected")
+collected_too = sine(id="collected_too")
+
+def register_on_collected() =
+  collected.on_frame(
+    synchronous=true,
+    before=false,
+    fun () -> ref.incr(collected_hits)
+  )
+  collected_too.on_frame(
+    synchronous=true,
+    before=false,
+    fun () -> ref.incr(collected_hits)
+  )
+  "returned"
+end
+
+for _ = 1 to 3 do
+  let {release, result} =
+    source.collect_callback_releases(
+      [collected, collected_too],
+      register_on_collected
+    )
+  if result != "returned" then test.fail() end
+  release()
+end
+
 base = sine(id="base")
 other = sine(id="other")
 
@@ -64,7 +94,7 @@ s.on_frame(
         selections() >= 5 and frames() > 100
       then
         if
-          released_hits() > 0
+          released_hits() > 0 or collected_hits() > 0
         then
           log.important(
             "released callback still fired!"

--- a/tests/regression/callback_release.liq
+++ b/tests/regression/callback_release.liq
@@ -48,6 +48,7 @@ for _ = 1 to 3 do
     )
   if result != "returned" then test.fail() end
   release()
+
 end
 
 base = sine(id="base")

--- a/tests/regression/callback_release_mixed_content.liq
+++ b/tests/regression/callback_release_mixed_content.liq
@@ -32,6 +32,7 @@ for _ = 1 to 3 do
         end
     )
   release()
+
 end
 
 def check() =
@@ -45,8 +46,7 @@ def check() =
 
   if
     not list.assoc.mem("audio", audio_content)
-  or
-    not list.assoc.mem("video", video_content)
+    or not list.assoc.mem("video", video_content)
   then
     test.fail()
   elsif

--- a/tests/regression/callback_release_mixed_content.liq
+++ b/tests/regression/callback_release_mixed_content.liq
@@ -1,0 +1,67 @@
+log.level.set(4)
+
+# `source.collect_callback_releases` takes sources of unknown content, so
+# sources streaming different content can be watched together without their
+# content types being unified into one.
+
+audio_source = source.methods((sine(id="audio") : source(audio=pcm)))
+video_source =
+  source.methods((video.testsrc(id="video") : source(video=yuv420p)))
+
+audio_hits = ref(0)
+video_hits = ref(0)
+
+# Registering on both, over and over, the way a function called on every
+# selection would.
+for _ = 1 to 3 do
+  let {release} =
+    source.collect_callback_releases(
+      [(audio_source : source(_)), (video_source : source(_))],
+      fun () ->
+        begin
+          audio_source.on_frame(
+            synchronous=true,
+            before=false,
+            fun () -> ref.incr(audio_hits)
+          )
+          video_source.on_frame(
+            synchronous=true,
+            before=false,
+            fun () -> ref.incr(video_hits)
+          )
+        end
+    )
+  release()
+end
+
+def check() =
+  audio_content = source.content(audio_source)
+  video_content = source.content(video_source)
+  log.important(
+    "audio: #{audio_content} #{audio_hits()} hits, video: #{video_content} #{
+      video_hits()
+    } hits"
+  )
+
+  if
+    not list.assoc.mem("audio", audio_content)
+  or
+    not list.assoc.mem("video", video_content)
+  then
+    test.fail()
+  elsif
+    audio_hits() > 0 or video_hits() > 0
+  then
+    test.fail()
+  else
+    test.pass()
+  end
+end
+
+output.dummy(fallible=true, audio_source)
+output.dummy(fallible=true, video_source)
+
+clock.assign_new(sync="none", [audio_source])
+clock.assign_new(sync="none", [video_source])
+
+thread.run(delay=1., check)

--- a/tests/regression/dune.inc
+++ b/tests/regression/dune.inc
@@ -1504,6 +1504,29 @@
   (run %{run_test} append liquidsoap %{test_liq} append.liq)))
 
 (rule
+ (alias test_callback_release)
+ (package liquidsoap)
+ (deps
+  callback_release.liq
+  (glob_files ../media/**)
+  ../liquidsoap-test-assets
+  ../../src/bin/liquidsoap.exe
+  ../streams/file1.png
+  ../streams/file1.mp3
+  ./theora-test.mp4
+  (package liquidsoap)
+  (source_tree ../../src/libs)
+  (:test_liq ../test.liq)
+  (:run_test ../run_test.exe))
+ (action
+  (run
+   %{run_test}
+   callback_release
+   liquidsoap
+   %{test_liq}
+   callback_release.liq)))
+
+(rule
  (alias test_cleanup)
  (package liquidsoap)
  (deps
@@ -2494,6 +2517,7 @@
   (alias test_append)
   (alias test_append-merge)
   (alias test_append-merge2)
+  (alias test_callback_release)
   (alias test_cleanup)
   (alias test_default_format)
   (alias test_delay_dry_between_tracks)

--- a/tests/regression/dune.inc
+++ b/tests/regression/dune.inc
@@ -1527,6 +1527,29 @@
    callback_release.liq)))
 
 (rule
+ (alias test_callback_release_mixed_content)
+ (package liquidsoap)
+ (deps
+  callback_release_mixed_content.liq
+  (glob_files ../media/**)
+  ../liquidsoap-test-assets
+  ../../src/bin/liquidsoap.exe
+  ../streams/file1.png
+  ../streams/file1.mp3
+  ./theora-test.mp4
+  (package liquidsoap)
+  (source_tree ../../src/libs)
+  (:test_liq ../test.liq)
+  (:run_test ../run_test.exe))
+ (action
+  (run
+   %{run_test}
+   callback_release_mixed_content
+   liquidsoap
+   %{test_liq}
+   callback_release_mixed_content.liq)))
+
+(rule
  (alias test_cleanup)
  (package liquidsoap)
  (deps
@@ -2518,6 +2541,7 @@
   (alias test_append-merge)
   (alias test_append-merge2)
   (alias test_callback_release)
+  (alias test_callback_release_mixed_content)
   (alias test_cleanup)
   (alias test_default_format)
   (alias test_delay_dry_between_tracks)


### PR DESCRIPTION
A callback registered on a source lives as long as that source, so a function that registers on a source it is given and runs more than once piles callbacks up on it for good: a switch transition building `fade.in`/`fade.out` on the sources it is handed grows the heap by ~240 live blocks per switch, which shows up as a CPU climb rather than a memory alarm, since major GC marking cost scales with live block count.

This is a scripting problem rather than a `fades.liq` one — any user function registering on a source it is passed leaks the same way — so it is answered at three levels: registering hands back a `release`, the engine says something when callbacks pile up, and operators handing sources to a script function take back what that function registered on them.

## Registering returns a release

```liquidsoap
c = s.on_metadata(synchronous=true, fn)
c.release()
```

The value is `unit` with a `release` method, so existing code is unaffected — `can_ignore` strips methods before checking for unit, and a callback registered and forgotten still typechecks in statement position.

This is honest everywhere rather than for `on_frame` alone: every hand-rolled `x <- x @ [fn]` callback list became a `Callbacks.t` (`src/core/source/callbacks.{ml,mli}`) that registers in order and returns what removes the callback — `on_blank`, `on_start`/`on_stop`, `on_connect`/`on_disconnect`, `on_error`, `on_socket`, `on_file_change`, `on_reopen`. So no callback advertises a release that only stops it firing while keeping the closure alive.

Each list keeps its register-and-forget method, which is what the engine's own wiring uses at 107 call sites, and gains a `register_on_*` returning the release, which is what script callbacks use.

## Callbacks piling up are reported

```
[playlist_A:3] 6 on_metadata callbacks registered on playlist_A. If you are
registering from a function that runs more than once, keep the value it returns
and call its release() method.
```

Counted per source *and* callback, so the message names what is piling up: six `on_metadata` warns, three `on_metadata` alongside three `on_track` does not.

Only script callbacks are counted. Counting the lists themselves would warn on every source: `source.ml`'s own initializers register several `on_wake_up` and `on_sleep` callbacks, and a handful is normal. A register/release loop never warns, since releasing decrements the count.

## Operators collect what they hand out

```liquidsoap
let {release, result} = source.collect_callback_releases(sources, fn)
```

Runs `fn`, gathering the callbacks it registered on any of `sources` into a single `release`. Registration performs an effect carrying the release, and `collect_callback_releases` handles it for the sources it was given, re-performing the rest.

The effect is raised in `Lang_source.callback`, the one boundary every script callback goes through, and only there. Raising it in the shared registration code would also fire for the engine's own wiring — sources register on themselves and on their children — and a collector would then be free to release internal machinery. Raising it at the boundary makes "only script callbacks are collectable" true by construction.

`switch` uses it around `on_select`, releasing when the selection ends, and `cross` around its transition, releasing when the crossing ends. Both watch the sources they hand out **and their own children**, which is what a transition captures. `source.dynamic` is deliberately left out: `next` takes no source arguments, so it has nothing to watch.

The first argument is `[source(_)]`, so sources streaming different content can be watched together.

## Why OCaml 5

Effect handlers scope the collection to a function call without an ambient, thread-local scope, which is what the first attempt used and what made it hard to reason about. The OCaml 5.4 requirement is the previous PR in the stack.

Script code runs in many threads — clock threads, Duppy task threads — and effects do not cross thread boundaries, so rather than install a default no-op handler at each thread entry, where one missed entry would raise at runtime, the perform swallows `Effect.Unhandled`: registration outside any collector is simply not observed.

## Tests

`tests/regression/callback_release.liq` counts firings rather than memory: a leaked registration makes one frame of the source fire the callback once per past selection. Without the release it reports `306 hits for 101 frames after 6 selections`. It also checks that a released callback stops firing, that releasing twice is a no-op, and that the callbacks still fire at all, so it cannot pass by dropping everything.

`tests/regression/callback_release_mixed_content.liq` registers on an audio and a video source through one collector call and checks both keep their own content type.

Measured on the reproduction — two dynamic request sources, each wrapped in `cross`, under a `switch` flipping every 250 frames, live blocks after `full_major`:

| arm | before | after |
| --- | --- | --- |
| transition on the sources `on_select` is handed | flat | flat |
| transition on the long-lived children | **+240 blocks/switch** | flat |

Also run: `cross`, `cross-override`, `cross-persist-override`, `cross-sequence-transition`, `crossfade`, `crossfade2`, `fades-overrides`, `fades-persistent-override`, `GH3239`, `GH3239-2`, `GH3239-bis`, `AC5109`, `source_dynamic`, `rotate` and the `switch_*` regressions.
