### PR TITLE
ffmpeg: flush decoder buffers on seek

### DIFF
--- a/src/modules/synced/ffmpeg/CHANGES
+++ b/src/modules/synced/ffmpeg/CHANGES
@@ -1,6 +1,8 @@
 1.4.0 (unreleased)
 ======
 * TODO: rename ffmpeg-av into ffmpeg-avformat
+* `Av.seek` drops the frames its decoders had buffered, which used to be
+  returned after the seek carrying their pre-seek timestamps.
 * Add version API
 * `mk_audio_opts` and `mk_video_opts` keep the options they derive (channel
   layout, sample format, time base, ...) to themselves, so that

--- a/src/modules/synced/ffmpeg/av/av_stubs.c
+++ b/src/modules/synced/ffmpeg/av/av_stubs.c
@@ -1441,6 +1441,15 @@ CAMLprim value ocaml_av_seek_native(value _flags, value _stream, value _min_ts,
   if (ret < 0)
     ocaml_avutil_raise_error(ret);
 
+  /* Frames buffered by a decoder still carry pre-seek timestamps and would be
+     handed to the caller as if they came from the new position. */
+  if (av->streams) {
+    for (i = 0; i < av->format_context->nb_streams; i++)
+      if (av->streams[i] && av->streams[i]->codec_context)
+        avcodec_flush_buffers(av->streams[i]->codec_context);
+  }
+  av->pending_stream_idx = -1;
+
   CAMLreturn(Val_unit);
 }
 

--- a/src/modules/synced/ffmpeg/gen/gen_test.ml
+++ b/src/modules/synced/ffmpeg/gen/gen_test.ml
@@ -14,6 +14,7 @@ let () =
         "test_info";
         "test_subtitle_read";
         "test_unhandled_packet";
+        "test_seek";
         "test_codec";
         "test_options";
         "test_swscale";
@@ -55,6 +56,7 @@ let () =
   (:read_metadata ../examples/read_metadata.exe)
   (:subtitle_read test_subtitle_read.exe)
   (:unhandled_packet test_unhandled_packet.exe)
+  (:seek test_seek.exe)
   (:subtitle_remux ../examples/subtitle_remux.exe)
   (:normalize normalize_line_endings.exe)
   (:srt fixtures/sample.srt))
@@ -116,6 +118,20 @@ let () =
     test_with_subs.mkv)
    (run %{runner} "subtitle_read" %{subtitle_read} test_with_subs.mkv)
    (run %{runner} "unhandled_packet" %{unhandled_packet} test_with_subs.mkv)
+   ; B-frames make the decoder buffer, which is what a seek has to drop.
+   (run
+    ffmpeg
+    -y
+    -f
+    lavfi
+    -i
+    "color=c=blue:s=320x240:d=25"
+    -c:v
+    mpeg4
+    -bf
+    2
+    test_seek.mkv)
+   (run %{runner} "seek" %{seek} test_seek.mkv)
    (run %{subtitle_remux} test_with_subs.mkv raw_remuxed_subs.srt subrip)
    (run %{normalize} raw_remuxed_subs.srt remuxed_subs.srt)
    (run diff fixtures/sample.srt remuxed_subs.srt))))

--- a/src/modules/synced/ffmpeg/test/test_seek.ml
+++ b/src/modules/synced/ffmpeg/test/test_seek.ml
@@ -1,0 +1,43 @@
+(* A seek leaves the stream decoders holding frames from before the seek
+   point. Handed back as-is, they carry pre-seek timestamps and look to the
+   caller like the new position, which is enough to make a rate filter
+   downstream fabricate the whole skipped interval. *)
+
+let () =
+  if Array.length Sys.argv < 2 then (
+    Printf.eprintf "Usage: %s input_file\n" Sys.argv.(0);
+    exit 1);
+
+  let input_file = Sys.argv.(1) in
+  let src = Av.open_input input_file in
+  let _, stream, _ = Av.find_best_video_stream src in
+  let { Avutil.num; den } = Av.get_time_base stream in
+  let seconds_of_pts pts = Int64.to_float pts *. float num /. float den in
+
+  let read_video () =
+    let rec f () =
+      match Av.read_input ~video_frame:[stream] src with
+        | `Video_frame (_, frame) -> Avutil.Frame.pts frame
+        | _ -> f ()
+    in
+    f ()
+  in
+
+  (* Enough frames for the decoder to have buffered some of its own. *)
+  for _ = 1 to 10 do
+    ignore (read_video ())
+  done;
+
+  let target = 20. in
+  Av.seek ~fmt:`Millisecond ~ts:(Int64.of_float (target *. 1000.)) src;
+
+  (match read_video () with
+    | None -> Test_assert.check "first frame after seek has a timestamp" false
+    | Some pts ->
+        let pos = seconds_of_pts pts in
+        Test_assert.checkf
+          (target -. 1. <= pos)
+          "first frame after a %.0fs seek is at %.3fs, not before it" target pos);
+
+  Av.close src;
+  Test_assert.finish ()


### PR DESCRIPTION
Fixes #5385.

A large `input.ffmpeg.seek()` on a long seekable video made memory grow by hundreds of MiB per second until the process was OOM-killed. The growth scaled with the skipped duration: at 640x360 yuv420p 24fps, a 3200s seek accounts for the ~24 GiB an unconstrained run reached.

`Av.seek` calls `avformat_seek_file` but leaves the stream decoders untouched, so frames they had already buffered are handed back after the seek still carrying their pre-seek timestamps, and `pending_stream_idx` keeps pointing at the stream that was mid-drain. The ffmpeg decoder rebuilds its streams after a seek, and with them the `Fps` filter graph, whose `setpts` expression anchors on the first frame it sees. That first frame is the stale one, so the graph anchors at the old position while the next frame arrives at the seek target: the `fps` filter then duplicates frames to bridge the whole interval between the two, around 76,800 of them for a 3200s seek. They accumulate in the seek pre-roll's discard generator, which is unbounded, hence the OOM.

`ocaml_av_seek_native` now calls `avcodec_flush_buffers` on every open stream codec context after a successful seek and resets `pending_stream_idx`, which is what `ffmpeg.c` itself does around a seek. With this, the reproducer from the issue holds a flat ~274 MiB and resumes playback at the requested position.

Not applicable to `v2.4.x`: `input.ffmpeg` has no `seek` method there, so the call returns 0 and never reaches this path. Seeking `input.ffmpeg` is new in 2.5.0, so no `CHANGES.md` entry either -- the feature has not shipped.

Added `test/test_seek.ml`: it reads a few frames, seeks 20s in, and asserts the next frame is not from before the seek point. The fixture is encoded with `-bf 2` because B-frames are what makes the decoder buffer in the first place; without them the test cannot fail. Verified that it fails without the fix (reporting a frame at 0.480s) and passes with it.
