### PR TITLE
source: keep frame generation from re-entering itself

### DIFF
--- a/src/core/source/source.ml
+++ b/src/core/source/source.ml
@@ -623,13 +623,20 @@ class virtual operator ?(stack = []) ?clock ~name sources =
       List.iter (fun fn -> fn ()) on_after_streaming_cycle;
       Atomic.set streaming_state `Pending
 
+    (* Frame generation executes script callbacks which may read the source's
+       frame again. Such a re-entrant call must not restart the generation, so
+       it reports the data left over from the previous cycle instead. *)
+    val mutable generating = false
+
     method peek_frame =
       match Atomic.get streaming_state with
         | `Pending | `Unavailable ->
             log#critical "source called while not ready!";
             raise Unavailable
+        | `Ready _ when generating -> self#cache
         | `Ready fn ->
-            fn ();
+            generating <- true;
+            Fun.protect ~finally:(fun () -> generating <- false) fn;
             self#peek_frame
         | `Done data -> data
 

--- a/tests/regression/GH5361.liq
+++ b/tests/regression/GH5361.liq
@@ -1,0 +1,30 @@
+# Regression test for a synchronous callback reading the source's own frame.
+#
+# Synchronous callbacks run in the middle of the source's frame generation, so
+# `s.time()`, `s.generate_frame()` and the like used to restart that generation
+# instead of reporting the frame in progress, generating a source's frame
+# several times per clock tick and, with a source that re-announces metadata on
+# each track, looping forever.
+
+log.level := 3
+
+s = sine()
+last_time = ref(-1.)
+
+s.on_frame(
+  before=true,
+  synchronous=true,
+  fun () ->
+    begin
+      t = source.time(s)
+      if t == last_time() then test.fail() end
+      last_time := t
+    end
+)
+
+s.on_metadata(synchronous=true, fun (_) -> ignore(s.time()))
+
+output.dummy(fallible=true, s)
+
+thread.run(delay=0.5, {s.insert_metadata([("title", "x")])})
+thread.run(delay=1.5, test.pass)

--- a/tests/regression/dune.inc
+++ b/tests/regression/dune.inc
@@ -1378,6 +1378,24 @@
   (run %{run_test} GH5348 liquidsoap %{test_liq} GH5348.liq)))
 
 (rule
+ (alias test_GH5361)
+ (package liquidsoap)
+ (deps
+  GH5361.liq
+  (glob_files ../media/**)
+  ../liquidsoap-test-assets
+  ../../src/bin/liquidsoap.exe
+  ../streams/file1.png
+  ../streams/file1.mp3
+  ./theora-test.mp4
+  (package liquidsoap)
+  (source_tree ../../src/libs)
+  (:test_liq ../test.liq)
+  (:run_test ../run_test.exe))
+ (action
+  (run %{run_test} GH5361 liquidsoap %{test_liq} GH5361.liq)))
+
+(rule
  (alias test_LS268)
  (package liquidsoap)
  (deps
@@ -2597,6 +2615,7 @@
   (alias test_GH5287)
   (alias test_GH5319)
   (alias test_GH5348)
+  (alias test_GH5361)
   (alias test_LS268)
   (alias test_LS354-1)
   (alias test_LS354-2)


### PR DESCRIPTION
Fixes #5361.

`s.time()` called from a `synchronous=true` `on_metadata` handler either loops forever or crashes. The reporter's script hangs before printing anything and never recovers.

Synchronous callbacks are executed by `instrumented_generate_frame`, i.e. while the source's streaming state still holds the `Ready` closure that produces the current frame. `peek_frame` runs that closure whenever it sees `Ready`, so any callback reading the source's own frame restarts the generation it is running inside of. The source then produces several frames for a single clock tick, and with a source that re-announces metadata on each track — `single`, through the `on_select` metadata replay — every extra generation fires the callback again, so the recursion never ends. `source.time(s)` is unaffected because it only reads the clock's tick count and never touches the frame.

`peek_frame` now tracks whether the generation closure is already running and, in that case, returns the data left over from the previous cycle instead of running it again. The fix is in `peek_frame` rather than in the `time` method because every frame accessor routes through it: `s.generate_frame()`, documented for use inside synchronous callbacks, had the same problem, and so does any operator reading `frame_position`, `frame_metadata` and friends from its own callbacks.

`s.time()` inside a synchronous callback now reports the source's clock time without the sub-frame offset, so it agrees with `source.time(s)`.

`tests/regression/GH5361.liq` drives a `sine` whose synchronous `on_metadata` calls `s.time()` and asserts that the source never generates two frames within the same clock tick. It fails on `main` and passes with the fix.

No `CHANGES.md` entry here: this ships as a 2.4.x bugfix (#5376) and is assumed fixed on forward versions.
