### PR TITLE
Remove daemon mode

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -121,6 +121,11 @@
 - Video scaling is now split over one thread per core, as `ffmpeg` does through its filter
   graphs. `settings.ffmpeg.scaling_threads` sets the count, `1` restoring the single-threaded
   scaling of previous versions (#5014).
+- Removed daemon mode: the `-d`/`--daemon` command-line option, the `settings.init.daemon`
+  settings and the pidfile they wrote. Detaching from the terminal meant forking, which is
+  unsafe now that liquidsoap runs on several cores. Use a service manager such as `systemd`
+  or `launchd` to run liquidsoap in the background; both handle pidfiles, log redirection and
+  privilege dropping.
 
 ## Fixed:
 

--- a/doc/content/icecast_server.md
+++ b/doc/content/icecast_server.md
@@ -268,7 +268,7 @@ Note: Only the first `listen-socket` entry is used. Multiple listen sockets are 
 | ------------------------------------- | --------------- | ----------------------------------------------------------------------------------------- |
 | `basedir`                             | Not implemented |                                                                                           |
 | `logdir`                              | Supported       | Enables log file and sets path to `#{logdir}/<script>.log`                                |
-| `pidfile`                             | Supported       | Enables pidfile and sets path to the value                                                |
+| `pidfile`                             | Not supported   |                                                                                           |
 | `tls-certificate` / `ssl-certificate` | Supported       | Path to TLS certificate file (required when TLS is enabled). May include the private key. |
 | `tls-key`                             | Supported       | Path to separate TLS private key file (icecast 2.5 only)                                  |
 | `webroot`                             | Not implemented | No built-in web interface                                                                 |

--- a/doc/content/in_production.md
+++ b/doc/content/in_production.md
@@ -8,8 +8,7 @@ when running a stable radio.
 Your production `.liq` files should go in `/etc/liquidsoap`.
 You'll then start/stop them using the init script, _e.g._
 `/etc/init.d/liquidsoap start`.
-Your scripts don't need to have the `#!` line,
-and liquidsoap will automatically be ran on daemon mode (`-d` option) for them.
+Your scripts don't need to have the `#!` line.
 
 You should not override the `log.file.path` setting because a
 logrotate configuration is also installed so that log files

--- a/doc/content/liq/radiopi.liq
+++ b/doc/content/liq/radiopi.liq
@@ -4,8 +4,6 @@
 log.file := true
 log.file.path := "/var/log/liquidsoap/pi.log"
 log.stdout := false
-init.daemon := true
-init.daemon.pidfile.path := "/var/run/liquidsoap/pi.pid"
 
 # Enable telnet server
 settings.server.telnet.set(true)

--- a/doc/content/liq/settings.liq
+++ b/doc/content/liq/settings.liq
@@ -1,7 +1,6 @@
 log.level := 4
 log.file := true
 log.stdout := true
-init.daemon := true
 audio.samplerate := 48000
 audio.channels := 2
 video.frame.width := 720

--- a/doc/content/migrating.md
+++ b/doc/content/migrating.md
@@ -331,6 +331,12 @@ See [sharing state between tasks](./scheduling.md#sharing-state-between-tasks) f
 
 If concurrent execution breaks a script and it cannot be fixed right away, `settings.scheduler.legacy := true` brings back the previous behavior, threads and queues included. It is a fail-safe and will be removed in a later version.
 
+### Daemon mode removed
+
+The `-d`/`--daemon` option and the `settings.init.daemon` settings are gone, pidfile writing included. Detaching from the terminal required forking, which is not safe now that liquidsoap runs on several cores.
+
+Run liquidsoap in the foreground under a service manager instead — `systemd` on Linux, `launchd` on macOS. Both keep track of the process, restart it, and capture its output, so a pidfile is not needed. A script still setting `init.daemon`, `init.daemon.pidfile` or `init.daemon.change_user` no longer typechecks (`this value has no method daemon`); drop those lines, and let the service manager set user and group.
+
 ## From 2.3.x to 2.4.x
 
 See our [2.4.0 blog post](https://www.liquidsoap.info/blog/2025-08-11-liquidsoap-2.4.0/) for a detailed presentation

--- a/doc/liquidsoap.1.md
+++ b/doc/liquidsoap.1.md
@@ -170,10 +170,6 @@ rather than to a file.
 \--check
 : Parse, type\-check but do not evaluate the script.
 
-\-d
-\--daemon
-: Run in daemon mode.
-
 \-f
 \--force-start
 : For advanced dynamic uses: force liquidsoap to start even when no active source is initially defined.

--- a/scripts/bash-completion
+++ b/scripts/bash-completion
@@ -28,7 +28,7 @@ _liquidsoap()
             ;;
 
         *)
-            _liquidsoap_reply+=("-c --check --list-settings -d --daemon --debug -h --help -i --interactive --list-functions --list-functions-md --list-extra-functions-md --list-plugins --list-protocols-md --no-stdlib --parse-only --profile --quiet -r --strict --unsafe --version -v --verbose")
+            _liquidsoap_reply+=("-c --check --list-settings --debug -h --help -i --interactive --list-functions --list-functions-md --list-extra-functions-md --list-plugins --list-protocols-md --no-stdlib --parse-only --profile --quiet -r --strict --unsafe --version -v --verbose")
             compgen_opt+=(-o filenames -f)
             ;;
     esac

--- a/src/bin/runtime/main.ml
+++ b/src/bin/runtime/main.ml
@@ -357,7 +357,7 @@ let options =
           translated into user-friendly errors. Use this option to let the \
           original error surface. This is useful when debugging." );
      ]
-    @ Dtools.Init.args @ Extra_args.args ()
+    @ Extra_args.args ()
     @ [
         ( ["-t"; "--enable-telnet"],
           Arg.Unit (fun _ -> Server.conf_telnet#set true),
@@ -552,9 +552,6 @@ let () =
 
       (* Set the default values. *)
       Dtools.Log.conf_file_path#set_d (Some "<syslogdir>/<script>.log");
-      Dtools.Init.conf_daemon_pidfile#set_d (Some true);
-      Dtools.Init.conf_daemon_pidfile_path#set_d
-        (Some "<sysrundir>/<script>.pid");
 
       Utils.add_subst "<sysrundir>" (Liquidsoap_paths.rundir ());
       Utils.add_subst "<syslogdir>" (Liquidsoap_paths.logdir ());
@@ -636,12 +633,11 @@ let () =
 
 (** Main procedure *)
 
-(** When the log/pid paths have their definitive values, expand substitutions
-    and check directories. This should be ran just before Dtools init. *)
+(** When the log path has its definitive value, expand substitutions and check
+    directories. This should be ran just before Dtools init. *)
 let check_directories () =
   (* Now that the paths have their definitive value, expand <shortcuts>. *)
   let subst conf = conf#set (Utils.subst_vars conf#get) in
-  subst Dtools.Init.conf_daemon_pidfile_path;
   let check_dir conf_path kind =
     let path = conf_path#get in
     let dir = Filename.dirname path in
@@ -658,67 +654,7 @@ To change it, add the following to your script:
   in
   if Dtools.Log.conf_file#get then (
     subst Dtools.Log.conf_file_path;
-    check_dir Dtools.Log.conf_file_path "Log");
-  if Dtools.Init.conf_daemon#get && Dtools.Init.conf_daemon_pidfile#get then
-    check_dir Dtools.Init.conf_daemon_pidfile_path "PID"
-
-let () =
-  Dtools.Init.conf_daemon#on_change (fun v ->
-      if v then
-        log#important
-          "Script-base daemonization is DEPRECATED! Please use a modern \
-           daemonization facility such as `systemd` or `launchd` instead.")
-
-let daemonize () =
-  (* Forking is refused by the runtime once a domain exists, and the scheduler
-     spawns its own. *)
-  if Tutils.scheduler_started () then
-    failwith "Cannot daemonize once the scheduler has started!";
-  Dtools.Log.conf_stdout#set false;
-  (* Change user.. *)
-  let conf_daemon_change_user =
-    Dtools.Conf.as_bool (Dtools.Init.conf_daemon#path ["change_user"])
-  in
-  let conf_daemon_user =
-    Dtools.Conf.as_string (conf_daemon_change_user#path ["user"])
-  in
-  let conf_daemon_group =
-    Dtools.Conf.as_string (conf_daemon_change_user#path ["group"])
-  in
-  if conf_daemon_change_user#get then begin
-    let grd = Unix.getgrnam conf_daemon_group#get in
-    let gid = grd.Unix.gr_gid in
-    if Unix.getegid () <> gid then Unix.setgid gid;
-    let pwd = Unix.getpwnam conf_daemon_user#get in
-    let uid = pwd.Unix.pw_uid in
-    if Unix.geteuid () <> uid then Unix.setuid uid
-  end;
-  if Unix.fork () <> 0 then exit 0;
-  (* Detach from the console *)
-  if Unix.setsid () < 0 then exit 1;
-  (* Refork.. *)
-  if Unix.fork () <> 0 then exit 0;
-  (* Change umask to 0 *)
-  ignore (Unix.umask 0);
-  (* chdir to / *)
-  Unix.chdir "/";
-  if Dtools.Init.conf_daemon_pidfile#get then begin
-    (* Write PID to file *)
-    let filename = Dtools.Init.conf_daemon_pidfile_path#get in
-    let f =
-      open_out_gen
-        [Open_wronly; Open_creat; Open_trunc]
-        Dtools.Init.conf_daemon_pidfile_perms#get filename
-    in
-    let pid = Unix.getpid () in
-    output_string f (string_of_int pid);
-    output_char f '\n';
-    close_out f
-  end;
-  (* Reopen usual file descriptor *)
-  Utils.reopen_in stdin "/dev/null";
-  Utils.reopen_out stdout "/dev/null";
-  Utils.reopen_out stderr "/dev/null"
+    check_dir Dtools.Log.conf_file_path "Log")
 
 let () =
   Lifecycle.before_start ~name:"main application before start" (fun () ->
@@ -736,8 +672,6 @@ let () =
         Printf.printf "No output defined, nothing to do.\n";
         flush_all ();
         exit 1);
-
-      if Dtools.Init.conf_daemon#get then daemonize ();
 
       check_directories ();
       start_log ();

--- a/src/core/utils/tutils.ml
+++ b/src/core/utils/tutils.ml
@@ -277,8 +277,6 @@ let () =
       Duppy.stop scheduler;
       log#important "Scheduler shut down.")
 
-let scheduler_started () = Duppy.started scheduler
-
 let scheduler_logger () =
   if scheduler_log#get then (
     let log = Log.make ["scheduler"] in

--- a/src/core/utils/tutils.mli
+++ b/src/core/utils/tutils.mli
@@ -60,10 +60,6 @@ type priority =
 (** task scheduler *)
 val scheduler : priority Duppy.scheduler
 
-(** Whether the scheduler's domains have been spawned. [Unix.fork] fails once
-    they have, so anything that forks must check this first. *)
-val scheduler_started : unit -> bool
-
 (** {1 Misc} *)
 
 (** Waits for [f()] to become true on condition [c]. The mutex [m] protecting

--- a/src/libs/extra/icecast_server.liq
+++ b/src/libs/extra/icecast_server.liq
@@ -378,15 +378,10 @@ def icecast.server.parser(path) =
     if
       null.defined(pidfile)
     then
-%ifdef settings.init.daemon
-      settings.init.daemon.pidfile := true
-      settings.init.daemon.pidfile.path := null.get(pidfile)
-%else
       log.important(
         label="icecast.server",
         "Config option 'pidfile' is not supported"
       )
-%endif
     end
 
     if

--- a/src/modules/dtools/dtools.mli
+++ b/src/modules/dtools/dtools.mli
@@ -221,15 +221,8 @@ module Init : sig
   exception StopError of exn
 
   val conf : Conf.ut
-  val conf_daemon : bool Conf.t
-  val conf_daemon_pidfile : bool Conf.t
-  val conf_daemon_pidfile_path : string Conf.t
-  val conf_daemon_pidfile_perms : int Conf.t
   val conf_trace : bool Conf.t
   val conf_catch_exn : bool Conf.t
-
-  (** A set of command line options to be used with the Arg module. *)
-  val args : (string list * Arg.spec * string) list
 end
 
 module Log : sig

--- a/src/modules/dtools/dtools_impl.ml
+++ b/src/modules/dtools/dtools_impl.ml
@@ -343,41 +343,6 @@ end
 module Init = struct
   let conf = Conf.void "initialization configuration"
 
-  (* Unix.fork is not implemented in Win32. *)
-  let daemon_conf =
-    if Sys.os_type <> "Win32" then conf else Conf.void "dummy conf"
-
-  let conf_daemon =
-    Conf.bool ~p:(daemon_conf#plug "daemon") ~d:false "run in daemon mode"
-
-  let conf_daemon_pidfile =
-    Conf.bool
-      ~p:(conf_daemon#plug "pidfile")
-      ~d:false "support for pidfile generation"
-
-  let conf_daemon_pidfile_path =
-    Conf.string ~p:(conf_daemon_pidfile#plug "path") "path to pidfile"
-
-  let conf_daemon_pidfile_perms =
-    Conf.int ~d:0o640
-      ~p:(conf_daemon_pidfile#plug "perms")
-      "Unix file permissions for pidfile. Default: `0o640`."
-
-  let conf_daemon_drop_user =
-    Conf.bool
-      ~p:(conf_daemon#plug "change_user")
-      ~d:false "Changes the effective user (drops privileges)."
-
-  let conf_daemon_user =
-    Conf.string
-      ~p:(conf_daemon_drop_user#plug "user")
-      ~d:"daemon" "User used to run the daemon."
-
-  let conf_daemon_group =
-    Conf.string
-      ~p:(conf_daemon_drop_user#plug "group")
-      ~d:"daemon" "Group used to run the daemon."
-
   let conf_trace =
     Conf.bool ~p:(conf#plug "trace") ~d:false "dump an initialization trace"
 
@@ -499,70 +464,9 @@ module Init = struct
           clean ();
           exit (-1)
 
-  (** A function to reopen a file descriptor * Thanks to Xavier Leroy! * Ref:
-      http://caml.inria.fr/pub/ml-archives/caml-list/2000/01/ *
-      a7e3bbdfaab33603320d75dbdcd40c37.en.html *)
-  let reopen_out outchan filename =
-    flush outchan;
-    let fd1 = Unix.descr_of_out_channel outchan in
-    let fd2 = Unix.openfile filename [Unix.O_WRONLY] 0o666 in
-    Unix.dup2 fd2 fd1;
-    Unix.close fd2
-
-  (** The same for inchan *)
-  let reopen_in inchan filename =
-    let fd1 = Unix.descr_of_in_channel inchan in
-    let fd2 = Unix.openfile filename [Unix.O_RDONLY] 0o666 in
-    Unix.dup2 fd2 fd1;
-    Unix.close fd2
-
-  let daemonize () =
-    if Unix.fork () <> 0 then exit 0;
-    (* Detach from the console *)
-    if Unix.setsid () < 0 then exit 1;
-    (* Refork.. *)
-    if Unix.fork () <> 0 then exit 0;
-    (* Change umask to 0 *)
-    ignore (Unix.umask 0);
-    (* chdir to / *)
-    Unix.chdir "/";
-    if conf_daemon_pidfile#get then begin
-      (* Write PID to file *)
-      let filename = conf_daemon_pidfile_path#get in
-      let f =
-        open_out_gen
-          [Open_wronly; Open_creat; Open_trunc]
-          conf_daemon_pidfile_perms#get filename
-      in
-      let pid = Unix.getpid () in
-      output_string f (string_of_int pid);
-      output_char f '\n';
-      close_out f
-    end;
-    (* Reopen usual file descriptor *)
-    reopen_in stdin "/dev/null";
-    reopen_out stdout "/dev/null";
-    reopen_out stderr "/dev/null"
-
-  let cleanup_daemon () =
-    if conf_daemon_pidfile#get then (
-      try
-        let filename = conf_daemon_pidfile_path#get in
-        Sys.remove filename
-      with _ -> ())
-
   exception Root_prohibited of [ `User | `Group | `Both ]
 
   let exit_when_root () =
-    (* Change user.. *)
-    if conf_daemon_drop_user#get then begin
-      let grd = Unix.getgrnam conf_daemon_group#get in
-      let gid = grd.Unix.gr_gid in
-      if Unix.getegid () <> gid then Unix.setgid gid;
-      let pwd = Unix.getpwnam conf_daemon_user#get in
-      let uid = pwd.Unix.pw_uid in
-      if Unix.geteuid () <> uid then Unix.setuid uid
-    end;
     match (Unix.geteuid (), Unix.getegid ()) with
       | 0, 0 -> raise (Root_prohibited `Both)
       | 0, _ -> raise (Root_prohibited `User)
@@ -571,7 +475,6 @@ module Init = struct
 
   let init ?(prohibit_root = false) f =
     if prohibit_root then exit_when_root ();
-    if conf_daemon#get && Sys.os_type <> "Win32" then daemonize ();
     let signal_h _ = () in
     Sys.set_signal Sys.sigterm (Sys.Signal_handle signal_h);
     Sys.set_signal Sys.sigint (Sys.Signal_handle signal_h);
@@ -581,20 +484,7 @@ module Init = struct
      * to shutdown is to terminate the main function [f]. *)
     if Sys.os_type <> "Win32" then
       ignore (Unix.sigprocmask Unix.SIG_BLOCK [Sys.sigterm; Sys.sigint]);
-    let cleanup =
-      if conf_daemon#get && Sys.os_type <> "Win32" then cleanup_daemon
-      else fun () -> ()
-    in
-    catch (main f) cleanup
-
-  let args =
-    if Sys.os_type <> "Win32" then
-      [
-        ( ["-d"; "--daemon"],
-          Arg.Unit (fun () -> conf_daemon#set true),
-          "Run in daemon mode." );
-      ]
-    else []
+    catch (main f) (fun () -> ())
 end
 
 module Log = struct


### PR DESCRIPTION
Daemon mode calls `Unix.fork`, which the OCaml runtime refuses once domains exist. Since duppy runs on a pool of domains (#5359), `-d` cannot work anymore: the scheduler has spawned its domains by the time the fork would happen. Rather than reordering startup to fork earlier, this removes the feature — it is legacy code that predates every modern service manager, and `systemd`/`launchd` do the job better (process tracking, restart, log capture, privilege dropping).

Removed: the `-d`/`--daemon` option, the `settings.init.daemon` tree (pidfile path/perms, `change_user` user/group), the pidfile writing and cleanup, and the deprecation warning that already pointed users at `systemd`. `Tutils.scheduler_started`, added in #5359 only to guard that fork, goes with it. The daemon code in the vendored `dtools` module goes too, so the settings no longer reach `settings.init` — a script still setting them fails to typecheck instead of silently staying in the foreground.

Docs updated: `-d` dropped from the man page and bash completion, `init.daemon` dropped from the example scripts, a "Daemon mode removed" section added to the migration guide, and a CHANGES entry.

No tests referenced daemon mode. Verified that the build is clean, `-d` is now rejected as an unknown option, `--list-settings` no longer lists `init.daemon`, and the edited example scripts still pass `liquidsoap --check`.
