### PR TITLE
cross: announce a track the transition dropped

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -92,6 +92,12 @@
 
 ## Fixed:
 
+- A transition that drops the incoming source no longer drops that track's announcement with
+  it. `cross` had already consumed the metadata into the buffer it hands the transition, so
+  the track played on, audible and unannounced, once the transition was over. It is now
+  announced on the tail, where that audio starts, and only when the transition did not
+  announce it itself (#5360).
+
 - `cross` no longer replays either track's metadata into the transition. The outgoing one was
   announced a second time by a transition keeping that source, and with an `add`-shaped
   transition both replays landed at the same frame position, so only one survived and the

--- a/src/core/operators/cross.ml
+++ b/src/core/operators/cross.ml
@@ -455,6 +455,24 @@ class cross val_source ~override_duration ~duration_getter ~persist_override
                    ~merge:true ~new_track_on_source_switch:false [s; compound]
                   :> Source.source)
             | None, Some s ->
+                (* The rest of the incoming track. Its metadata went into the
+                   buffered head, so a transition that drops the incoming
+                   source leaves it unannounced. Replay it here, marked, so it
+                   is dropped again when the transition did announce it. *)
+                let s =
+                  if after_metadata = Frame.Metadata.empty then
+                    (s :> Source.source)
+                  else (
+                    let s =
+                      new Replay_metadata.replay
+                        ~name:(Printf.sprintf "%s.after_tail_metadata" self#id)
+                        (Frame.Metadata.add "liq_cross_replayed_metadata" "true"
+                           after_metadata)
+                        (s :> Source.source)
+                    in
+                    Typing.(s#frame_type <: self#frame_type);
+                    (s :> Source.source))
+                in
                 (new Sequence.sequence
                    ~name:(Printf.sprintf "%s.after_tail" self#id)
                    ~new_track_on_source_switch:false ~single_track:false

--- a/src/core/operators/liquidsoap_core_operators.ml
+++ b/src/core/operators/liquidsoap_core_operators.ml
@@ -72,6 +72,7 @@ module Pitch = Pitch
 module Replaygain_op = Replaygain_op
 module Resample = Resample
 module Rms_smooth = Rms_smooth
+module Replay_metadata = Replay_metadata
 module Sequence = Sequence
 module Server_builtins = Server_builtins
 module Stereo = Stereo

--- a/src/core/operators/liquidsoap_core_operators.mli
+++ b/src/core/operators/liquidsoap_core_operators.mli
@@ -72,6 +72,7 @@ module Pitch = Pitch
 module Replaygain_op = Replaygain_op
 module Resample = Resample
 module Rms_smooth = Rms_smooth
+module Replay_metadata = Replay_metadata
 module Sequence = Sequence
 module Server_builtins = Server_builtins
 module Stereo = Stereo

--- a/src/core/operators/replay_metadata.ml
+++ b/src/core/operators/replay_metadata.ml
@@ -1,0 +1,45 @@
+(*****************************************************************************
+
+  Liquidsoap, a programmable stream generator.
+  Copyright 2003-2026 Savonet team
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details, fully stated in the COPYING
+  file at the root of the liquidsoap distribution.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA
+
+ *****************************************************************************)
+
+open Source
+
+(** Insert metadata at the beginning if none is set. Currently used by the
+    switch classes. *)
+class replay ?(name = "replay_metadata") meta src =
+  object
+    inherit operator ~name [src]
+    val mutable first = true
+    method fallible = src#fallible
+    method private can_generate_frame = src#is_ready
+    method abort_track = src#abort_track
+    method remaining = src#remaining
+    method self_sync = src#self_sync
+    method effective_source = src#effective_source
+
+    method private generate_frame =
+      let buf = src#get_frame in
+      if first then (
+        first <- false;
+        if Frame.get_all_metadata buf = [] then Frame.add_metadata buf 0 meta
+        else buf)
+      else buf
+  end

--- a/src/libs/fades.liq
+++ b/src/libs/fades.liq
@@ -866,20 +866,40 @@ end
 # @param ~deduplicate  Crossfade transitions can generate duplicate metadata. When `true`, the operator \
 #                      removes duplicate metadata from the returned source.
 def replaces cross(%argsof(cross), ~deduplicate=true, transition, s) =
-  if
-    not deduplicate
-  then
-    cross(%argsof(cross), transition, s)
-  else
-    s = cross(%argsof(cross[!id]), transition, s)
-    dedup = metadata.deduplicate(s)
+  s = cross(%argsof(cross[!id]), transition, s)
 
-    dedup.{
-      buffered = s.buffered,
-      duration = s.duration,
-      cross_duration = s.cross_duration
-    }
+  # `cross` marks a metadata it announces as a fallback, for a track whose own
+  # announcement the transition did not carry through. Keep it only when
+  # nothing else announced that track: a crossing begins a track, so what
+  # matters is whether anything was announced since the track mark, not whether
+  # it repeats an earlier value. This is delivery, not deduplication, so it
+  # does not depend on `deduplicate`. The mark never leaves the operator.
+  announced = ref(false)
+  source.methods(s).on_track(synchronous=true, fun (_) -> announced := false)
+
+  def f(m) =
+    replayed = list.assoc.mem("liq_cross_replayed_metadata", m)
+    m = list.assoc.remove("liq_cross_replayed_metadata", m)
+    if
+      replayed and announced()
+    then
+      []
+    else
+      announced := true
+      m
+    end
   end
+
+  delivered =
+    metadata.map(id=id, insert_missing=false, update=false, strip=true, f, s)
+
+  dedup = if deduplicate then metadata.deduplicate(delivered) else delivered end
+
+  dedup.{
+    buffered = s.buffered,
+    duration = s.duration,
+    cross_duration = s.cross_duration
+  }
 end
 
 # Crossfade between tracks, taking the respective volume levels into account in

--- a/tests/streams/cross-transition-drops-incoming.liq
+++ b/tests/streams/cross-transition-drops-incoming.liq
@@ -1,0 +1,59 @@
+# A transition is free to drop the incoming source. `cross` has already
+# consumed that track's metadata into the buffer it hands the transition, so
+# dropping the source dropped the announcement with it, while the rest of the
+# track still played once the transition was over: audible, unannounced.
+#
+# `cross` announces it on the tail instead, when that audio starts, and only
+# when the transition did not announce it itself. The third track repeats the
+# second, so this also checks the fallback is not mistaken for a repeat.
+
+def titled(t, s) =
+  metadata.map(
+    insert_missing=true,
+    update=false,
+    (fun (_) -> [("title", t)]),
+    s
+  )
+end
+
+s =
+  sequence(
+    [
+      titled("a", sine(duration=4., 440.)),
+      titled("b", sine(duration=4., 880.)),
+      titled("b", sine(duration=4., 660.))
+    ]
+  )
+
+def transition(before, _) =
+  before.source
+end
+
+s = cross(duration=1., transition, s)
+
+seen = ref([])
+
+def on_metadata(m) =
+  t = m["title"]
+  seen := [...seen(), t]
+end
+
+s.on_metadata(synchronous=true, on_metadata)
+clock.assign_new(sync="none", [s])
+
+o = output.dummy(fallible=true, s)
+
+def on_stop() =
+  if
+    seen() == ["a", "b", "b"]
+  then
+    test.pass()
+  else
+    print(
+      "expected [\"a\", \"b\", \"b\"], got #{seen()}"
+    )
+    test.fail()
+  end
+end
+
+o.on_stop(synchronous=true, on_stop)

--- a/tests/streams/dune.inc
+++ b/tests/streams/dune.inc
@@ -277,6 +277,42 @@
    cross-transition-arguments.liq)))
 
 (rule
+ (alias test_cross-transition-drops-incoming)
+ (package liquidsoap)
+ (deps
+  cross-transition-drops-incoming.liq
+  ./file1.mp3
+  ./file2.mp3
+  ./file3.mp3
+  ./jingle1.mp3
+  ./jingle2.mp3
+  ./jingle3.mp3
+  ./file1.png
+  ./file2.png
+  ./jingles
+  ./playlist
+  ./huge_playlist
+  ./replaygain_track_gain.mp3
+  ./r128_track_gain.mp3
+  ./replaygain_r128_track_gain.mp3
+  ./replaygain_track_gain.opus
+  ./r128_track_gain.opus
+  ./replaygain_r128_track_gain.opus
+  ./without_replaygain_track_gain.mp3
+  ../media/test-subtitle.srt
+  ../../src/bin/liquidsoap.exe
+  (package liquidsoap)
+  (:test_liq ../test.liq)
+  (:run_test ../run_test.exe))
+ (action
+  (run
+   %{run_test}
+   cross-transition-drops-incoming.liq
+   liquidsoap
+   %{test_liq}
+   cross-transition-drops-incoming.liq)))
+
+(rule
  (alias test_cross-transition-metadata)
  (package liquidsoap)
  (deps
@@ -2586,6 +2622,7 @@
   (alias test_cross-persist-override)
   (alias test_cross-sequence-transition)
   (alias test_cross-transition-arguments)
+  (alias test_cross-transition-drops-incoming)
   (alias test_cross-transition-metadata)
   (alias test_cross_on_track)
   (alias test_crossfade)


### PR DESCRIPTION
Follow-up to #5377 and #5381, closing the last gap in #5360 on this branch.

## The bug

A transition is free to drop the incoming source — `fun (before, _) -> before.source` is a legitimate way to say "play the outgoing track out, then cut". `cross` has already consumed that track's metadata into the buffer it hands the transition, so dropping the source dropped the announcement with it. The rest of the track still plays once the transition is over, via the tail: audible and unannounced.

Before #5377 the announcement did come through, but from the *next* crossing's replay of it, one crossing late. #5377 removed that replay, which is why it went from late to absent. That is the one row where #5377 regressed something, and I missed it at the time.

## The fix

`cross` announces the incoming track's metadata on the tail, where that audio starts, marked as a fallback. The wrapper keeps it only when nothing else announced that track.

The gate is the **track mark**, not the value. A crossing begins a track, so what decides is whether anything was announced since the mark. Comparing values instead cannot tell a fallback for a genuinely new track from one for a track already announced — the same ambiguity that made a repeated track's metadata disappear in the first place. `on_track` fires exactly once per crossing since #5379, so the mark is a reliable signal here.

Delivery no longer depends on `~deduplicate`. That argument goes back to meaning only what it says — general consecutive-duplicate removal, still bounded to a track through `metadata.deduplicate`.

This restores `Replay_metadata`, which #5377 deleted, in a new position: on the tail rather than on the incoming source.

## Result

Three tracks in, three announcements out, in order, for every transition shape. The third track repeats the second, which is the #5360 shape.

| transition | stock | #5377 | this |
| --- | --- | --- | --- |
| `crossfade` (default) | `a, b` | `a, b, b` | `a, b, b` |
| `add([after, before])` | `a, b, b` | `a, b, b` | `a, b, b` |
| `after.source` only | `a, b, b` | `a, b, b` | `a, b, b` |
| `add([before, after])` | `a, b` | `a, b, b` | `a, b, b` |
| `sequence([before, after])` | `a, b, c` | `a, b, c` | `a, b, c` |
| fades reading the stream | `a, b` | `a, b, b` | `a, b, b` |
| **`before.source` only** | `a, b` (late) | **`a`** | **`a, b, b`** |

## Tests

`tests/streams/cross-transition-drops-incoming.liq` uses a transition that returns only the outgoing source and asserts all three tracks are announced. It reports `got ["a"]` without this change. Its third track repeats the second, so it also covers the fallback being mistaken for a repeat rather than delivered.

`GH4828`, which checksums the frame stream with metadata included, is unchanged, as are the `crossfade-plot` and `autocue-plot` snapshots — the fallback is dropped again in every shape that already announced the track. `GH5360`, `cross_on_track`, `cross-sequence-transition`, `cross-transition-metadata`, `cross-transition-arguments`, `cross-no-empty-metadata`, `cross`, `cross-override`, `cross-persist-override`, `crossfade` and `crossfade2` all pass unmodified.

## Note

`v2.4.x-latest` needs a different fix and has one in #5382: `add` there propagates the metadata of a single source, so the replay is still a delivery mechanism on that branch and removing it loses announcements. That PR marks the replay instead of removing it, and does not attempt this row — on a bugfix channel it only restores what stock already did.
