### PR TITLE
Don't discard existing RG tags, and prevent double calculation

### DIFF
--- a/src/libs/lufs.liq
+++ b/src/libs/lufs.liq
@@ -195,8 +195,12 @@ def enable_lufs_track_gain_metadata(
   ~ratio=null
 ) =
   ratio = ratio ?? settings.lufs.decoding_ratio()
-  def lufs_metadata(~metadata:_, file_name) =
+  def lufs_metadata(~metadata, file_name) =
     if
+      list.assoc.mem(settings.normalize_track_gain_metadata(), metadata)
+    then
+      []
+    elsif
       compute and true_peak
     then
       # Single-pass scan: measure both LUFS and true peak, apply TP correction.

--- a/src/libs/replaygain.liq
+++ b/src/libs/replaygain.liq
@@ -111,19 +111,25 @@ end
 # @param ~ratio Decoding ratio. A value of `50.` means try to decode the file `50x` faster than real time, if possible. Use this setting to lower CPU peaks when computing replaygain tags.
 # @category Liquidsoap
 def enable_replaygain_metadata(~compute=true, ~ratio=50.) =
-  def replaygain_metadata(~metadata:_, file_name) =
-    gain = file.replaygain(compute=compute, ratio=ratio, file_name)
+  def replaygain_metadata(~metadata, file_name) =
     if
-      gain != null
+      list.assoc.mem(settings.normalize_track_gain_metadata(), metadata)
     then
-      [
-        (
-          settings.normalize_track_gain_metadata(),
-          "#{null.get(gain)} dB"
-        )
-      ]
-    else
       []
+    else
+      gain = file.replaygain(compute=compute, ratio=ratio, file_name)
+      if
+        gain != null
+      then
+        [
+          (
+            settings.normalize_track_gain_metadata(),
+            "#{null.get(gain)} dB"
+          )
+        ]
+      else
+        []
+      end
     end
   end
 


### PR DESCRIPTION
This changes the behavior of the combination of `enable_replaygain_metadata()` and `replaygain:`. Now, received metadata is not discarded but is used. This prevents calculations happening twice for one track.

The same applies to `enable_lufs_track_gain_metadata()` combined with `lufs_track_gain:`, which did the same thing.

Fixes: #5355 