### PR TITLE
fades: do not divide by a zero duration while the fade delay is pending

### DIFF
--- a/src/libs/fades.liq
+++ b/src/libs/fades.liq
@@ -131,8 +131,11 @@ def mkfade(
     if start_time() < 0. then start_time := source.time(s) end
 
     t = source.time(s) - start_time() - delay
+
+    # While the delay is pending, do not touch `duration`: a zero duration
+    # would divide by zero and amplify by inf.
     if
-      0. < duration and t <= 0.
+      t < 0.
     then
       start
     elsif

--- a/tests/regression/dune.inc
+++ b/tests/regression/dune.inc
@@ -1863,6 +1863,29 @@
    external-encoder.liq)))
 
 (rule
+ (alias test_fade-zero-duration-delay)
+ (package liquidsoap)
+ (deps
+  fade-zero-duration-delay.liq
+  (glob_files ../media/**)
+  ../liquidsoap-test-assets
+  ../../src/bin/liquidsoap.exe
+  ../streams/file1.png
+  ../streams/file1.mp3
+  ./theora-test.mp4
+  (package liquidsoap)
+  (source_tree ../../src/libs)
+  (:test_liq ../test.liq)
+  (:run_test ../run_test.exe))
+ (action
+  (run
+   %{run_test}
+   fade-zero-duration-delay
+   liquidsoap
+   %{test_liq}
+   fade-zero-duration-delay.liq)))
+
+(rule
  (alias test_fallible_ogg)
  (package liquidsoap)
  (deps
@@ -2790,6 +2813,7 @@
   (alias test_double-nullable)
   (alias test_eval-check-demeth)
   (alias test_external-encoder)
+  (alias test_fade-zero-duration-delay)
   (alias test_fallible_ogg)
   (alias test_ffmpeg-copy-encode)
   (alias test_ffmpeg-copy-input-http)

--- a/tests/regression/fade-zero-duration-delay.liq
+++ b/tests/regression/fade-zero-duration-delay.liq
@@ -1,0 +1,16 @@
+# A zero-duration fade with a pending delay must not divide by zero.
+s = sine()
+
+# Delay pending: returns start.
+f = mkfade(start=1., stop=0., delay=1., duration=0., s)
+if f() != 1. then test.fail() end
+
+# No delay, zero duration: returns stop on the first frame (#4887).
+f = mkfade(start=0., stop=1., delay=0., duration=0., s)
+if f() != 1. then test.fail() end
+
+# Fade start with a positive duration still returns start.
+f = mkfade(start=1., stop=0., delay=0., duration=3., s)
+if f() != 1. then test.fail() end
+
+test.pass()


### PR DESCRIPTION
On 2.4.5, scripts sending `liq_fade_out=0` together with a positive `liq_fade_out_delay` got a burst of non-finite samples for the whole cross window at every track change. The encoder turns those into full-scale DC.

In `mkfade`, the pre-delay guard was `0. < duration and t <= 0.`. With a zero duration and a pending delay (`t < 0`) both guards are skipped and the else branch evaluates `shape(1. - t / 0.)`, i.e. infinity. `fade.scale` then amplifies the track by inf, and `add()` in a crossfade transition spreads it into the incoming track. That guard came from #4887, which needed `t = 0, duration = 0` to return `stop` rather than `start`.

The guard is now `t < 0.`: while the delay is pending it returns `start` without touching `duration`. `t = 0` with a zero duration still falls through to `t >= duration` and returns `stop`, so #4887 is preserved. With a positive duration, `t = 0` reaches the else branch and every shape maps `0.` to `0.`, so it still returns `start`.

`cross.ml`'s autocue adjustments can synthesise the same zero-fade-plus-delay combination internally, so this can trigger without any script sending the metadata.

Tests: `tests/regression/fade-zero-duration-delay.liq` calls `mkfade` directly for the three boundary cases. It fails on the previous `fades.liq` and passes with this change. Existing fade and crossfade tests (`GH5019`, `fades-overrides`, `fades-persistent-override`, `crossfade`, `crossfade2`, `switch_per_source_no_reselect_during_fade`) still pass.
