### PR TITLE
switch: do not treat animated-but-not-pulled cycles as resuming

### DIFF
--- a/src/core/operators/switch.ml
+++ b/src/core/operators/switch.ml
@@ -171,17 +171,20 @@ class switch ~all_predicates children =
     (* We cannot reselect the same source twice during a streaming cycle. *)
     val mutable excluded_sources = []
 
-    (* A selection only holds while we are being streamed: when we resume after
+    (* A selection only holds while we are being animated: when we resume after
        going quiet it has to be re-evaluated, and nothing is playing for a new
-       one to interrupt. *)
-    val mutable last_streamed_tick = -1
+       one to interrupt. A parent that is not playing us does not animate us at
+       all, which is what we detect here. Being animated without being pulled is
+       not quiet: a passive clock is ticked by its parent on cycles where its
+       consumer asks for no data. *)
+    val mutable last_animated_tick = -1
     val mutable resuming = false
 
     initializer
-      self#on_frame
-        (`After_frame (fun _ -> last_streamed_tick <- Clock.ticks self#clock));
       self#on_before_streaming_cycle (fun () ->
-          resuming <- 1 < Clock.ticks self#clock - last_streamed_tick;
+          let tick = Clock.ticks self#clock in
+          resuming <- 1 < tick - last_animated_tick;
+          last_animated_tick <- tick;
           excluded_sources <- [];
           Atomic.set track_sensitive (List.for_all is_track_sensitive children));
       self#on_after_streaming_cycle (fun () ->

--- a/tests/regression/GH5348.liq
+++ b/tests/regression/GH5348.liq
@@ -1,0 +1,89 @@
+# A switch inside a passive child clock used to re-evaluate its selection on
+# every frame: such a clock is ticked by its parent even on cycles where its
+# consumer pulls nothing, which the switch mistook for resuming after having
+# gone quiet. Track sensitivity was lost, so `rotate` weights were ignored and
+# each jingle was cut after a couple of frames.
+#
+# `stretch(ratio=2.)` gives us such a clock: it slows the stream down, so it
+# only pulls its child on every other cycle. Track durations are stretched
+# along with it, hence the doubled expectations below.
+
+def tagged(~every, ~title, s) =
+  chop(every=every, metadata={[("title", title)]}, s)
+end
+
+jingles = tagged(every=1., title="jingle", sine(660.))
+music = tagged(every=2., title="music", sine(440.))
+
+radio = rotate(id="rotate", [jingles, music.{weight = 2}])
+
+# Track starts, as (title, time), oldest first.
+marks = ref([])
+
+def check(m) =
+  marks := [...marks(), (m["title"], source.time(radio))]
+
+  if
+    list.length(marks()) == 8
+  then
+    failed = ref(false)
+
+    def fail(msg) =
+      print(msg)
+      failed := true
+    end
+
+    # The last mark only gives us the end of the track before it, so we check
+    # the six tracks that both start and end within what we collected.
+    tracks =
+      list.map(
+        fun (i) ->
+          begin
+            let (title, start) = list.nth(marks(), i)
+            let (_, stop) = list.nth(marks(), i + 1)
+            (title, stop - start)
+          end,
+        [1, 2, 3, 4, 5, 6]
+      )
+
+    print(
+      "played: #{tracks}"
+    )
+
+    # Six consecutive tracks cover two full rotations, whichever one we start
+    # on: one jingle for every two music tracks.
+    if
+      list.length(list.filter(fun ((title, _)) -> title == "jingle", tracks)) !=
+        2
+    then
+      fail(
+        "expected 2 jingles out of 6 tracks"
+      )
+    end
+
+    list.iter(
+      fun ((title, duration)) ->
+        begin
+          expected = title == "jingle" ? 2. : 4.
+          if
+            abs(duration - expected) > 0.1
+          then
+            fail(
+              "#{title} track lasted #{duration}s, expected #{expected}s"
+            )
+          end
+        end,
+      tracks
+    )
+
+    if failed() then test.fail() else test.pass() end
+  end
+end
+
+radio.on_metadata(synchronous=true, check)
+
+radio = stretch(ratio=2., radio)
+
+clock.assign_new(sync="none", [radio])
+
+output.dummy(radio)

--- a/tests/regression/dune.inc
+++ b/tests/regression/dune.inc
@@ -1360,6 +1360,24 @@
   (run %{run_test} GH5319 liquidsoap %{test_liq} GH5319.liq)))
 
 (rule
+ (alias test_GH5348)
+ (package liquidsoap)
+ (deps
+  GH5348.liq
+  (glob_files ../media/**)
+  ../liquidsoap-test-assets
+  ../../src/bin/liquidsoap.exe
+  ../streams/file1.png
+  ../streams/file1.mp3
+  ./theora-test.mp4
+  (package liquidsoap)
+  (source_tree ../../src/libs)
+  (:test_liq ../test.liq)
+  (:run_test ../run_test.exe))
+ (action
+  (run %{run_test} GH5348 liquidsoap %{test_liq} GH5348.liq)))
+
+(rule
  (alias test_LS268)
  (package liquidsoap)
  (deps
@@ -2555,6 +2573,7 @@
   (alias test_GH5261)
   (alias test_GH5287)
   (alias test_GH5319)
+  (alias test_GH5348)
   (alias test_LS268)
   (alias test_LS354-1)
   (alias test_LS354-2)


### PR DESCRIPTION
Fixes #5348.

A `switch` living inside a passive child clock — the kind `ffmpeg.encode.*`, `crossfade`, `stretch`, `soundtouch`, `pipe` and the ffmpeg filters create — was re-evaluating its selection on every frame, losing track sensitivity entirely. In the reported script, a `rotate` under `ffmpeg.encode.audio` played about a tenth of a second of each jingle and ignored the per-source weights.

Such a clock is ticked by its parent even on cycles where its consumer pulls nothing. On those cycles the switch is animated (its `is_ready` runs) but generates no frame, so `last_streamed_tick`, which only advanced on `After_frame`, permanently trailed the clock by at least two ticks. `resuming` was therefore always true, `at_boundary` always returned true, and `get_source` re-selected on every single frame.

The fix records the last tick the switch was *animated* instead of the last one it streamed. Being animated without being pulled is not quiet; not being animated at all is, and that is the case `resuming` was introduced for — a switch whose parent is not playing it, which `tests/regression/switch_reselect_after_idle.liq` covers and which still passes.

Testing: added `tests/regression/GH5348.liq`. It rotates a 1s-track jingle source and a 2s-track music source with `weight = 2`, wraps the rotation in `stretch(ratio=2.)` so the child clock is pulled on every other cycle (no ffmpeg needed), and asserts both the rotation ratio — two jingles out of six consecutive tracks — and the full duration of every track. It fails on `main` with all tracks cut to a single frame (0.04s), and passes here. The existing `switch_*`, `rotate`, `random`, `cross` and `callback_release` tests were re-run with `dune build --force` and are unaffected.
