### PR TITLE
Run a scheduler worker on the domain that evaluates the script

### DIFF
--- a/src/core/utils/tutils.ml
+++ b/src/core/utils/tutils.ml
@@ -319,7 +319,7 @@ let start () =
              settings.scheduler.legacy is set.";
         None)
     in
-    Duppy.start ?pool ~max_blocking:blocking_tasks#get
+    Duppy.start ?pool ~current_domain:true ~max_blocking:blocking_tasks#get
       ?log:(scheduler_logger ()) scheduler)
 
 (** Waits for [f()] to become true on condition [c]. *)

--- a/src/modules/duppy/duppy.ml
+++ b/src/modules/duppy/duppy.ml
@@ -668,7 +668,7 @@ let poller s =
         poll_once s
       done)
 
-let start ?pool ?(max_blocking = 64) ?log:logger s =
+let start ?pool ?(current_domain = false) ?(max_blocking = 64) ?log:logger s =
   if not (Atomic.compare_and_set s.started false true) then
     failwith "Duppy.start: scheduler already started";
   s.log <- logger;
@@ -682,27 +682,36 @@ let start ?pool ?(max_blocking = 64) ?log:logger s =
             (fun _ _ -> true)
   in
   s.threaded <- (match pool with Some (`Threads _) -> true | _ -> false);
-  let count = List.length accepts in
-  s.blocking_per_worker <- max 1 ((max_blocking + count - 1) / count);
-  let workers =
-    List.map
-      (fun accepts ->
-        {
-          worker_m = Mutex.create ();
-          worker_c = Condition.create ();
-          wake = false;
-          took_batch = false;
-          blocking = Atomic.make 0;
-          accepts;
-          domain = -1;
-          aux_m = Mutex.create ();
-          aux_c = Condition.create ();
-          aux_pending = [];
-          aux_busy = 0;
-          aux_total = 0;
-        })
-      accepts
+  let make_worker accepts =
+    {
+      worker_m = Mutex.create ();
+      worker_c = Condition.create ();
+      wake = false;
+      took_batch = false;
+      blocking = Atomic.make 0;
+      accepts;
+      domain = -1;
+      aux_m = Mutex.create ();
+      aux_c = Condition.create ();
+      aux_pending = [];
+      aux_busy = 0;
+      aux_total = 0;
+    }
   in
+  let workers = List.map make_worker accepts in
+  (* A thread on the calling domain, so the domain that evaluated the script
+     takes tasks too and collects what it allocated: a GC only reclaims the
+     heap of the domain it runs on. A thread pool already sits there. *)
+  let current =
+    if current_domain && not s.threaded then (
+      let w = make_worker (fun _ -> true) in
+      w.domain <- (Domain.self () :> int);
+      Some w)
+    else None
+  in
+  let workers = workers @ Option.to_list current in
+  let count = List.length workers in
+  s.blocking_per_worker <- max 1 ((max_blocking + count - 1) / count);
   s.workers <- workers;
   let guard fn () =
     try fn ()
@@ -722,6 +731,12 @@ let start ?pool ?(max_blocking = 64) ?log:logger s =
       | `Domain d -> w.domain <- (Domain.get_id d :> int)
       | `Thread _ -> ());
     m
+  in
+  let spawn_worker w =
+    match current with
+      | Some c when c == w ->
+          `Thread (Thread.create (guard (fun () -> dispatch s w)) ())
+      | _ -> spawn_worker w
   in
   s.members <- spawn (fun () -> poller s) :: List.map spawn_worker workers;
   log s (fun () ->

--- a/src/modules/duppy/duppy.mli
+++ b/src/modules/duppy/duppy.mli
@@ -110,6 +110,10 @@ val create :
   * in place on the thread that took it. Nothing runs in parallel and
   * [Unix.fork] stays usable.
   * @param pool Default: [`Domains (Domain.recommended_domain_count ())]
+  * @param current_domain also run one worker as a thread on the calling
+  * domain, so that domain takes tasks too and a GC there reclaims what it
+  * allocated. Ignored for a thread pool, which is on the calling domain
+  * already. Default: [false]
   * @param max_blocking the most [`Blocking] tasks that may be in flight at
   * once, spread evenly over the domains. Each domain keeps at least one slot,
   * rounded up, so the whole budget is available even when it does not divide
@@ -118,6 +122,7 @@ val create :
   * @param log Logging function. Default: no logging *)
 val start :
   ?pool:[ `Domains of int | `Threads of ('a -> bool) list ] ->
+  ?current_domain:bool ->
   ?max_blocking:int ->
   ?log:(string -> unit) ->
   'a scheduler ->

--- a/src/modules/duppy/test/test_duppy.ml
+++ b/src/modules/duppy/test/test_duppy.ml
@@ -458,6 +458,31 @@ let test_pinned () =
   ok "a pinned task and its %d reruns all ran on domain %d" (runs - 1) home;
   Duppy.stop s
 
+(* The calling domain joins the pool as a thread when asked, so a task can be
+   pinned to it; without asking, that domain has no worker. *)
+let test_current_domain () =
+  let here = domain_id () in
+  let s = Duppy.create ~classify () in
+  Duppy.start ~pool:(`Domains 2) s;
+  (match Duppy.Task.add ~domain:here s (task Immediate (fun _ -> [])) with
+    | () -> fail "the calling domain had a worker without asking for one"
+    | exception Duppy.Unknown_domain _ -> ());
+  Duppy.stop s;
+  let s = Duppy.create ~classify () in
+  Duppy.start ~pool:(`Domains 2) ~current_domain:true s;
+  let ran_on = Atomic.make (-1) in
+  let seen = latch () in
+  Duppy.Task.add ~domain:here s
+    (task Immediate (fun _ ->
+         Atomic.set ran_on (domain_id ());
+         bump seen;
+         []));
+  await seen 1;
+  if Atomic.get ran_on <> here then
+    fail "pinned to the calling domain %d, ran on %d" here (Atomic.get ran_on);
+  ok "the calling domain %d takes tasks as a pool worker" here;
+  Duppy.stop s
+
 let () =
   watchdog 60.;
   test_threads ();
@@ -476,4 +501,5 @@ let () =
   test_capacity_hands_off ();
   test_direct_survives_a_batch ();
   test_pinned ();
+  test_current_domain ();
   print_endline "all duppy pool checks passed"

--- a/tests/regression/GH5389.liq
+++ b/tests/regression/GH5389.liq
@@ -4,6 +4,7 @@
 stopped = ref(false)
 collected = ref(false)
 tracks = ref(0)
+home = ref(-1)
 
 current = ref(source.fail())
 dynamic =
@@ -20,6 +21,7 @@ def replace() =
 end
 
 def install() =
+  home := runtime.domain()
   first =
     input.ffmpeg(
       id="first",
@@ -40,7 +42,8 @@ def install() =
 end
 
 # The second track is the switch away from `first`, whose last reference is
-# dropped a cycle or so later, so collection is asked for until it happens.
+# dropped a cycle or so later, so collection is asked for until it happens, on
+# the domain that allocated it since a GC only reclaims its own domain's heap.
 #
 # Compacting from the clock thread would deadlock, since the finaliser passes
 # the test and that shuts down the clock it is running on.
@@ -49,7 +52,11 @@ def on_track(_) =
   if
     tracks() == 2
   then
-    thread.run(every={(collected() ? -1. : 0.1)}, runtime.gc.compact)
+    thread.run(
+      domain=home(),
+      every={(collected() ? -1. : 0.1)},
+      runtime.gc.compact
+    )
   end
 end
 

--- a/tests/regression/cleanup.liq
+++ b/tests/regression/cleanup.liq
@@ -2,10 +2,9 @@ log.level := 5
 
 collected = ref(false)
 
-# An object is collected only by a GC on the domain that allocated it, and the
-# script itself runs on the main domain where no task ever does. So the source
-# is created from a task, on whichever worker takes it, and everything after
-# runs pinned to that same domain.
+# An object is collected only by a GC on the domain that allocated it, so the
+# source is created from a task and everything after runs pinned to that
+# task's domain, whichever worker took it.
 def setup() =
   home = runtime.domain()
   b = blank(id="first")


### PR DESCRIPTION
`Duppy.start` takes `?current_domain`, adding one worker that runs as a thread on the calling domain, and `Tutils.start` passes it. Every domain now takes scheduler tasks, the one that evaluates the script included.

This finishes the move to full concurrency. With the scheduler on a domain pool and clocks running as its tasks, the main domain was the one domain still singled out: it evaluated the script, then sat in `wait_done` doing nothing while every other domain dispatched. There is no reason for it to be special, so it joins the pool like the others. The main thread itself keeps its `select`-based wait rather than running the dispatch loop, only because SIGTERM interrupts `select` and would not interrupt a `Condition.wait`; the worker is a thread beside it on the same domain.

`test_duppy.ml` gains a check that the calling domain has no worker unless asked for, and takes a pinned task when it is. Verified by hand: a task pinned to domain 0 runs there from top level and from inside a task, unpinned tasks land on domain 0 among the others, SIGTERM still exits cleanly, and `tests/regression/cleanup.liq` holds at 10/10 with the extra worker in the pool.
