### PR TITLE
ffmpeg: spread decoding, encoding and scaling over every core

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -94,6 +94,14 @@
   multi-document streams are now rejected with an explicit error instead of being parsed, and
   `yaml.stringify` lost its `scalar_style` and `layout_style` arguments: it always renders in
   block style with plain scalars, quoting only where needed.
+- FFmpeg encoders and decoders now pick their thread count automatically, as the `ffmpeg`
+  command-line tools do, instead of running on a single thread. Transcoding no longer
+  bottlenecks on one core: an `%ffmpeg` output using `libx265` and a 4K input is about 2.5
+  times faster. Pass `threads=1` to an `%ffmpeg` encoder to get the previous behavior back
+  (#5014).
+- Video scaling is now split over one thread per core, as `ffmpeg` does through its filter
+  graphs. `settings.ffmpeg.scaling_threads` sets the count, `1` restoring the single-threaded
+  scaling of previous versions (#5014).
 
 ## Fixed:
 

--- a/src/core/optionals/ffmpeg/base/ffmpeg_utils.ml
+++ b/src/core/optionals/ffmpeg/base/ffmpeg_utils.ml
@@ -73,6 +73,17 @@ let conf_scaling_algorithm =
         "\"bilinear\" or \"bicubic\".";
       ]
 
+let conf_scaling_threads =
+  Dtools.Conf.int
+    ~p:(conf_ffmpeg#plug "scaling_threads")
+    "Scaling threads" ~d:0
+    ~comments:
+      [
+        "Number of threads a video frame is scaled over. `0`, the default,";
+        "uses one per core. Scaling is a small part of what a video stream";
+        "costs, so the extra cores buy little once the codecs are using them.";
+      ]
+
 let () =
   Lifecycle.on_start ~name:"ffmpeg utils initialization" (fun () ->
       let verbosity =
@@ -114,6 +125,7 @@ let scaling_algorithm () =
     | "bicubic" -> Some Swscale.Bicubic
     | _ -> None
 
+let scaling_threads () = max 0 conf_scaling_threads#get
 let liq_frame_pixel_format = `Yuv420p
 let liq_frame_pixel_format_with_alpha = `Yuva420p
 

--- a/src/core/optionals/ffmpeg/base/ffmpeg_utils.mli
+++ b/src/core/optionals/ffmpeg/base/ffmpeg_utils.mli
@@ -28,10 +28,14 @@ val conf_log : Dtools.Conf.ut
 val conf_verbosity : string Dtools.Conf.t
 val conf_level : int Dtools.Conf.t
 val conf_scaling_algorithm : string Dtools.Conf.t
+val conf_scaling_threads : int Dtools.Conf.t
 
 (** Swscale flag for [conf_scaling_algorithm], [None] when it holds a value
     swscale does not know. *)
 val scaling_algorithm : unit -> Swscale.flag option
+
+(** [conf_scaling_threads], clamped to [0], which stands for one per core. *)
+val scaling_threads : unit -> int
 
 val liq_main_ticks_time_base : unit -> Avutil.rational
 val liq_audio_sample_time_base : unit -> Avutil.rational

--- a/src/core/optionals/ffmpeg/decoder/builtins_ffmpeg_decoder.ml
+++ b/src/core/optionals/ffmpeg/decoder/builtins_ffmpeg_decoder.ml
@@ -215,8 +215,9 @@ let decode_video_frame ~field ~mode generator =
             color_range,
             stream_idx );
       let scaler =
-        InternalScaler.create [] width height pixel_format internal_width
-          internal_height
+        InternalScaler.create
+          ~threads:(Ffmpeg_utils.scaling_threads ())
+          [] width height pixel_format internal_width internal_height
           (Ffmpeg_utils.liq_frame_pixel_format_for pixel_format)
       in
       let fps_converter =

--- a/src/core/optionals/ffmpeg/decoder/ffmpeg_image_decoder.ml
+++ b/src/core/optionals/ffmpeg/decoder/ffmpeg_image_decoder.ml
@@ -66,7 +66,9 @@ let decode_image fname =
       let height = Avcodec.Video.get_height codec in
       let out_pixel_format = Ffmpeg_utils.liq_frame_pixel_format_with_alpha in
       let scaler =
-        Scaler.create [] width height pixel_format width height out_pixel_format
+        Scaler.create
+          ~threads:(Ffmpeg_utils.scaling_threads ())
+          [] width height pixel_format width height out_pixel_format
       in
       match Av.read_input ~video_frame:[stream] container with
         | `Video_frame (_, frame) ->

--- a/src/core/optionals/ffmpeg/decoder/ffmpeg_internal_decoder.ml
+++ b/src/core/optionals/ffmpeg/decoder/ffmpeg_internal_decoder.ml
@@ -146,7 +146,9 @@ let mk_video_decoder ~width ~height ~alpha ~stream ~field codec =
       scale_proportional (width, height) (target_width, target_height)
     in
     let scaler =
-      Scaler.create [] width height pixel_format aw ah target_pixel_format
+      Scaler.create
+        ~threads:(Ffmpeg_utils.scaling_threads ())
+        [] width height pixel_format aw ah target_pixel_format
     in
     fun frame : Video.Canvas.Image.t ->
       let img =
@@ -252,8 +254,9 @@ let mk_bitmap_subtitle_decoder ~field ~width ~height =
       | Some (w', h', scaler) when w = w' && h = h' -> scaler
       | _ ->
           let scaler =
-            SubScaler.create [] w h `Pal8 w h
-              Ffmpeg_utils.liq_frame_pixel_format_with_alpha
+            SubScaler.create
+              ~threads:(Ffmpeg_utils.scaling_threads ())
+              [] w h `Pal8 w h Ffmpeg_utils.liq_frame_pixel_format_with_alpha
           in
           cached_scaler := Some (w, h, scaler);
           scaler

--- a/src/core/optionals/ffmpeg/encoder/builtins_ffmpeg_encoder.ml
+++ b/src/core/optionals/ffmpeg/encoder/builtins_ffmpeg_encoder.ml
@@ -224,7 +224,9 @@ let encode_video_frame ~source_idx ~type_t ~mode ~opts ?codec ~format
     chosen_pixel_format := target_pixel_format;
     scaler :=
       Some
-        (InternalScaler.create [flag] internal_width internal_height
+        (InternalScaler.create
+           ~threads:(Ffmpeg_utils.scaling_threads ())
+           [flag] internal_width internal_height
            (Ffmpeg_utils.liq_frame_pixel_format_for target_pixel_format)
            target_width target_height target_pixel_format)
   in

--- a/src/core/optionals/ffmpeg/encoder/ffmpeg_internal_encoder.ml
+++ b/src/core/optionals/ffmpeg/encoder/ffmpeg_internal_encoder.ml
@@ -509,7 +509,9 @@ let mk_video ~pos ~on_keyframe ~mode ~codec ~params ~options ~field output =
           | Some s -> s
           | None ->
               let s =
-                InternalScaler.create [flag] src_width src_height
+                InternalScaler.create
+                  ~threads:(Ffmpeg_utils.scaling_threads ())
+                  [flag] src_width src_height
                   (Ffmpeg_utils.liq_frame_pixel_format_for target_pixel_format)
                   target_width target_height target_pixel_format
               in
@@ -549,9 +551,10 @@ let mk_video ~pos ~on_keyframe ~mode ~codec ~params ~options ~field output =
               let f =
                 if src_width <> target_width || src_height <> target_height then (
                   let scaler =
-                    RawScaler.create [flag] src_width src_height
-                      src_pixel_format target_width target_height
-                      src_pixel_format
+                    RawScaler.create
+                      ~threads:(Ffmpeg_utils.scaling_threads ())
+                      [flag] src_width src_height src_pixel_format target_width
+                      target_height src_pixel_format
                   in
                   fun frame ->
                     let scaled = RawScaler.convert scaler frame in

--- a/src/modules/synced/ffmpeg/av/av_stubs.c
+++ b/src/modules/synced/ffmpeg/av/av_stubs.c
@@ -1116,9 +1116,7 @@ static stream_t *open_stream_index(av_t *av, int index, const AVCodec *dec) {
   }
 
   // Open the decoder
-  caml_release_runtime_system();
-  err = avcodec_open2(stream->codec_context, dec, NULL);
-  caml_acquire_runtime_system();
+  err = ocaml_avcodec_open_codec(stream->codec_context, dec, NULL);
 
   if (err < 0) {
     av_free(stream);
@@ -1881,9 +1879,7 @@ static void init_stream_encoder(AVBufferRef *device_ctx, AVBufferRef *frame_ctx,
     }
   }
 
-  caml_release_runtime_system();
-  ret = avcodec_open2(enc_ctx, enc_ctx->codec, options);
-  caml_acquire_runtime_system();
+  ret = ocaml_avcodec_open_codec(enc_ctx, enc_ctx->codec, options);
 
   if (ret < 0) {
     av_dict_free(options);

--- a/src/modules/synced/ffmpeg/avcodec/avcodec_stubs.c
+++ b/src/modules/synced/ffmpeg/avcodec/avcodec_stubs.c
@@ -58,9 +58,7 @@ static AVCodecContext *create_AVCodecContext(AVCodecParameters *params,
   }
 
   // Open the codec
-  caml_release_runtime_system();
-  ret = avcodec_open2(codec_context, codec, NULL);
-  caml_acquire_runtime_system();
+  ret = ocaml_avcodec_open_codec(codec_context, codec, NULL);
 
   if (ret < 0) {
     avcodec_free_context(&codec_context);
@@ -566,9 +564,7 @@ CAMLprim value ocaml_avcodec_create_audio_encoder(value _sample_fmt,
   }
 
   // Open the codec
-  caml_release_runtime_system();
-  err = avcodec_open2(ctx->codec_context, ctx->codec, &options);
-  caml_acquire_runtime_system();
+  err = ocaml_avcodec_open_codec(ctx->codec_context, ctx->codec, &options);
 
   if (err < 0) {
     av_dict_free(&options);
@@ -643,9 +639,7 @@ CAMLprim value ocaml_avcodec_create_video_encoder(value _device_context,
   }
 
   // Open the codec
-  caml_release_runtime_system();
-  err = avcodec_open2(ctx->codec_context, ctx->codec, &options);
-  caml_acquire_runtime_system();
+  err = ocaml_avcodec_open_codec(ctx->codec_context, ctx->codec, &options);
 
   if (err < 0) {
     av_dict_free(&options);

--- a/src/modules/synced/ffmpeg/avcodec/avcodec_stubs.h
+++ b/src/modules/synced/ffmpeg/avcodec/avcodec_stubs.h
@@ -2,12 +2,31 @@
 #define _AVCODEC_STUBS_H_
 
 #include <caml/mlvalues.h>
+#include <caml/threads.h>
 #include <libavcodec/avcodec.h>
 
 #if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(60, 26, 100)
 #define AV_PROFILE_UNKNOWN FF_PROFILE_UNKNOWN
 #define AV_LEVEL_UNKNOWN FF_LEVEL_UNKNOWN
 #endif
+
+/* libavcodec runs a codec on a single thread unless told otherwise, ffmpeg's
+   own tools raise that to automatic before opening one: do the same. Codecs
+   that thread badly opt out through their own defaults, and [options], which
+   avcodec_open2 applies itself, still wins over ours. */
+static inline int ocaml_avcodec_open_codec(AVCodecContext *codec_context,
+                                           const AVCodec *codec,
+                                           AVDictionary **options) {
+  int ret;
+
+  codec_context->thread_count = 0;
+
+  caml_release_runtime_system();
+  ret = avcodec_open2(codec_context, codec, options);
+  caml_acquire_runtime_system();
+
+  return ret;
+}
 
 /***** AVCodec *****/
 

--- a/src/modules/synced/ffmpeg/swscale/swscale.ml
+++ b/src/modules/synced/ffmpeg/swscale/swscale.ml
@@ -66,6 +66,7 @@ module Make (I : VideoData) (O : VideoData) = struct
   type t = (I.t, O.t) ctx
 
   external create :
+    int ->
     flag array ->
     vector_kind ->
     int ->
@@ -77,10 +78,10 @@ module Make (I : VideoData) (O : VideoData) = struct
     pixel_format ->
     t = "ocaml_swscale_create_byte" "ocaml_swscale_create"
 
-  let create flags in_width in_height in_pixel_format out_width out_height
-      out_pixel_format =
-    create (Array.of_list flags) I.vk in_width in_height in_pixel_format O.vk
-      out_width out_height out_pixel_format
+  let create ?(threads = 1) flags in_width in_height in_pixel_format out_width
+      out_height out_pixel_format =
+    create threads (Array.of_list flags) I.vk in_width in_height in_pixel_format
+      O.vk out_width out_height out_pixel_format
 
   (*
      let from_codec flags in_codec out_width out_height out_pixel_format =

--- a/src/modules/synced/ffmpeg/swscale/swscale.mli
+++ b/src/modules/synced/ffmpeg/swscale/swscale.mli
@@ -47,9 +47,18 @@ module Make (I : VideoData) (O : VideoData) : sig
   type t = (I.t, O.t) ctx
 
   (** [Swscale.create flags in_w in_h in_pf out_w out_h out_pf] do the same as
-      {!Swscale.create}. *)
+      {!Swscale.create}. [threads] is the number of threads scaling a frame is
+      split over, defaulting to [1]. [0] lets swscale pick one per core. *)
   val create :
-    flag list -> int -> int -> pixel_format -> int -> int -> pixel_format -> t
+    ?threads:int ->
+    flag list ->
+    int ->
+    int ->
+    pixel_format ->
+    int ->
+    int ->
+    pixel_format ->
+    t
 
   (*
   val from_codec : flag list -> video Avcodec.t -> int -> int -> pixel_format -> t

--- a/src/modules/synced/ffmpeg/swscale/swscale_stubs.c
+++ b/src/modules/synced/ffmpeg/swscale/swscale_stubs.c
@@ -14,6 +14,7 @@
 #include <string.h>
 
 #include <libavutil/imgutils.h>
+#include <libavutil/opt.h>
 #include <libswscale/swscale.h>
 
 #include "avutil_stubs.h"
@@ -80,6 +81,32 @@ static struct custom_operations context_ops = {
     custom_serialize_default,   custom_deserialize_default,
     custom_compare_ext_default, custom_fixed_length_default};
 
+static struct SwsContext *get_context(int src_w, int src_h,
+                                      enum AVPixelFormat src_format, int dst_w,
+                                      int dst_h, enum AVPixelFormat dst_format,
+                                      int flags, int threads) {
+  struct SwsContext *context = sws_alloc_context();
+
+  if (!context)
+    return NULL;
+
+  av_opt_set_int(context, "srcw", src_w, 0);
+  av_opt_set_int(context, "srch", src_h, 0);
+  av_opt_set_int(context, "src_format", src_format, 0);
+  av_opt_set_int(context, "dstw", dst_w, 0);
+  av_opt_set_int(context, "dsth", dst_h, 0);
+  av_opt_set_int(context, "dst_format", dst_format, 0);
+  av_opt_set_int(context, "sws_flags", flags, 0);
+  av_opt_set_int(context, "threads", threads, 0);
+
+  if (sws_init_context(context, NULL, NULL) < 0) {
+    sws_freeContext(context);
+    return NULL;
+  }
+
+  return context;
+}
+
 CAMLprim value ocaml_swscale_get_context(value flags_, value src_w_,
                                          value src_h_, value src_format_,
                                          value dst_w_, value dst_h_,
@@ -101,8 +128,7 @@ CAMLprim value ocaml_swscale_get_context(value flags_, value src_w_,
     flags |= Flag_val(Field(flags_, i));
 
   caml_release_runtime_system();
-  c = sws_getContext(src_w, src_h, src_format, dst_w, dst_h, dst_format, flags,
-                     NULL, NULL, NULL);
+  c = get_context(src_w, src_h, src_format, dst_w, dst_h, dst_format, flags, 1);
   caml_acquire_runtime_system();
 
   if (!c)
@@ -190,8 +216,8 @@ typedef struct sws_t sws_t;
 
 struct sws_t {
   struct SwsContext *context;
-  int srcSliceY;
-  int srcSliceH;
+  AVFrame *in_frame;
+  AVFrame *out_frame;
   struct video_t in;
   struct video_t out;
 
@@ -377,6 +403,69 @@ static int alloc_out_packed_ba(sws_t *sws, value *out_vect, value *tmp) {
   return 0;
 }
 
+static void free_nothing(void *opaque, uint8_t *data) {
+  (void)opaque;
+  (void)data;
+}
+
+/* Slice threading is only reachable through sws_scale_frame, which wants
+   frames holding refcounted buffers: wrap the planes, owned by the caller, in
+   buffers that free nothing. Both frames are unref'ed once the scaling is
+   done, leaving nothing pointing at them. */
+static int wrap_planes(AVFrame *frame, struct video_t *video) {
+  ptrdiff_t linesizes[4];
+  size_t plane_sizes[4];
+  int i, ret;
+
+  frame->width = video->width;
+  frame->height = video->height;
+  frame->format = video->pixel_format;
+
+  for (i = 0; i < 4; i++)
+    linesizes[i] = video->stride[i];
+
+  ret = av_image_fill_plane_sizes(plane_sizes, video->pixel_format,
+                                  video->height, linesizes);
+
+  if (ret < 0)
+    return ret;
+
+  for (i = 0; i < 4; i++) {
+    /* A zero size means the format has no buffer at that index. Paletted
+       formats do have one, holding the palette rather than a plane. */
+    if (!plane_sizes[i])
+      continue;
+
+    if (!video->slice[i])
+      return AVERROR(EINVAL);
+
+    frame->data[i] = video->slice[i];
+    frame->linesize[i] = video->stride[i];
+    frame->buf[i] = av_buffer_create(video->slice[i], plane_sizes[i],
+                                     free_nothing, NULL, 0);
+
+    if (!frame->buf[i])
+      return AVERROR(ENOMEM);
+  }
+
+  return 0;
+}
+
+static int scale(sws_t *sws) {
+  int ret = wrap_planes(sws->in_frame, &sws->in);
+
+  if (ret >= 0)
+    ret = wrap_planes(sws->out_frame, &sws->out);
+
+  if (ret >= 0)
+    ret = sws_scale_frame(sws->context, sws->out_frame, sws->in_frame);
+
+  av_frame_unref(sws->in_frame);
+  av_frame_unref(sws->out_frame);
+
+  return ret;
+}
+
 CAMLprim value ocaml_swscale_convert(value _sws, value _in_vector) {
   CAMLparam2(_sws, _in_vector);
   CAMLlocal2(out_vect, tmp);
@@ -393,9 +482,7 @@ CAMLprim value ocaml_swscale_convert(value _sws, value _in_vector) {
 
   // Scale and convert input data to output data
   caml_release_runtime_system();
-  ret = sws_scale(sws->context, (const uint8_t *const *)sws->in.slice,
-                  sws->in.stride, sws->srcSliceY, sws->srcSliceH,
-                  sws->out.slice, sws->out.stride);
+  ret = scale(sws);
   caml_acquire_runtime_system();
 
   if (ret < 0)
@@ -415,6 +502,9 @@ void swscale_free(sws_t *sws) {
 
   if (sws->context)
     sws_freeContext(sws->context);
+
+  av_frame_free(&sws->in_frame);
+  av_frame_free(&sws->out_frame);
 
   /* slice points at a 4-slot table, zero-initialised: walking it until a NULL
      runs into stride_tab for a 4-plane format, so bound by the table size and
@@ -440,14 +530,15 @@ static struct custom_operations sws_ops = {
     custom_serialize_default,   custom_deserialize_default,
     custom_compare_ext_default, custom_fixed_length_default};
 
-CAMLprim value ocaml_swscale_create(value flags_, value in_vector_kind_,
-                                    value in_width_, value in_height_,
-                                    value in_pixel_format_,
+CAMLprim value ocaml_swscale_create(value threads_, value flags_,
+                                    value in_vector_kind_, value in_width_,
+                                    value in_height_, value in_pixel_format_,
                                     value out_vect_kind_, value out_width_,
                                     value out_height_,
                                     value out_pixel_format_) {
-  CAMLparam5(flags_, in_vector_kind_, in_width_, in_height_, in_pixel_format_);
-  CAMLxparam4(out_vect_kind_, out_width_, out_height_, out_pixel_format_);
+  CAMLparam5(threads_, flags_, in_vector_kind_, in_width_, in_height_);
+  CAMLxparam5(in_pixel_format_, out_vect_kind_, out_width_, out_height_,
+              out_pixel_format_);
   CAMLlocal1(ans);
   vector_kind in_vector_kind = Int_val(in_vector_kind_);
   vector_kind out_vect_kind = Int_val(out_vect_kind_);
@@ -465,7 +556,13 @@ CAMLprim value ocaml_swscale_create(value flags_, value in_vector_kind_,
   sws->in.height = Int_val(in_height_);
   sws->in.pixel_format = PixelFormat_val(in_pixel_format_);
 
-  sws->srcSliceH = sws->in.height;
+  sws->in_frame = av_frame_alloc();
+  sws->out_frame = av_frame_alloc();
+
+  if (!sws->in_frame || !sws->out_frame) {
+    swscale_free(sws);
+    caml_raise_out_of_memory();
+  }
 
   sws->out.slice = sws->out.slice_tab;
   sws->out.stride = sws->out.stride_tab;
@@ -478,13 +575,13 @@ CAMLprim value ocaml_swscale_create(value flags_, value in_vector_kind_,
     flags |= Flag_val(Field(flags_, i));
 
   caml_release_runtime_system();
-  sws->context = sws_getContext(
+  sws->context = get_context(
       sws->in.width, sws->in.height, sws->in.pixel_format, sws->out.width,
-      sws->out.height, sws->out.pixel_format, flags, NULL, NULL, NULL);
+      sws->out.height, sws->out.pixel_format, flags, Int_val(threads_));
   caml_acquire_runtime_system();
 
   if (!sws->context) {
-    av_free(sws);
+    swscale_free(sws);
     Fail("Failed to create Swscale context");
   }
 
@@ -542,5 +639,5 @@ CAMLprim value ocaml_swscale_create(value flags_, value in_vector_kind_,
 CAMLprim value ocaml_swscale_create_byte(value *argv, int argn) {
   (void)argn;
   return ocaml_swscale_create(argv[0], argv[1], argv[2], argv[3], argv[4],
-                              argv[5], argv[6], argv[7], argv[8]);
+                              argv[5], argv[6], argv[7], argv[8], argv[9]);
 }


### PR DESCRIPTION
Closes #5014.

## Why

libavcodec opens a codec context with `thread_count = 1` unless the codec overrides it, and ffmpeg's own tools raise that to automatic before opening (`fftools/ffmpeg_dec.c`, `fftools/ffmpeg_enc.c`). liquidsoap never set it, so every decoder ran on a single thread, and so did every encoder except `libx264` — the one codec shipping `{"threads", "0"}` in its own defaults. That is why the `threads=2` in the report looked ignored: x264 was already threading, and the single-threaded 4K decode was the actual bottleneck.

## What changed

Every codec is now opened through one helper that defaults the thread count to automatic. `avcodec_open2` applies the caller's option dictionary itself, so an explicit `%ffmpeg(%video(codec="...", threads=N))` still wins over the default, and codecs that thread badly keep opting out through their own defaults.

Scaling has its own threads, which only `sws_scale_frame` reaches: `sws_scale` deliberately falls back to `slice_ctx[0]` whatever the context is set to. Conversion therefore goes through frames wrapping the planes the caller owns, in buffers that free nothing, and `Swscale.Make.create` takes the count. `settings.ffmpeg.scaling_threads` sets it, one per core by default, as ffmpeg does through its filter graphs.

## Measurements

8-core arm64, 20s of 3840x2160 h264 transcoded to 1280x720, measuring the content produced during a fixed 20s window (higher is better):

| pipeline | before | after |
|---|---|---|
| `libx264`, ultrafast | 23.6s @ 108% CPU | 32.5s @ 209% CPU |
| `libx265`, slow | 9.4s @ 252% CPU | 25.8s @ 418% CPU |

The x265 pipeline goes from 0.47x realtime, which stutters by construction, to 1.3x. The scaling half is the smaller share of that: scaling is roughly 15% of the serial cost of a video pipeline, so threading it is worth a few percent on its own, and the extra cores buy little once the codecs are already using them.

## Testing

No new automated test. The verification that could have said the opposite is an output comparison: a 5s 4K to 720p decode, scaled and written out as rawvideo, is byte-identical across the pre-change build, the new frame-based path at `scaling_threads=1`, and the same path at `0`.

Individual ffmpeg media tests fail identically with and without this changeset on my machine, the harness being unable to write its generated encoder scripts there, so CI is the real signal for those.

This touches `src/modules/synced/ffmpeg`, so the ocaml-ffmpeg mirror picks it up.
