### PR TITLE
Stop and release active inputs replaced through source.dynamic

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -105,6 +105,9 @@
 
 ## Fixed:
 
+- Active inputs such as `input.ffmpeg` replaced through `source.dynamic` are now stopped and
+  released. They used to keep their connection, decoder and threads alive for the lifetime of
+  the script (#5389).
 - A transition that drops the incoming source no longer drops that track's announcement with
   it. `cross` had already consumed the metadata into the buffer it hands the transition, so
   the track played on, audible and unannounced, once the transition was over. It is now

--- a/src/core/optionals/ffmpeg/io/ffmpeg_io.ml
+++ b/src/core/optionals/ffmpeg/io/ffmpeg_io.ml
@@ -106,15 +106,16 @@ class input ?(name = "input.ffmpeg") ~autostart ~self_sync ~poll_delay ~debug
     method private connect_task () =
       Generator.set_max_length self#buffer max_length;
       try
-        if self#source_status = `Stopping then raise Stopped;
-        assert (self#source_status = `Starting);
-        Atomic.set source_status `Polling;
+        if not (Atomic.compare_and_set source_status `Starting `Polling) then
+          raise Stopped;
         let opts = Hashtbl.copy opts in
         let url = self#url in
         let closed = Atomic.make false in
         let container =
           Av.open_input
-            ~interrupt:(fun () -> Atomic.get shutdown || Atomic.get closed)
+            ~interrupt:(fun () ->
+              Atomic.get shutdown || Atomic.get closed
+              || self#source_status <> `Polling)
             ?format ~opts
             ~configure_audio_stream:Ffmpeg_decoder_common.configure_audio_stream
             ~configure_video_stream:Ffmpeg_decoder_common.configure_video_stream
@@ -142,11 +143,23 @@ class input ?(name = "input.ffmpeg") ~autostart ~self_sync ~poll_delay ~debug
         List.iter (fun fn -> fn m) (Callbacks.elements on_connect);
         Generator.add_track_mark self#buffer;
         let container = { decoder; remaining; buffer; closed } in
-        Atomic.set source_status (`Connected (url, container));
+        if
+          not
+            (Atomic.compare_and_set source_status `Polling
+               (`Connected (url, container)))
+        then (
+          decoder.close ();
+          List.iter (fun fn -> fn ()) (Callbacks.elements on_disconnect);
+          raise Stopped);
         -1.
       with
         | Stopped ->
-            Atomic.set source_status `Stopped;
+            ignore (Atomic.compare_and_set source_status `Stopping `Stopped);
+            -1.
+        | _ when not (Atomic.compare_and_set source_status `Polling `Starting)
+          ->
+            (* [disconnect] interrupted the connection. *)
+            ignore (Atomic.compare_and_set source_status `Stopping `Stopped);
             -1.
         | e ->
             let bt = Printexc.get_raw_backtrace () in
@@ -156,31 +169,27 @@ class input ?(name = "input.ffmpeg") ~autostart ~self_sync ~poll_delay ~debug
             let err = Lang.runtime_error_of_exception ~bt ~kind:"ffmpeg" e in
             List.iter (fun fn -> fn err) (Callbacks.elements on_error);
             if debug then Printexc.raise_with_backtrace e bt;
-            Atomic.set source_status `Starting;
             poll_delay
 
     method private connect =
       match self#source_status with
         | `Starting | `Polling | `Connected _ -> ()
-        | `Stopping | `Stopped -> (
+        | `Stopping | `Stopped ->
             Atomic.set source_status `Starting;
-            match Atomic.get connect_task with
-              | Some t -> Duppy.Async.wake_up t
-              | None ->
-                  let t =
-                    Duppy.Async.add ~priority:`Blocking Tutils.scheduler
-                      self#connect_task
-                  in
-                  Atomic.set connect_task (Some t);
-                  Duppy.Async.wake_up t)
+            let t =
+              Duppy.Async.add ~priority:`Blocking Tutils.scheduler
+                self#connect_task
+            in
+            Atomic.set connect_task (Some t);
+            Duppy.Async.wake_up t
 
     method private disconnect =
       let stop_task () =
-        match Atomic.get connect_task with
-          | None -> Atomic.set source_status `Stopped
-          | Some t ->
-              Atomic.set source_status `Stopping;
-              Duppy.Async.wake_up t
+        (* A task mid-connection sees [`Stopping] and finalizes itself. The
+           stopped task no longer retains this source. *)
+        if not (Atomic.compare_and_set source_status `Polling `Stopping) then
+          Atomic.set source_status `Stopped;
+        Option.iter Duppy.Async.stop (Atomic.exchange connect_task None)
       in
       match self#source_status with
         | `Stopping | `Stopped -> ()

--- a/src/core/optionals/ffmpeg/io/ffmpeg_io.ml
+++ b/src/core/optionals/ffmpeg/io/ffmpeg_io.ml
@@ -50,7 +50,7 @@ class input ?(name = "input.ffmpeg") ~autostart ~self_sync ~poll_delay ~debug
     val source_status
         : [ `Stopped
           | `Starting
-          | `Polling
+          | `Polling of bool Atomic.t
           | `Connected of string * container
           | `Stopping ]
           Atomic.t =
@@ -105,17 +105,19 @@ class input ?(name = "input.ffmpeg") ~autostart ~self_sync ~poll_delay ~debug
 
     method private connect_task () =
       Generator.set_max_length self#buffer max_length;
+      (* [closed] belongs to this attempt only: [disconnect] raises it to
+         interrupt [open_input], then it keeps interrupting the container's
+         reads once connected. *)
+      let closed = Atomic.make false in
+      let polling = `Polling closed in
       try
-        if not (Atomic.compare_and_set source_status `Starting `Polling) then
+        if not (Atomic.compare_and_set source_status `Starting polling) then
           raise Stopped;
         let opts = Hashtbl.copy opts in
         let url = self#url in
-        let closed = Atomic.make false in
         let container =
           Av.open_input
-            ~interrupt:(fun () ->
-              Atomic.get shutdown || Atomic.get closed
-              || self#source_status <> `Polling)
+            ~interrupt:(fun () -> Atomic.get shutdown || Atomic.get closed)
             ?format ~opts
             ~configure_audio_stream:Ffmpeg_decoder_common.configure_audio_stream
             ~configure_video_stream:Ffmpeg_decoder_common.configure_video_stream
@@ -145,7 +147,7 @@ class input ?(name = "input.ffmpeg") ~autostart ~self_sync ~poll_delay ~debug
         let container = { decoder; remaining; buffer; closed } in
         if
           not
-            (Atomic.compare_and_set source_status `Polling
+            (Atomic.compare_and_set source_status polling
                (`Connected (url, container)))
         then (
           decoder.close ();
@@ -156,8 +158,7 @@ class input ?(name = "input.ffmpeg") ~autostart ~self_sync ~poll_delay ~debug
         | Stopped ->
             ignore (Atomic.compare_and_set source_status `Stopping `Stopped);
             -1.
-        | _ when not (Atomic.compare_and_set source_status `Polling `Starting)
-          ->
+        | _ when not (Atomic.compare_and_set source_status polling `Starting) ->
             (* [disconnect] interrupted the connection. *)
             ignore (Atomic.compare_and_set source_status `Stopping `Stopped);
             -1.
@@ -173,7 +174,7 @@ class input ?(name = "input.ffmpeg") ~autostart ~self_sync ~poll_delay ~debug
 
     method private connect =
       match self#source_status with
-        | `Starting | `Polling | `Connected _ -> ()
+        | `Starting | `Polling _ | `Connected _ -> ()
         | `Stopping | `Stopped ->
             Atomic.set source_status `Starting;
             let t =
@@ -184,16 +185,21 @@ class input ?(name = "input.ffmpeg") ~autostart ~self_sync ~poll_delay ~debug
             Duppy.Async.wake_up t
 
     method private disconnect =
+      (* The stopped task no longer retains this source. *)
       let stop_task () =
-        (* A task mid-connection sees [`Stopping] and finalizes itself. The
-           stopped task no longer retains this source. *)
-        if not (Atomic.compare_and_set source_status `Polling `Stopping) then
-          Atomic.set source_status `Stopped;
         Option.iter Duppy.Async.stop (Atomic.exchange connect_task None)
       in
       match self#source_status with
         | `Stopping | `Stopped -> ()
-        | `Polling | `Starting -> stop_task ()
+        | `Starting ->
+            Atomic.set source_status `Stopped;
+            stop_task ()
+        | `Polling closed as polling ->
+            Atomic.set closed true;
+            (* The interrupted task sees [`Stopping] and finalizes itself. *)
+            if not (Atomic.compare_and_set source_status polling `Stopping) then
+              Atomic.set source_status `Stopped;
+            stop_task ()
         | `Connected (_, { decoder; closed }) ->
             Atomic.set closed true;
             (try decoder.close ()
@@ -203,11 +209,12 @@ class input ?(name = "input.ffmpeg") ~autostart ~self_sync ~poll_delay ~debug
                  (Printf.sprintf "Error while disconnecting: %s"
                     (Printexc.to_string exn)));
             List.iter (fun fn -> fn ()) (Callbacks.elements on_disconnect);
+            Atomic.set source_status `Stopped;
             stop_task ()
 
     method private reconnect =
       match self#source_status with
-        | `Stopping | `Stopped | `Polling | `Starting -> ()
+        | `Stopping | `Stopped | `Polling _ | `Starting -> ()
         | `Connected _ ->
             self#disconnect;
             self#connect
@@ -526,7 +533,7 @@ let register_input protocol =
                              | `Stopped -> "stopped"
                              | `Starting -> "starting"
                              | `Stopping -> "stopping"
-                             | `Polling -> "polling"
+                             | `Polling _ -> "polling"
                              | `Connected (url, _) ->
                                  Printf.sprintf "connected %s" url)));
                };

--- a/src/core/source/start_stop.ml
+++ b/src/core/source/start_stop.ml
@@ -91,7 +91,9 @@ class virtual active_source ~name ~fallible ~autostart () =
 
     initializer
       self#on_wake_up (fun () -> if autostart then base#transition_to `Started);
-      self#on_sleep (fun () -> base#transition_to `Stopped)
+      (* A sleeping source gets no further streaming cycle, so a queued
+         transition would never run. *)
+      self#on_sleep (fun () -> base#execute_transition `Stopped)
 
     method fallible = fallible
     method private started = state = `Started

--- a/tests/regression/GH5389.liq
+++ b/tests/regression/GH5389.liq
@@ -1,0 +1,38 @@
+# An active input replaced through source.dynamic must be stopped and become
+# collectable.
+
+stopped = ref(false)
+
+current = ref(source.fail())
+dynamic =
+  source.dynamic(track_sensitive=false, init=current(), fun () -> current())
+output.dummy(mksafe(dynamic))
+
+def replace() =
+  current :=
+    input.ffmpeg(
+      id="second",
+      format="lavfi",
+      "sine=frequency=880:sample_rate=48000"
+    )
+end
+
+def install() =
+  first =
+    input.ffmpeg(
+      id="first",
+      format="lavfi",
+      "sine=frequency=440:sample_rate=48000"
+    )
+  first.on_stop(synchronous=true, fun () -> stopped := true)
+  first.on_collect(
+    synchronous=true,
+    fun () -> if stopped() then test.pass() else test.fail() end
+  )
+  first.on_connect(synchronous=true, fun () -> thread.run(delay=0.2, replace))
+  current := first
+end
+
+thread.run(delay=0.1, install)
+thread.run(delay=2., runtime.gc.compact)
+thread.run(delay=4., test.fail)

--- a/tests/regression/dune.inc
+++ b/tests/regression/dune.inc
@@ -1414,6 +1414,24 @@
   (run %{run_test} GH5361 liquidsoap %{test_liq} GH5361.liq)))
 
 (rule
+ (alias test_GH5389)
+ (package liquidsoap)
+ (deps
+  GH5389.liq
+  (glob_files ../media/**)
+  ../liquidsoap-test-assets
+  ../../src/bin/liquidsoap.exe
+  ../streams/file1.png
+  ../streams/file1.mp3
+  ./theora-test.mp4
+  (package liquidsoap)
+  (source_tree ../../src/libs)
+  (:test_liq ../test.liq)
+  (:run_test ../run_test.exe))
+ (action
+  (run %{run_test} GH5389 liquidsoap %{test_liq} GH5389.liq)))
+
+(rule
  (alias test_LS268)
  (package liquidsoap)
  (deps
@@ -2635,6 +2653,7 @@
   (alias test_GH5348)
   (alias test_GH5360)
   (alias test_GH5361)
+  (alias test_GH5389)
   (alias test_LS268)
   (alias test_LS354-1)
   (alias test_LS354-2)


### PR DESCRIPTION
Fixes #5389.

An active input replaced through `source.dynamic` was detached from its clock but never actually stopped, and with `input.ffmpeg` never became collectable either. Every replacement leaked the previous input's connection, decoder and FFmpeg worker threads for the lifetime of the script.

Two independent gaps were involved. `Start_stop.active_source` registered its mandatory stop through `transition_to`, which has queued the transition for the next streaming cycle since #4849. A source that has just gone to sleep is detached from its clock and never gets that cycle, so the stop never ran. Outputs were already switched to the synchronous `execute_transition` in #4849; this does the same on the input side, which covers every active input, not only `input.ffmpeg`.

Separately, `input.ffmpeg` never stopped its `Duppy.Async` connect task on disconnect. The task closure kept the source and its wake-up socket pair reachable from the scheduler, so `on_collect` could not fire even after an explicit stop. The task is now stopped and cleared the way `input.srt` already does it. Since `Duppy.Async.stop` does not interrupt a task that is mid-`open_input`, `disconnect` also has to interrupt the connection itself, and the task's status writes are compare-and-set so a cancelled or stale run finalizes to `Stopped` without clobbering a newer `Starting`.

The interrupt callback stays installed on the `AVFormatContext` for the container's whole lifetime, so it cannot be keyed on the shared source status: doing so interrupts every read once connected. The per-attempt `closed` flag already carries exactly the right scope, it simply was not reachable from `disconnect` before the container existed. `` `Polling `` now carries it, `disconnect` raises it to interrupt a connection in progress, and the physical identity of that `` `Polling `` value doubles as the generation token that keeps a stale attempt from clobbering a newer one.

Added `tests/regression/GH5389.liq`, the reporter's reproducer reduced to the `on_stop`/`on_collect` assertions. It fails on `main` and passes with this change. `tests/regression/GH4840.liq` covers the connected-read side: it serves a stream over harbor and fails as soon as a connected input interrupts its own reads. Explicit `stop()`/`start()` cycles on `input.ffmpeg` were checked manually and still reconnect.
