### PR TITLE
Run clocks as scheduler tasks

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -64,6 +64,12 @@
   domain and never fewer than 8, so a machine with few cores keeps room to run several at once. Raising it pays off
   when those tasks truly wait. A task that uses a core instead of waiting on one, such as probing a
   file for its decoder, only takes cores the streaming threads need.
+- Clocks run as scheduler tasks rather than each on a thread of its own. A clock that is ahead
+  of real time parks and is resumed by the scheduler's timer, so a machine running many outputs
+  has as many busy threads as cores instead of one per clock competing for them. A clock
+  catching up yields its domain to the others after each burst of frames. Ticks run directly on
+  a scheduler domain, one at a time, ahead of request resolution.
+  `settings.clock.task := false` restores a thread per clock.
 - When the scheduler is busy, quick work is served before slow work: the server, then request resolutions, then
   long tasks such as last.fm submissions. The order used to be arbitrary and often favoured the slow ones.
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -46,6 +46,9 @@
   one is expected, so sources of different content can be held together, for instance in a list,
   without unifying their content types, while nothing can be assumed about what a `source(_)`
   streams.
+- Added `domain` to `thread.run`, pinning the function and every rerun to the
+  scheduler worker on that domain. An object is only collected by a GC on the
+  domain that allocated it, which makes this the way to ask for one.
 
 ## Changed:
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -69,7 +69,8 @@
   has as many busy threads as cores instead of one per clock competing for them. A clock
   catching up yields its domain to the others after each burst of frames. Ticks run directly on
   a scheduler domain, one at a time, ahead of request resolution.
-  `settings.clock.task := false` restores a thread per clock.
+  A clock driving JACK input or output keeps a thread of its own, since it rests by waiting on the
+  JACK server. `settings.clock.task := false` restores a thread per clock everywhere.
 - When the scheduler is busy, quick work is served before slow work: the server, then request resolutions, then
   long tasks such as last.fm submissions. The order used to be arbitrary and often favoured the slow ones.
 

--- a/doc/content/clocks.md
+++ b/doc/content/clocks.md
@@ -241,8 +241,8 @@ fallback.
 
 ## Parallel encoding with `clock.assign_new`
 
-Each clock runs in its own thread, which means sources assigned to different
-clocks can run on separate CPU cores. This matters most for video encoding,
+Each clock is animated on its own, as a scheduler task by default, which means
+sources assigned to different clocks can run on separate CPU cores. This matters most for video encoding,
 which is typically the most CPU-intensive part of a streaming workflow.
 
 When two outputs share the same default clock, they encode sequentially:

--- a/src/core/builtins/builtins_thread.ml
+++ b/src/core/builtins/builtins_thread.ml
@@ -52,6 +52,12 @@ let _ =
         Lang.float_t,
         Some (Lang.float 0.),
         Some "Delay (in sec.) after which the thread should be launched." );
+      ( "domain",
+        Lang.nullable_t Lang.int_t,
+        Some Lang.null,
+        Some
+          "Domain to run on, as reported by `runtime.domain()`. Every rerun \
+           stays there. Only meaningful once the scheduler is started." );
       ( "on_error",
         Lang.nullable_t (Lang.fun_t [(false, "", Lang.error_t)] Lang.float_t),
         Some Lang.null,
@@ -74,6 +80,9 @@ let _ =
       let priority =
         if Lang.to_bool (List.assoc "fast" p) then `Maybe_blocking
         else `Blocking
+      in
+      let domain =
+        Option.map Lang.to_int (Lang.to_option (List.assoc "domain" p))
       in
       let on_error = Lang.to_option (List.assoc "on_error" p) in
       let on_error =
@@ -106,7 +115,15 @@ let _ =
         }
       in
       Lifecycle.after_start ~name:"thread start" (fun () ->
-          Duppy.Task.add Tutils.scheduler (task delay));
+          try Duppy.Task.add ?domain Tutils.scheduler (task delay)
+          with Duppy.Unknown_domain d ->
+            Lang.raise_error ~pos:(Lang.pos p)
+              ~message:
+                (Printf.sprintf
+                   "No scheduler worker runs on domain %d. Use a value from \
+                    runtime.domain() taken inside a task."
+                   d)
+              "invalid");
       Lang.unit)
 
 let _ =

--- a/src/core/clock/clock.ml
+++ b/src/core/clock/clock.ml
@@ -767,15 +767,14 @@ and stop c =
            current tick and calls [has_stopped]. *)
         Atomic.set clock.state (`Stopping params)
 
+(* A clock reports back at the end of its tick, so stopping is asynchronous in
+   both animator modes. The steps that follow tear down the sources a tick
+   reads from, and a clock task is not in the set [Tutils.cleanup] joins, so
+   the wait belongs here, ahead of every [on_core_shutdown]. *)
 let () =
   Lifecycle.before_core_shutdown ~name:"Clocks stop" (fun () ->
       Atomic.set global_stop true;
-      Registry.iter_started (fun c -> if sync c <> `Passive then stop c))
-
-(* A clock parked as a task wakes on its timer to find it has been stopped, so
-   the scheduler has to stay up until every started clock has reported back. *)
-let () =
-  Lifecycle.before_scheduler_shutdown ~name:"Clocks drain" (fun () ->
+      Registry.iter_started (fun c -> if sync c <> `Passive then stop c);
       let module Time = (val Liq_time.unix : Liq_time.T) in
       let now () = Time.to_float (Time.time ()) in
       let deadline = now () +. conf_max_latency#get in
@@ -785,7 +784,7 @@ let () =
       let left = ref [] in
       Registry.iter_started (fun c -> left := id c :: !left);
       if !left <> [] then
-        log#important "Clocks still running at scheduler shutdown: %s"
+        log#important "Clocks still running at shutdown: %s"
           (String.concat ", " !left))
 
 (* {1 Unification}

--- a/src/core/clock/clock.ml
+++ b/src/core/clock/clock.ml
@@ -252,6 +252,26 @@ type main_conflict = {
 
 exception Main_conflict of main_conflict
 
+type animator_conflict = { pos : Pos.Option.t; clock : string }
+
+exception Animator_conflict of animator_conflict
+
+let () =
+  Printexc.register_printer (function
+    | Animator_conflict { pos; clock } ->
+        let buf = Buffer.create Utils.buflen in
+        let formatter = Format.formatter_of_buffer buf in
+        Liquidsoap_lang.Runtime.error_header ~formatter 18 pos;
+        Format.fprintf formatter
+          "Clock %s has already started as a scheduler task.@ A source that \
+           rests by waiting on an external server, such as JACK input or \
+           output,@ needs a clock animated by a thread of its own and cannot \
+           join a clock that is already running.@]@."
+          clock;
+        Format.pp_print_flush formatter ();
+        Some (Buffer.contents buf)
+    | _ -> None)
+
 let () =
   Liquidsoap_lang.Runtime.on_error_print (fun ~formatter -> function
     | Conflict (pos, a, b) ->
@@ -457,6 +477,10 @@ type clock = {
      tick (unless already ticked during it, e.g. by an operator pulling data
      from them) and stopped when this clock stops. *)
   sub_clocks : t Queue.t;
+  (* Set by a source whose sync rests by blocking in a foreign call, which a
+     clock animated by a scheduler task cannot do without holding a domain for
+     the whole rest. *)
+  needs_thread : bool Atomic.t;
   on_error : (exn -> Printexc.raw_backtrace -> unit) Queue.t;
 }
 
@@ -700,6 +724,18 @@ let deregister_sub_clock parent sub =
   Queue.filter_out (Unifier.deref parent).sub_clocks (fun c ->
       Unifier.deref c == clock)
 
+(* The animator is picked once, when the clock starts, so a source declaring
+   this has to do it from its initializer. *)
+let _force_thread ~pos clock =
+  if Atomic.get clock.state <> `Stopped then
+    raise (Animator_conflict { pos; clock = _descr clock });
+  Atomic.set clock.needs_thread true
+
+let force_thread c =
+  let clock = Unifier.deref c in
+  let pos = match Atomic.get clock.stack with p :: _ -> Some p | [] -> None in
+  _force_thread ~pos clock
+
 (* {1 Source attachment} *)
 
 let attach c s =
@@ -836,6 +872,7 @@ let unify =
     Queue.flush_iter clock.pending_activations
       (Queue.push clock'.pending_activations);
     Queue.flush_iter clock.sub_clocks (Queue.push clock'.sub_clocks);
+    if Atomic.get clock.needs_thread then _force_thread ~pos clock';
     Queue.flush_iter clock.on_error (Queue.push clock'.on_error);
     (match (Atomic.get clock.id, Atomic.get clock'.id) with
       | Some _, Some id ->
@@ -1249,7 +1286,7 @@ let _start_animator ~clock ~c params =
       on_stop ()
     with Has_stopped -> on_stop ()
   in
-  if conf_task#get then (
+  if conf_task#get && not (Atomic.get clock.needs_thread) then (
     params.animator <- `Task;
     Duppy.Task.add Tutils.scheduler
       {
@@ -1400,6 +1437,7 @@ let create ?(stack = []) ?(controller = `None) ?on_error ?id
         stack = Atomic.make stack;
         pending_activations = Queue.create ();
         sub_clocks = Queue.create ();
+        needs_thread = Atomic.make false;
         state = Atomic.make `Stopped;
         on_error = on_error_queue;
       }

--- a/src/core/clock/clock.ml
+++ b/src/core/clock/clock.ml
@@ -342,6 +342,16 @@ let conf_latency =
         "we wait until re-starting the streaming loop.";
       ]
 
+let conf_task =
+  Dtools.Conf.bool ~p:(conf_clock#plug "task") ~d:true
+    "Run clocks as scheduler tasks"
+    ~comments:
+      [
+        "A clock that is ahead of real time rests by parking as a scheduler";
+        "task and is resumed by the scheduler's timer, instead of sleeping on";
+        "a thread of its own.";
+      ]
+
 let conf_leak_warning =
   Dtools.Conf.int
     ~p:(conf_clock#plug "leak_warning")
@@ -392,6 +402,12 @@ type active_params = {
   (* Time implementation used for latency control. Re-anchored whenever the
      sync source changes so that [time () = 0] at tick [0]. *)
   mutable time_implementation : Liq_time.implementation;
+  (* What animates the clock: parking only makes sense from inside a
+     scheduler task, and a clock can also be ticked from outside. *)
+  mutable animator : [ `None | `Thread | `Task ];
+  (* Ticks taken in a row without getting ahead, for pacing yields while a
+     task-animated clock catches up. *)
+  mutable catchup_ticks : int;
   log_delay : float;
   log_delay_threshold : float;
   frame_duration : float;
@@ -638,6 +654,7 @@ module Registry = struct
     WeakQueue.filter_out all_clocks (fun el -> el == c)
 
   let iter_started fn = Queue.iter started fn
+  let none_started () = Queue.is_empty started
 
   let managed () =
     Queue.elements retained @ WeakQueue.elements pending
@@ -754,6 +771,22 @@ let () =
   Lifecycle.before_core_shutdown ~name:"Clocks stop" (fun () ->
       Atomic.set global_stop true;
       Registry.iter_started (fun c -> if sync c <> `Passive then stop c))
+
+(* A clock parked as a task wakes on its timer to find it has been stopped, so
+   the scheduler has to stay up until every started clock has reported back. *)
+let () =
+  Lifecycle.before_scheduler_shutdown ~name:"Clocks drain" (fun () ->
+      let module Time = (val Liq_time.unix : Liq_time.T) in
+      let now () = Time.to_float (Time.time ()) in
+      let deadline = now () +. conf_max_latency#get in
+      while (not (Registry.none_started ())) && now () < deadline do
+        Thread.delay 0.01
+      done;
+      let left = ref [] in
+      Registry.iter_started (fun c -> left := id c :: !left);
+      if !left <> [] then
+        log#important "Clocks still running at scheduler shutdown: %s"
+          (String.concat ", " !left))
 
 (* {1 Unification}
 
@@ -966,17 +999,29 @@ let _set_time { time_implementation; frame_duration; ticks } t =
   let module Time = (val time_implementation : Liq_time.T) in
   Atomic.set ticks (int_of_float (Time.to_float t /. frame_duration))
 
+(* Give the animating domain up for [delay], returning [false] when there is
+   no handler to park on: a tick driven from outside the clock's own task. *)
+let _park params ~delay =
+  match params.animator with
+    | `Thread | `None -> false
+    | `Task -> (
+        try
+          Duppy.reschedule ~delay ~priority:`Clock Tutils.scheduler;
+          true
+        with Effect.Unhandled _ -> false)
+
+let _latency params =
+  match params.current_sync_source with
+    | Some { latency } -> latency
+    | None -> conf_latency#get
+
 (* The clock is ahead of its target time: rest until the target time, but
    only when far enough ahead. *)
 let _sleep_until_target params ~end_time ~target_time =
   let module Time = (val params.time_implementation : Liq_time.T) in
-  let latency =
-    match params.current_sync_source with
-      | Some { latency } -> latency
-      | None -> conf_latency#get
-  in
-  if Time.(of_float latency |<=| (target_time |-| end_time)) then
-    Time.sleep_until target_time
+  if Time.(of_float (_latency params) |<=| (target_time |-| end_time)) then (
+    let delay = Time.(to_float (target_time |-| time ())) in
+    if not (0. < delay && _park params ~delay) then Time.sleep_until target_time)
 
 (* The clock is behind its target time: reset the sources when latency
    exceeds the maximum, otherwise log periodic catchup warnings. *)
@@ -1013,6 +1058,18 @@ let _handle_latency params ~end_time ~target_time =
        info."
       Time.(to_float (end_time |-| target_time)))
 
+(* Catching up means ticking without rest, which would hold the animating
+   domain for as long as it takes, so the clock yields to the other clocks on
+   the pool. It first runs the ticks it takes to earn a rest, one latency's
+   worth: yielding more often than that means fighting for a domain several
+   times over for what is naturally a single burst. *)
+let _yield_while_catching_up params =
+  let turn = max 1 (int_of_float (_latency params /. params.frame_duration)) in
+  params.catchup_ticks <- params.catchup_ticks + 1;
+  if turn <= params.catchup_ticks then (
+    params.catchup_ticks <- 0;
+    ignore (_park params ~delay:0.))
+
 let _after_tick params =
   (* [Queue.flush_iter] takes the queue's mutation lock even when empty:
      check emptiness lock-free first, this runs on every tick. *)
@@ -1025,10 +1082,16 @@ let _after_tick params =
   let target_time = _target_time params in
   check_stopped ();
   match (params.sync, Time.(end_time |<| target_time)) with
-    | `Unsynced, _ | `Passive, _ -> ()
+    | `Passive, _ -> ()
+    (* Never ahead by construction, so it yields the same way a clock catching
+       up does. *)
+    | `Unsynced, _ -> _yield_while_catching_up params
     | `Automatic, true | `CPU, true ->
+        params.catchup_ticks <- 0;
         _sleep_until_target params ~end_time ~target_time
-    | _ -> _handle_latency params ~end_time ~target_time
+    | _ ->
+        _handle_latency params ~end_time ~target_time;
+        _yield_while_catching_up params
 
 (* {1 Streaming loop} *)
 
@@ -1154,7 +1217,7 @@ let rec _tick ?(pull = false) ~clock params =
   _after_tick params;
   check_stopped ()
 
-let _clock_thread ~clock ~c params =
+let _start_animator ~clock ~c params =
   let has_sources_to_process () =
     0 < Queue.length clock.pending_activations
     || 0 < Queue.length params.outputs
@@ -1174,8 +1237,7 @@ let _clock_thread ~clock ~c params =
           ("no more sources to process", not (has_sources_to_process ()));
         ]
     in
-    params.log#important "Clock thread has stopped: %s."
-      (String.concat ", " reasons);
+    params.log#important "Clock has stopped: %s." (String.concat ", " reasons);
     has_stopped ~clear_controller:true ~clock ~c params
   in
   let run () =
@@ -1188,12 +1250,31 @@ let _clock_thread ~clock ~c params =
       on_stop ()
     with Has_stopped -> on_stop ()
   in
-  Tutils.create
-    (fun () ->
-      params.log#info "Clock thread is starting";
-      run ())
-    ()
-    ("Clock " ^ _id clock)
+  if conf_task#get then (
+    params.animator <- `Task;
+    Duppy.Task.add Tutils.scheduler
+      {
+        Duppy.Task.priority = `Clock;
+        events = [`Delay 0.];
+        handler =
+          (fun _ ->
+            Duppy.run (fun () ->
+                params.log#info "Clock task is starting";
+                run ());
+            []);
+      };
+    ("task", "task-" ^ string_of_int clock.unique_id))
+  else (
+    params.animator <- `Thread;
+    let th =
+      Tutils.create
+        (fun () ->
+          params.log#info "Clock thread is starting";
+          run ())
+        ()
+        ("Clock " ^ _id clock)
+    in
+    ("thread", string_of_int (Thread.id th)))
 
 (* {1 Starting}
 
@@ -1284,20 +1365,22 @@ let rec _start ?force ~c clock =
       outputs = Queue.create ();
       ticks = Atomic.make 0;
       pulled = Atomic.make false;
+      animator = `None;
+      catchup_ticks = 0;
     }
   in
   Queue.iter clock.sub_clocks (fun c -> start ?force c);
   Atomic.set clock.state (`Started params);
   if sync <> `Passive then (
-    let th = _clock_thread ~clock ~c params in
+    let kind, id = _start_animator ~clock ~c params in
     match controller with
       | `None ->
           let controller =
             object
-              method id = string_of_int (Thread.id th)
+              method id = id
             end
           in
-          Atomic.set clock.controller (`Other ("thread", controller))
+          Atomic.set clock.controller (`Other (kind, controller))
       | _ -> raise Invalid_state)
 
 and start ?force c =

--- a/src/core/clock/clock.mli
+++ b/src/core/clock/clock.mli
@@ -46,6 +46,12 @@ type main_conflict = {
 
 exception Main_conflict of main_conflict
 
+type animator_conflict = { pos : Pos.Option.t; clock : string }
+
+(** Raised when a source that needs a thread-animated clock reaches a clock that
+    has already started as a scheduler task. *)
+exception Animator_conflict of animator_conflict
+
 (** A clock handle. Two handles can dereference to the same underlying clock
     after unification. *)
 type t
@@ -214,6 +220,13 @@ val unify : pos:Liquidsoap_lang_prelude.Pos.Option.t -> t -> t -> unit
 
 val register_sub_clock : t -> t -> unit
 val deregister_sub_clock : t -> t -> unit
+
+(** Animate the clock with a thread of its own rather than a scheduler task. For
+    a source whose sync rests by blocking in a foreign call, which a task cannot
+    do without holding a scheduler domain for the whole rest. The animator is
+    picked when the clock starts, so this belongs in the source's initializer:
+    it raises {!Animator_conflict} on a clock that already started. *)
+val force_thread : t -> unit
 
 (** Attach a source to the clock. The source is placed in the pending
     activations and activated when the clock starts or at the beginning of its

--- a/src/core/clock/dune
+++ b/src/core/clock/dune
@@ -27,5 +27,6 @@
   liquidsoap-lang.data
   liquidsoap-lang.prelude
   liquidsoap_core_utils
+  duppy
   threads.posix
   liquidsoap_core_stream))

--- a/src/core/optionals/jack/jack_io.ml
+++ b/src/core/optionals/jack/jack_io.ml
@@ -370,6 +370,7 @@ class virtual base ~server () =
     method virtual log : Log.t
     method virtual audio_channels : int
     method virtual id : string
+    method virtual clock : Clock.t
     method virtual on_wake_up : (unit -> unit) -> unit
     method virtual on_sleep : (unit -> unit) -> unit
     method virtual private is_input : bool
@@ -405,6 +406,9 @@ class virtual base ~server () =
       ( `Dynamic,
         match _jack_client with None -> None | Some _ -> Some sync_source )
 
+    (* Resting means [ServerState.wait_until], which blocks until the JACK
+       server's process callback fires. *)
+    initializer Clock.force_thread self#clock
     method private samples_per_second = samples_per_second
     method private jack_stopped = ServerState.get_stopped server_state
 

--- a/src/core/utils/tutils.ml
+++ b/src/core/utils/tutils.ml
@@ -223,7 +223,8 @@ let create f x s =
     ()
 
 type priority =
-  [ `Blocking  (** For example a last.fm submission. *)
+  [ `Clock  (** A clock resuming to produce its next frames. *)
+  | `Blocking  (** For example a last.fm submission. *)
   | `Maybe_blocking  (** Request resolutions vary a lot. *)
   | `Non_blocking  (** Non-blocking tasks like the server. *) ]
 
@@ -244,12 +245,13 @@ let rec error_handler ~bt exn =
         error_handler ~bt exn
 
 (* Polymorphic compare orders these by name hash, which is not the order we
-   want: the server must come first, and a request resolution before a last.fm
-   submission. *)
+   want: the server must come first, then a clock holding a stream to real
+   time, then a request resolution before a last.fm submission. *)
 let priority_rank = function
   | `Non_blocking -> 0
-  | `Maybe_blocking -> 1
-  | `Blocking -> 2
+  | `Clock -> 1
+  | `Maybe_blocking -> 2
+  | `Blocking -> 3
 
 let scheduler : priority Duppy.scheduler =
   Duppy.create
@@ -268,7 +270,13 @@ let scheduler : priority Duppy.scheduler =
       flush_all ();
       _exit 1)
     ~compare:(fun a b -> compare (priority_rank a) (priority_rank b))
-    ~classify:(function `Non_blocking -> `Immediate | _ -> `Blocking)
+    ~classify:(function
+      | `Non_blocking -> `Immediate
+      (* A clock tick is long and holds a stream to real time: it runs on the
+         domain, alone, so ticks spread rather than queueing behind each
+         other. *)
+      | `Clock -> `Direct
+      | _ -> `Blocking)
       (* Tasks run script code, which registers its callbacks through an
          effect. *)
     ~wrapper:{ Duppy.wrap = Script_callback.uncollected }

--- a/src/core/utils/tutils.mli
+++ b/src/core/utils/tutils.mli
@@ -53,7 +53,8 @@ val join_all : unit -> unit
 
 (** Priorities for the different scheduler usages. *)
 type priority =
-  [ `Blocking  (** For example a last.fm submission. *)
+  [ `Clock  (** A clock resuming to produce its next frames. *)
+  | `Blocking  (** For example a last.fm submission. *)
   | `Maybe_blocking  (** Request resolutions vary a lot. *)
   | `Non_blocking  (** Non-blocking tasks like the server. *) ]
 

--- a/src/libs/thread.liq
+++ b/src/libs/thread.liq
@@ -3,10 +3,18 @@
 # @param ~fast Whether the thread is supposed to return quickly or not. Typically, blocking tasks (e.g. fetching data over the internet) should not be considered to be fast. When set to `false` its priority will be lowered below that of request resolutions and fast timeouts.
 # @param ~delay Delay (in seconds) after which the thread should be launched.
 # @param ~every How often (in seconds) the thread should be run. If negative or `null`, run once.
+# @param ~domain Domain to run on, as reported by `runtime.domain()`. Every rerun stays there.
 # @param ~on_error Error callback executed when an error occurred while running the given function. When passed, \
 #                  all raised errors are silenced unless re-raised by the callback.
 # @param f Function to execute.
-def replaces thread.run(~fast=true, ~delay=0., ~on_error=null, ~every=null, f) =
+def replaces thread.run(
+  ~fast=true,
+  ~delay=0.,
+  ~on_error=null,
+  ~every=null,
+  ~domain=null,
+  f
+) =
   every = every ?? getter(-1.)
 
   def f() =
@@ -25,7 +33,13 @@ def replaces thread.run(~fast=true, ~delay=0., ~on_error=null, ~every=null, f) =
       on_error
     )
 
-  thread.run.recurrent(fast=fast, delay=delay, on_error=on_error, f)
+  thread.run.recurrent(
+    fast=fast,
+    delay=delay,
+    on_error=on_error,
+    domain=domain,
+    f
+  )
 end
 
 # Unless told not to, we want to batch thread.when calls when the getter is a fixed

--- a/src/modules/duppy/duppy.ml
+++ b/src/modules/duppy/duppy.ml
@@ -37,7 +37,13 @@ type 'a t = {
   deadline : float;
   fire : event list -> 'a t list;
   mutable dispatched : bool;
+  (* The one worker allowed to run it, by domain. *)
+  pinned : int option;
 }
+
+(** A task whose events fired, waiting for a worker. [target] is the domain of
+    the one worker that may take it. *)
+type 'a ready = { prio : 'a; run : unit -> 'a t list; target : int option }
 
 (** Waiting tasks ordered by when they expire, the id breaking ties between
     tasks sharing a deadline. *)
@@ -106,6 +112,8 @@ type 'a worker = {
   mutable took_batch : bool;
   blocking : int Atomic.t;
   accepts : 'a -> bool;
+  (* Set by [start] from the spawned domain; stays [-1] on a thread pool. *)
+  mutable domain : int;
   aux_m : Mutex.t;
   aux_c : Condition.t;
   mutable aux_pending : (unit -> unit) list;
@@ -128,7 +136,7 @@ type 'a scheduler = {
   by_fd : (fd, 'a t list) Hashtbl.t;
   mutable timers : 'a t Timers.t;
   tasks_m : Mutex.t;
-  mutable ready : ('a * (unit -> 'a t list)) list;
+  mutable ready : 'a ready list;
   mutable idle : 'a worker list;
   ready_m : Mutex.t;
   started : bool Atomic.t;
@@ -270,10 +278,18 @@ let wake_idle s n =
   let workers = Mutex.protect s.ready_m (fun () -> take_idle s n) in
   List.iter signal_worker workers
 
+(** Take one worker off the idle list. [s.ready_m] must be held. *)
+let claim_worker s w =
+  s.idle <- List.filter (fun x -> x != w) s.idle;
+  w
+
 let wake_worker s w =
-  Mutex.protect s.ready_m (fun () ->
-      s.idle <- List.filter (fun x -> x != w) s.idle);
+  Mutex.protect s.ready_m (fun () -> ignore (claim_worker s w));
   signal_worker w
+
+let worker_for s domain = List.find_opt (fun w -> w.domain = domain) s.workers
+
+exception Unknown_domain of int
 
 module Task = struct
   (** Events and tasks from the user's point-of-view. *)
@@ -286,7 +302,7 @@ module Task = struct
     handler : 'b list -> ('a, 'b) task list;
   }
 
-  let rec t_of_task (task : ('a, [< event ]) task) =
+  let rec t_of_task ?domain (task : ('a, [< event ]) task) =
     let t0 = time () in
     let events = (task.events :> event list) in
     {
@@ -303,12 +319,14 @@ module Task = struct
           let l =
             List.filter (fun ev -> List.mem (ev :> event) fired) task.events
           in
-          List.map t_of_task (task.handler l));
+          List.map (t_of_task ?domain) (task.handler l));
       dispatched = false;
+      pinned = domain;
     }
 
   let add_t s items =
     let ready = ref 0 in
+    let pinned = ref [] in
     let f item =
       match fired_events item [] with
         | [] ->
@@ -318,15 +336,34 @@ module Task = struct
         | fired ->
             item.dispatched <- true;
             Mutex.lock s.ready_m;
-            s.ready <- (item.prio, fun () -> item.fire fired) :: s.ready;
+            s.ready <-
+              {
+                prio = item.prio;
+                run = (fun () -> item.fire fired);
+                target = item.pinned;
+              }
+              :: s.ready;
             Mutex.unlock s.ready_m;
-            incr ready
+            incr ready;
+            Option.iter (fun d -> pinned := d :: !pinned) item.pinned
     in
     List.iter f items;
     if 0 < !ready then wake_idle s !ready;
+    List.iter (fun d -> Option.iter (wake_worker s) (worker_for s d)) !pinned;
     wake_up s
 
-  let add s t = add_t s [t_of_task t]
+  (* A pin names a worker that has to exist and accept the task, so a wrong one
+     fails here rather than leaving a task nobody will ever take. *)
+  let add ?domain s t =
+    (match domain with
+      | None -> ()
+      | Some d -> (
+          if (not (Atomic.get s.started)) || s.threaded then
+            raise (Unknown_domain d);
+          match worker_for s d with
+            | Some w when w.accepts t.priority -> ()
+            | _ -> raise (Unknown_domain d)));
+    add_t s [t_of_task ?domain t]
 end
 
 open Task
@@ -394,12 +431,17 @@ type 'a work =
     no blocking slot, since it runs on the domain rather than on one of its
     auxiliary threads. *)
 let take_work s w =
-  let mine, others = List.partition (fun (p, _) -> w.accepts p) s.ready in
+  let mine, others =
+    List.partition
+      (fun e ->
+        w.accepts e.prio && (e.target = None || e.target = Some w.domain))
+      s.ready
+  in
   let direct, rest =
-    List.partition (fun (p, _) -> s.classify p = `Direct) mine
+    List.partition (fun e -> s.classify e.prio = `Direct) mine
   in
   let immediate, blocking =
-    List.partition (fun (p, _) -> s.classify p = `Immediate) rest
+    List.partition (fun e -> s.classify e.prio = `Immediate) rest
   in
   let singles =
     if Atomic.get w.blocking < s.blocking_per_worker then direct @ blocking
@@ -414,19 +456,19 @@ let take_work s w =
     | _ :: _ when not (w.took_batch && can_block) ->
         s.ready <- direct @ blocking @ others;
         w.took_batch <- true;
-        ( Some (Batch (List.rev_map snd immediate)),
+        ( Some (Batch (List.rev_map (fun e -> e.run) immediate)),
           take_idle s (List.length s.ready) )
     | _ when can_block ->
         let best =
           List.fold_left
-            (fun best x -> if s.compare (fst x) (fst best) < 0 then x else best)
+            (fun best x -> if s.compare x.prio best.prio < 0 then x else best)
             (List.hd singles) singles
         in
         s.ready <- List.filter (fun x -> x != best) s.ready;
         w.took_batch <- false;
         let work =
-          if s.classify (fst best) = `Direct then Direct (snd best)
-          else One (snd best)
+          if s.classify best.prio = `Direct then Direct best.run
+          else One best.run
         in
         (Some work, take_idle s (List.length s.ready))
     (* Blocking work is ready but this worker is at its own capacity for it:
@@ -598,11 +640,23 @@ let poll_once s =
     | _ ->
         let wake =
           Mutex.protect s.ready_m (fun () ->
+              let targets =
+                List.filter_map
+                  (fun ((t : _ t), _) -> Option.bind t.pinned (worker_for s))
+                  collected
+              in
               List.iter
-                (fun (t, events) ->
-                  s.ready <- (t.prio, fun () -> t.fire events) :: s.ready)
+                (fun ((t : _ t), events) ->
+                  s.ready <-
+                    {
+                      prio = t.prio;
+                      run = (fun () -> t.fire events);
+                      target = t.pinned;
+                    }
+                    :: s.ready)
                 collected;
-              take_idle s (List.length collected))
+              List.map (claim_worker s) targets
+              @ take_idle s (List.length collected))
         in
         List.iter signal_worker wake
 
@@ -640,6 +694,7 @@ let start ?pool ?(max_blocking = 64) ?log:logger s =
           took_batch = false;
           blocking = Atomic.make 0;
           accepts;
+          domain = -1;
           aux_m = Mutex.create ();
           aux_c = Condition.create ();
           aux_pending = [];
@@ -659,9 +714,16 @@ let start ?pool ?(max_blocking = 64) ?log:logger s =
     if s.threaded then `Thread (Thread.create (guard fn) ())
     else `Domain (Domain.spawn (guard fn))
   in
-  s.members <-
-    spawn (fun () -> poller s)
-    :: List.map (fun w -> spawn (fun () -> dispatch s w)) workers;
+  (* The parent reads the spawned domain's id directly, so a pin can be
+     validated before the worker has run a single instruction. *)
+  let spawn_worker w =
+    let m = spawn (fun () -> dispatch s w) in
+    (match m with
+      | `Domain d -> w.domain <- (Domain.get_id d :> int)
+      | `Thread _ -> ());
+    m
+  in
+  s.members <- spawn (fun () -> poller s) :: List.map spawn_worker workers;
   log s (fun () ->
       if s.threaded then Printf.sprintf "Started %d dispatch threads." count
       else

--- a/src/modules/duppy/duppy.ml
+++ b/src/modules/duppy/duppy.ml
@@ -89,7 +89,7 @@ let fired_events t ready =
             match of_fd fd with Some i -> i.Pollset.except | None -> false))
     t.events
 
-type execution_class = [ `Immediate | `Blocking ]
+type execution_class = [ `Immediate | `Direct | `Blocking ]
 
 (** Wraps every task body. Effect handlers do not cross the thread a task is
     dispatched to, so a caller whose tasks need one installs it here. *)
@@ -379,29 +379,40 @@ let run fn =
 
 let tmp = Bytes.create 1024
 
-type 'a work = Batch of (unit -> 'a t list) list | One of (unit -> 'a t list)
+type 'a work =
+  | Batch of (unit -> 'a t list) list
+  | Direct of (unit -> 'a t list)
+  | One of (unit -> 'a t list)
 
 (** Pick this worker's next unit of work and the idle workers to signal for what
     is left behind. [s.ready_m] must be held.
 
     Immediate tasks go as one batch: they do not block, so running them in
-    sequence on the calling domain costs less than a hand-off each. Blocking
-    tasks go one at a time, so they spread over the pool. *)
+    sequence on the calling domain costs less than a hand-off each. Direct and
+    blocking tasks go one at a time, so they spread over the pool: batching them
+    would run several long tasks in sequence on one domain. A direct task holds
+    no blocking slot, since it runs on the domain rather than on one of its
+    auxiliary threads. *)
 let take_work s w =
   let mine, others = List.partition (fun (p, _) -> w.accepts p) s.ready in
+  let direct, rest =
+    List.partition (fun (p, _) -> s.classify p = `Direct) mine
+  in
   let immediate, blocking =
-    List.partition (fun (p, _) -> s.classify p = `Immediate) mine
+    List.partition (fun (p, _) -> s.classify p = `Immediate) rest
   in
-  let can_block =
-    blocking <> [] && Atomic.get w.blocking < s.blocking_per_worker
+  let singles =
+    if Atomic.get w.blocking < s.blocking_per_worker then direct @ blocking
+    else direct
   in
-  (* A worker alternates between the two classes. Taking every ready immediate
-     task on every round starves blocking work whenever the ready list refills
+  let can_block = singles <> [] in
+  (* A worker alternates between a batch and a single task. Taking every ready
+     immediate task on every round starves the rest whenever the ready list refills
      as fast as it drains, which a lone worker cannot escape by leaving the
      rest to someone else. *)
     match immediate with
     | _ :: _ when not (w.took_batch && can_block) ->
-        s.ready <- blocking @ others;
+        s.ready <- direct @ blocking @ others;
         w.took_batch <- true;
         ( Some (Batch (List.rev_map snd immediate)),
           take_idle s (List.length s.ready) )
@@ -409,11 +420,15 @@ let take_work s w =
         let best =
           List.fold_left
             (fun best x -> if s.compare (fst x) (fst best) < 0 then x else best)
-            (List.hd blocking) blocking
+            (List.hd singles) singles
         in
         s.ready <- List.filter (fun x -> x != best) s.ready;
         w.took_batch <- false;
-        (Some (One (snd best)), take_idle s (List.length s.ready))
+        let work =
+          if s.classify (fst best) = `Direct then Direct (snd best)
+          else One (snd best)
+        in
+        (Some work, take_idle s (List.length s.ready))
     (* Blocking work is ready but this worker is at its own capacity for it:
        leaving it there would strand the task until a worker happens to look
        for an unrelated reason, so hand it to the ones that are idle. *)
@@ -515,6 +530,7 @@ let dispatch s w =
     List.iter signal_worker wake;
     begin match work with
       | Some (Batch fns) -> List.iter (fun fn -> add_t s (run_task s fn)) fns
+      | Some (Direct fn) -> add_t s (run_task s fn)
       | Some (One fn) -> run_blocking s w fn
       | None -> wait_for_work s w
     end

--- a/src/modules/duppy/duppy.mli
+++ b/src/modules/duppy/duppy.mli
@@ -66,8 +66,12 @@ type 'a scheduler
 
     [`Blocking] tasks may park in a syscall. Each one is run on an auxiliary
     thread inside its domain, so that parking releases the runtime lock and the
-    domain goes back to dispatching. *)
-type execution_class = [ `Immediate | `Blocking ]
+    domain goes back to dispatching.
+
+    [`Direct] tasks are long but do not block: each one runs on a domain by
+    itself, one at a time, so several of them spread over the pool rather than
+    running in sequence on one domain. *)
+type execution_class = [ `Immediate | `Direct | `Blocking ]
 
 (** Wraps every task body. Effect handlers do not cross the thread a task is
     dispatched to, so a caller whose tasks need one installs it here rather than

--- a/src/modules/duppy/duppy.mli
+++ b/src/modules/duppy/duppy.mli
@@ -78,6 +78,8 @@ type execution_class = [ `Immediate | `Direct | `Blocking ]
     at each of its own entry points. *)
 type wrapper = { wrap : 'a. (unit -> 'a) -> 'a }
 
+exception Unknown_domain of int
+
 (** Initiate a new scheduler. It has no domains until [start] is called.
   * @param on_error called when a task raises.
   * @param on_fatal called when the event loop itself crashes, which should be
@@ -149,8 +151,11 @@ module Task : sig
     | `Read of Unix.file_descr
     | `Exception of Unix.file_descr ]
 
-  (** Schedule a task. *)
-  val add : 'a scheduler -> ('a, [< event ]) task -> unit
+  (** Schedule a task. With [domain], only the worker on that domain runs it,
+      and so does every task its handler returns. Raises [Unknown_domain] when
+      no started worker is on that domain or accepts the task's priority, and
+      always on a thread pool, where workers share a domain. *)
+  val add : ?domain:int -> 'a scheduler -> ('a, [< event ]) task -> unit
 end
 
 (** {2 Direct-style computations}

--- a/src/modules/duppy/test/bench_timer.ml
+++ b/src/modules/duppy/test/bench_timer.ml
@@ -1,0 +1,56 @@
+(* How late a parked computation resumes after [reschedule ~delay], against a
+   plain sleep in the same process. *)
+
+type prio = Blocking
+
+let classify (_ : prio) = `Blocking
+
+let quantiles xs =
+  let xs = List.sort compare xs in
+  let n = List.length xs in
+  let q p = List.nth xs (int_of_float (p *. float (n - 1))) in
+  (q 0.5, q 0.95, q 1.0)
+
+let report name d (m, p95, mx) =
+  Printf.printf
+    "%-10s delay=%7.1fms  late: median=%7.3fms  p95=%7.3fms  max=%7.3fms\n%!"
+    name (d *. 1000.) (m *. 1000.) (p95 *. 1000.) (mx *. 1000.)
+
+let () =
+  let s = Duppy.create ~classify () in
+  Duppy.start ~pool:(`Domains (Domain.recommended_domain_count ())) s;
+  let trials =
+    [(0.001, 300); (0.005, 300); (0.02, 300); (0.1, 100); (0.5, 20)]
+  in
+  List.iter
+    (fun (d, n) ->
+      let sleep = ref [] in
+      for _ = 1 to n do
+        let t0 = Unix.gettimeofday () in
+        Unix.sleepf d;
+        sleep := (Unix.gettimeofday () -. t0 -. d) :: !sleep
+      done;
+      report "sleepf" d (quantiles !sleep);
+      let late = ref [] in
+      let finished = Atomic.make false in
+      Duppy.Task.add s
+        {
+          Duppy.Task.priority = Blocking;
+          events = [`Delay 0.];
+          handler =
+            (fun _ ->
+              Duppy.run (fun () ->
+                  for _ = 1 to n do
+                    let t0 = Unix.gettimeofday () in
+                    Duppy.reschedule ~delay:d ~priority:Blocking s;
+                    late := (Unix.gettimeofday () -. t0 -. d) :: !late
+                  done;
+                  Atomic.set finished true);
+              []);
+        };
+      while not (Atomic.get finished) do
+        Thread.delay 0.005
+      done;
+      report "duppy" d (quantiles !late))
+    trials;
+  Duppy.stop s

--- a/src/modules/duppy/test/dune
+++ b/src/modules/duppy/test/dune
@@ -1,5 +1,5 @@
 (executables
- (names test_duppy bench_duppy)
+ (names test_duppy bench_duppy bench_timer)
  (libraries duppy unix threads.posix))
 
 (rule

--- a/src/modules/duppy/test/test_duppy.ml
+++ b/src/modules/duppy/test/test_duppy.ml
@@ -1,9 +1,13 @@
 (* The pool dispatches across domains, batches immediate tasks onto one of
    them, delivers socket events, and lets running tasks finish on stop. *)
 
-type priority = Immediate | Blocking
+type priority = Immediate | Direct | Blocking
 
-let classify = function Immediate -> `Immediate | Blocking -> `Blocking
+let classify = function
+  | Immediate -> `Immediate
+  | Direct -> `Direct
+  | Blocking -> `Blocking
+
 let domain_id () = (Domain.self () :> int)
 
 let fail fmt =
@@ -393,6 +397,28 @@ let test_capacity_hands_off () =
   ok "a worker at capacity hands ready blocking work to a free one";
   Duppy.stop s
 
+(* A batch of immediate tasks is taken while a direct task is ready. The direct
+   one is neither run nor left behind by a ready list rebuilt from the classes
+   the batch did not cover. *)
+let test_direct_survives_a_batch () =
+  let s = Duppy.create ~classify () in
+  let ran = latch () in
+  Duppy.Task.add s
+    (task Direct (fun _ ->
+         bump ran;
+         []));
+  for _ = 1 to 20 do
+    Duppy.Task.add s (task Immediate (fun _ -> []))
+  done;
+  Duppy.start ~pool:(`Domains 1) s;
+  let deadline = Unix.gettimeofday () +. 2. in
+  while Atomic.get ran.n = 0 && Unix.gettimeofday () < deadline do
+    Thread.delay 0.01
+  done;
+  if Atomic.get ran.n = 0 then fail "a direct task was dropped by a batch";
+  ok "a direct task survives an immediate batch";
+  Duppy.stop s
+
 let () =
   watchdog 60.;
   test_threads ();
@@ -409,4 +435,5 @@ let () =
   test_await_outside_run ();
   test_no_starvation ();
   test_capacity_hands_off ();
+  test_direct_survives_a_batch ();
   print_endline "all duppy pool checks passed"

--- a/src/modules/duppy/test/test_duppy.ml
+++ b/src/modules/duppy/test/test_duppy.ml
@@ -419,6 +419,45 @@ let test_direct_survives_a_batch () =
   ok "a direct task survives an immediate batch";
   Duppy.stop s
 
+(* A pinned task and every task its handler returns run on the worker for that
+   domain, found the way script code finds it: by asking from inside an
+   unpinned task. A pin naming no worker is refused rather than left waiting. *)
+let test_pinned () =
+  let s = Duppy.create ~classify () in
+  (match Duppy.Task.add ~domain:0 s (task Immediate (fun _ -> [])) with
+    | () -> fail "a pin was accepted before the pool started"
+    | exception Duppy.Unknown_domain _ -> ());
+  Duppy.start ~pool:(`Domains 4) s;
+  (match Duppy.Task.add ~domain:9999 s (task Immediate (fun _ -> [])) with
+    | () -> fail "a pin to a domain with no worker was accepted"
+    | exception Duppy.Unknown_domain 9999 -> ());
+  let home = Atomic.make (-1) in
+  let seen = latch () in
+  Duppy.Task.add s
+    (task Direct (fun _ ->
+         Atomic.set home (domain_id ());
+         bump seen;
+         []));
+  await seen 1;
+  let home = Atomic.get home in
+  (* Immediate tasks are the ones a batch could carry off to the wrong worker. *)
+  let runs = 20 in
+  let where = Array.make runs (-1) in
+  let finished = latch () in
+  let rec hop i _ =
+    where.(i) <- domain_id ();
+    bump finished;
+    if i + 1 < runs then [task Immediate (hop (i + 1))] else []
+  in
+  Duppy.Task.add ~domain:home s (task Immediate (hop 0));
+  await finished runs;
+  Array.iteri
+    (fun i d ->
+      if d <> home then fail "rerun %d ran on domain %d instead of %d" i d home)
+    where;
+  ok "a pinned task and its %d reruns all ran on domain %d" (runs - 1) home;
+  Duppy.stop s
+
 let () =
   watchdog 60.;
   test_threads ();
@@ -436,4 +475,5 @@ let () =
   test_no_starvation ();
   test_capacity_hands_off ();
   test_direct_survives_a_batch ();
+  test_pinned ();
   print_endline "all duppy pool checks passed"

--- a/tests/language/error.liq
+++ b/tests/language/error.liq
@@ -69,7 +69,7 @@ def f() =
     )
 
   test.equal(r/error.liq, line 58 char 4 - line 63 char 7/.test(pos), true)
-  test.equal(r/thread.liq, line 13, char 11-14/.test(pos), true)
+  test.equal(r/thread.liq, line 21, char 11-14/.test(pos), true)
   e' = error.register("bla")
   test.equal(false, (e == e'))
 

--- a/tests/regression/cleanup.liq
+++ b/tests/regression/cleanup.liq
@@ -1,31 +1,32 @@
 log.level := 5
 
-def s_ref =
+collected = ref(false)
+
+# An object is collected only by a GC on the domain that allocated it, and the
+# script itself runs on the main domain where no task ever does. So the source
+# is created from a task, on whichever worker takes it, and everything after
+# runs pinned to that same domain.
+def setup() =
+  home = runtime.domain()
   b = blank(id="first")
-  b.on_collect(synchronous=true, test.pass)
-  ref(b)
+  b.on_collect(
+    synchronous=true,
+    fun () ->
+      begin
+        collected := true
+        test.pass()
+      end
+  )
+  s_ref = ref(b)
+  s = source.dynamic(track_sensitive=false, {s_ref()})
+  ignore(output.dummy(fallible=true, s))
+  thread.run(domain=home, delay=1., fun () -> s_ref.set(blank(id="second")))
+  thread.run(
+    domain=home,
+    delay=2.,
+    every={collected() ? -1. : 0.2},
+    runtime.gc.full_major
+  )
 end
 
-s = source.dynamic(track_sensitive=false, {s_ref()})
-
-output.dummy(fallible=true, s)
-
-thread.run(delay=1., fun () -> s_ref.set(blank(id="second")))
-
-thread.run(
-  delay=2.,
-  fun () ->
-    begin
-      runtime.gc.compact()
-      log(level=2, "Compacting")
-    end
-)
-
-thread.run(
-  delay=3.,
-  fun () ->
-    begin
-      runtime.gc.compact()
-      log(level=2, "Compacting")
-    end
-)
+thread.run(setup)


### PR DESCRIPTION
Clocks become scheduler tasks instead of each running on a thread of its own, and duppy gains the execution class that makes that work. `settings.clock.task` (default `true`) selects the animator.

The gain shows up on many small streams with a clock each, where it holds 51 streams in real time against 27 on 2.4.6. A few large video streams do not show it: there one stream is most of a core on its own, so the machine runs out before the scheduler does.

## Measured: many small streams, one clock each

Each stream decodes one file, encodes it once into three variants with a [shared encoder](https://www.liquidsoap.info/blog/2025-09-02-shared-encoders/), and serves those tracks as an HLS playlist and three icecast mounts. Each stream is an independent graph, so the stream count is the clock count.

<details>
<summary>Workload script</summary>

```liquidsoap
def make_stream(i) =
  s = mksafe(single("music.mp3"))

  # One encode per variant, copied by every output below.
  aac_low = ffmpeg.encode.audio(%ffmpeg(%audio(codec = "aac", b = "48k")), s)
  aac_high = ffmpeg.encode.audio(%ffmpeg(%audio(codec = "aac", b = "128k")), s)
  lame = ffmpeg.encode.audio(%ffmpeg(%audio(codec = "libmp3lame", b = "128k")), s)

  let {audio = low, metadata = m, track_marks = tm} = source.tracks(aac_low)
  let {audio = high} = source.tracks(aac_high)
  let {audio = mp3} = source.tracks(lame)

  encoded =
    source({audio_low = low, audio_high = high, audio_mp3 = mp3,
            metadata = m, track_marks = tm})

  clock.assign_new(id="stream_#{i}", [encoded])

  low_only = %ffmpeg(format = "mpegts", %audio_low.copy, %audio_high.drop, %audio_mp3.drop)

  # Two HLS variants and three icecast mounts, all copying the tracks above.
  output.file.hls("/dev/shm/hls/s#{i}", [("low", low_only), ("high", ...)], encoded)
  output.icecast(%ffmpeg(format = "adts", %audio_low.copy, ...), mount="s#{i}_low", encoded)
end

list.iter(make_stream, list.init(n, fun (i) -> i))
```

</details>

The stream count rises until a clock reports a catchup of a second or more. A rung is 45 s with the first 10 s discarded. 8 cores, aarch64, local files, icecast on the same box. 2.4.6 is the control for what a thread per clock cost before domains existed.

<img width="1125" height="593" alt="clock-ceiling" src="https://github.com/user-attachments/assets/7b5204da-f240-4dc4-afab-15582f27609f" />

| | streams held | against 2.4.6 | voluntary switches per added stream |
|---|---|---|---|
| 2.4.6 | 27 | | 2,565 |
| 2.5 `clock.task := false` | 19 | -30% | 4,136 |
| 2.5 `clock.task := true` | **51** | **+89%** | **69** |

The two animators fail differently. As tasks the process runs out of machine: CPU climbs to 673%, the marginal cost of one more stream goes from 4.4% of a core to 74% over the last four rungs, and involuntary switches triple. With a thread per clock it never gets there, giving up at 228% of eight cores with CPU falling rather than rising, which is a scheduling collapse rather than a compute ceiling.

<img width="1125" height="593" alt="clock-cpu" src="https://github.com/user-attachments/assets/79acb4fa-0f48-469d-b550-5c9d38963e54" />

What separates them is what each added stream costs in wakeups. Every clock on a thread sleeps and wakes on its own every frame; a parked clock is a continuation resumed on a domain that is already running.

<img width="1125" height="593" alt="clock-ctxt" src="https://github.com/user-attachments/assets/5af3d0ea-78c0-4ad0-a5d5-30889187a8d0" />

At 19 streams, the last count both 2.5 modes hold: 243% CPU against 292%, 14% duty against 45%, 1.7k switches per second against 48.2k.

## A regression this turned up

2.5 with `clock.task := false` holds fewer streams than 2.4.6, 19 against 27, on the same machine and workload, and costs 1.6x the switches per added stream. So part of the gap is 2.5's thread path having got worse, not the task path having got better; against 2.4.6 the honest number is +89%. Not addressed here, and it matters because the thread animator is the fallback whenever `settings.clock.task` is off, and JACK forces it.

## How it works: a `Direct` execution class in duppy

A clock tick is long and does not block, which fits neither existing class. `Immediate` tasks are batched onto one domain, so clocks waking together would tick in sequence. `Blocking` tasks each take an auxiliary thread and a blocking slot, which is thread machinery a tick has no use for. `Direct` runs a task on a domain alone, holding no blocking slot, so ticks spread over the pool.

## How it works: clocks

The loop is unchanged; what changed is how it rests. `_sleep_until_target` parks through `Duppy.reschedule` when the clock is task-animated and a handler is in scope, and sleeps for real otherwise, since a clock can also be ticked from outside its own task (crossfade children, `clock.tick`). A clock that is behind never rests, so it yields its domain after one latency's worth of ticks instead of holding it until caught up. Clocks get their own priority, `Clock`, ranked after the server and before request resolution. Shutdown drains, since a parked clock is not a thread `join_all` can wait for.

## Tests and caveats

`test_duppy.ml` gains a `Direct` priority and a check that a direct task survives a batch of immediate tasks being taken. By hand: both animators tick and stop cleanly on SIGINT with the drain reporting nothing left; a crossfade with child clocks ticked from the parent raises no unhandled effect; an unsynced clock as a task yields its domain. Duppy's timer costs nothing on a resume: median 0.05 to 0.1 ms late, same as a plain `sleepf` (`src/modules/duppy/test/bench_timer.ml`).

`tests/regression/cleanup.liq` hung under the task animator. An object is only collected by a GC running on the domain that allocated it, and script evaluation runs on domain 0, which no scheduler task ever runs on, so nothing could reclaim the replaced source once the clock no longer kept domain 0 collecting. Duppy gains `Task.add ?domain`, pinning a task and every task its handler returns to the worker on that domain, exposed as `thread.run(domain=)`. The test now creates its source from a task, reads that task's domain with `runtime.domain()`, and pins the collection there: 40/40 across both animators, against an unpinned 7/8. A pin naming no worker raises rather than leaving a task nobody will take.

One run per rung on one machine, no repeats, and the control differs from 2.5 in more than the clock, so the claim is "2.5 thread mode is worse here", not "the clock change caused it". Per-stream cost is not constant across stream counts (27% of a core at n=1, 5.7% at n=70, as the cores stop dropping into idle states), so everything is read at equal stream count.

A parked continuation resumes on whichever domain picks it up, so ticks driving thread-affine libraries (SDL, JACK) are untested here; `settings.clock.task := false` is the escape hatch.

