### PR TITLE
Don't discard existing RG tags, and prevent double calculation (#5356)

### DIFF
--- a/src/libs/lufs.liq
+++ b/src/libs/lufs.liq
@@ -125,19 +125,25 @@ end
 # @category Liquidsoap
 def enable_lufs_track_gain_metadata(~compute=true, ~ratio=null) =
   ratio = ratio ?? settings.lufs.decoding_ratio()
-  def lufs_metadata(~metadata:_, file_name) =
-    gain = file.lufs(compute=compute, ratio=ratio, file_name)
+  def lufs_metadata(~metadata, file_name) =
     if
-      gain != null
+      list.assoc.mem(settings.normalize_track_gain_metadata(), metadata)
     then
-      [
-        (
-          settings.normalize_track_gain_metadata(),
-          "#{settings.lufs.track_gain_target() - null.get(gain)} dB"
-        )
-      ]
-    else
       []
+    else
+      gain = file.lufs(compute=compute, ratio=ratio, file_name)
+      if
+        gain != null
+      then
+        [
+          (
+            settings.normalize_track_gain_metadata(),
+            "#{settings.lufs.track_gain_target() - null.get(gain)} dB"
+          )
+        ]
+      else
+        []
+      end
     end
   end
 

--- a/src/libs/replaygain.liq
+++ b/src/libs/replaygain.liq
@@ -111,19 +111,25 @@ end
 # @param ~ratio Decoding ratio. A value of `50.` means try to decode the file `50x` faster than real time, if possible. Use this setting to lower CPU peaks when computing replaygain tags.
 # @category Liquidsoap
 def enable_replaygain_metadata(~compute=true, ~ratio=50.) =
-  def replaygain_metadata(~metadata:_, file_name) =
-    gain = file.replaygain(compute=compute, ratio=ratio, file_name)
+  def replaygain_metadata(~metadata, file_name) =
     if
-      gain != null
+      list.assoc.mem(settings.normalize_track_gain_metadata(), metadata)
     then
-      [
-        (
-          settings.normalize_track_gain_metadata(),
-          "#{null.get(gain)} dB"
-        )
-      ]
-    else
       []
+    else
+      gain = file.replaygain(compute=compute, ratio=ratio, file_name)
+      if
+        gain != null
+      then
+        [
+          (
+            settings.normalize_track_gain_metadata(),
+            "#{null.get(gain)} dB"
+          )
+        ]
+      else
+        []
+      end
     end
   end
 


### PR DESCRIPTION
(cherry picked from commit 03d4a9bd003978bb2864d1d9a117278c3898da15)