### PR TITLE
source: begin a track on a source switch at a frame boundary

### DIFF
--- a/src/core/operators/cross.ml
+++ b/src/core/operators/cross.ml
@@ -44,11 +44,22 @@ class cross val_source ~override_duration ~duration_getter ~persist_override
   ~rms_width transition =
   let s = Lang.to_source val_source in
   let original_duration_getter = duration_getter in
+  let status :
+      [ `Idle
+      | `Before of Clock.activation * Source.source
+      | `After of Clock.activation * Source.source ]
+      ref =
+    ref `Idle
+  in
   object (self)
     inherit source ~name:"cross" ()
 
+    (* Switching to the transition is where the new track begins; switching back
+       to a buffering source at the end of it continues that same track. *)
     inherit
       generate_from_multiple_sources
+        ~new_track_on_source_switch:(fun () ->
+          match !status with `After _ -> true | _ -> false)
         ~merge:(fun () -> false)
         ~track_sensitive:(fun () -> false)
         ()
@@ -138,22 +149,16 @@ class cross val_source ~override_duration ~duration_getter ~persist_override
           s#sleep (Option.get a);
           source <- (None, s))
 
-    val mutable status
-        : [ `Idle
-          | `Before of Clock.activation * Source.source
-          | `After of Clock.activation * Source.source ] =
-      `Idle
-
     (* Releases what the transition registered, if we are holding one. *)
     val mutable release_transition = fun () -> ()
 
     method set_status v =
-      (match status with
+      (match !status with
         | `Idle -> ()
         | `Before (a, s) | `After (a, s) -> s#sleep a);
       release_transition ();
       release_transition <- (fun () -> ());
-      status <- v
+      status := v
 
     method! child_clock_controller =
       Some (`Other ("source", (self :> < id : string >)))
@@ -212,18 +217,18 @@ class cross val_source ~override_duration ~duration_getter ~persist_override
       let a = self#prepare_source before in
       self#set_status (`Before (a, (before :> Source.source)));
       self#buffer_before ~is_first:true ();
-      match status with
+      match !status with
         | `After (_, s) | `Before (_, s) -> if s#is_ready then Some s else None
         | _ -> assert false
 
     method private get_source ~reselect () =
       let reselect = match reselect with `Force -> `Ok | _ -> reselect in
-      match status with
+      match !status with
         | `Idle when self#child_is_ready -> self#prepare_before
         | `Idle -> None
         | `Before _ -> (
             self#buffer_before ~is_first:false ();
-            match status with
+            match !status with
               | `Idle -> assert false
               | `Before (_, before_source)
                 when self#can_reselect ~reselect before_source ->
@@ -451,12 +456,13 @@ class cross val_source ~override_duration ~duration_getter ~persist_override
             | Some s, None ->
                 (new Sequence.sequence
                    ~name:(Printf.sprintf "%s.before_head" self#id)
-                   ~merge:true [s; compound]
+                   ~merge:true ~new_track_on_source_switch:false [s; compound]
                   :> Source.source)
             | None, Some s ->
                 (new Sequence.sequence
                    ~name:(Printf.sprintf "%s.after_tail" self#id)
-                   ~single_track:false [compound; s]
+                   ~new_track_on_source_switch:false ~single_track:false
+                   [compound; s]
                   :> Source.source)
             | Some _, Some _ -> assert false
         in
@@ -469,7 +475,7 @@ class cross val_source ~override_duration ~duration_getter ~persist_override
       release_transition <- release_callbacks
 
     method remaining =
-      match status with
+      match !status with
         | `Idle -> self#source#remaining
         | `Before (_, s) -> (
             match (s#remaining, self#source#remaining) with
@@ -478,7 +484,7 @@ class cross val_source ~override_duration ~duration_getter ~persist_override
         | `After (_, s) -> s#remaining
 
     method effective_source =
-      match status with
+      match !status with
         | `Idle -> self#source#effective_source
         | `Before (_, s) | `After (_, s) -> s#effective_source
 
@@ -487,7 +493,7 @@ class cross val_source ~override_duration ~duration_getter ~persist_override
     initializer
       self#on_before_streaming_cycle (fun () ->
           if Atomic.exchange pending_abort_track false then (
-            match status with
+            match !status with
               | `Idle -> ()
               | `Before _ | `After _ -> ignore self#prepare_before))
 

--- a/src/core/operators/sequence.ml
+++ b/src/core/operators/sequence.ml
@@ -27,8 +27,8 @@ open Source
     sequence. The [merge] flag will *not* merge tracks while looping on the last
     source -- this behavior would not be suited to the current use of [sequence]
     in transitions. *)
-class sequence ?(name = "sequence") ?(merge = false) ?(single_track = true)
-  sources =
+class sequence ?(name = "sequence") ?(merge = false)
+  ?(new_track_on_source_switch = true) ?(single_track = true) sources =
   let self_sync_type = Clock.self_sync_type_of_sources sources in
   let seq_sources = Atomic.make sources in
   object (self)
@@ -36,6 +36,7 @@ class sequence ?(name = "sequence") ?(merge = false) ?(single_track = true)
 
     inherit
       generate_from_multiple_sources
+        ~new_track_on_source_switch:(fun () -> new_track_on_source_switch)
         ~merge:(fun () -> merge && List.length (Atomic.get seq_sources) <> 1)
         ~track_sensitive:(fun () -> true)
         ()

--- a/src/core/source/source.ml
+++ b/src/core/source/source.ml
@@ -967,7 +967,8 @@ class virtual active_source ?stack ?clock ~name () =
    captures. *)
 type reselect = [ `Ok | `Force | `After_position of int ]
 
-class virtual generate_from_multiple_sources ~merge ~track_sensitive () =
+class virtual generate_from_multiple_sources
+  ?(new_track_on_source_switch = fun () -> true) ~merge ~track_sensitive () =
   object (self)
     method virtual get_source : reselect:reselect -> unit -> source option
     method virtual split_frame : Frame.t -> Frame.t * Frame.t option
@@ -1004,6 +1005,13 @@ class virtual generate_from_multiple_sources ~merge ~track_sensitive () =
         self#execute_on_track buf;
         buf)
 
+    (* A source switch carries potentially different content, so it begins a
+       track unless the operator knows better. *)
+    method private on_source_switch buf =
+      if new_track_on_source_switch () then self#begin_track buf
+      else if merge () then Frame.drop_track_marks buf
+      else buf
+
     method private can_reselect ~(reselect : reselect) (s : source) =
       s#is_ready
       &&
@@ -1021,7 +1029,11 @@ class virtual generate_from_multiple_sources ~merge ~track_sensitive () =
                 match current_source with
                   | Some s' when s == s' -> self#empty_frame
                   | _ -> self#begin_track next_track)
-            | buf, _ -> buf)
+            | buf, _ -> (
+                match current_source with
+                  | Some s' when s != s' && Frame.position buf > 0 ->
+                      self#on_source_switch buf
+                  | _ -> buf))
 
     method private generate_frame =
       let s = Option.get ready_source in
@@ -1067,7 +1079,7 @@ class virtual generate_from_multiple_sources ~merge ~track_sensitive () =
                         | buf, _ -> Frame.slice buf rem)
                 in
                 f ~last_source:s ~last_chunk:new_track
-                  (Frame.append buf (self#begin_track new_track))
+                  (Frame.append buf (self#on_source_switch new_track))
             | _ -> (last_source, buf))
         else (last_source, buf)
       in

--- a/src/core/source/source.mli
+++ b/src/core/source/source.mli
@@ -451,8 +451,11 @@ type reselect = [ `Ok | `Force | `After_position of int ]
 (* Helper to generate data from a sequence of source.
    Data generation calls [get_source] on track marks.
    When frame is partial, a track mark is added unless [merge] is
-   set to [true]. *)
+   set to [true]. Switching to a different source begins a track unless
+   [new_track_on_source_switch] says otherwise, for operators such as [cross]
+   that know which of their switches is a real track boundary. *)
 class virtual generate_from_multiple_sources :
+  ?new_track_on_source_switch:(unit -> bool) ->
   merge:(unit -> bool) ->
   track_sensitive:(unit -> bool) ->
   unit ->
@@ -464,6 +467,7 @@ object
   method virtual private set_last_metadata : Frame.t -> unit
   method virtual log : Log.t
   method virtual id : string
+  method private on_source_switch : Frame.t -> Frame.t
   method private can_reselect : reselect:reselect -> source -> bool
   method private can_generate_frame : bool
   method private generate_frame : Frame.t

--- a/tests/regression/GH4828.liq
+++ b/tests/regression/GH4828.liq
@@ -1,6 +1,6 @@
 log.level := 4
 
-expected_checksum = "5122ca63495343bed07dfa27b900d79d"
+expected_checksum = "451aa2945c5547cc56a58475591b5680"
 
 settings.frame.checksum.metadata := true
 settings.frame.checksum.track_marks := true

--- a/tests/streams/cross_on_track.liq
+++ b/tests/streams/cross_on_track.liq
@@ -1,0 +1,38 @@
+# The transition returned by a crossfade is add-shaped and carries no track
+# mark, so `cross` has to announce the new track itself. Check that each
+# crossing fires `on_track` exactly once, with the incoming track's metadata.
+
+def titled(t, s) =
+  metadata.map(
+    insert_missing=true,
+    update=false,
+    (fun (_) -> [("title", t)]),
+    s
+  )
+end
+
+s =
+  sequence(
+    [titled("a", sine(duration=2., 440.)), titled("b", sine(duration=2., 880.))]
+  )
+s = crossfade(duration=1., s)
+
+seen = ref([])
+
+def on_track(m) =
+  seen := [...seen(), m["title"]]
+end
+
+s.on_track(synchronous=true, on_track)
+clock.assign_new(sync="none", [s])
+
+o = output.dummy(fallible=true, s)
+
+def check() =
+  print(
+    "titles: #{seen()}"
+  )
+  if seen() == ["a", "b"] then test.pass() else test.fail() end
+end
+
+thread.run(delay=5., check)

--- a/tests/streams/dune.inc
+++ b/tests/streams/dune.inc
@@ -236,6 +236,42 @@
   (run %{run_test} cross.liq liquidsoap %{test_liq} cross.liq)))
 
 (rule
+ (alias test_cross_on_track)
+ (package liquidsoap)
+ (deps
+  cross_on_track.liq
+  ./file1.mp3
+  ./file2.mp3
+  ./file3.mp3
+  ./jingle1.mp3
+  ./jingle2.mp3
+  ./jingle3.mp3
+  ./file1.png
+  ./file2.png
+  ./jingles
+  ./playlist
+  ./huge_playlist
+  ./replaygain_track_gain.mp3
+  ./r128_track_gain.mp3
+  ./replaygain_r128_track_gain.mp3
+  ./replaygain_track_gain.opus
+  ./r128_track_gain.opus
+  ./replaygain_r128_track_gain.opus
+  ./without_replaygain_track_gain.mp3
+  ../media/test-subtitle.srt
+  ../../src/bin/liquidsoap.exe
+  (package liquidsoap)
+  (:test_liq ../test.liq)
+  (:run_test ../run_test.exe))
+ (action
+  (run
+   %{run_test}
+   cross_on_track.liq
+   liquidsoap
+   %{test_liq}
+   cross_on_track.liq)))
+
+(rule
  (alias test_crossfade)
  (package liquidsoap)
  (deps
@@ -2440,6 +2476,7 @@
   (alias test_cross-override)
   (alias test_cross-persist-override)
   (alias test_cross-sequence-transition)
+  (alias test_cross_on_track)
   (alias test_crossfade)
   (alias test_crossfade2)
   (alias test_ctype1)


### PR DESCRIPTION
A source switch potentially carries different content, so it begins a track. `generate_from_multiple_sources` applied that rule only when the switch happened mid-frame; at a frame boundary, `continue_frame` marked a track only if the incoming frame already carried a mark of its own.

`switch`, `fallback`, `rotate` and `sequence` never noticed, since their children's own end-of-track mark lands mid-frame and takes the other path. `cross` switches at a frame boundary every time, and its transition is add-shaped: the track mark that the underlying source produced is buffered into the after generator, reaches the transition's input, and dies inside it. The result is that `cross` fired `on_track` once at startup and never again, so handlers a script registers after a crossfade only ever saw the first track.

Both switch sites now go through a single `on_source_switch`, and the class takes an optional `new_track_on_source_switch` getter so an operator can answer the question at the point it inherits the class. Passing nothing keeps the generic rule, which is what `switch`, `source.dynamic` and the `sequence` operator do.

`cross` knows more than the generic rule: it changes source twice per crossing, and only one of the two is a content boundary. Switching to the transition is where the new track begins — it is also where the new track's metadata is replayed — while switching back to a buffering source at the end of the transition continues that same track. Its `status` moves from a `val mutable` into the class prelude so the getter can read it. The two internal sequences `cross` uses to splice its buffered remainders around the transition are within one track and decline the mark as well; without that, each crossing announced two tracks.

Tests: `tests/streams/cross_on_track.liq` crossfades a two-track sequence and checks that `on_track` fires once per track, with the incoming track's title. It reports `["a"]` before the change and `["a", "b"]` after.
