### PR TITLE
Fix Last.fm Audioscrobbler HTTPS endpoint

### DIFF
--- a/src/libs/extra/audioscrobbler.liq
+++ b/src/libs/extra/audioscrobbler.liq
@@ -20,7 +20,7 @@ let settings.audioscrobbler.api_secret =
 audioscrobbler = ()
 
 def audioscrobbler.request(
-  ~base_url="http://ws.audioscrobbler.com/2.0",
+  ~base_url="https://ws.audioscrobbler.com/2.0",
   ~api_key=null,
   ~api_secret=null,
   params

--- a/tests/regression/GH5398.liq
+++ b/tests/regression/GH5398.liq
@@ -1,0 +1,18 @@
+# Regression test for https://github.com/savonet/liquidsoap/issues/5398
+# Last.fm rejects Audioscrobbler requests sent to the former HTTP default.
+
+contents = file.contents("../../src/libs/extra/audioscrobbler.liq")
+
+if
+  string.contains(
+    substring='~base_url="https://ws.audioscrobbler.com/2.0"',
+    contents
+  ) and not string.contains(
+    substring='~base_url="http://ws.audioscrobbler.com/2.0"',
+    contents
+  )
+then
+  test.pass()
+else
+  test.fail("Audioscrobbler must default to the Last.fm HTTPS endpoint")
+end

--- a/tests/regression/dune.inc
+++ b/tests/regression/dune.inc
@@ -1432,6 +1432,24 @@
   (run %{run_test} GH5389 liquidsoap %{test_liq} GH5389.liq)))
 
 (rule
+ (alias test_GH5398)
+ (package liquidsoap)
+ (deps
+  GH5398.liq
+  (glob_files ../media/**)
+  ../liquidsoap-test-assets
+  ../../src/bin/liquidsoap.exe
+  ../streams/file1.png
+  ../streams/file1.mp3
+  ./theora-test.mp4
+  (package liquidsoap)
+  (source_tree ../../src/libs)
+  (:test_liq ../test.liq)
+  (:run_test ../run_test.exe))
+ (action
+  (run %{run_test} GH5398 liquidsoap %{test_liq} GH5398.liq)))
+
+(rule
  (alias test_LS268)
  (package liquidsoap)
  (deps
@@ -2792,6 +2810,7 @@
   (alias test_GH5360)
   (alias test_GH5361)
   (alias test_GH5389)
+  (alias test_GH5398)
   (alias test_LS268)
   (alias test_LS354-1)
   (alias test_LS354-2)


### PR DESCRIPTION
Fixes #5398.

Last.fm rejects the Audioscrobbler default endpoint with error code 4 because it is still configured as HTTP. This changes the shared request default to HTTPS, so authentication and track submissions use the accepted endpoint while preserving the existing `base_url` override.

A focused regression checks the exact default and is registered in the existing `citest` suite. Broadcast Control Lab reproduced the insecure default before the change and verified the corrected default after it. The focused check and all 80 BCL infrastructure tests pass; the full Liquidsoap OCaml suite was not built locally and is left to upstream CI.
