### PR TITLE
source: count script callbacks on the source itself

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,4 +26,4 @@ tests/liquidsoap-test-assets
 /doc/.website/
 /doc/.website-bundle/
 
-_opam/
+_opam

--- a/src/bin/runtime/main.ml
+++ b/src/bin/runtime/main.ml
@@ -783,10 +783,12 @@ let () =
         ignore
           (Thread.create
              (fun () ->
-               Runtime.interactive ();
+               Script_callback.uncollected Runtime.interactive;
                Tutils.shutdown 0)
              ()));
   Lifecycle.on_main_loop ~name:"main application main loop" Tutils.main
 
-(* Here we go! *)
-let start = Lifecycle.init
+(* Here we go! The main thread runs the script that builds the streaming graph,
+   so it needs the same outermost callback handler [Tutils] installs on the
+   threads it creates. *)
+let start () = Script_callback.uncollected Lifecycle.init

--- a/src/core/liquidsoap_core.ml
+++ b/src/core/liquidsoap_core.ml
@@ -133,6 +133,7 @@ module Log = Log
 module Tutils = Tutils
 module Process_handler = Process_handler
 module Sandbox = Sandbox
+module Script_callback = Script_callback
 module Liq_time = Liq_time
 module Charset = Charset
 module Utils = Utils

--- a/src/core/liquidsoap_core.mli
+++ b/src/core/liquidsoap_core.mli
@@ -166,6 +166,7 @@ module Log = Log
 module Tutils = Tutils
 module Process_handler = Process_handler
 module Sandbox = Sandbox
+module Script_callback = Script_callback
 module Liq_time = Liq_time
 module Charset = Charset
 module Utils = Utils

--- a/src/core/optionals/lo/builtins_lo.ml
+++ b/src/core/optionals/lo/builtins_lo.ml
@@ -82,9 +82,10 @@ let start_server () =
     (Thread.create
        (fun () ->
          try
-           while true do
-             S.recv s
-           done
+           Script_callback.uncollected (fun () ->
+               while true do
+                 S.recv s
+               done)
          with
            | Lo.Server.Stopped -> ()
            | exn ->

--- a/src/core/optionals/osc/builtins_osc.ml
+++ b/src/core/optionals/osc/builtins_osc.ml
@@ -78,12 +78,13 @@ let start_server () =
     (Thread.create
        (fun () ->
          try
-           while !server <> None do
-             match Osc_unix.Udp.Server.recv s with
-               | Ok (Osc.Types.Message m, _) ->
-                   handler m.address (Array.of_list m.arguments)
-               | _ -> ()
-           done
+           Script_callback.uncollected (fun () ->
+               while !server <> None do
+                 match Osc_unix.Udp.Server.recv s with
+                   | Ok (Osc.Types.Message m, _) ->
+                       handler m.address (Array.of_list m.arguments)
+                   | _ -> ()
+               done)
          with exn ->
            let backtrace = Printexc.get_backtrace () in
            log#important "OSC server thread exited with exception: %s\n%s"

--- a/src/core/source/lang_source.ml
+++ b/src/core/source/lang_source.ml
@@ -126,94 +126,15 @@ type 'a callback = {
   register : params:(string * value) list -> 'a -> (env -> unit) -> unit -> unit;
 }
 
-(* Performed for every callback a script registers, carrying what releases it.
-   Registering is the only way a script can add a callback to a source, so an
-   operator handing sources to a script function can take back everything that
-   function registered on them, and nothing else: the engine's own wiring does
-   not go through here. *)
-type _ Effect.t +=
-  | Callback_registered : {
-      owner : int;
-      release : unit -> unit;
-    }
-      -> unit Effect.t
-
-type 'a collected = { release : unit -> unit; result : 'a }
+type 'a collected = 'a Script_callback.collected = {
+  release : unit -> unit;
+  result : 'a;
+}
 
 (* Sources are identified by [Oo.id]: callbacks are registered on outputs and
    other objects too, and this is the one identity they all share. *)
 let collect_callback_releases sources fn =
-  let owners = List.map Oo.id sources in
-  let releases = ref [] in
-  let result =
-    Effect.Deep.try_with fn ()
-      {
-        Effect.Deep.effc =
-          (fun (type a) (eff : a Effect.t) ->
-            match eff with
-              | Callback_registered { owner; release }
-                when List.mem owner owners ->
-                  Some
-                    (fun (k : (a, _) Effect.Deep.continuation) ->
-                      releases := release :: !releases;
-                      Effect.Deep.continue k ())
-              | _ -> None);
-      }
-  in
-  let release () =
-    List.iter (fun release -> release ()) !releases;
-    releases := []
-  in
-  { release; result }
-
-(* Callbacks are registered from every thread that runs script code, and effects
-   do not cross thread boundaries. Rather than install a default handler at each
-   thread entry, where a missed one would raise at runtime, registration outside
-   any collector is simply not observed. *)
-let notify_callback_registered ~owner release =
-  try Effect.perform (Callback_registered { owner; release })
-  with Effect.Unhandled _ -> ()
-
-let max_script_callbacks = 5
-
-(* Script callbacks currently registered, per source and callback: naming the
-   callback that is piling up is what makes it findable. Counting the callback
-   lists themselves would not do: they also hold the engine's own wiring, of
-   which a handful is normal. What is not normal is a script piling them up,
-   which is what a function registering on a source it is given does every time
-   it runs. *)
-let script_callbacks : (int * string, int) Hashtbl.t = Hashtbl.create 10
-let script_callbacks_m = Mutex.create ()
-
-let count_script_callback ~log ~id ~name ~owner release =
-  let key = (owner, name) in
-  let count =
-    Mutex_utils.mutexify script_callbacks_m
-      (fun () ->
-        let count =
-          1 + Option.value ~default:0 (Hashtbl.find_opt script_callbacks key)
-        in
-        Hashtbl.replace script_callbacks key count;
-        count)
-      ()
-  in
-  if count = max_script_callbacks + 1 then
-    (log : Log.t)#important
-      "%d %s callbacks registered on %s. If you are registering from a \
-       function that runs more than once, keep the value it returns and call \
-       its release() method."
-      count name id;
-  let released = Atomic.make false in
-  fun () ->
-    if Atomic.compare_and_set released false true then (
-      Mutex_utils.mutexify script_callbacks_m
-        (fun () ->
-          match Hashtbl.find_opt script_callbacks key with
-            | Some count when count <= 1 -> Hashtbl.remove script_callbacks key
-            | Some count -> Hashtbl.replace script_callbacks key (count - 1)
-            | None -> ())
-        ();
-      release ())
+  Script_callback.collect (List.map Oo.id sources) fn
 
 let callback { name; params; descr; arg_t; register } : _ Lang.meth =
   {
@@ -264,10 +185,9 @@ let callback { name; params; descr; arg_t; register } : _ Lang.meth =
               (if synchronous then "synchronous" else "asynchronous");
             let owner = Oo.id s in
             let release =
-              count_script_callback ~log:s#log ~id:s#id ~name ~owner
-                (register ~params:p s fn)
+              s#register_script_callback name (register ~params:p s fn)
             in
-            notify_callback_registered ~owner release;
+            Script_callback.notify ~owner release;
             meth unit
               [
                 ( "release",
@@ -453,6 +373,22 @@ let source_methods : source_meth list =
       scheme = (fun _ -> ([], fun_t [] string_t));
       descr = "Identifier of the source.";
       value = (fun s -> val_fun [] (fun _ -> string s#id));
+    };
+    {
+      name = "callbacks_count";
+      scheme = (fun _ -> ([], fun_t [] (list_t (product_t string_t int_t))));
+      descr =
+        "Callbacks a script has registered on this source, as pairs of \
+         callback name and count. A count that keeps growing is a function \
+         registering on a source it is handed without releasing what it \
+         registered.";
+      value =
+        (fun s ->
+          val_fun [] (fun _ ->
+              list
+                (List.map
+                   (fun (name, count) -> product (string name) (int count))
+                   s#script_callback_counts)));
     };
     {
       name = "is_ready";

--- a/src/core/source/source.ml
+++ b/src/core/source/source.ml
@@ -99,6 +99,8 @@ let check_sleep ~activations ~s =
       src#id s#id;
     s#sleep src)
 
+let max_script_callbacks = 5
+
 let on_finalize ~on_collect id =
  fun () ->
   List.iter (fun fn -> fn ()) (Callbacks.elements on_collect);
@@ -457,6 +459,52 @@ class virtual operator ?(stack = []) ?clock ~name sources =
 
     method register_on_collect fn = Callbacks.register on_collect fn
     method on_collect fn = Callbacks.add on_collect fn
+    val script_callbacks : (string, int) Hashtbl.t = Hashtbl.create 0
+    val script_callbacks_m = Mutex.create ()
+
+    method script_callback_counts =
+      Mutex_utils.mutexify script_callbacks_m
+        (fun () ->
+          Hashtbl.fold
+            (fun name count l -> (name, count) :: l)
+            script_callbacks [])
+        ()
+
+    (* Callbacks a script registers live as long as this source does, so a
+       function registering on a source it is handed piles them up every time it
+       runs. Counting per name is what lets the warning name the one at fault;
+       the engine's own wiring does not come through here, and a handful of it
+       is normal anyway. *)
+    method register_script_callback name release =
+      let count =
+        Mutex_utils.mutexify script_callbacks_m
+          (fun () ->
+            let count =
+              1
+              + Option.value ~default:0 (Hashtbl.find_opt script_callbacks name)
+            in
+            Hashtbl.replace script_callbacks name count;
+            count)
+          ()
+      in
+      if count = max_script_callbacks + 1 then
+        self#log#important
+          "%d %s callbacks registered on %s. If you are registering from a \
+           function that runs more than once, keep the value it returns and \
+           call its release() method."
+          count name self#id;
+      let released = Atomic.make false in
+      fun () ->
+        if Atomic.compare_and_set released false true then (
+          Mutex_utils.mutexify script_callbacks_m
+            (fun () ->
+              match Hashtbl.find_opt script_callbacks name with
+                | Some count when count <= 1 ->
+                    Hashtbl.remove script_callbacks name
+                | Some count -> Hashtbl.replace script_callbacks name (count - 1)
+                | None -> ())
+            ();
+          release ())
 
     initializer
       Gc.finalise_last (on_finalize ~on_collect id) self;

--- a/src/core/source/source.mli
+++ b/src/core/source/source.mli
@@ -144,6 +144,14 @@ object
       on the source for as long as it lives. *)
   method register_on_collect : (unit -> unit) -> unit -> unit
 
+  (** Register a callback a script asked for, returning the function releasing
+      it. Registrations are counted per name, and a script piling them up on a
+      source it is handed gets warned about the one at fault. *)
+  method register_script_callback : string -> (unit -> unit) -> unit -> unit
+
+  (** Script callbacks currently registered, per callback name. *)
+  method script_callback_counts : (string * int) list
+
   (** The clock under which the source will run. *)
   method clock : Clock.t
 

--- a/src/core/utils/liquidsoap_core_utils.ml
+++ b/src/core/utils/liquidsoap_core_utils.ml
@@ -41,6 +41,7 @@ module Pool = Pool
 module Process_handler = Process_handler
 module Queues = Queues
 module Sandbox = Sandbox
+module Script_callback = Script_callback
 module Server = Server
 module Sha1 = Sha1
 module Startup = Startup

--- a/src/core/utils/liquidsoap_core_utils.mli
+++ b/src/core/utils/liquidsoap_core_utils.mli
@@ -41,6 +41,7 @@ module Pool = Pool
 module Process_handler = Process_handler
 module Queues = Queues
 module Sandbox = Sandbox
+module Script_callback = Script_callback
 module Server = Server
 module Sha1 = Sha1
 module Startup = Startup

--- a/src/core/utils/script_callback.ml
+++ b/src/core/utils/script_callback.ml
@@ -1,0 +1,73 @@
+(*****************************************************************************
+
+  Liquidsoap, a programmable stream generator.
+  Copyright 2003-2026 Savonet team
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details, fully stated in the COPYING
+  file at the root of the liquidsoap distribution.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA
+
+ *****************************************************************************)
+
+(* Performed for every callback a script registers, carrying what releases it.
+   Registering is the only way a script can add a callback to a source, so an
+   operator handing sources to a script function can take back everything that
+   function registered on them, and nothing else: the engine's own wiring does
+   not go through here. *)
+type _ Effect.t +=
+  | Registered : { owner : int; release : unit -> unit } -> unit Effect.t
+
+type 'a collected = { release : unit -> unit; result : 'a }
+
+let notify ~owner release = Effect.perform (Registered { owner; release })
+
+let collect owners fn =
+  let releases = ref [] in
+  let result =
+    Effect.Deep.try_with fn ()
+      {
+        Effect.Deep.effc =
+          (fun (type a) (eff : a Effect.t) ->
+            match eff with
+              | Registered { owner; release } when List.mem owner owners ->
+                  Some
+                    (fun (k : (a, _) Effect.Deep.continuation) ->
+                      releases := release :: !releases;
+                      Effect.Deep.continue k ())
+              | _ -> None);
+      }
+  in
+  let release () =
+    List.iter (fun release -> release ()) !releases;
+    releases := []
+  in
+  { release; result }
+
+(* Effects do not cross thread boundaries, so every thread that can run script
+   code installs this outermost handler: a registration no operator asked to
+   collect is simply not collected. A context that forgot to install it raises
+   [Effect.Unhandled] at the registration site rather than losing the release
+   silently, which would keep what it counts alive for good. *)
+let uncollected fn =
+  Effect.Deep.try_with fn ()
+    {
+      Effect.Deep.effc =
+        (fun (type a) (eff : a Effect.t) ->
+          match eff with
+            | Registered _ ->
+                Some
+                  (fun (k : (a, _) Effect.Deep.continuation) ->
+                    Effect.Deep.continue k ())
+            | _ -> None);
+    }

--- a/src/core/utils/tutils.ml
+++ b/src/core/utils/tutils.ml
@@ -168,7 +168,7 @@ let create ~queue f x s =
         let process x =
           Utils.Thread.set_current_thread_name s;
           try
-            f x;
+            Script_callback.uncollected (fun () -> f x);
             Mutex_utils.mutexify lock
               (fun () ->
                 set := Set.remove (s, c) !set;

--- a/tests/regression/callback_counts.liq
+++ b/tests/regression/callback_counts.liq
@@ -1,0 +1,69 @@
+# Callbacks a script registers are counted on the source itself, so a function
+# registering on a source it is handed and never releasing what it registered
+# shows up as a count that grows. `cross` runs its transition on every crossing
+# and releases what it registered on the sources it owns, so that count stays
+# flat however many crossings go by.
+
+def count(s, name) =
+  list.assoc(default=0, name, s.callbacks_count())
+end
+
+# Releasing takes the registration back off the source.
+r = sine(id="released")
+for _ = 1 to 20 do r.on_track(synchronous=true, fun (_) -> ()).release()  end
+if
+  count(r, "on_track") != 0
+then
+  test.fail(
+    "released callbacks still counted: #{count(r, "on_track")}"
+  )
+end
+
+tracks = chop(every=0.5, sine())
+
+crossings = ref(0)
+registered = ref(0)
+
+# Registers on the crossed source, which `cross` owns and collects. Measured
+# here rather than downstream: this is the one moment the registration is
+# guaranteed to be live, so the count is exactly what the previous crossings
+# left behind plus one.
+def transition(a, b) =
+  tracks.on_metadata(synchronous=true, fun (_) -> ())
+  on_metadata = count(tracks, "on_metadata")
+  if on_metadata > registered() then registered := on_metadata end
+  if
+    4 < on_metadata
+  then
+    test.fail(
+      "#{on_metadata} transition callbacks piling up on the crossed source"
+    )
+  end
+  sequence([a.source, b.source])
+end
+
+s = cross(duration=0.1, transition, tracks)
+
+clock.assign_new(sync="none", id="test", [s])
+output.dummy(fallible=true, s)
+
+def on_track(_) =
+  ref.incr(crossings)
+  if
+    crossings() == 45
+  then
+    # Seeing none at any point means the transition never ran and the
+    # collector is not being exercised.
+    if
+      registered() < 1
+    then
+      test.fail(
+        "the transition registered nothing on the crossed source"
+      )
+    else
+      test.pass()
+    end
+  end
+end
+
+tracks.on_track(synchronous=true, on_track)

--- a/tests/regression/dune.inc
+++ b/tests/regression/dune.inc
@@ -1522,6 +1522,29 @@
   (run %{run_test} append liquidsoap %{test_liq} append.liq)))
 
 (rule
+ (alias test_callback_counts)
+ (package liquidsoap)
+ (deps
+  callback_counts.liq
+  (glob_files ../media/**)
+  ../liquidsoap-test-assets
+  ../../src/bin/liquidsoap.exe
+  ../streams/file1.png
+  ../streams/file1.mp3
+  ./theora-test.mp4
+  (package liquidsoap)
+  (source_tree ../../src/libs)
+  (:test_liq ../test.liq)
+  (:run_test ../run_test.exe))
+ (action
+  (run
+   %{run_test}
+   callback_counts
+   liquidsoap
+   %{test_liq}
+   callback_counts.liq)))
+
+(rule
  (alias test_callback_release)
  (package liquidsoap)
  (deps
@@ -2582,6 +2605,7 @@
   (alias test_append)
   (alias test_append-merge)
   (alias test_append-merge2)
+  (alias test_callback_counts)
   (alias test_callback_release)
   (alias test_callback_release_mixed_content)
   (alias test_cleanup)


### PR DESCRIPTION
Every `cross` transition permanently added two rows to the global `script_callbacks` table in `src/core/source/lang_source.ml`, at a measured +4.0 live blocks per crossing, because `fade.in` and `fade.out` register on sources they create and discard, and a registration no collector owns never gets its release called.

The count now lives on the source as a per-name table, so it dies with the source and needs no `Oo.id` key, no global table and no death notification, and sources expose it as the `callbacks_count` method; separately, the registration effect moves to a leaf `Script_callback` module and every thread that can run script code installs an outermost handler, so a registration with no handler in scope raises instead of being silently dropped.

`tests/regression/callback_counts.liq` asserts that releasing takes a registration back off a source and that a transition registering on the crossed source does not pile up across 45 crossings, and it fails on the matching assertion when either the decrement or the collector's release is neutered.
