### PR TITLE
source: tell a crossfade's replayed metadata from a fresh announcement (2.4.x)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,14 @@
 
 ## Fixed:
 
+- `cross` and `crossfade` with their default `deduplicate=true` no longer drop
+  the metadata of a track that repeats the one before it, e.g. a single file on
+  a loop, which silenced the handlers a script registers after the operator.
+  `cross` now marks the outgoing track's metadata where it replays it into the
+  transition, so the repeat it is meant to remove is told apart from a fresh
+  announcement rather than guessed at by comparing values (#5360)
+- `metadata.deduplicate` no longer compares across a track mark, for the same
+  reason (#5360)
 - `cross` and `crossfade` now fire `on_track` on every crossing. The default
   transition mixes the two tracks and carries no track mark of its own, so
   handlers registered after a crossfade only ever saw the first track (#5379)

--- a/src/core/base/operators/cross.ml
+++ b/src/core/base/operators/cross.ml
@@ -498,7 +498,13 @@ class cross val_source ~end_duration_getter ~override_end_duration
         let before =
           new Replay_metadata.replay
             ~name:(Printf.sprintf "%s.before_metadata" self#id)
-            before_metadata
+            (* The outgoing track was already announced downstream. Mark the
+               replay so `deduplicate` can tell it from a fresh announcement
+               that happens to repeat it. *)
+            (if before_metadata = Frame.Metadata.empty then before_metadata
+             else
+               Frame.Metadata.add "liq_cross_replayed_metadata" "true"
+                 before_metadata)
             (new consumer
                ~name:(Printf.sprintf "%s.before_buffer" self#id)
                ~clock:self#clock gen_before)

--- a/src/libs/fades.liq
+++ b/src/libs/fades.liq
@@ -851,21 +851,37 @@ end
 # @param ~deduplicate  Crossfade transitions can generate duplicate metadata. When `true`, the operator \
 #                      removes duplicate metadata from the returned source.
 def replaces cross(%argsof(cross), ~deduplicate=true, transition, s) =
-  if
-    not deduplicate
-  then
-    cross(%argsof(cross), transition, s)
-  else
-    s = cross(%argsof(cross[!id]), transition, s)
-    dedup = metadata.deduplicate(s)
+  s = cross(%argsof(cross[!id]), transition, s)
 
-    dedup.{
-      buffered=s.buffered,
-      duration=s.duration,
-      start_duration=s.start_duration,
-      end_duration=s.end_duration
-    }
+  # `cross` marks the outgoing track's metadata where it replays it into the
+  # transition. Drop that replay when it repeats what was just announced, and
+  # never drop a fresh announcement, so a track repeating the one before it,
+  # e.g. a single file on a loop, still shows up. The mark is removed either
+  # way.
+  last_meta = ref([])
+
+  def f(m) =
+    replayed = list.assoc.mem("liq_cross_replayed_metadata", m)
+    m = list.assoc.remove("liq_cross_replayed_metadata", m)
+    if
+      deduplicate and replayed and m == last_meta()
+    then
+      []
+    else
+      last_meta := m
+      m
+    end
   end
+
+  dedup =
+    metadata.map(id=id, insert_missing=false, update=false, strip=true, f, s)
+
+  dedup.{
+    buffered=s.buffered,
+    duration=s.duration,
+    start_duration=s.start_duration,
+    end_duration=s.end_duration
+  }
 end
 
 # Crossfade between tracks, taking the respective volume levels into account in

--- a/src/libs/source.liq
+++ b/src/libs/source.liq
@@ -65,7 +65,7 @@ def track.metadata.deduplicate(
     strip=true,
     f,
     t
-  )
+  ).{reset=fun () -> last_meta := []}
 end
 
 # Remove duplicate metadata in a source.
@@ -76,10 +76,12 @@ end
 # @param s source
 def metadata.deduplicate(~id=null("metadata.deduplicate"), ~using=null, s) =
   tracks = source.tracks(s)
-  source(
-    id=id,
-    tracks.{metadata=track.metadata.deduplicate(using=using, tracks.metadata)}
-  )
+  metadata = track.metadata.deduplicate(using=using, tracks.metadata)
+
+  # Comparing across a track mark would drop the metadata of a track that
+  # repeats the previous one, e.g. a single file on a loop.
+  source.methods(s).on_track(synchronous=true, fun (_) -> metadata.reset())
+  source(id=id, tracks.{metadata=metadata})
 end
 
 # Rewrite metadata on the fly using a function.

--- a/tests/regression/GH5360.liq
+++ b/tests/regression/GH5360.liq
@@ -1,0 +1,42 @@
+# Regression test for metadata.deduplicate comparing across track marks.
+#
+# The operator removes a metadata that repeats the one before it, so that a
+# crossfade re-announcing the outgoing track does not show up twice. Comparing
+# without bound also swallowed the metadata of every track that repeated the
+# previous one, e.g. a single file on a loop, which silenced the handlers a
+# script attaches after `cross`.
+
+log.level := 3
+
+s = sine()
+d = metadata.deduplicate(s)
+
+announced = ref(0)
+d.on_metadata(synchronous=true, fun (_) -> announced := announced() + 1)
+
+output.dummy(fallible=true, d)
+
+m = [("title", "same")]
+
+thread.run(delay=1.0, {s.insert_metadata(new_track=true, m)})
+
+# Repeated within the track: dropped.
+thread.run(delay=1.5, {s.insert_metadata(new_track=false, m)})
+
+thread.run(delay=2.0, {s.insert_metadata(new_track=true, m)})
+
+thread.run(
+  delay=3.0,
+  {
+    if
+      announced() == 2
+    then
+      test.pass()
+    else
+      print(
+        "expected 2 announcements, got #{announced()}"
+      )
+      test.fail()
+    end
+  }
+)

--- a/tests/regression/dune.inc
+++ b/tests/regression/dune.inc
@@ -1196,6 +1196,23 @@
  (action (run %{run_test} GH5319 liquidsoap %{test_liq} GH5319.liq)))
   
 (rule
+ (alias GH5360)
+ (package liquidsoap)
+ 
+ (deps
+  GH5360.liq
+  ../media/all_media_files
+  ../../src/bin/liquidsoap.exe
+  ../streams/file1.png
+  ../streams/file1.mp3
+  ./theora-test.mp4
+  (package liquidsoap)
+  (source_tree ../../src/libs)
+  (:test_liq ../test.liq)
+  (:run_test ../run_test.exe))
+ (action (run %{run_test} GH5360 liquidsoap %{test_liq} GH5360.liq)))
+  
+(rule
  (alias GH5361)
  (package liquidsoap)
  
@@ -1862,6 +1879,7 @@
     (alias GH5260)
     (alias GH5287)
     (alias GH5319)
+    (alias GH5360)
     (alias GH5361)
     (alias LS268)
     (alias LS354-1)

--- a/tests/streams/cross-repeated-track-metadata.liq
+++ b/tests/streams/cross-repeated-track-metadata.liq
@@ -1,0 +1,55 @@
+# A crossfade re-announces the outgoing track and `deduplicate=true` removes
+# that repeat. The comparison used to be unbounded, so it also swallowed the
+# metadata of a track that repeated the one before it: a single file on a loop
+# announced its first track and nothing after, and handlers a script registers
+# after `cross` stopped firing.
+#
+# Check that a repeated track is still announced, and that the crossfade's own
+# repeat is still removed.
+
+def titled(t, s) =
+  metadata.map(
+    insert_missing=true,
+    update=false,
+    (fun (_) -> [("title", t)]),
+    s
+  )
+end
+
+s =
+  sequence(
+    [
+      titled("a", sine(duration=3., 440.)),
+      titled("b", sine(duration=3., 880.)),
+      titled("b", sine(duration=3., 660.))
+    ]
+  )
+
+s = crossfade(duration=1., s)
+
+seen = ref([])
+
+def on_metadata(m) =
+  t = m["title"]
+  seen := [...seen(), t]
+end
+
+s.on_metadata(synchronous=true, on_metadata)
+clock.assign_new(sync="none", [s])
+
+o = output.dummy(fallible=true, s)
+
+def on_stop() =
+  if
+    seen() == ["a", "b", "b"]
+  then
+    test.pass()
+  else
+    print(
+      "expected 3 announcements a, b, b, got #{seen()}"
+    )
+    test.fail()
+  end
+end
+
+o.on_stop(synchronous=true, on_stop)

--- a/tests/streams/dune.inc
+++ b/tests/streams/dune.inc
@@ -232,6 +232,35 @@
  (action (run %{run_test} cross-persist-start-override.liq liquidsoap %{test_liq} cross-persist-start-override.liq)))
   
 (rule
+ (alias cross-repeated-track-metadata)
+ (package liquidsoap)
+ (deps
+  cross-repeated-track-metadata.liq
+  ./file1.mp3
+  ./file2.mp3
+  ./file3.mp3
+  ./jingle1.mp3
+  ./jingle2.mp3
+  ./jingle3.mp3
+  ./file1.png
+  ./file2.png
+  ./jingles
+  ./playlist
+  ./huge_playlist
+  ./replaygain_track_gain.mp3
+  ./r128_track_gain.mp3
+  ./replaygain_r128_track_gain.mp3
+  ./replaygain_track_gain.opus
+  ./r128_track_gain.opus
+  ./replaygain_r128_track_gain.opus
+  ./without_replaygain_track_gain.mp3
+  ../../src/bin/liquidsoap.exe
+  (package liquidsoap)
+  (:test_liq ../test.liq)
+  (:run_test ../run_test.exe))
+ (action (run %{run_test} cross-repeated-track-metadata.liq liquidsoap %{test_liq} cross-repeated-track-metadata.liq)))
+  
+(rule
  (alias cross-sequence-transition)
  (package liquidsoap)
  (deps
@@ -2040,6 +2069,7 @@
     (alias cross-persist-end-override)
     (alias cross-persist-override)
     (alias cross-persist-start-override)
+    (alias cross-repeated-track-metadata)
     (alias cross-sequence-transition)
     (alias cross_on_track)
     (alias crossfade)


### PR DESCRIPTION
Fixes the `on_metadata` half of #5360 on the stable branch. Replaces #5378, which was merged and reverted: that one removed the metadata `cross` replays into its transition, and on this branch that loses announcements. Details below.

## The bug

`cross` replays the outgoing track's metadata at the start of the transition, so a transition that keeps the outgoing source announces that track a second time. `deduplicate=true` removes the repeat by dropping a metadata equal to the one before it.

That comparison has no bound, so it also drops the metadata of any track that repeats the previous one. A single file on a loop repeats every time, so every announcement after the first was swallowed and handlers registered after `cross` stopped firing.

## The fix

The two cases are indistinguishable downstream — same bytes — and the only reset signal available, the track mark, lands exactly where the crossfade's repeat arrives. So the comparison cannot tell them apart on its own.

`cross` can. It now marks the metadata where it replays it, and the wrapper drops a repeat only when it is that replay. A fresh announcement is never dropped, so a track repeating the one before it shows up. The mark is removed either way, including when `deduplicate` is `false`, so it never reaches user metadata.

`metadata.deduplicate` no longer compares across a track mark either, for direct users of the operator. `cross` no longer goes through it, so that change cannot affect a crossfade.

## Why not remove the replay, as #5378 did

Because on this branch the replay is also a delivery mechanism, not just a duplicate. `add` here propagates the metadata of a single source, the one whose track ends first, so for a transition listing the outgoing source first the incoming track's metadata never comes through `add` — its only delivery is the next crossing's replay. Measured over seven transition shapes, removing the replay dropped a real title and artist in three of them:

| transition | stock | #5378 | this PR |
| --- | --- | --- | --- |
| `crossfade` (default) | `a, b` | `a, b, b` | `a, b, b` |
| `add([after, before])` | `a, b, b` | `a, b, b` | `a, b, b` |
| `after.source` only | `a, b, b` | `a, b, b` | `a, b, b` |
| `sequence([before, after])` | `a, b, c` | `a, b, b` | `a, b, c` |
| `add([before, after])` | `a, b` | **`a`** | `a, b` |
| `before.source` only | `a, b` | **`a`** | `a, b` |
| fades reading the stream | `a, b` | **`a`** | `a, b` |

Nothing is removed from the stream here that was not removed before. `cross.plot` needs no adaptation either, and both plot snapshots are unchanged.

## Tests

`tests/streams/cross-repeated-track-metadata.liq` covers the reported path: three tracks through `crossfade` where the third repeats the second. It reports `got ["a", "b"]` without the fix.

`tests/regression/GH5360.liq` covers `metadata.deduplicate` on its own: new track, same track, new track, expecting exactly two survivors. It reports `got 1` without the fix.

Both fail on the current branch tip and pass with this change. `cross-sequence-transition`, `cross_on_track`, `cross`, `cross-override`, `cross-override-start`, `cross-override-end`, `cross-persist-override`, `cross-persist-end-override`, `crossfade`, `crossfade2`, `crossfade-plot` and `autocue-plot` all pass unmodified.
