### PR TITLE
ci: build the base images with the global-root debugging patches

### DIFF
--- a/.github/docker/alpine-base.dockerfile
+++ b/.github/docker/alpine-base.dockerfile
@@ -5,7 +5,7 @@ ENTRYPOINT bash
 MAINTAINER The Savonet Team <contact@liquidsoap.info>
 
 ARG OCAML_VERSION=5.5.0
-ARG OCAML_PATCH_URL=https://github.com/toots/ocaml/archive/4ebecb3902f8f2fcfa0a3eb9f268e51b64d05ea1.tar.gz
+ARG OCAML_PATCH_URL=https://github.com/toots/ocaml/archive/b62191b568d80253b882b4702a1b2f5272c3d595.tar.gz
 
 USER root
 

--- a/.github/docker/alpine-base.dockerfile
+++ b/.github/docker/alpine-base.dockerfile
@@ -5,6 +5,7 @@ ENTRYPOINT bash
 MAINTAINER The Savonet Team <contact@liquidsoap.info>
 
 ARG OCAML_VERSION=5.5.0
+ARG OCAML_PATCH_URL=https://github.com/toots/ocaml/archive/4ebecb3902f8f2fcfa0a3eb9f268e51b64d05ea1.tar.gz
 
 USER root
 
@@ -25,6 +26,13 @@ RUN \
     opam init -y --disable-sandboxing --compiler=$OCAML_VERSION && \
     opam update -y && \
     opam clean
+
+# The global-root debugging patches, ocaml/ocaml#15027. They are all #ifdef DEBUG,
+# so they only show up in the runtime reached through -runtime-variant d. Build with
+# an empty OCAML_PATCH_URL for a stock compiler.
+RUN test -z "$OCAML_PATCH_URL" || \
+    (opam pin add -y ocaml-compiler.$OCAML_VERSION "$OCAML_PATCH_URL" && \
+     opam clean)
 
 ARG LIQUIDSOAP_SHA=main
 

--- a/.github/docker/alpine-base.dockerfile
+++ b/.github/docker/alpine-base.dockerfile
@@ -65,9 +65,14 @@ RUN \
     PACKAGES=`cat /tmp/packages | xargs echo` && \
     opam install --no-depexts -y liquidsoap $PACKAGES $EXT_PACKAGES && \
     opam uninstall --no-depexts -y liquidsoap-lang $PACKAGES ffmpeg-avutil && \
-    opam pin list --short | xargs -r opam pin remove -y && \
+    opam pin list --short | grep -v '^ocaml-compiler$' | xargs -r opam pin remove -y && \
     rm -rf /tmp/liquidsoap && \
     opam clean
+
+# The compiler pin has to survive the pin cleanup above, or the patched compiler is
+# silently replaced by the release one.
+RUN test -z "$OCAML_PATCH_URL" || \
+    (eval $(opam env) && opam pin list --short | grep -qx ocaml-compiler)
 
 USER root
 

--- a/.github/docker/debian-base.dockerfile
+++ b/.github/docker/debian-base.dockerfile
@@ -6,6 +6,7 @@ FROM $BASE_IMAGE AS ocaml
 MAINTAINER The Savonet Team <contact@liquidsoap.info>
 
 ARG OCAML_VERSION=5.5.0
+ARG OCAML_PATCH_URL=https://github.com/toots/ocaml/archive/4ebecb3902f8f2fcfa0a3eb9f268e51b64d05ea1.tar.gz
 
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -26,6 +27,13 @@ RUN opam init -y --disable-sandboxing --bare && \
     opam switch create $OCAML_VERSION ocaml-variants.$OCAML_VERSION+options ocaml-option-flambda && \
     opam update -y && \
     opam clean
+
+# The global-root debugging patches, ocaml/ocaml#15027. They are all #ifdef DEBUG,
+# so they only show up in the runtime reached through -runtime-variant d. Build with
+# an empty OCAML_PATCH_URL for a stock compiler.
+RUN test -z "$OCAML_PATCH_URL" || \
+    (opam pin add -y ocaml-compiler.$OCAML_VERSION "$OCAML_PATCH_URL" && \
+     opam clean)
 
 # Stage 2: Clone liquidsoap and pin all synced modules
 FROM ocaml AS pinned

--- a/.github/docker/debian-base.dockerfile
+++ b/.github/docker/debian-base.dockerfile
@@ -1,5 +1,5 @@
 ARG BASE_IMAGE
-ARG OCAML_PATCH_URL=https://github.com/toots/ocaml/archive/4ebecb3902f8f2fcfa0a3eb9f268e51b64d05ea1.tar.gz
+ARG OCAML_PATCH_URL=https://github.com/toots/ocaml/archive/b62191b568d80253b882b4702a1b2f5272c3d595.tar.gz
 
 # Stage 1: OCaml compiler
 FROM $BASE_IMAGE AS ocaml

--- a/.github/docker/debian-base.dockerfile
+++ b/.github/docker/debian-base.dockerfile
@@ -1,4 +1,5 @@
 ARG BASE_IMAGE
+ARG OCAML_PATCH_URL=https://github.com/toots/ocaml/archive/4ebecb3902f8f2fcfa0a3eb9f268e51b64d05ea1.tar.gz
 
 # Stage 1: OCaml compiler
 FROM $BASE_IMAGE AS ocaml
@@ -6,7 +7,7 @@ FROM $BASE_IMAGE AS ocaml
 MAINTAINER The Savonet Team <contact@liquidsoap.info>
 
 ARG OCAML_VERSION=5.5.0
-ARG OCAML_PATCH_URL=https://github.com/toots/ocaml/archive/4ebecb3902f8f2fcfa0a3eb9f268e51b64d05ea1.tar.gz
+ARG OCAML_PATCH_URL
 
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -98,6 +99,8 @@ USER root
 # Stage 4: Install remaining external and opam dependencies
 FROM static-packages AS build
 
+ARG OCAML_PATCH_URL
+
 ENV EXT_PACKAGES="camomile-embedded ocurl irc-client-unix osc-unix inotify prometheus-liquidsoap tsdl sdl-liquidsoap tls-liquidsoap syslog memtrace ssl posix-time2 yaml js_of_ocaml js_of_ocaml-ppx re sqlite3 odoc"
 
 USER opam
@@ -128,9 +131,14 @@ RUN eval $(opam env) && \
     PACKAGES=$(cat /tmp/packages | grep -Ev "^(speex|theora)$" | xargs echo) && \
     opam install --no-depexts -y liquidsoap $PACKAGES $EXT_PACKAGES && \
     opam uninstall --no-depexts -y liquidsoap-lang $PACKAGES ffmpeg-avutil && \
-    opam pin list --short | xargs -r opam pin remove -y && \
+    opam pin list --short | grep -v '^ocaml-compiler$' | xargs -r opam pin remove -y && \
     rm -rf /tmp/liquidsoap && \
     opam clean
+
+# The compiler pin has to survive the pin cleanup above, or the patched compiler is
+# silently replaced by the release one.
+RUN test -z "$OCAML_PATCH_URL" || \
+    (eval $(opam env) && opam pin list --short | grep -qx ocaml-compiler)
 
 USER root
 


### PR DESCRIPTION
Chasing the global-root corruption needs the patched compiler from ocaml/ocaml#15027, which so far meant editing a dockerfile by hand.

Both base images now build their compiler from `globroots-debugging-5.5`, four patches on top of the 5.5.0 release tag. The rebuild happens right after the switch is created, before anything else is installed, and `--build-arg OCAML_PATCH_URL=` still gets a stock compiler.

The package pinned is `ocaml-compiler`. `ocaml-variants` and `ocaml-base-compiler` carry no build commands in current opam-repository — pinning either downloads the archive and builds the release compiler anyway.

The patches are all `#ifdef DEBUG`, so nothing changes until something is linked with `-runtime-variant d`.
