### PR TITLE
Fix CamlinternalLazy.Undefined crashes on concurrently forced lazies

### DIFF
--- a/src/core/clock/clock.ml
+++ b/src/core/clock/clock.ml
@@ -196,10 +196,21 @@ type source =
   ; on_sync_source_change :
       (old:sync_source option -> sync_source option -> unit) -> unit -> unit >
 
+(* [self_sync] is reached from several threads at once; the value is
+   deterministic, so a racing computation is harmless. *)
 let self_sync_type_of_sources sources =
-  Lazy.from_fun (fun () ->
-      if List.exists (fun s -> fst s#self_sync = `Dynamic) sources then `Dynamic
-      else `Static)
+  let cached = Atomic.make None in
+  fun () ->
+    match Atomic.get cached with
+      | Some self_sync_type -> self_sync_type
+      | None ->
+          let self_sync_type =
+            if List.exists (fun s -> fst s#self_sync = `Dynamic) sources then
+              `Dynamic
+            else `Static
+          in
+          Atomic.set cached (Some self_sync_type);
+          self_sync_type
 
 let self_sync_of_sources sources =
   let self_sync_type = self_sync_type_of_sources sources in
@@ -220,8 +231,8 @@ let self_sync_of_sources sources =
         (fun { sync_source = s } { sync_source = s' } -> Stdlib.compare s s')
         sync_sources
     with
-      | [] -> (Lazy.force self_sync_type, None)
-      | [{ sync_source }] -> (Lazy.force self_sync_type, Some sync_source)
+      | [] -> (self_sync_type (), None)
+      | [{ sync_source }] -> (self_sync_type (), Some sync_source)
       | sync_sources ->
           raise
             (Sync_error { name = source#id; stack = source#stack; sync_sources })

--- a/src/core/clock/clock.mli
+++ b/src/core/clock/clock.mli
@@ -141,7 +141,7 @@ val self_sync_of_sources :
 
 (** [`Dynamic] as soon as one of the sources is, [`Static] otherwise. *)
 val self_sync_type_of_sources :
-  < self_sync : self_sync ; .. > list -> [ `Static | `Dynamic ] Lazy.t
+  < self_sync : self_sync ; .. > list -> unit -> [ `Static | `Dynamic ]
 
 (** Sync mode of a clock:
     - [`Automatic]: the clock delegates latency control to its current sync

--- a/src/core/operators/sequence.ml
+++ b/src/core/operators/sequence.ml
@@ -41,7 +41,7 @@ class sequence ?(name = "sequence") ?(merge = false) ?(single_track = true)
         ()
 
     method self_sync =
-      ( Lazy.force self_sync_type,
+      ( self_sync_type (),
         match sources with hd :: _ -> snd hd#self_sync | [] -> None )
 
     method fallible =

--- a/src/core/operators/switch.ml
+++ b/src/core/operators/switch.ml
@@ -344,7 +344,7 @@ class switch ~all_predicates children =
               | _ -> None)
 
     method self_sync =
-      ( Lazy.force self_sync_type,
+      ( self_sync_type (),
         match self#selected with
           | Some s -> snd s.effective_source#self_sync
           | None -> None )

--- a/src/core/stream/frame_settings.ml
+++ b/src/core/stream/frame_settings.ml
@@ -160,18 +160,24 @@ type ideal_size = { width : int; height : int; source : string }
     allows auto-detection from the first decoded video file. *)
 let video_dimensions =
   (* We don't want to use delayed config here because those are evaluated too early. *)
-  let dimensions =
-    lazy
-      (assert !lazy_config_eval;
-       let w = conf_video_width#get in
-       let h = conf_video_height#get in
-       (w, h))
+  let cached = Atomic.make None in
+  (* The clock and decoder threads read the dimensions concurrently; the value
+     is deterministic, so a racing computation is harmless. *)
+  let dimensions () =
+    match Atomic.get cached with
+      | Some dimensions -> dimensions
+      | None ->
+          assert !lazy_config_eval;
+          let w = conf_video_width#get in
+          let h = conf_video_height#get in
+          Atomic.set cached (Some (w, h));
+          (w, h)
   in
   fun ?ideal_size () ->
     (match ideal_size with
       | Some { width; height; source }
         when conf_video_detect_dimensions#get
-             && (not (Lazy.is_val dimensions))
+             && Atomic.get cached = None
              && (not conf_video_width#is_set)
              && not conf_video_height#is_set ->
           log#important "Auto-detected video dimensions: %dx%d (source: %s)."
@@ -179,8 +185,8 @@ let video_dimensions =
           conf_video_width#set width;
           conf_video_height#set height
       | _ -> ());
-    let width = lazy (fst (Lazy.force dimensions)) in
-    let height = lazy (snd (Lazy.force dimensions)) in
+    let width = lazy (fst (dimensions ())) in
+    let height = lazy (snd (dimensions ())) in
     (width, height)
 
 let audio_rate = delayed_conf ~to_string:string_of_int conf_audio_samplerate

--- a/tests/core/clock_self_sync_type_test.ml
+++ b/tests/core/clock_self_sync_type_test.ml
@@ -1,0 +1,45 @@
+(* Two threads reading [Clock.self_sync_type_of_sources] at once must both get
+   the value. *)
+
+let entered = Atomic.make 0
+let overlapped = Atomic.make false
+
+(* Rendezvous inside the computation so both threads are provably in it at the
+   same time. *)
+let slow_source =
+  object
+    method self_sync : Clock.self_sync =
+      Atomic.incr entered;
+      let rec wait n =
+        if Atomic.get entered < 2 && 0 < n then (
+          Thread.delay 0.01;
+          wait (n - 1))
+      in
+      wait 200;
+      if 2 <= Atomic.get entered then Atomic.set overlapped true;
+      (`Static, None)
+  end
+
+let self_sync_type = Clock.self_sync_type_of_sources [slow_source]
+let results = Array.make 2 None
+let errors = Array.make 2 None
+
+let compute pos () =
+  try results.(pos) <- Some (self_sync_type ())
+  with exn -> errors.(pos) <- Some exn
+
+let () =
+  let threads = Array.init 2 (fun pos -> Thread.create (compute pos) ()) in
+  Array.iter Thread.join threads;
+  Array.iteri
+    (fun pos exn ->
+      match exn with
+        | Some exn ->
+            failwith
+              (Printf.sprintf "thread %d raised %s" pos (Printexc.to_string exn))
+        | None -> ())
+    errors;
+  assert (Atomic.get overlapped);
+  Array.iter (fun result -> assert (result = Some `Static)) results;
+  assert (self_sync_type () = `Static);
+  assert (Atomic.get entered = 2)

--- a/tests/core/dune.inc
+++ b/tests/core/dune.inc
@@ -92,6 +92,37 @@
   (run %{clock_error_print_test})))
 
 (executable
+ (name clock_self_sync_type_test)
+ (modules clock_self_sync_type_test)
+ (flags
+  (:standard -open Liquidsoap_core))
+ (libraries
+  liquidsoap_core
+  liquidsoap_builtins
+  liquidsoap_optionals
+  liquidsoap_ffmpeg_base
+  liquidsoap_ffmpeg_decoder
+  ffmpeg-avutil
+  ffmpeg-avcodec
+  mm
+  mm.base
+  mm.audio
+  mm.video
+  mm.image
+  dtools
+  stdlib_utils
+  threads.posix
+  unix))
+
+(rule
+ (alias clock_self_sync_type_test)
+ (package liquidsoap)
+ (deps
+  (:clock_self_sync_type_test clock_self_sync_type_test.exe))
+ (action
+  (run %{clock_self_sync_type_test})))
+
+(executable
  (name clock_tick_test)
  (modules clock_tick_test)
  (flags
@@ -1221,6 +1252,7 @@
   (alias binary_strings_test)
   (alias child_support_test)
   (alias clock_error_print_test)
+  (alias clock_self_sync_type_test)
   (alias clock_tick_test)
   (alias clock_unify_test)
   (alias clock_utils_test)

--- a/tests/core/dune.inc
+++ b/tests/core/dune.inc
@@ -464,6 +464,37 @@
   (run %{frame_test})))
 
 (executable
+ (name frame_video_dimensions_test)
+ (modules frame_video_dimensions_test)
+ (flags
+  (:standard -open Liquidsoap_core))
+ (libraries
+  liquidsoap_core
+  liquidsoap_builtins
+  liquidsoap_optionals
+  liquidsoap_ffmpeg_base
+  liquidsoap_ffmpeg_decoder
+  ffmpeg-avutil
+  ffmpeg-avcodec
+  mm
+  mm.base
+  mm.audio
+  mm.video
+  mm.image
+  dtools
+  stdlib_utils
+  threads.posix
+  unix))
+
+(rule
+ (alias frame_video_dimensions_test)
+ (package liquidsoap)
+ (deps
+  (:frame_video_dimensions_test frame_video_dimensions_test.exe))
+ (action
+  (run %{frame_video_dimensions_test})))
+
+(executable
  (name generator_test)
  (modules generator_test)
  (flags
@@ -1264,6 +1295,7 @@
   (alias flush_test)
   (alias frame_checksum_test)
   (alias frame_test)
+  (alias frame_video_dimensions_test)
   (alias generator_test)
   (alias http_test)
   (alias is_url)

--- a/tests/core/frame_video_dimensions_test.ml
+++ b/tests/core/frame_video_dimensions_test.ml
@@ -1,0 +1,18 @@
+(* Video dimensions are auto-detected from the first decoded file, so an
+   [ideal_size] is only a default until they are first read. *)
+
+let () =
+  Frame_settings.lazy_config_eval := true;
+  Frame_settings.conf_video_detect_dimensions#set true;
+  assert (not Frame_settings.conf_video_width#is_set);
+  assert (not Frame_settings.conf_video_height#is_set);
+  let width, height = Frame.video_dimensions () in
+  let width = Lazy.force width in
+  let height = Lazy.force height in
+  assert (0 < width && 0 < height);
+  let ideal_size =
+    { Frame.width = width + 320; height = height + 180; source = "test" }
+  in
+  let detected_width, detected_height = Frame.video_dimensions ~ideal_size () in
+  assert (Lazy.force detected_width = width);
+  assert (Lazy.force detected_height = height)


### PR DESCRIPTION
Fixes #5363.

Starting a script that creates its Icecast output dynamically and feeds it through `source.dynamic` could abort the clock thread with `CamlinternalLazy.Undefined` before the first frame. The reported setup only failed on slow starts and came back up fine on the automatic restart.

`Lazy` is not thread safe: forcing a lazy that another thread is already forcing reaches the marker closure the runtime installs for the duration of the computation, which raises `CamlinternalLazy.Undefined`. With systhreads everything runs in a single domain, so a concurrent force raises that rather than `RacyLazy`. `Clock.self_sync_type_of_sources` returned a `Lazy.t`, forced by `switch#self_sync`, `sequence#self_sync` and `self_sync_of_sources`. Those are reached from the clock threads, from the sync source notifications that `notify_sync_source` propagates up the source tree when a child's state changes, and from the GC finalizers that call `#sleep`, so two threads can force the same lazy at once. The backtrace in the issue carries no frame from the lazy's own body underneath the raise, which rules out a re-entrant force from the same stack and leaves a concurrent one.

`Frame_settings.video_dimensions` has the same exposure. It is deliberately kept out of the settings evaluated right after the script is parsed, because video dimensions can be auto-detected from the first decoded file, so it is first read while streaming: from the clock threads allocating video content, and from the decoder threads.

Both values are deterministic and side-effect free, so both are now memoized with an `Atomic.t`: a racing computation may run twice and yields the same result. A lock would be the wrong tool here. `Mutex_utils.atomic_lock` is a non-reentrant spin lock, and the finalizer path can re-enter `self_sync` while it is being computed — a source collected during the computation sleeps, notifies its parents, and comes back around to the same memo — so a lock would trade the crash for a permanent hang of the clock thread.

The guard that gates video dimension auto-detection on the dimensions not having been read yet moves from `Lazy.is_val` to a check on the memo.

Tests: `tests/core/clock_self_sync_type_test.ml` has two threads rendezvous inside the computation so both are provably in it at once, and requires both to come back with the value; against the previous `Lazy.t` it fails with `CamlinternalLazy.Undefined`. `tests/core/frame_video_dimensions_test.ml` reads the dimensions and then passes a different `ideal_size`, requiring the values not to change; it fails if the memo does not hold.

No `CHANGES.md` entry: both bugs were introduced in the current development cycle, so no released version is affected.

One caveat left, worth a separate change: `Frame.video_dimensions` still returns `int Lazy.t` wrappers around the memo. Most callers force them on the next line, but `lang_ffmpeg.ml`, `lang_avi.ml`, `lang_theora.ml`, `lang_external_encoder.ml` and `liq_ogg_decoder.ml` bind them at module level and store them in shared format records, where two encoder threads can still force the same wrapper. The memo shrinks that window to a single atomic read but does not close it; closing it means returning getters instead of `Lazy.t`, which ripples into `Ffmpeg_format` and the content parameter types.
