### PR TITLE
Reuse auxiliary threads for blocking tasks and size the budget to the cores

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -60,7 +60,10 @@
   `settings.scheduler.non_blocking_queues`: the scheduler sizes itself from the number of cores and there is
   nothing left to tune. They now only configure the legacy scheduler, and setting them without it logs a
   warning. `settings.scheduler.blocking_tasks` replaces them, limiting how many slow tasks — request
-  resolutions, `thread.run` handlers, last.fm submissions — may run at once.
+  resolutions, `thread.run` handlers, last.fm submissions — may run at once. It defaults to one per
+  domain and never fewer than 5, which is what the generic queues allowed before. Raising it pays off
+  when those tasks truly wait. A task that uses a core instead of waiting on one, such as probing a
+  file for its decoder, only takes cores the streaming threads need.
 - When the scheduler is busy, quick work is served before slow work: the server, then request resolutions, then
   long tasks such as last.fm submissions. The order used to be arbitrary and often favoured the slow ones.
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -61,7 +61,7 @@
   nothing left to tune. They now only configure the legacy scheduler, and setting them without it logs a
   warning. `settings.scheduler.blocking_tasks` replaces them, limiting how many slow tasks — request
   resolutions, `thread.run` handlers, last.fm submissions — may run at once. It defaults to one per
-  domain and never fewer than 5, which is what the generic queues allowed before. Raising it pays off
+  domain and never fewer than 8, so a machine with few cores keeps room to run several at once. Raising it pays off
   when those tasks truly wait. A task that uses a core instead of waiting on one, such as probing a
   file for its decoder, only takes cores the streaming threads need.
 - When the scheduler is busy, quick work is served before slow work: the server, then request resolutions, then

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -118,9 +118,11 @@
   bottlenecks on one core: an `%ffmpeg` output using `libx265` and a 4K input is about 2.5
   times faster. Pass `threads=1` to an `%ffmpeg` encoder to get the previous behavior back
   (#5014).
-- Video scaling is now split over one thread per core, as `ffmpeg` does through its filter
-  graphs. `settings.ffmpeg.scaling_threads` sets the count, `1` restoring the single-threaded
-  scaling of previous versions (#5014).
+- Video scaling can be split across cores through `settings.ffmpeg.scaling_threads`, as
+  `ffmpeg` does through its filter graphs. It defaults to `1`, scaling on the calling thread:
+  splitting a frame costs a fan-out and a join every frame, which a stream held to real time
+  pays continuously and, on our measurements, does not earn back. `0` uses one thread per
+  core (#5014).
 - Removed daemon mode: the `-d`/`--daemon` command-line option, the `settings.init.daemon`
   settings and the pidfile they wrote. Detaching from the terminal meant forking, which is
   unsafe now that liquidsoap runs on several cores. Use a service manager such as `systemd`

--- a/src/core/optionals/ffmpeg/base/ffmpeg_utils.ml
+++ b/src/core/optionals/ffmpeg/base/ffmpeg_utils.ml
@@ -76,12 +76,13 @@ let conf_scaling_algorithm =
 let conf_scaling_threads =
   Dtools.Conf.int
     ~p:(conf_ffmpeg#plug "scaling_threads")
-    "Scaling threads" ~d:0
+    "Scaling threads" ~d:1
     ~comments:
       [
-        "Number of threads a video frame is scaled over. `0`, the default,";
-        "uses one per core. Scaling is a small part of what a video stream";
-        "costs, so the extra cores buy little once the codecs are using them.";
+        "Number of threads a video frame is scaled over. `1`, the default,";
+        "scales on the calling thread. Splitting a frame costs a fan-out and";
+        "a join on every frame, which a stream held to real time pays over";
+        "and over and rarely earns back. `0` uses one thread per core.";
       ]
 
 let () =

--- a/src/core/utils/tutils.ml
+++ b/src/core/utils/tutils.ml
@@ -70,14 +70,17 @@ let exit () =
 let blocking_tasks =
   Dtools.Conf.int
     ~p:(conf_scheduler#plug "blocking_tasks")
-    ~d:64 "Blocking tasks"
+    ~d:(max 5 (Domain.recommended_domain_count ()))
+    "Blocking tasks"
     ~comments:
       [
         "Maximum number of blocking tasks running at once, spread evenly over";
-        "the scheduler's domains. Blocking tasks spend most of their time";
-        "waiting on a socket or a file rather than using a core, so this can";
-        "be much larger than the number of cores. Each domain keeps at least";
-        "one slot, so setting this below the number of cores has no effect.";
+        "the scheduler's domains. Defaults to one per domain, and never fewer";
+        "than 5. Raising it helps when the tasks truly wait, on a socket or a";
+        "slow mount. A task that uses a core instead of waiting on one, such as";
+        "probing a file for its decoder, gains nothing from extra slots and";
+        "takes cores the streaming threads need. Each domain keeps at least one";
+        "slot, so setting this below the number of domains has no effect.";
       ]
 
 let legacy =

--- a/src/core/utils/tutils.ml
+++ b/src/core/utils/tutils.ml
@@ -70,13 +70,13 @@ let exit () =
 let blocking_tasks =
   Dtools.Conf.int
     ~p:(conf_scheduler#plug "blocking_tasks")
-    ~d:(max 5 (Domain.recommended_domain_count ()))
+    ~d:(max 8 (Domain.recommended_domain_count ()))
     "Blocking tasks"
     ~comments:
       [
         "Maximum number of blocking tasks running at once, spread evenly over";
         "the scheduler's domains. Defaults to one per domain, and never fewer";
-        "than 5. Raising it helps when the tasks truly wait, on a socket or a";
+        "than 8. Raising it helps when the tasks truly wait, on a socket or a";
         "slow mount. A task that uses a core instead of waiting on one, such as";
         "probing a file for its decoder, gains nothing from extra slots and";
         "takes cores the streaming threads need. Each domain keeps at least one";

--- a/src/modules/duppy/duppy.ml
+++ b/src/modules/duppy/duppy.ml
@@ -98,7 +98,7 @@ type wrapper = { wrap : 'a. (unit -> 'a) -> 'a }
 (** One domain or thread of the pool. [wake] carries a signal across the window
     between registering as idle and blocking on [worker_c], so a wake-up sent in
     that window is not lost. [blocking] counts the tasks parked on this worker's
-    auxiliary threads. *)
+    auxiliary threads, which live in [aux_pending] and the fields around it. *)
 type 'a worker = {
   worker_m : Mutex.t;
   worker_c : Condition.t;
@@ -106,6 +106,11 @@ type 'a worker = {
   mutable took_batch : bool;
   blocking : int Atomic.t;
   accepts : 'a -> bool;
+  aux_m : Mutex.t;
+  aux_c : Condition.t;
+  mutable aux_pending : (unit -> unit) list;
+  mutable aux_busy : int;
+  mutable aux_total : int;
 }
 
 type member = [ `Domain of unit Domain.t | `Thread of Thread.t ]
@@ -419,10 +424,39 @@ let run_task s fn =
         []
     | v -> v
 
+(** Auxiliary threads are kept parked between tasks, since a task in this class
+    can be shorter than the spawn it would otherwise pay for.
+
+    Finishing a job leads back into the queue check under the same lock, so a
+    thread with work waiting never parks and is never counted idle in the window
+    where a submission would pick it. *)
+let aux_loop s w =
+  let rec loop () =
+    while w.aux_pending = [] && not (Atomic.get s.stopped) do
+      Condition.wait w.aux_c w.aux_m
+    done;
+    match w.aux_pending with
+      | [] ->
+          w.aux_total <- w.aux_total - 1;
+          Mutex.unlock w.aux_m
+      | job :: rest ->
+          w.aux_pending <- rest;
+          w.aux_busy <- w.aux_busy + 1;
+          Mutex.unlock w.aux_m;
+          (try job ()
+           with exn ->
+             let bt = Printexc.get_raw_backtrace () in
+             s.on_error exn bt);
+          Mutex.lock w.aux_m;
+          w.aux_busy <- w.aux_busy - 1;
+          loop ()
+  in
+  Mutex.lock w.aux_m;
+  loop ()
+
 (** Blocking tasks run on an auxiliary systhread inside the worker's domain:
     once the task parks in a syscall it releases the runtime lock and the domain
-    goes back to dispatching. One thread per task rather than a pool, since a
-    task in this class is long enough that the spawn does not show.
+    goes back to dispatching.
 
     A worker that is itself a thread already releases the lock when it parks, so
     it runs the task in place. *)
@@ -434,13 +468,23 @@ let run_blocking s w fn =
     add_t s tasks
   in
   if s.threaded then run ()
-  else
-    ignore
-      (Thread.create
-         (fun () ->
-           run ();
-           wake_worker s w)
-         ())
+  else begin
+    let job () =
+      run ();
+      wake_worker s w
+    in
+    Mutex.lock w.aux_m;
+    w.aux_pending <- w.aux_pending @ [job];
+    if
+      w.aux_total - w.aux_busy < List.length w.aux_pending
+      && w.aux_total < s.blocking_per_worker
+    then begin
+      w.aux_total <- w.aux_total + 1;
+      ignore (Thread.create (fun () -> aux_loop s w) ())
+    end
+    else Condition.signal w.aux_c;
+    Mutex.unlock w.aux_m
+  end
 
 let wait_for_work s w =
   Mutex.lock w.worker_m;
@@ -576,6 +620,11 @@ let start ?pool ?(max_blocking = 64) ?log:logger s =
           took_batch = false;
           blocking = Atomic.make 0;
           accepts;
+          aux_m = Mutex.create ();
+          aux_c = Condition.create ();
+          aux_pending = [];
+          aux_busy = 0;
+          aux_total = 0;
         })
       accepts
   in
@@ -605,6 +654,9 @@ let stop s =
     Atomic.set s.stopped true;
     wake_up s;
     List.iter signal_worker s.workers;
+    List.iter
+      (fun w -> Mutex.protect w.aux_m (fun () -> Condition.broadcast w.aux_c))
+      s.workers;
     (* Let the tasks still parked on the workers finish, bounded because a
        blocking task is under no obligation to return. *)
     let deadline = time () +. drain_timeout in

--- a/src/modules/duppy/duppy.ml
+++ b/src/modules/duppy/duppy.ml
@@ -414,6 +414,10 @@ let take_work s w =
         s.ready <- List.filter (fun x -> x != best) s.ready;
         w.took_batch <- false;
         (Some (One (snd best)), take_idle s (List.length s.ready))
+    (* Blocking work is ready but this worker is at its own capacity for it:
+       leaving it there would strand the task until a worker happens to look
+       for an unrelated reason, so hand it to the ones that are idle. *)
+    | _ when blocking <> [] -> (None, take_idle s (List.length blocking))
     | _ -> (None, [])
 
 let run_task s fn =
@@ -609,7 +613,7 @@ let start ?pool ?(max_blocking = 64) ?log:logger s =
   in
   s.threaded <- (match pool with Some (`Threads _) -> true | _ -> false);
   let count = List.length accepts in
-  s.blocking_per_worker <- max 1 (max_blocking / count);
+  s.blocking_per_worker <- max 1 ((max_blocking + count - 1) / count);
   let workers =
     List.map
       (fun accepts ->

--- a/src/modules/duppy/duppy.mli
+++ b/src/modules/duppy/duppy.mli
@@ -106,8 +106,9 @@ val create :
   * @param pool Default: [`Domains (Domain.recommended_domain_count ())]
   * @param max_blocking the most [`Blocking] tasks that may be in flight at
   * once, spread evenly over the domains. Each domain keeps at least one slot,
-  * so a value below their number gives one per domain. Unused by a thread
-  * pool. Default: [64]
+  * rounded up, so the whole budget is available even when it does not divide
+  * evenly and a value below their number gives one per domain. Unused by a
+  * thread pool. Default: [64]
   * @param log Logging function. Default: no logging *)
 val start :
   ?pool:[ `Domains of int | `Threads of ('a -> bool) list ] ->

--- a/src/modules/duppy/test/test_duppy.ml
+++ b/src/modules/duppy/test/test_duppy.ml
@@ -363,6 +363,36 @@ let test_threads () =
     | _ -> fail "tasks did not each stay on the thread accepting their priority");
   ok "%d tasks ran on the main domain, one thread per priority" (2 * count)
 
+(* A worker that takes a blocking task goes back to idle while its auxiliary
+   thread runs it, so it sits at the front of the idle list at its own
+   capacity. The next blocking task must not be stranded on it while other
+   workers are free. *)
+let test_capacity_hands_off () =
+  let s = Duppy.create ~classify () in
+  Duppy.start ~pool:(`Domains 4) ~max_blocking:4 s;
+  let held = latch () in
+  let extra = latch () in
+  Duppy.Task.add s
+    (task Blocking (fun _ ->
+         bump held;
+         Thread.delay 2.;
+         []));
+  await held 1;
+  (* Let the worker finish declining and settle at the front of the idle list. *)
+  Thread.delay 0.3;
+  Duppy.Task.add s
+    (task Blocking (fun _ ->
+         bump extra;
+         []));
+  let deadline = Unix.gettimeofday () +. 1. in
+  while Atomic.get extra.n = 0 && Unix.gettimeofday () < deadline do
+    Thread.delay 0.01
+  done;
+  if Atomic.get extra.n = 0 then
+    fail "a blocking task was stranded on a worker already at its capacity";
+  ok "a worker at capacity hands ready blocking work to a free one";
+  Duppy.stop s
+
 let () =
   watchdog 60.;
   test_threads ();
@@ -378,4 +408,5 @@ let () =
   test_effect_raises_to_on_error ();
   test_await_outside_run ();
   test_no_starvation ();
+  test_capacity_hands_off ();
   print_endline "all duppy pool checks passed"

--- a/tests/regression/GH5389.liq
+++ b/tests/regression/GH5389.liq
@@ -2,6 +2,8 @@
 # collectable.
 
 stopped = ref(false)
+collected = ref(false)
+tracks = ref(0)
 
 current = ref(source.fail())
 dynamic =
@@ -27,12 +29,30 @@ def install() =
   first.on_stop(synchronous=true, fun () -> stopped := true)
   first.on_collect(
     synchronous=true,
-    fun () -> if stopped() then test.pass() else test.fail() end
+    fun () ->
+      begin
+        collected := true
+        if stopped() then test.pass() else test.fail() end
+      end
   )
   first.on_connect(synchronous=true, fun () -> thread.run(delay=0.2, replace))
   current := first
 end
 
+# The second track is the switch away from `first`, whose last reference is
+# dropped a cycle or so later, so collection is asked for until it happens.
+#
+# Compacting from the clock thread would deadlock, since the finaliser passes
+# the test and that shuts down the clock it is running on.
+def on_track(_) =
+  tracks := tracks() + 1
+  if
+    tracks() == 2
+  then
+    thread.run(every={collected() ? -1. : 0.1}, runtime.gc.compact)
+  end
+end
+
+dynamic.on_track(synchronous=true, on_track)
+
 thread.run(delay=0.1, install)
-thread.run(delay=2., runtime.gc.compact)
-thread.run(delay=4., test.fail)

--- a/tests/regression/GH5389.liq
+++ b/tests/regression/GH5389.liq
@@ -49,7 +49,7 @@ def on_track(_) =
   if
     tracks() == 2
   then
-    thread.run(every={collected() ? -1. : 0.1}, runtime.gc.compact)
+    thread.run(every={(collected() ? -1. : 0.1)}, runtime.gc.compact)
   end
 end
 


### PR DESCRIPTION
Three changes to how concurrent work is scheduled, all found by measuring a rate-constrained streaming workload rather than a throughput benchmark. Numbers are from an 8-core machine.

## Blocking tasks ran on a thread spawned per task

`run_blocking` created a systhread for every blocking task and let it exit when the task returned. Its comment justified that: a task in this class is long enough that the spawn does not show. That holds for a socket read. It does not hold for a request probe on a file already in page cache. Starting 640 playlists behind one switch, 553% of a 578% burst was CPU in threads that had already exited, and the burst gained only 10% over the legacy scheduler while using 1.6x the cores.

Each worker now keeps its auxiliary threads and feeds them through a queue. They stay inside the worker's own domain, which is what lets a task parking in a syscall release that domain's runtime lock and leave the dispatch loop free, so a pool shared across domains would not do. Growth counts busy threads rather than idle ones: a parked thread has not claimed anything until it reacquires the mutex, so two submissions arriving together would otherwise both pick it, lose one signal and serialise. At 640 playlists this takes churn from 553% to 6% and the burst from 10.10s to 8.80s.

## The blocking task budget assumed tasks wait rather than compute

`settings.scheduler.blocking_tasks` defaulted to 64 on the reasoning, stated in its own comments, that blocking tasks spend their time waiting on a socket or a file and so the budget can safely exceed the core count. Resolving a playlist entry does not wait. `avformat_find_stream_info` decodes real frames, and with automatic thread counts a single probe can occupy more than one core. So 64 concurrent probes are more runnable threads than the machine has cores, and the streaming thread has to win a slot against all of them every frame.

Sweeping the budget at 1280 playlists, going from 64 to 8 cut catchups from 11 to 1 and worst lag from 9.00s to 0.96s. The burst got slightly faster and used slightly more CPU at the same time, so nothing was traded away for the stability. The default is now one slot per domain with a floor of 5, which is what 2.4.5's five generic queues allowed. The setting is a total divided across domains and each domain keeps at least one slot, so any value below the domain count already collapsed to one per domain.

## Video scaling defaulted to one thread per core

Splitting a frame across cores costs a fan-out and a join on every frame, which a stream held to real time pays continuously. Across a resolution ladder up to the point where the encoder saturated the machine, automatic scaler threading did not improve the frame budget at any resolution. `settings.ffmpeg.scaling_threads` now defaults to 1, scaling on the calling thread. `0` still selects one thread per core.

## Results

640 playlists behind one switch, one output, one clock:

| | burst | burst CPU | catchups | peak threads |
|---|---|---|---|---|
| before | 10.10s | 578%, of which 553% churn | 5 | 96 |
| after | 8.80s | 435%, of which 6% churn | 0 | 39 |

The legacy scheduler on the same workload is 10.50s with 0 catchups. The concurrent scheduler is now ahead of it on speed without giving up clock stability, which was not true before.

## Testing

Measured rather than unit tested, since the failure is a performance and timing property. The workload is a fixed count of playlists behind one switch feeding one output, with process CPU, per-core occupancy, thread count and thread churn sampled from `/proc` at 5 Hz, and catchups read from the clock's own log. Sweeps covered 40 to 2560 playlists against both schedulers, and blocking budgets of 8, 16, 32 and 64. A harbor sweep serving static HTTP checked that the pool change did not regress genuinely non-blocking work.

Two caveats. All numbers come from a single 8-core machine with local files and a warm page cache. Resolution that genuinely waits, over HTTP or a slow mount, is the case the old default was sized for and is not covered here. The new default is still above the 5 that 2.4.5 allowed, so it should not regress against what users are upgrading from, but that case is not directly measured.
